### PR TITLE
Stack overflow error in AssembleModelGenerator.kt for arrays

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -420,7 +420,7 @@ data class UtArrayModel(
     override val id: Int,
     override val classId: ClassId,
     val length: Int = 0,
-    val constModel: UtModel,
+    var constModel: UtModel,
     val stores: MutableMap<Int, UtModel>
 ) : UtReferenceModel(id, classId) {
     override fun toString() = withToStringThreadLocalReentrancyGuard {

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/arrays/ArrayOfArraysTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/arrays/ArrayOfArraysTest.kt
@@ -266,4 +266,14 @@ internal class ArrayOfArraysTest : AbstractTestCaseGeneratorTest(testClass = Arr
             { valueBefore, valueAfter -> valueAfter.withIndex().all { it.value == valueBefore[it.index] + it.index } }
         )
     }
+
+    @Test
+    fun testArrayWithItselfAnAsElement() {
+        check(
+            ArrayOfArrays::arrayWithItselfAnAsElement,
+            eq(2),
+            coverage = atLeast(percents = 94)
+            // because of the assumption
+        )
+    }
 }

--- a/utbot-sample/src/main/java/org/utbot/examples/arrays/ArrayOfArrays.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/arrays/ArrayOfArrays.java
@@ -152,4 +152,14 @@ public class ArrayOfArrays {
 
         return array;
     }
+
+    public Object[] arrayWithItselfAnAsElement(Object[] array) {
+        UtMock.assume(array != null && array.length > 0);
+
+        if (array[0] == array) {
+            return array;
+        }
+
+        return null;
+    }
 }


### PR DESCRIPTION
Closes #33.

The problem was inside `assembleArrayModel` function. We used to check whether we have already instantiated a model, then, if we don't, we assembled its const model and stores, and, finally, put assembled model in the memory. Because of the processing order, when we had a source model that has itself as an element, we got a stack overflow error. 

To avoid it, I changed the assembling model. At first, we create a new assemble model with empty stores and the const model taken from the source model. Then we put it into the cache, and only after that we transform the const model and add transformed stores to it.