### PR TITLE
Bring back error handling in the Idea plugin

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/error/ErrorUtils.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/error/ErrorUtils.kt
@@ -1,0 +1,11 @@
+package org.utbot.intellij.plugin.error
+
+import com.intellij.openapi.application.invokeLater
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
+
+fun showErrorDialogLater(project: Project, message: String, title: String) {
+    invokeLater {
+        Messages.showErrorDialog(project, message, title)
+    }
+}

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/TestGenerator.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/TestGenerator.kt
@@ -62,6 +62,7 @@ import org.jetbrains.kotlin.psi.KtPsiFactory
 import org.jetbrains.kotlin.psi.psiUtil.endOffset
 import org.jetbrains.kotlin.psi.psiUtil.startOffset
 import org.jetbrains.kotlin.scripting.resolve.classId
+import org.utbot.intellij.plugin.error.showErrorDialogLater
 
 object TestGenerator {
     fun generateTests(model: GenerateTestsModel, testCases: Map<PsiClass, List<UtTestCase>>) {
@@ -268,7 +269,11 @@ object TestGenerator {
                 SarifReportIdea.createAndSave(model, testCases, generatedTestsCode, sourceFinding)
             }
         } catch (e: Exception) {
-            logger.error{ "Cannot save Sarif report via generated tests: error occurred '${e.message}'"}
+            showErrorDialogLater(
+                project,
+                message = "Cannot save Sarif report via generated tests: error occurred '${e.message}'",
+                title = "Failed to save Sarif report"
+            )
         }
 
         try {
@@ -280,7 +285,11 @@ object TestGenerator {
                 }
             }
         } catch (e: Exception) {
-            logger.error { "Cannot save tests generation report: error occurred '${e.message}'" }
+            showErrorDialogLater(
+                project,
+                message = "Cannot save tests generation report: error occurred '${e.message}'",
+                title = "Failed to save tests report"
+            )
         }
     }
 
@@ -393,6 +402,10 @@ object TestGenerator {
     }
 
     private fun showCreatingClassError(project: Project, testClassName: String) {
-        logger.error { "Cannot Create Class '$testClassName'" }
+        showErrorDialogLater(
+            project,
+            message = "Cannot Create Class '$testClassName'",
+            title = "Failed to Create Class"
+        )
     }
 }

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/UtTestsDialogProcessor.kt
@@ -40,6 +40,7 @@ import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
 import mu.KotlinLogging
 import org.jetbrains.kotlin.idea.util.module
+import org.utbot.intellij.plugin.error.showErrorDialogLater
 
 object UtTestsDialogProcessor {
 
@@ -165,7 +166,11 @@ object UtTestsDialogProcessor {
                                     }
 
                                     if (notEmptyCases.isEmpty()) {
-                                        logger.error { "Failed to generate unit tests for class $className" }
+                                        showErrorDialogLater(
+                                            model.project,
+                                            errorMessage(className, secondsTimeout),
+                                            title = "Failed to generate unit tests for class $className"
+                                        )
                                     } else {
                                         testCasesByClass[srcClass] = notEmptyCases
                                     }


### PR DESCRIPTION
## Expected Behavior
In case of an unexpected exception during test case generation, saving test report, class creation, we are supposed to show a dialog, that describes the issue


## Current Behavior
In case of such exceptions, we print an error in output.


## Steps to Reproduce (for bugs)
Start generation of a test that usually takes long time. Stop the generation with a cross button. Notice the blinking square in the right bottom corner of the IDE.

## Environment
* Component Version: IntelliJ plugin
* Operating System: Windows

## Tech Design
No tech design for a bug fix

## Testing
Only manual testing is possible