### PR TITLE
Fuzzer generates uncompilable test methods in Contest Estimator #111

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
@@ -584,7 +584,7 @@ class UtBotSymbolicEngine(
                         path = mutableListOf(),
                         fullPath = emptyList(),
                         coverage = concreteExecutionResult.coverage,
-                        testMethodName = "test${methodUnderTest.callable.name.capitalize()}ByFuzzer${index}"
+                        testMethodName = if (methodUnderTest.isMethod) "test${methodUnderTest.callable.name.capitalize()}ByFuzzer${index}" else null
                     )
                 )
             } catch (e: CancellationException) {


### PR DESCRIPTION
# Description

Constructors have "&lt;init&gt;" as a method name therefore bad methods created by fuzzer which uses method name as a part of test method.

Fixes #111

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Read issue section "To Reproduce"

# Checklist:

- [ ] The change followed the style guidelines of the UTBot project
- [ ] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [ ] No new warnings
- [ ] Tests that prove my change is effective
- [ ] All tests pass locally with my changes