### PR TITLE
Fix wrong test resources directory in Android Studio

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/TestGenerator.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/TestGenerator.kt
@@ -95,7 +95,7 @@ object TestGenerator {
     }
 
     private fun mergeSarifReports(model: GenerateTestsModel) {
-        val sarifReportsPath = model.testModule.getOrCreateSarifReportsPath()
+        val sarifReportsPath = model.getOrCreateSarifReportsPath()
         val sarifReports = sarifReportsPath.toFile()
             .walkTopDown()
             .filter { it.extension == "sarif" }
@@ -294,7 +294,7 @@ object TestGenerator {
     }
 
     private fun saveTestsReport(testsCodeWithTestReport: TestsCodeWithTestReport, model: GenerateTestsModel) {
-        val testResourcesDirPath = model.testModule.getOrCreateTestResourcesPath()
+        val testResourcesDirPath = model.getOrCreateTestResourcesPath()
 
         require(testResourcesDirPath.exists()) {
             "Test resources directory $testResourcesDirPath does not exist"

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/TestGenerator.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/TestGenerator.kt
@@ -95,7 +95,7 @@ object TestGenerator {
     }
 
     private fun mergeSarifReports(model: GenerateTestsModel) {
-        val sarifReportsPath = model.getOrCreateSarifReportsPath()
+        val sarifReportsPath = model.testModule.getOrCreateSarifReportsPath(model.testSourceRoot)
         val sarifReports = sarifReportsPath.toFile()
             .walkTopDown()
             .filter { it.extension == "sarif" }
@@ -294,7 +294,7 @@ object TestGenerator {
     }
 
     private fun saveTestsReport(testsCodeWithTestReport: TestsCodeWithTestReport, model: GenerateTestsModel) {
-        val testResourcesDirPath = model.getOrCreateTestResourcesPath()
+        val testResourcesDirPath = model.testModule.getOrCreateTestResourcesPath(model.testSourceRoot)
 
         require(testResourcesDirPath.exists()) {
             "Test resources directory $testResourcesDirPath does not exist"

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/sarif/SarifReportIdea.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/sarif/SarifReportIdea.kt
@@ -21,7 +21,7 @@ object SarifReportIdea {
     ) {
         // building the path to the report file
         val classFqn = testCases.firstOrNull()?.method?.clazz?.qualifiedName ?: return
-        val sarifReportsPath = model.getOrCreateSarifReportsPath()
+        val sarifReportsPath = model.testModule.getOrCreateSarifReportsPath(model.testSourceRoot)
         val reportFilePath = sarifReportsPath.resolve("${classFqnToPath(classFqn)}-utbot.sarif")
 
         // creating report related directory

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/sarif/SarifReportIdea.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/sarif/SarifReportIdea.kt
@@ -21,7 +21,7 @@ object SarifReportIdea {
     ) {
         // building the path to the report file
         val classFqn = testCases.firstOrNull()?.method?.clazz?.qualifiedName ?: return
-        val sarifReportsPath = model.testModule.getOrCreateSarifReportsPath()
+        val sarifReportsPath = model.getOrCreateSarifReportsPath()
         val reportFilePath = sarifReportsPath.resolve("${classFqnToPath(classFqn)}-utbot.sarif")
 
         // creating report related directory

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -575,7 +575,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
     }
 
     private fun configureStaticMocking() {
-        val testResourcesUrl = model.testModule.getOrCreateTestResourcesPath()
+        val testResourcesUrl = model.getOrCreateTestResourcesPath()
         configureMockitoResources(testResourcesUrl)
 
         val staticsMockingValue = staticsMocking.item

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -575,7 +575,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
     }
 
     private fun configureStaticMocking() {
-        val testResourcesUrl = model.getOrCreateTestResourcesPath()
+        val testResourcesUrl = model.testModule.getOrCreateTestResourcesPath(model.testSourceRoot)
         configureMockitoResources(testResourcesUrl)
 
         val staticsMockingValue = staticsMocking.item

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/ModuleUtils.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/ModuleUtils.kt
@@ -146,12 +146,14 @@ private fun getOrCreateTestResourcesUrl(module: Module): String {
     val moduleInstance = ModuleRootManager.getInstance(module)
     val sourceFolders = moduleInstance.contentEntries.flatMap { it.sourceFolders.toList() }
 
-    val testResourcesFolder = sourceFolders.firstOrNull { it.rootType in testResourceRootTypes }
+    val testResourcesFolder = sourceFolders.firstOrNull {
+        it.rootType in testResourceRootTypes && !it.isForGeneratedSources()
+    }
     if (testResourcesFolder != null) {
         return testResourcesFolder.url
     }
 
-    val testFolder = sourceFolders.firstOrNull { f -> f.rootType in testSourceRootTypes }
+    val testFolder = sourceFolders.firstOrNull { it.rootType in testSourceRootTypes }
     val contentEntry = testFolder?.contentEntry ?: moduleInstance.contentEntries.first()
 
     val parentFolderUrl = testFolder?.let { getParentPath(testFolder.url) }

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/RootUtils.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/RootUtils.kt
@@ -11,14 +11,11 @@ import org.jetbrains.kotlin.config.ResourceKotlinRootType
 import org.jetbrains.kotlin.config.SourceKotlinRootType
 import org.jetbrains.kotlin.config.TestResourceKotlinRootType
 import org.jetbrains.kotlin.config.TestSourceKotlinRootType
-import org.jetbrains.kotlin.idea.configuration.externalProjectPath
-import org.utbot.common.PathUtil.safeRelativize
-import org.utbot.common.PathUtil.toPath
 
 val sourceRootTypes: Set<JpsModuleSourceRootType<JavaSourceRootProperties>> = setOf(JavaSourceRootType.SOURCE, SourceKotlinRootType)
-val testSourceRootTypes: Set<JpsModuleSourceRootType<JavaSourceRootProperties>>  = setOf(JavaSourceRootType.TEST_SOURCE, TestSourceKotlinRootType)
-val resourceRootTypes: Set<JpsModuleSourceRootType<JavaResourceRootProperties>> =  setOf(JavaResourceRootType.RESOURCE, ResourceKotlinRootType)
-val testResourceRootTypes: Set<JpsModuleSourceRootType<JavaResourceRootProperties>>  = setOf(JavaResourceRootType.TEST_RESOURCE, TestResourceKotlinRootType)
+val testSourceRootTypes: Set<JpsModuleSourceRootType<JavaSourceRootProperties>> = setOf(JavaSourceRootType.TEST_SOURCE, TestSourceKotlinRootType)
+val resourceRootTypes: Set<JpsModuleSourceRootType<JavaResourceRootProperties>> = setOf(JavaResourceRootType.RESOURCE, ResourceKotlinRootType)
+val testResourceRootTypes: Set<JpsModuleSourceRootType<JavaResourceRootProperties>> = setOf(JavaResourceRootType.TEST_RESOURCE, TestResourceKotlinRootType)
 
 /**
  * Defines test root type for selected codegen language.
@@ -45,15 +42,5 @@ fun SourceFolder.isForGeneratedSources(): Boolean {
     val properties = jpsElement.getProperties(sourceRootTypes + testSourceRootTypes)
     val resourceProperties = jpsElement.getProperties(resourceRootTypes + testResourceRootTypes)
 
-    return isInBuildGeneratedFolder() || properties?.isForGeneratedSources == true && resourceProperties?.isForGeneratedSources == true
-}
-
-/**
- * Returns true if the [SourceFolder] is located in the `build/generated` directory.
- */
-fun SourceFolder.isInBuildGeneratedFolder(): Boolean {
-    val sourceFolderPath = this.file?.path
-    val moduleRootPath = this.contentEntry.rootModel.module.externalProjectPath
-    val relativePath = safeRelativize(sourceFolderPath, moduleRootPath)?.toPath()
-    return relativePath?.startsWith("build/generated") == true
+    return properties?.isForGeneratedSources == true && resourceProperties?.isForGeneratedSources == true
 }

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/RootUtils.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/RootUtils.kt
@@ -11,6 +11,9 @@ import org.jetbrains.kotlin.config.ResourceKotlinRootType
 import org.jetbrains.kotlin.config.SourceKotlinRootType
 import org.jetbrains.kotlin.config.TestResourceKotlinRootType
 import org.jetbrains.kotlin.config.TestSourceKotlinRootType
+import org.jetbrains.kotlin.idea.configuration.externalProjectPath
+import org.utbot.common.PathUtil.safeRelativize
+import org.utbot.common.PathUtil.toPath
 
 val sourceRootTypes: Set<JpsModuleSourceRootType<JavaSourceRootProperties>> = setOf(JavaSourceRootType.SOURCE, SourceKotlinRootType)
 val testSourceRootTypes: Set<JpsModuleSourceRootType<JavaSourceRootProperties>>  = setOf(JavaSourceRootType.TEST_SOURCE, TestSourceKotlinRootType)
@@ -42,5 +45,15 @@ fun SourceFolder.isForGeneratedSources(): Boolean {
     val properties = jpsElement.getProperties(sourceRootTypes + testSourceRootTypes)
     val resourceProperties = jpsElement.getProperties(resourceRootTypes + testResourceRootTypes)
 
-    return properties?.isForGeneratedSources == true && resourceProperties?.isForGeneratedSources == true
+    return isInBuildGeneratedFolder() || properties?.isForGeneratedSources == true && resourceProperties?.isForGeneratedSources == true
+}
+
+/**
+ * Returns true if the [SourceFolder] is located in the `build/generated` directory.
+ */
+fun SourceFolder.isInBuildGeneratedFolder(): Boolean {
+    val sourceFolderPath = this.file?.path
+    val moduleRootPath = this.contentEntry.rootModel.module.externalProjectPath
+    val relativePath = safeRelativize(sourceFolderPath, moduleRootPath)?.toPath()
+    return relativePath?.startsWith("build/generated") == true
 }


### PR DESCRIPTION
# Description

1. Fixed searching test resources folder
2. Changed order of suitable test source folders:

![image](https://user-images.githubusercontent.com/43010567/172149870-48f126f2-0c8a-48f4-a69d-a4a41647ff74.png)
