### PR TITLE
Multiline array initializer formatted rendered

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgAbstractRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgAbstractRenderer.kt
@@ -756,14 +756,30 @@ internal abstract class CgAbstractRenderer(val context: CgContext, val printer: 
     }
 
     protected fun UtArrayModel.renderElements(length: Int, elementsInLine: Int) {
-        for (i in 0 until length) {
-            val expr = this.getElementExpr(i)
-
-            if (i == 0 && length >= elementsInLine || i != 0 && i % elementsInLine == 0) {
-                println()
+        if (length <= elementsInLine) { // one-line array
+            for (i in 0 until length) {
+                val expr = this.getElementExpr(i)
+                expr.accept(this@CgAbstractRenderer)
+                if (i != length - 1) {
+                    print(", ")
+                }
             }
-            expr.accept(this@CgAbstractRenderer)
-            if (i != length - 1) print(",")
+        } else { // multiline array
+            println() // line break after `int[] x = {`
+            withIndent {
+                for (i in 0 until length) {
+                    val expr = this.getElementExpr(i)
+                    expr.accept(this@CgAbstractRenderer)
+
+                    if (i == length - 1) {
+                        println()
+                    } else if (i % elementsInLine == elementsInLine - 1) {
+                        println(",")
+                    } else {
+                        print(", ")
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
# Description

Now we render multiline arrays creation with the line breaks, e.g.:

```Java
public void testIsValid_NEquals5() throws Throwable  {
    IntArrayBasics intArrayBasics = new IntArrayBasics();
    int[] intArray = {
        -255, -255, -255, -255, -255, 10, -255, -255,
        -255, -255, -255, -255, -255, -255, -254
    };
    
    boolean actual = intArrayBasics.isValid(intArray, 5);
    
    assertTrue(actual);
}
```

Fixes [#113](https://github.com/UnitTestBot/UTBotJava/issues/113)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Automated Testing

- [x] tests in package `org.utbot.examples.arrays`

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] Tests that prove my change is effective
- [x] All tests pass locally with my changes