### PR TITLE
Useless throws in methods signature

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/builtin/MockitoBuiltins.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/builtin/MockitoBuiltins.kt
@@ -1,6 +1,7 @@
 package org.utbot.framework.codegen.model.constructor.builtin
 
 import org.utbot.framework.plugin.api.BuiltinClassId
+import org.utbot.framework.plugin.api.MethodId
 import org.utbot.framework.plugin.api.util.booleanClassId
 import org.utbot.framework.plugin.api.util.builtinMethodId
 import org.utbot.framework.plugin.api.util.builtinStaticMethodId
@@ -14,6 +15,13 @@ import org.utbot.framework.plugin.api.util.longClassId
 import org.utbot.framework.plugin.api.util.objectClassId
 import org.utbot.framework.plugin.api.util.shortClassId
 import org.utbot.framework.plugin.api.util.stringClassId
+
+internal val mockitoBuiltins: Set<MethodId>
+    get() = setOf(
+        mockMethodId, whenMethodId, thenMethodId, thenReturnMethodId,
+        any, anyOfClass, anyByte, anyChar, anyShort, anyInt, anyLong,
+        anyFloat, anyDouble, anyBoolean, anyString
+    )
 
 internal val mockitoClassId = BuiltinClassId(
     name = "org.mockito.Mockito",

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/builtin/ReflectionBuiltins.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/builtin/ReflectionBuiltins.kt
@@ -1,6 +1,7 @@
 package org.utbot.framework.codegen.model.constructor.builtin
 
 import org.utbot.framework.plugin.api.ClassId
+import org.utbot.framework.plugin.api.MethodId
 import org.utbot.framework.plugin.api.util.booleanClassId
 import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.intClassId
@@ -8,12 +9,24 @@ import org.utbot.framework.plugin.api.util.methodId
 import org.utbot.framework.plugin.api.util.objectClassId
 import org.utbot.framework.plugin.api.util.stringClassId
 import org.utbot.framework.plugin.api.util.voidClassId
+import sun.misc.Unsafe
 import java.lang.reflect.AccessibleObject
 import java.lang.reflect.Field
 import java.lang.reflect.InvocationTargetException
-import sun.misc.Unsafe
 
 // reflection methods ids
+
+//TODO: these methods are called builtins, but actually are just [MethodId]
+//may be fixed in https://github.com/UnitTestBot/UTBotJava/issues/138
+
+internal val reflectionBuiltins: Set<MethodId>
+         get() = setOf(
+                setAccessible, invoke, newInstance, get, forName,
+                getDeclaredMethod, getDeclaredConstructor, allocateInstance,
+                getClass, getDeclaredField, isEnumConstant, getFieldName,
+                equals, getSuperclass, set, newArrayInstance,
+                setArrayElement, getArrayElement, getTargetException,
+        )
 
 internal val setAccessible = methodId(
         classId = AccessibleObject::class.id,

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgCallableAccessManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgCallableAccessManager.kt
@@ -16,6 +16,7 @@ import org.utbot.framework.codegen.model.constructor.builtin.getDeclaredMethod
 import org.utbot.framework.codegen.model.constructor.builtin.getEnumConstantByNameMethodId
 import org.utbot.framework.codegen.model.constructor.builtin.getFieldValueMethodId
 import org.utbot.framework.codegen.model.constructor.builtin.getStaticFieldValueMethodId
+import org.utbot.framework.codegen.model.constructor.builtin.getTargetException
 import org.utbot.framework.codegen.model.constructor.builtin.getUnsafeInstanceMethodId
 import org.utbot.framework.codegen.model.constructor.builtin.hasCustomEqualsMethodId
 import org.utbot.framework.codegen.model.constructor.builtin.invoke
@@ -126,6 +127,13 @@ internal class CgCallableAccessManagerImpl(val context: CgContext) : CgCallableA
         //so we need to collect required exceptions manually from source codes
         if (methodId is BuiltinMethodId) {
             methodId.findExceptionTypes().forEach { addException(it) }
+            return
+        }
+        //If [InvocationTargetException] is thrown manually in test, we need
+        // to add "throws Throwable" and other exceptions are not required so on.
+        if (methodId == getTargetException) {
+            collectedExceptions.clear()
+            addException(Throwable::class.id)
             return
         }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
@@ -1134,7 +1134,7 @@ internal class CgMethodConstructor(val context: CgContext) : CgContextOwner by c
                         val varType = CgClassId(
                             it.variableType,
                             TypeParameters(listOf(typeParameter)),
-                            isNullable=true,
+                            isNullable = true,
                         )
                         +CgDeclaration(
                             varType,
@@ -1638,21 +1638,14 @@ internal class CgMethodConstructor(val context: CgContext) : CgContextOwner by c
      * that may be thrown by these calls.
      */
     private fun CgExecutableCall.intercepted() {
-        when (executableId) {
-            is MethodId -> {
-                if (executableId == invoke) {
-                    this.wrapReflectiveCall()
-                } else {
-                    +this
-                }
-            }
-            is ConstructorId -> {
-                if (executableId == newInstance) {
-                    this.wrapReflectiveCall()
-                } else {
-                    +this
-                }
-            }
+        val executableToWrap = when (executableId) {
+            is MethodId -> invoke
+            is ConstructorId -> newInstance
+        }
+        if (executableId == executableToWrap) {
+            this.wrapReflectiveCall()
+        } else {
+            +this
         }
     }
 }


### PR DESCRIPTION
A test method signature will be generated as follows:
```kotlin
public void testObjectArray_ALengthEqualsZero() throws <ONLY REALLY REQUIRED EXCEPTIONS> {
```

Verifications: all generated tests still can be compiled