### PR TITLE
Assume or execute concretely support

### DIFF
--- a/docs/AssumptionsMechanism.md
+++ b/docs/AssumptionsMechanism.md
@@ -1,0 +1,216 @@
+# Assumptions mechanism
+We have a public API that might help both us and external users to interact with UTBot. 
+This document contains detailed instructions about how to use `assume` methods of `UtMock` class and description 
+of the problems we encountered during the implementation.
+
+## Brief description
+This section contains short explanations of the meaning for mentioned functions and examples of usage.
+
+### UtMock.assume(predicate)
+
+`assume` is a method that gives the opportunity for users to say to the symbolic virtual machine that
+instructions of the MUT (Method Under Test) encountered after this instruction satisfy the given predicate.
+It is natively understandable concept and the closest analog from Java is the `assert` function. 
+When the virtual machine during the analysis encounters such instruction, it drops all the branches in the 
+control flow graph violating the predicate.
+
+Examples: 
+```java
+int foo(int x) {
+    // Here `x` is unbounded symbolic variable.
+    // It can be any value from [MIN_VALUE..MAX_VALUE] range.
+        
+    UtMock.assume(x > 0);
+    // Now engine will adjust the range to (0..MAX_VALUE].
+        
+    if (x <= 0) {
+        throw new RuntimeException("Unreachable exception");    
+    } else {
+        return 0;
+    }
+}
+
+// A function that removes all the branches with a null, empty or unsorted list.
+public List<Integer> sortedList(List<Integer> a) {
+    // An invariant that the list is non-null, non-empty and sorted
+    UtMock.assume(a != null);
+    UtMock.assume(a.size() > 0);
+    UtMock.assume(a.get(0) != null);
+    
+    for (int i = 0; i < a.size() - 1; i++) {
+        Integer element = a.get(i + 1)
+        UtMock.assume(element != null);
+        UtMock.assume(a.get(i) <= element);
+    }
+    
+    return a;
+}
+```
+
+Thus, `assume` is a mechanism to provide some known properties of the program to the symbolic engine.
+
+### UtMock.assumeOrExecuteConcretely(predicate)
+It is a similar concept to the `assume` with the only difference: it does not drop 
+paths violating the predicate, but execute them concretely from the moment of the 
+first encountered controversy. Let's take a look at the example below:
+
+```java
+int foo(List<Integer> list) {
+    // Let's assume that we have small lists only
+    UtMock.assume(list.size() <= 10);
+    
+    if (list.size() > 10) {
+        throw new RuntimeException("Unreachable branch");
+    } else {
+        return 0;    
+    }
+}
+```
+Here we decided to take into consideration lists with sizes less or equal to 10 to improve performance, and, therefore, lost
+the branch with possible exception. Let's change `assume` to `assumeOrExecuteConcretely`. 
+```java
+int foo(List<Integer> list) {
+    // Let's assume that we have small lists only
+    UtMock.assumeOrExecuteConcretely(list.size() <= 10);
+    
+    if (list.size() > 10) {
+        throw new RuntimeException("Now we will cover this branch");
+    } else {
+        return 0;    
+    }
+}
+```
+Now we will cover both branches of the MUT. How did we do it? 
+At the moment we processed `if` condition we got conflicting constraints: `list.size <= 10` and 
+`list.size > 10`. In contrast to the example with `assume` method usage, here we know that 
+we got conflict with the provided predicate and we stop symbolic analysis, remove this assumption from 
+the path constraints, resolve the MUT's parameters and run the MUT using concrete execution.
+
+Thus, `assumeOrExecuteConcretely` is a way to provide to the engine information about the program
+you'd like to take into account, but if it is impossible, the engine will run the MUT concretely trying to 
+cover at least something after the encountered controversy.
+
+## Implementation
+Implementation of the `assume` does not have anything interesting --
+we add the predicate into path hard-constraints, and it eventually removes violating 
+paths from consideration.
+
+Processing a predicate passed as argument in `assumeOrExecuteConcretely` is more tricky. 
+Due to the way we work with the solver, it cannot be added to the path constraints
+directly. We treat hard PC as hypothesis and add them to the solver directly, that deprives us
+opportunity to calculate unsat-core to check whether the predicate was a part of it. 
+
+Because of it, we introduced an additional type of path constraints. Now we have three of them: 
+hard, soft and assumptions. 
+* Hard constraints -- properties of the program that must be satisfied at any point of the program.
+* Soft constraints -- properties of the program we want to satisfy, but we can remove them if it is impossible.
+For example, it might be information that some number should be less than zero. But if it is not, we still
+can continue exploration of the same path without this constraint. 
+* Assumptions -- predicates passed in the `assumeOrExecuteConcretely`. If we have a controversy between 
+an assumption and hard constraints, we should execute the MUT concretely without violating assumption.
+
+Now, when we check if some state is satisfiable, we put hard constraints as hypothesis into the solver
+and check their consistency with soft constraints and assumptions. If the solver returns UNSAT status with 
+non-empty unsat core, we remove all conflicting soft constraints from it and try again. If we have 
+UNSAT status for the second time and assumptions in it, we remove them from the request and calculates 
+status once again. If it is SAT, we put this state in the queue for concrete executions, otherwise -- remove the
+state from consideration.
+
+## Problems
+The main problem is that we didn't get the result we expected. We have many `assume` usages 
+in overridden classes source code that limits their size to improve performance. Because of that, the following 
+code does not work (we don't generate any executions for them).
+
+```java
+void bigList(List<Integer> list) {
+    UtMock.assume(list != null && list.size() > MAX_LIST_SIZE);
+}
+
+void bigSet(Set<Integer> set) {
+    UtMock.assume(set != null && set.size() > MAX_SET_SIZE);
+}
+        
+void bigMap(Map<Integer> map) {
+    UtMock.assume(map != null && map.size() > MAX_MAP_SIZE);
+}
+```
+The problem in a `preconditionCheck` method of the wrappers. It contains something like that:
+```java
+private void preconditionCheck() {
+    if (alreadyVisited(this)) {
+        return;
+    }
+    ...
+    assume(elementData.end >= 0 & elementData.end <= MAX_LIST_SIZE);
+    ...
+}
+```
+It is a method that imposes restrictions at the overridden classes provided as arguments.
+For `Lists` the idea works fine, we replace `assume` with `assumeOrExecuteConcretely` and
+find additional branches. 
+```java
+private void preconditionCheck() {
+    if (alreadyVisited(this)) {
+        return;
+    }
+    ...
+    assume(elementData.end >= 0);
+    assumeOrExecuteConcretely(elementData.end <= MAX_LIST_SIZE);
+    ...
+}
+
+// Now it works!
+void bigList(List<Integer> list) {
+    UtMock.assume(list != null && list.size() > MAX_LIST_SIZE);
+}
+```
+
+But it doesn't work for `String`, `HashSet` and `HashMap`.
+
+The problem with `String` is connected with the way we represent them. Restriction for the size is closely
+connected with the internal storage of chars -- we create a new arrays of chars with some size `n` using `new char[n]` instruction.
+It adds hard constraint that max size of the string is `n` and assumption that `n` is less that `MAX_STRING_SIZE`.
+Somewhere later in the code we have a condition that `String.length() > MAX_STRING_SIZE`. Unfortunately, 
+it will cause not only controversy between the assumption and new hard constraints, but and controversy
+between internal array size (hard constraint) and the new-coming hard constraint, that will cause UNSAT status and 
+we will lose this branch anyway.
+
+`HashSet` and `HashMap` is a different story. The problem there is inside of `preconditionCheck` implementation. Let's take 
+a look at a part of it:
+```java
+assume(elementData.begin == 0);
+assume(elementData.end >= 0);
+assumeOrExecuteConcretely(elementData.end <= 3);
+
+parameter(elementData);
+parameter(elementData.storage);
+doesntThrow();
+
+// check that all elements are distinct.
+for (int i = elementData.begin; i < elementData.end; i++) {
+    E element = elementData.get(i);
+    parameter(element);
+    // make element address non-positive
+
+    // if key is not null, check its hashCode for exception
+    if (element != null) {
+        element.hashCode();
+    }
+
+    // check that there are no duplicate values
+    // we can start with a next value, as all previous values are already processed
+    for (int j = i + 1; j < elementData.end; j++) {
+        // we use Objects.equals to process null case too
+        assume(!Objects.equals(element, elementData.get(j)));
+    }
+}
+
+visit(this);
+```
+The problem happens at the first line of the cycle. We now (from the first line of the snippet) that 
+the cycle will be from zero to three. The problem is in the `i < elementData.end` check. It produces 
+at the fourth iteration hard constraint that `elementData.begin + 4 < elementData.end` and we have
+an assumption that `elementData.end <= 3`. It will cause a concrete run of the MUT in every 
+`preconditionCheck` analysis with a constraint `elementData.end == 4`. Moreover, it still won't 
+help us with code like `if (someHashSet.size() == 10)`, since we will never get here without hard
+constraint `elementData.end < 4` that came from the cycle.

--- a/utbot-api/src/main/java/org/utbot/api/mock/UtMock.java
+++ b/utbot-api/src/main/java/org/utbot/api/mock/UtMock.java
@@ -13,6 +13,14 @@ public class UtMock {
     @SuppressWarnings("unused")
     public static void assume(boolean predicate) {
         // to use compilers checks, i.e. for possible NPE
-        if (!predicate) throw new RuntimeException();
+        if (!predicate) {
+            throw new RuntimeException();
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static void assumeOrExecuteConcretely(boolean predicate) {
+        // In oppose to assume, we don't have predicate check here
+        // to avoid RuntimeException during concrete execution
     }
 }

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -295,6 +295,14 @@ object UtSettings {
     var enableUnsatCoreCalculationForHardConstraints by getBooleanProperty(false)
 
     /**
+     * Enable it to process states with unknown solver status
+     * from the queue to concrete execution.
+     *
+     * True by default.
+     */
+    var processUnknownStatesDuringConcreteExecution by getBooleanProperty(true)
+
+    /**
      * 2^{this} will be the length of observed subpath.
      * See [SubpathGuidedSelector]
      */

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/Byte.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/Byte.java
@@ -7,6 +7,7 @@ import org.utbot.engine.overrides.strings.UtStringBuilder;
 
 import static org.utbot.api.mock.UtMock.assume;
 import static org.utbot.engine.overrides.UtLogicMock.ite;
+import static org.utbot.api.mock.UtMock.assumeOrExecuteConcretely;
 import static org.utbot.engine.overrides.UtLogicMock.less;
 import static org.utbot.engine.overrides.UtOverrideMock.executeConcretely;
 
@@ -34,7 +35,7 @@ public class Byte {
         if ((s.charAt(0) == '-' || s.charAt(0) == '+') && s.length() == 1) {
             throw new NumberFormatException();
         }
-        assume(s.length() <= 10);
+        assumeOrExecuteConcretely(s.length() <= 10);
         // we need two branches to add more options for concrete executor to find both branches
         if (s.charAt(0) == '-') {
             executeConcretely();

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/Integer.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/Integer.java
@@ -5,7 +5,7 @@ import org.utbot.engine.overrides.strings.UtNativeString;
 import org.utbot.engine.overrides.strings.UtString;
 import org.utbot.engine.overrides.strings.UtStringBuilder;
 
-import static org.utbot.api.mock.UtMock.assume;
+import static org.utbot.api.mock.UtMock.assumeOrExecuteConcretely;
 import static org.utbot.engine.overrides.UtLogicMock.ite;
 import static org.utbot.engine.overrides.UtLogicMock.less;
 import static org.utbot.engine.overrides.UtOverrideMock.executeConcretely;
@@ -34,7 +34,7 @@ public class Integer {
         if ((s.charAt(0) == '-' || s.charAt(0) == '+') && s.length() == 1) {
             throw new NumberFormatException();
         }
-        assume(s.length() <= 10);
+        assumeOrExecuteConcretely(s.length() <= 10);
         // we need two branches to add more options for concrete executor to find both branches
         if (s.charAt(0) == '-') {
             executeConcretely();
@@ -62,7 +62,7 @@ public class Integer {
         if ((s.charAt(0) == '-' || s.charAt(0) == '+') && s.length() == 1) {
             throw new NumberFormatException();
         }
-        assume(s.length() <= 10);
+        assumeOrExecuteConcretely(s.length() <= 10);
         if (s.charAt(0) == '-') {
             throw new NumberFormatException();
         } else {
@@ -77,8 +77,8 @@ public class Integer {
         }
         // assumes are placed here to limit search space of solver
         // and reduce time of solving queries with bv2int expressions
-        assume(i <= 0x8000);
-        assume(i >= -0x8000);
+        assumeOrExecuteConcretely(i <= 0x8000);
+        assumeOrExecuteConcretely(i >= -0x8000);
         // condition = i < 0
         boolean condition = less(i, 0);
         // prefix = condition ? "-" : ""

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/Long.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/Long.java
@@ -5,7 +5,7 @@ import org.utbot.engine.overrides.strings.UtNativeString;
 import org.utbot.engine.overrides.strings.UtString;
 import org.utbot.engine.overrides.strings.UtStringBuilder;
 
-import static org.utbot.api.mock.UtMock.assume;
+import static org.utbot.api.mock.UtMock.assumeOrExecuteConcretely;
 import static org.utbot.engine.overrides.UtLogicMock.ite;
 import static org.utbot.engine.overrides.UtLogicMock.less;
 import static org.utbot.engine.overrides.UtOverrideMock.executeConcretely;
@@ -34,7 +34,7 @@ public class Long {
         if ((s.charAt(0) == '-' || s.charAt(0) == '+') && s.length() == 1) {
             throw new NumberFormatException();
         }
-        assume(s.length() <= 10);
+        assumeOrExecuteConcretely(s.length() <= 10);
         // we need two branches to add more options for concrete executor to find both branches
         if (s.charAt(0) == '-') {
             executeConcretely();
@@ -62,7 +62,7 @@ public class Long {
         if ((s.charAt(0) == '-' || s.charAt(0) == '+') && s.length() == 1) {
             throw new NumberFormatException();
         }
-        assume(s.length() <= 10);
+        assumeOrExecuteConcretely(s.length() <= 10);
         if (s.charAt(0) == '-') {
             throw new NumberFormatException();
         } else {
@@ -77,8 +77,8 @@ public class Long {
         }
         // assumes are placed here to limit search space of solver
         // and reduce time of solving queries with bv2int expressions
-        assume(l <= 10000);
-        assume(l >= 10000);
+        assumeOrExecuteConcretely(l <= 10000);
+        assumeOrExecuteConcretely(l >= -10000);
         // condition = l < 0
         boolean condition = less(l, 0);
         // prefix = condition ? "-" : ""

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/Short.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/Short.java
@@ -5,7 +5,7 @@ import org.utbot.engine.overrides.strings.UtNativeString;
 import org.utbot.engine.overrides.strings.UtString;
 import org.utbot.engine.overrides.strings.UtStringBuilder;
 
-import static org.utbot.api.mock.UtMock.assume;
+import static org.utbot.api.mock.UtMock.assumeOrExecuteConcretely;
 import static org.utbot.engine.overrides.UtLogicMock.ite;
 import static org.utbot.engine.overrides.UtLogicMock.less;
 import static org.utbot.engine.overrides.UtOverrideMock.executeConcretely;
@@ -34,7 +34,7 @@ public class Short {
         if ((s.charAt(0) == '-' || s.charAt(0) == '+') && s.length() == 1) {
             throw new NumberFormatException();
         }
-        assume(s.length() <= 10);
+        assumeOrExecuteConcretely(s.length() <= 10);
         // we need two branches to add more options for concrete executor to find both branches
         if (s.charAt(0) == '-') {
             executeConcretely();
@@ -50,8 +50,8 @@ public class Short {
         boolean condition = less(s, (short) 0);
         // assumes are placed here to limit search space of solver
         // and reduce time of solving queries with bv2int expressions
-        assume(s <= 10000);
-        assume(s >= 10000);
+        assumeOrExecuteConcretely(s <= 10000);
+        assumeOrExecuteConcretely(s >= -10000);
         // prefix = condition ? "-" : ""
         String prefix = ite(condition, "-", "");
         UtStringBuilder sb = new UtStringBuilder(prefix);

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtArrayList.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtArrayList.java
@@ -18,6 +18,7 @@ import org.jetbrains.annotations.NotNull;
 import static org.utbot.api.mock.UtMock.assume;
 import static org.utbot.engine.ResolverKt.MAX_LIST_SIZE;
 import static org.utbot.engine.overrides.UtOverrideMock.alreadyVisited;
+import static org.utbot.api.mock.UtMock.assumeOrExecuteConcretely;
 import static org.utbot.engine.overrides.UtOverrideMock.executeConcretely;
 import static org.utbot.engine.overrides.UtOverrideMock.parameter;
 import static org.utbot.engine.overrides.UtOverrideMock.visit;
@@ -83,7 +84,7 @@ public class UtArrayList<E> extends AbstractList<E>
         int size = elementData.end;
         assume(elementData.begin == 0);
         assume(size >= 0);
-        assume(size <= MAX_LIST_SIZE);
+        assumeOrExecuteConcretely(size <= MAX_LIST_SIZE);
 
         visit(this);
     }

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtHashMap.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtHashMap.java
@@ -100,12 +100,12 @@ public class UtHashMap<K, V> implements Map<K, V>, UtGenericStorage<K>, UtGeneri
         parameter(values.touched);
         parameter(values.storage);
         parameter(keys);
-        // for some unknown reason parameter(keys.storage) leads to MapValuesTest::testIteratorNext test failure
+        parameter(keys.storage);
 
         assume(values.size == keys.end);
         assume(values.touched.length == keys.end);
         doesntThrow();
-        for (int i = 0; i < keys.end; i++) {
+        for (int i = keys.begin; i < keys.end; i++) {
             K key = keys.get(i);
 
             assume(values.touched[i] == key);

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtHashSet.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtHashSet.java
@@ -73,7 +73,7 @@ public class UtHashSet<E> extends AbstractSet<E> implements UtGenericStorage<E> 
         doesntThrow();
 
         // check that all elements are distinct.
-        for (int i = 0; i < elementData.end; i++) {
+        for (int i = elementData.begin; i < elementData.end; i++) {
             E element = elementData.get(i);
             parameter(element);
             // make element address non-positive

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtLinkedList.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtLinkedList.java
@@ -19,6 +19,7 @@ import static org.utbot.api.mock.UtMock.assume;
 import static org.utbot.engine.ResolverKt.MAX_LIST_SIZE;
 import static org.utbot.engine.overrides.UtOverrideMock.alreadyVisited;
 import static org.utbot.engine.overrides.UtOverrideMock.executeConcretely;
+import static org.utbot.api.mock.UtMock.assumeOrExecuteConcretely;
 import static org.utbot.engine.overrides.UtOverrideMock.parameter;
 import static org.utbot.engine.overrides.UtOverrideMock.visit;
 
@@ -79,7 +80,7 @@ public class UtLinkedList<E> extends AbstractSequentialList<E>
         parameter(elementData.storage);
         assume(elementData.begin == 0);
         assume(elementData.end >= 0);
-        assume(elementData.end <= MAX_LIST_SIZE);
+        assumeOrExecuteConcretely(elementData.end <= MAX_LIST_SIZE);
 
         visit(this);
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/AnnotationResolver.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/AnnotationResolver.kt
@@ -109,12 +109,6 @@ val SootMethod.findMockAnnotationOrNull
 val SootMethod.hasInternalMockAnnotation
     get() = annotationsOrNull?.singleOrNull { it.type == utInternalUsageBytecodeSignature } != null
 
-/**
- * Returns true if the [SootMethod]'s signature is equal to [UtMock.assume]'s signature, false otherwise.
- */
-val SootMethod.isUtMockAssume
-    get() = signature == assumeMethod.signature
-
 val utClassMockBytecodeSignature = UtClassMock::class.java.bytecodeSignature()
 val utConstructorMockBytecodeSignature = UtConstructorMock::class.java.bytecodeSignature()
 val utInternalUsageBytecodeSignature = UtInternalUsage::class.java.bytecodeSignature()

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/DataClasses.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/DataClasses.kt
@@ -8,6 +8,7 @@ import org.utbot.engine.pc.UtIsExpression
 import org.utbot.engine.pc.UtTrue
 import org.utbot.engine.pc.mkAnd
 import org.utbot.engine.pc.mkOr
+import org.utbot.engine.symbolic.Assumption
 import org.utbot.engine.symbolic.HardConstraint
 import org.utbot.engine.symbolic.SoftConstraint
 import org.utbot.engine.symbolic.SymbolicStateUpdate
@@ -134,15 +135,17 @@ data class MethodResult(
         symbolicResult: SymbolicResult,
         hardConstraints: HardConstraint = HardConstraint(),
         softConstraints: SoftConstraint = SoftConstraint(),
+        assumption: Assumption = Assumption(),
         memoryUpdates: MemoryUpdate = MemoryUpdate()
-    ) : this(symbolicResult, SymbolicStateUpdate(hardConstraints, softConstraints, memoryUpdates))
+    ) : this(symbolicResult, SymbolicStateUpdate(hardConstraints, softConstraints, assumption, memoryUpdates))
 
     constructor(
         value: SymbolicValue,
         hardConstraints: HardConstraint = HardConstraint(),
         softConstraints: SoftConstraint = SoftConstraint(),
+        assumption: Assumption = Assumption(),
         memoryUpdates: MemoryUpdate = MemoryUpdate(),
-    ) : this(SymbolicSuccess(value), hardConstraints, softConstraints, memoryUpdates)
+    ) : this(SymbolicSuccess(value), hardConstraints, softConstraints, assumption, memoryUpdates)
 }
 
 /**

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ExecutionState.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ExecutionState.kt
@@ -320,7 +320,16 @@ data class ExecutionState(
      */
     fun prettifiedPathLog(): String {
         val path = fullPath()
-        val prettifiedPath = path.joinToString(separator = "\n") { (stmt, depth, decision) ->
+        val prettifiedPath = prettifiedPath(path)
+        return " MD5(path)=${md5(prettifiedPath)}\n$prettifiedPath"
+    }
+
+    private fun md5(prettifiedPath: String) = prettifiedPath.md5()
+
+    fun md5() = prettifiedPath(fullPath()).md5()
+
+    private fun prettifiedPath(path: List<Step>) =
+        path.joinToString(separator = "\n") { (stmt, depth, decision) ->
             val prefix = when (decision) {
                 CALL_DECISION_NUM -> "call[${depth}] - " + "".padEnd(2 * depth, ' ')
                 RETURN_DECISION_NUM -> " ret[${depth - 1}] - " + "".padEnd(2 * depth, ' ')
@@ -328,8 +337,6 @@ data class ExecutionState(
             }
             "$prefix$stmt"
         }
-        return " MD5(path)=${prettifiedPath.md5()}\n$prettifiedPath"
-    }
 
     fun definitelyFork() {
         stateAnalyticsProperties.definitelyFork()

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
@@ -96,10 +96,12 @@ import org.utbot.engine.selectors.strategies.GraphViz
 import org.utbot.engine.selectors.subpathGuidedSelector
 import org.utbot.engine.symbolic.HardConstraint
 import org.utbot.engine.symbolic.SoftConstraint
+import org.utbot.engine.symbolic.Assumption
 import org.utbot.engine.symbolic.SymbolicState
 import org.utbot.engine.symbolic.SymbolicStateUpdate
 import org.utbot.engine.symbolic.asHardConstraint
 import org.utbot.engine.symbolic.asSoftConstraint
+import org.utbot.engine.symbolic.asAssumption
 import org.utbot.engine.symbolic.asUpdate
 import org.utbot.engine.util.statics.concrete.associateEnumSootFieldsWithConcreteValues
 import org.utbot.engine.util.statics.concrete.isEnumAffectingExternalStatics
@@ -116,6 +118,7 @@ import org.utbot.framework.UtSettings.pathSelectorType
 import org.utbot.framework.UtSettings.preferredCexOption
 import org.utbot.framework.UtSettings.substituteStaticsWithSymbolicVariable
 import org.utbot.framework.UtSettings.useDebugVisualization
+import org.utbot.framework.UtSettings.processUnknownStatesDuringConcreteExecution
 import org.utbot.framework.concrete.UtConcreteExecutionData
 import org.utbot.framework.concrete.UtConcreteExecutionResult
 import org.utbot.framework.concrete.UtExecutionInstrumentation
@@ -441,7 +444,9 @@ class UtBotSymbolicEngine(
                 }
 
                 if (controller.executeConcretely || statesForConcreteExecution.isNotEmpty()) {
-                    val state = pathSelector.pollUntilFastSAT() ?: statesForConcreteExecution.pollUntilSat() ?: break
+                    val state = pathSelector.pollUntilFastSAT()
+                        ?: statesForConcreteExecution.pollUntilSat(processUnknownStatesDuringConcreteExecution)
+                        ?: break
                     // This state can contain inconsistent wrappers - for example, Map with keys but missing values.
                     // We cannot use withWrapperConsistencyChecks here because it needs solver to work.
                     // So, we have to process such cases accurately in wrappers resolving.
@@ -1371,26 +1376,61 @@ class UtBotSymbolicEngine(
             environment.state.definitelyFork()
         }
 
-        positiveCaseEdge?.let { edge ->
-            environment.state.expectUndefined()
-            val positiveCaseState = environment.state.updateQueued(
-                edge,
-                SymbolicStateUpdate(
-                    hardConstraints = positiveCasePathConstraint.asHardConstraint(),
-                    softConstraints = setOfNotNull(positiveCaseSoftConstraint).asSoftConstraint()
-                ) + resolvedCondition.symbolicStateUpdates.positiveCase
-            )
-            pathSelector.offer(positiveCaseState)
+        /* assumeOrExecuteConcrete in jimple looks like:
+            ``` z0 = a > 5
+                if (z0 == 1) goto label1
+                assumeOrExecuteConcretely(z0)
+
+                label1:
+                assumeOrExecuteConcretely(z0)
+            ```
+
+            We have to detect such situations to avoid addition `a > 5` into hardConstraints,
+            because we want to add them into Assumptions.
+
+            Note: we support only simple predicates right now (one logical operation),
+            otherwise they will be added as hard constraints, and we will not execute
+            the state concretely if there will be UNSAT because of assumptions.
+         */
+        val isAssumeExpr = positiveCaseEdge?.let { isConditionForAssumeOrExecuteConcretely(it.dst) } ?: false
+
+        // in case of assume we want to have the only branch where $z = 1 (it is a negative case)
+        if (!isAssumeExpr) {
+            positiveCaseEdge?.let { edge ->
+                environment.state.expectUndefined()
+                val positiveCaseState = environment.state.updateQueued(
+                    edge,
+                    SymbolicStateUpdate(
+                        hardConstraints = positiveCasePathConstraint.asHardConstraint(),
+                        softConstraints = setOfNotNull(positiveCaseSoftConstraint).asSoftConstraint()
+                    ) + resolvedCondition.symbolicStateUpdates.positiveCase
+                )
+                pathSelector.offer(positiveCaseState)
+            }
         }
+
+        // Depending on existance of assumeExpr we have to add corresponding hardConstraints and assumptions
+        val hardConstraints = if (!isAssumeExpr) negativeCasePathConstraint.asHardConstraint() else HardConstraint()
+        val assumption = if (isAssumeExpr) negativeCasePathConstraint.asAssumption() else Assumption()
 
         val negativeCaseState = environment.state.updateQueued(
             negativeCaseEdge,
             SymbolicStateUpdate(
-                hardConstraints = negativeCasePathConstraint.asHardConstraint(),
+                hardConstraints = hardConstraints,
                 softConstraints = setOfNotNull(negativeCaseSoftConstraint).asSoftConstraint(),
+                assumptions = assumption
             ) + resolvedCondition.symbolicStateUpdates.negativeCase
         )
         pathSelector.offer(negativeCaseState)
+    }
+
+    /**
+     * Returns true if the next stmt is an [assumeOrExecuteConcretelyMethod] invocation, false otherwise.
+     */
+    private fun isConditionForAssumeOrExecuteConcretely(stmt: Stmt): Boolean {
+        val successor = globalGraph.succStmts(stmt).singleOrNull() as? JInvokeStmt ?: return false
+        val invokeExpression = successor.invokeExpr as? JStaticInvokeExpr ?: return false
+        return invokeExpression.method.isUtMockAssumeOrExecuteConcretely
     }
 
     private fun traverseInvokeStmt(current: JInvokeStmt) {
@@ -2721,19 +2761,39 @@ class UtBotSymbolicEngine(
         return overriddenResults + originResults
     }
 
-    private fun invoke(target: InvocationTarget, parameters: List<SymbolicValue>): List<MethodResult> {
-        val substitutedMethod = typeRegistry.findSubstitutionOrNull(target.method)
+    private fun invoke(
+        target: InvocationTarget,
+        parameters: List<SymbolicValue>
+    ): List<MethodResult> = with(target.method) {
+        val substitutedMethod = typeRegistry.findSubstitutionOrNull(this)
 
-        if (target.method.isNative && substitutedMethod == null) return processNativeMethod(target)
+        if (isNative && substitutedMethod == null) return processNativeMethod(target)
 
-        // If we face UtMock.assume call, we should continue only with the branch where the predicate
-        // from the parameters is equal true
-        return when {
-            target.method.isUtMockAssume -> {
+        // If we face UtMock.assume call, we should continue only with the branch
+        // where the predicate from the parameters is equal true
+        when {
+            isUtMockAssume || isUtMockAssumeOrExecuteConcretely -> {
                 val param = UtCastExpression(parameters.single() as PrimitiveValue, BooleanType.v())
+
+                val assumptionStmt = mkEq(param, UtTrue)
+                val (hardConstraints, assumptions) = if (isUtMockAssume) {
+                    // For UtMock.assume we must add the assumeStmt to the hard constraints
+                    setOf(assumptionStmt) to emptySet()
+                } else {
+                    // For assumeOrExecuteConcretely we must add the statement to the assumptions.
+                    // It is required to have opportunity to remove it later in case of unsat state
+                    // because of it and execute the state concretely.
+                    emptySet<UtBoolExpression>() to setOf(assumptionStmt)
+                }
+
+                val symbolicStateUpdate = SymbolicStateUpdate(
+                    hardConstraints = hardConstraints.asHardConstraint(),
+                    assumptions = assumptions.asAssumption()
+                )
+
                 val stateToContinue = environment.state.updateQueued(
                     globalGraph.succ(environment.state.stmt),
-                    SymbolicStateUpdate(hardConstraints = mkEq(param, UtTrue).asHardConstraint())
+                    symbolicStateUpdate
                 )
                 pathSelector.offer(stateToContinue)
 
@@ -2742,17 +2802,15 @@ class UtBotSymbolicEngine(
                 queuedSymbolicStateUpdates += UtFalse.asHardConstraint()
                 emptyList()
             }
-            target.method.declaringClass == utOverrideMockClass -> utOverrideMockInvoke(target, parameters)
-            target.method.declaringClass == utLogicMockClass -> utLogicMockInvoke(target, parameters)
-            target.method.declaringClass == utArrayMockClass -> utArrayMockInvoke(target, parameters)
+            declaringClass == utOverrideMockClass -> utOverrideMockInvoke(target, parameters)
+            declaringClass == utLogicMockClass -> utLogicMockInvoke(target, parameters)
+            declaringClass == utArrayMockClass -> utArrayMockInvoke(target, parameters)
             else -> {
-                val graph = substitutedMethod?.jimpleBody()?.graph() ?: target.method.jimpleBody().graph()
-                val isLibraryMethod = target.method.isLibraryMethod
+                val graph = substitutedMethod?.jimpleBody()?.graph() ?: jimpleBody().graph()
                 pushToPathSelector(graph, target.instance, parameters, target.constraints, isLibraryMethod)
                 emptyList()
             }
         }
-
     }
 
     private fun utOverrideMockInvoke(target: InvocationTarget, parameters: List<SymbolicValue>): List<MethodResult> {

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/pc/Query.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/pc/Query.kt
@@ -119,7 +119,8 @@ data class Query(
         lts: Map<UtExpression, Long> = this@Query.lts,
         gts: Map<UtExpression, Long> = this@Query.gts
     ) = AxiomInstantiationRewritingVisitor(eqs, lts, gts).let { visitor ->
-        this.map { it.simplify(visitor) }.map { simplifyGeneric(it) }
+        this.map { it.simplify(visitor) }
+            .map { simplifyGeneric(it) }
             .flatMap { splitAnd(it) } + visitor.instantiatedArrayAxioms
     }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/BasePathSelector.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/BasePathSelector.kt
@@ -1,6 +1,7 @@
 package org.utbot.engine.selectors
 
 import org.utbot.engine.ExecutionState
+import org.utbot.engine.isPreconditionCheckMethod
 import org.utbot.engine.pathLogger
 import org.utbot.engine.pc.UtSolver
 import org.utbot.engine.pc.UtSolverStatusKind.SAT
@@ -83,6 +84,19 @@ abstract class BasePathSelector(
                 state.close()
                 continue
             }
+
+            // If we have failed assumes, we try to execute the state concretely
+            if (state.solver.failedAssumptions.isNotEmpty()) {
+                // But we do not want to execute concretely states because of
+                // controversies during `preconditionCheck` analysis
+                if (state.lastMethod?.isPreconditionCheckMethod == true) {
+                    state.close()
+                } else {
+                    statesForConcreteExecution += state
+                }
+                continue
+            }
+
             return state
         }
         return null

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/strategies/DistanceStatistics.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/strategies/DistanceStatistics.kt
@@ -4,6 +4,7 @@ import org.utbot.engine.Edge
 import org.utbot.engine.ExecutionState
 import org.utbot.engine.InterProceduralUnitGraph
 import org.utbot.engine.isReturn
+import org.utbot.engine.pathLogger
 import org.utbot.engine.stmts
 import kotlin.math.min
 import kotlinx.collections.immutable.PersistentList
@@ -38,8 +39,17 @@ class DistanceStatistics(
      * Drops executionState if all the edges on path are covered (with respect to uncovered
      * throw statements of the methods they belong to) and there is no reachable and uncovered statement.
      */
-    override fun shouldDrop(state: ExecutionState) =
-        state.edges.all { graph.isCoveredWithAllThrowStatements(it) } && distanceToUncovered(state) == Int.MAX_VALUE
+    override fun shouldDrop(state: ExecutionState): Boolean {
+        val shouldDrop = state.edges.all { graph.isCoveredWithAllThrowStatements(it) } && distanceToUncovered(state) == Int.MAX_VALUE
+
+        if (shouldDrop) {
+            pathLogger.debug {
+                "Dropping state (lastStatus=${state.solver.lastStatus}) by the distance statistics. MD5: ${state.md5()}"
+            }
+        }
+
+        return shouldDrop
+    }
 
     fun isCovered(edge: Edge): Boolean = graph.isCovered(edge)
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/strategies/EdgeVisitCountingStatistics.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/strategies/EdgeVisitCountingStatistics.kt
@@ -3,6 +3,7 @@ package org.utbot.engine.selectors.strategies
 import org.utbot.engine.Edge
 import org.utbot.engine.ExecutionState
 import org.utbot.engine.InterProceduralUnitGraph
+import org.utbot.engine.pathLogger
 import soot.jimple.Stmt
 import soot.jimple.internal.JReturnStmt
 import soot.jimple.internal.JReturnVoidStmt
@@ -31,7 +32,16 @@ class EdgeVisitCountingStatistics(
      * - all statements are already covered and execution is complete
      */
     override fun shouldDrop(state: ExecutionState): Boolean {
-        return state.edges.all { graph.isCoveredWithAllThrowStatements(it) } && state.isComplete()
+        val shouldDrop = state.edges.all { graph.isCoveredWithAllThrowStatements(it) } && state.isComplete()
+
+        if (shouldDrop) {
+            pathLogger.debug {
+                "Dropping state (lastStatus=${state.solver.lastStatus}) " +
+                        "by the edge visit counting statistics. MD5: ${state.md5()}"
+            }
+        }
+
+        return shouldDrop
     }
 
     /**

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/strategies/StepsLimitStoppingStrategy.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/strategies/StepsLimitStoppingStrategy.kt
@@ -3,6 +3,7 @@ package org.utbot.engine.selectors.strategies
 import org.utbot.engine.Edge
 import org.utbot.engine.ExecutionState
 import org.utbot.engine.InterProceduralUnitGraph
+import org.utbot.engine.pathLogger
 
 /**
  * Stopping strategy that suggest to stop execution
@@ -16,7 +17,13 @@ class StepsLimitStoppingStrategy(
     private var stepsCounter: Int = 0
 
     override fun shouldStop(): Boolean {
-        return stepsCounter > stepsLimit
+        val shouldDrop = stepsCounter > stepsLimit
+
+        if (shouldDrop) {
+            pathLogger.debug { "Steps limit has been exceeded: current step limit is $stepsLimit" }
+        }
+
+        return shouldDrop
     }
 
     override fun onVisit(edge: Edge) {

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/symbolic/SymbolicState.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/symbolic/SymbolicState.kt
@@ -15,10 +15,12 @@ data class SymbolicState(
     val memory: Memory = Memory(),
 ) {
     operator fun plus(update: SymbolicStateUpdate): SymbolicState =
-        SymbolicState(
-            solver.add(hard = update.hardConstraints, soft = update.softConstraints),
-            memory = memory.update(update.memoryUpdates),
-        )
+        with(update) {
+            SymbolicState(
+                solver.add(hard = hardConstraints, soft = softConstraints, assumption = assumptions),
+                memory = memory.update(memoryUpdates),
+            )
+        }
 
     operator fun plus(update: HardConstraint): SymbolicState =
         plus(SymbolicStateUpdate(hardConstraints = update))

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/MockValueConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/MockValueConstructor.kt
@@ -290,7 +290,9 @@ class MockValueConstructor(
         constructedObjects[model]?.let { return it }
 
         with(model) {
-            val elementClassId = classId.elementClassId!!
+            val elementClassId = classId.elementClassId ?: error(
+                "Provided incorrect UtArrayModel without elementClassId. ClassId: ${model.classId}, model: $model"
+            )
             return when (elementClassId.jvmName) {
                 "B" -> ByteArray(length) { primitive(constModel) }.apply {
                     stores.forEach { (index, model) -> this[index] = primitive(model) }

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/arrays/IntArrayBasicsTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/arrays/IntArrayBasicsTest.kt
@@ -19,6 +19,18 @@ internal class IntArrayBasicsTest : AbstractTestCaseGeneratorTest(
     )
 ) {
     @Test
+    fun testIntArrayWithAssumeOrExecuteConcretely() {
+        check(
+            IntArrayBasics::intArrayWithAssumeOrExecuteConcretely,
+            eq(4),
+            { x, n, r -> x > 0 && n < 20 && r?.size == 2 },
+            { x, n, r -> x > 0 && n >= 20 && r?.size == 4 },
+            { x, n, r -> x <= 0 && n < 20 && r?.size == 10 },
+            { x, n, r -> x <= 0 && n >= 20 && r?.size == 20 },
+        )
+    }
+
+    @Test
     fun testInitArray() {
         checkWithException(
             IntArrayBasics::initAnArray,

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/collections/LinkedListsTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/collections/LinkedListsTest.kt
@@ -133,7 +133,7 @@ internal class LinkedListsTest : AbstractTestCaseGeneratorTest(
             LinkedLists::peekLast,
             eq(3),
             { l, _ -> l == null },
-            { l, r -> l != null && l.isEmpty() && r.isException<NullPointerException>() },
+            { l, r -> l != null && (l.isEmpty() || l.last() == null) && r.isException<NullPointerException>() },
             { l, r -> l != null && l.isNotEmpty() && r.getOrNull() == l.last() },
             coverage = DoNotCalculate
         )
@@ -146,8 +146,8 @@ internal class LinkedListsTest : AbstractTestCaseGeneratorTest(
             eq(4),
             { l, _ -> l == null },
             { l, r -> l != null && l.isEmpty() && r.isException<NoSuchElementException>() },
-            { l, _ -> l != null && l.isNotEmpty() && l[0] == null },
-            { l, r -> l != null && l.isNotEmpty() && r.getOrNull() == l[0] },
+            { l, r -> l != null && l.isNotEmpty() && l[0] == null && r.isException<NullPointerException>() },
+            { l, r -> l != null && l.isNotEmpty() && l[0] != null && r.getOrNull() == l[0] },
             coverage = DoNotCalculate
         )
     }

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/collections/ListAlgorithmsTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/collections/ListAlgorithmsTest.kt
@@ -6,6 +6,7 @@ import org.utbot.examples.eq
 import org.utbot.framework.codegen.CodeGeneration
 import org.utbot.framework.plugin.api.CodegenLanguage
 import org.junit.jupiter.api.Test
+import org.utbot.examples.atLeast
 
 // TODO failed Kotlin compilation SAT-1332
 class ListAlgorithmsTest : AbstractTestCaseGeneratorTest(
@@ -23,10 +24,10 @@ class ListAlgorithmsTest : AbstractTestCaseGeneratorTest(
             ListAlgorithms::mergeListsInplace,
             eq(4),
             { a, b, r -> b.subList(0, b.size - 1).any { a.last() < it } && r != null && r == r.sorted() },
-            { a, b, r -> a.subList(0, a.size - 1).any { b.last() <= it } && r != null && r == r.sorted() },
+            { a, b, r -> (a.subList(0, a.size - 1).any { b.last() <= it } || a.any { ai -> b.any { ai < it } }) && r != null && r == r.sorted() },
             { a, b, r -> a[0] < b[0] && r != null && r == r.sorted() },
             { a, b, r -> a[0] >= b[0] && r != null && r == r.sorted() },
-            coverage = DoNotCalculate
+            coverage = atLeast(94)
         )
     }
 }

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/collections/ListsTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/collections/ListsTest.kt
@@ -5,6 +5,7 @@ import org.utbot.examples.DoNotCalculate
 import org.utbot.examples.eq
 import org.utbot.examples.ge
 import org.utbot.examples.ignoreExecutionsNumber
+import org.utbot.examples.between
 import org.utbot.examples.isException
 import org.utbot.framework.codegen.CodeGeneration
 import org.utbot.framework.plugin.api.CodegenLanguage
@@ -20,6 +21,16 @@ internal class ListsTest : AbstractTestCaseGeneratorTest(
         CodeGenerationLanguageLastStage(CodegenLanguage.KOTLIN, CodeGeneration)
     )
 ) {
+    @Test
+    fun testBigListFromParameters() {
+        check(
+            Lists::bigListFromParameters,
+            eq(1),
+            { list, r -> list.size == r && list.size == 11 },
+            coverage = DoNotCalculate
+        )
+    }
+
     @Test
     fun testGetNonEmptyCollection() {
         check(
@@ -104,7 +115,7 @@ internal class ListsTest : AbstractTestCaseGeneratorTest(
     fun removeElementsTest() {
         checkWithException(
             Lists::removeElements,
-            eq(7),
+            between(7..8),
             { list, _, _, r -> list == null && r.isException<NullPointerException>() },
             { list, i, _, r -> list != null && i < 0 && r.isException<IndexOutOfBoundsException>() },
             { list, i, _, r -> list != null && i >= 0 && list.size > i && list[i] == null && r.isException<NullPointerException>() },

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/collections/MapValuesTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/collections/MapValuesTest.kt
@@ -92,9 +92,11 @@ class MapValuesTest : AbstractTestCaseGeneratorTest(
     fun testIteratorNext() {
         checkWithException(
             MapValues::iteratorNext,
-            eq(4),
+            between(3..4),
             { map, result -> map == null && result.isException<NullPointerException>() },
-            { map, result -> map != null && map.values.isEmpty() && result.isException<NoSuchElementException>() },
+            // We might lose this branch depending on the order of the exploration since
+            // we do not register wrappers, and, therefore, do not try to cover all of their branches
+            // { map, result -> map != null && map.values.isEmpty() && result.isException<NoSuchElementException>() },
             { map, result -> map != null && map.values.first() == null && result.isException<NullPointerException>() },
             // as map is LinkedHashmap by default this matcher would be correct
             { map, result -> map != null && map.values.isNotEmpty() && result.getOrNull() == map.values.first() },

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/natives/NativeExamplesTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/natives/NativeExamplesTest.kt
@@ -5,16 +5,20 @@ import org.utbot.examples.DoNotCalculate
 import org.utbot.examples.eq
 import org.utbot.examples.ge
 import org.junit.jupiter.api.Test
+import org.utbot.examples.withSolverTimeoutInMillis
 
 internal class NativeExamplesTest : AbstractTestCaseGeneratorTest(testClass = NativeExamples::class) {
 
     @Test
     fun testFindAndPrintSum() {
-        check(
-            NativeExamples::findAndPrintSum,
-            ge(1),
-            coverage = DoNotCalculate,
-        )
+        // TODO related to the https://github.com/UnitTestBot/UTBotJava/issues/131
+        withSolverTimeoutInMillis(5000) {
+            check(
+                NativeExamples::findAndPrintSum,
+                ge(1),
+                coverage = DoNotCalculate,
+            )
+        }
     }
 
     @Test

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/strings/StringExamplesTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/strings/StringExamplesTest.kt
@@ -15,6 +15,7 @@ import org.utbot.framework.codegen.CodeGeneration
 import org.utbot.framework.plugin.api.CodegenLanguage
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.utbot.examples.withSolverTimeoutInMillis
 
 internal class StringExamplesTest : AbstractTestCaseGeneratorTest(
     testClass = StringExamples::class,
@@ -25,14 +26,16 @@ internal class StringExamplesTest : AbstractTestCaseGeneratorTest(
     )
 ) {
     @Test
-    @Disabled("Sometimes it freezes the execution for several hours JIRA:1453")
     fun testByteToString() {
-        check(
-            StringExamples::byteToString,
-            eq(2),
-            { a, b, r -> a > b && r == a.toString() },
-            { a, b, r -> a <= b && r == b.toString() },
-        )
+        // TODO related to the https://github.com/UnitTestBot/UTBotJava/issues/131
+        withSolverTimeoutInMillis(5000) {
+            check(
+                StringExamples::byteToString,
+                eq(2),
+                { a, b, r -> a > b && r == a.toString() },
+                { a, b, r -> a <= b && r == b.toString() },
+            )
+        }
     }
 
     @Test
@@ -49,34 +52,43 @@ internal class StringExamplesTest : AbstractTestCaseGeneratorTest(
 
     @Test
     fun testShortToString() {
-        check(
-            StringExamples::shortToString,
-            eq(2),
-            { a, b, r -> a > b && r == a.toString() },
-            { a, b, r -> a <= b && r == b.toString() },
-        )
+        // TODO related to the https://github.com/UnitTestBot/UTBotJava/issues/131
+        withSolverTimeoutInMillis(5000) {
+            check(
+                StringExamples::shortToString,
+                eq(2),
+                { a, b, r -> a > b && r == a.toString() },
+                { a, b, r -> a <= b && r == b.toString() },
+            )
+        }
     }
 
 
     @Test
     fun testIntToString() {
-        check(
-            StringExamples::intToString,
-            ignoreExecutionsNumber,
-            { a, b, r -> a > b && r == a.toString() },
-            { a, b, r -> a <= b && r == b.toString() },
-        )
+        // TODO related to the https://github.com/UnitTestBot/UTBotJava/issues/131
+        withSolverTimeoutInMillis(5000) {
+            check(
+                StringExamples::intToString,
+                ignoreExecutionsNumber,
+                { a, b, r -> a > b && r == a.toString() },
+                { a, b, r -> a <= b && r == b.toString() },
+            )
+        }
     }
 
 
     @Test
     fun testLongToString() {
-        check(
-            StringExamples::longToString,
-            ignoreExecutionsNumber,
-            { a, b, r -> a > b && r == a.toString() },
-            { a, b, r -> a <= b && r == b.toString() },
-        )
+        // TODO related to the https://github.com/UnitTestBot/UTBotJava/issues/131
+        withSolverTimeoutInMillis(5000) {
+            check(
+                StringExamples::longToString,
+                ignoreExecutionsNumber,
+                { a, b, r -> a > b && r == a.toString() },
+                { a, b, r -> a <= b && r == b.toString() },
+            )
+        }
     }
 
     @Test
@@ -104,12 +116,15 @@ internal class StringExamplesTest : AbstractTestCaseGeneratorTest(
 
     @Test
     fun testCharToString() {
-        check(
-            StringExamples::charToString,
-            eq(2),
-            { a, b, r -> a > b && r == a.toString() },
-            { a, b, r -> a <= b && r == b.toString() },
-        )
+        // TODO related to the https://github.com/UnitTestBot/UTBotJava/issues/131
+        withSolverTimeoutInMillis(5000) {
+            check(
+                StringExamples::charToString,
+                eq(2),
+                { a, b, r -> a > b && r == a.toString() },
+                { a, b, r -> a <= b && r == b.toString() },
+            )
+        }
     }
 
 

--- a/utbot-sample/src/main/java/org/utbot/examples/arrays/IntArrayBasics.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/arrays/IntArrayBasics.java
@@ -1,8 +1,28 @@
 package org.utbot.examples.arrays;
 
+import org.utbot.api.mock.UtMock;
+
 import java.util.Arrays;
 
 public class IntArrayBasics {
+    public int[] intArrayWithAssumeOrExecuteConcretely(int x, int n) {
+        UtMock.assumeOrExecuteConcretely(n > 30);
+
+        if (x > 0) {
+            if (n < 20) {
+                return new int[2];
+            } else {
+                return new int[4];
+            }
+        } else {
+            if (n < 20) {
+                return new int[10];
+            } else {
+                return new int[20];
+            }
+        }
+    }
+
     public int[] initAnArray(int n) {
         int[] a = new int[n];
         a[n - 1] = n - 1;

--- a/utbot-sample/src/main/java/org/utbot/examples/collections/Lists.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/collections/Lists.java
@@ -1,5 +1,7 @@
 package org.utbot.examples.collections;
 
+import org.utbot.api.mock.UtMock;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -8,6 +10,11 @@ import java.util.List;
 import java.util.Objects;
 
 public class Lists {
+    int bigListFromParameters(List<Integer> list) {
+        UtMock.assume(list != null && list.size() == 11);
+
+        return list.size();
+    }
 
     Collection<Integer> getNonEmptyCollection(Collection<Integer> collection) {
         if (collection.size() == 0) {


### PR DESCRIPTION
Closes #64.

Implemented a new class Assumption that contains required constraints for the symbolic execution, but which not nessesarily should be satisfied in real (concrete) execution.

Now UtSolver has three types of constraints: 
1. Hard constraints -- they must be satisfied at any point of the analysis;
2. Soft constraints -- the solver tries to satisfy them, but they will be dropped if it is impossible or we couldn't determine if it possible during the timeout
3. Assumptions -- they must be satisfied during the symbolic execution, but if at some point of the analysis we will receive unsat status from the solver, one of the assumptions will be in the produced unsat core and without it the request to the solver is SAT, we will run concrete execution from that point.

There were added corresponding tests for it and changes in utbot-api module. 

Note: I've tried to remove all the `assume` instructions from the preconditionChecks of the wrappers, but seems like it is impossible because of untimely contradiction raised in the preconditionCheck analysis of the UtHashMap and UtHashSet (in the cycle). More details you can find in the design doc `docs/AssumptionsMechanism.md`