### PR TITLE
New fuzzing model providers:

### DIFF
--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/FuzzedMethodDescription.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/FuzzedMethodDescription.kt
@@ -32,7 +32,7 @@ class FuzzedMethodDescription(
     }
 
     constructor(executableId: ExecutableId, concreteValues: Collection<FuzzedConcreteValue> = emptyList()) : this(
-        executableId.name,
+        executableId.classId.simpleName + "." + executableId.name,
         executableId.returnType,
         executableId.parameters,
         concreteValues

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/Fuzzer.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/Fuzzer.kt
@@ -1,15 +1,19 @@
 package org.utbot.fuzzer
 
-import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.UtModel
-import org.utbot.framework.plugin.api.util.defaultValueModel
 import org.utbot.fuzzer.providers.ConstantsModelProvider
 import org.utbot.fuzzer.providers.ObjectModelProvider
 import org.utbot.fuzzer.providers.PrimitivesModelProvider
 import org.utbot.fuzzer.providers.StringConstantModelProvider
 import mu.KotlinLogging
+import org.utbot.fuzzer.providers.ArrayModelProvider
+import org.utbot.fuzzer.providers.CharToStringModelProvider
+import org.utbot.fuzzer.providers.CollectionModelProvider
+import org.utbot.fuzzer.providers.PrimitiveDefaultsModelProvider
+import org.utbot.fuzzer.providers.EnumModelProvider
+import org.utbot.fuzzer.providers.PrimitiveWrapperModelProvider
 import java.util.concurrent.atomic.AtomicInteger
-import java.util.function.ToIntFunction
+import java.util.function.IntSupplier
 import kotlin.random.Random
 
 private val logger = KotlinLogging.logger {}
@@ -24,21 +28,47 @@ fun fuzz(description: FuzzedMethodDescription, vararg modelProviders: ModelProvi
     description.parameters.forEachIndexed { index, classId ->
         val models = values[index]
         if (models.isEmpty()) {
-            logger.warn { "There's no models provided classId=$classId. Null or default value will be provided" }
-            models.add(classId.defaultValueModel())
+            logger.warn { "There's no models provided classId=$classId. No suitable values are generated for ${description.name}" }
+            return emptySequence()
         }
     }
     return CartesianProduct(values, Random(0L)).asSequence()
 }
 
-fun defaultModelProviders(idGenerator: ToIntFunction<ClassId> = SimpleIdGenerator()): ModelProvider {
-    return ObjectModelProvider(idGenerator)
-        .with(ConstantsModelProvider)
-        .with(StringConstantModelProvider)
-        .with(PrimitivesModelProvider)
+/**
+ * Creates a model provider from a list of default providers.
+ */
+fun defaultModelProviders(idGenerator: IntSupplier = SimpleIdGenerator()): ModelProvider {
+    return ModelProvider.of(
+        ObjectModelProvider(idGenerator),
+        CollectionModelProvider(idGenerator),
+        ArrayModelProvider(idGenerator),
+        EnumModelProvider,
+        ConstantsModelProvider,
+        StringConstantModelProvider,
+        CharToStringModelProvider,
+        PrimitivesModelProvider,
+        PrimitiveWrapperModelProvider,
+    )
 }
 
-private class SimpleIdGenerator : ToIntFunction<ClassId> {
+/**
+ * Creates a model provider for [ObjectModelProvider] that generates values for object constructor.
+ */
+fun objectModelProviders(idGenerator: IntSupplier = SimpleIdGenerator()): ModelProvider {
+    return ModelProvider.of(
+        CollectionModelProvider(idGenerator),
+        ArrayModelProvider(idGenerator),
+        EnumModelProvider,
+        StringConstantModelProvider,
+        CharToStringModelProvider,
+        ConstantsModelProvider,
+        PrimitiveDefaultsModelProvider,
+        PrimitiveWrapperModelProvider,
+    )
+}
+
+private class SimpleIdGenerator : IntSupplier {
     private val id = AtomicInteger()
-    override fun applyAsInt(value: ClassId?) = id.incrementAndGet()
+    override fun getAsInt() = id.incrementAndGet()
 }

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/ModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/ModelProvider.kt
@@ -102,6 +102,18 @@ fun interface ModelProvider {
         fun of(vararg providers: ModelProvider): ModelProvider {
             return Combined(providers.toList())
         }
+
+        fun BiConsumer<Int, UtModel>.consumeAll(indices: List<Int>, models: Sequence<UtModel>) {
+            models.forEach { model ->
+                indices.forEach { index ->
+                    accept(index, model)
+                }
+            }
+        }
+
+        fun BiConsumer<Int, UtModel>.consumeAll(indices: List<Int>, models: List<UtModel>) {
+            consumeAll(indices, models.asSequence())
+        }
     }
 
     /**
@@ -114,4 +126,8 @@ fun interface ModelProvider {
             }
         }
     }
+}
+
+inline fun <reified T> ModelProvider.exceptIsInstance(): ModelProvider {
+    return except { it is T }
 }

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/ArrayModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/ArrayModelProvider.kt
@@ -1,0 +1,32 @@
+package org.utbot.fuzzer.providers
+
+import org.utbot.framework.plugin.api.UtArrayModel
+import org.utbot.framework.plugin.api.UtModel
+import org.utbot.framework.plugin.api.util.defaultValueModel
+import org.utbot.framework.plugin.api.util.isArray
+import org.utbot.fuzzer.FuzzedMethodDescription
+import org.utbot.fuzzer.ModelProvider
+import org.utbot.fuzzer.ModelProvider.Companion.consumeAll
+import java.util.function.BiConsumer
+import java.util.function.IntSupplier
+
+class ArrayModelProvider(
+    private val idGenerator: IntSupplier
+) : ModelProvider {
+    override fun generate(description: FuzzedMethodDescription, consumer: BiConsumer<Int, UtModel>) {
+        description.parametersMap
+            .asSequence()
+            .filter { (classId, _) -> classId.isArray }
+            .forEach { (arrayClassId, indices) ->
+                consumer.consumeAll(indices, listOf(0, 10).map { arraySize ->
+                    UtArrayModel(
+                        id = idGenerator.asInt,
+                        arrayClassId,
+                        length = arraySize,
+                        arrayClassId.elementClassId!!.defaultValueModel(),
+                        mutableMapOf()
+                    )
+                })
+            }
+    }
+}

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/CharToStringModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/CharToStringModelProvider.kt
@@ -1,0 +1,31 @@
+package org.utbot.fuzzer.providers
+
+import org.utbot.framework.plugin.api.UtModel
+import org.utbot.framework.plugin.api.UtPrimitiveModel
+import org.utbot.framework.plugin.api.util.charClassId
+import org.utbot.framework.plugin.api.util.stringClassId
+import org.utbot.fuzzer.FuzzedMethodDescription
+import org.utbot.fuzzer.ModelProvider
+import java.util.function.BiConsumer
+
+/**
+ * Collects all char constants and creates string with them.
+ */
+object CharToStringModelProvider : ModelProvider {
+    override fun generate(description: FuzzedMethodDescription, consumer: BiConsumer<Int, UtModel>) {
+        val indices = description.parametersMap[stringClassId] ?: return
+        if (indices.isNotEmpty()) {
+            val string = description.concreteValues.asSequence()
+                .filter { it.classId == charClassId }
+                .map { it.value }
+                .filterIsInstance<Char>()
+                .joinToString(separator = "")
+            if (string.isNotEmpty()) {
+                val model = UtPrimitiveModel(string)
+                indices.forEach {
+                    consumer.accept(it, model)
+                }
+            }
+        }
+    }
+}

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/CollectionModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/CollectionModelProvider.kt
@@ -1,0 +1,105 @@
+package org.utbot.fuzzer.providers
+
+import org.utbot.framework.plugin.api.ConstructorId
+import org.utbot.framework.plugin.api.ExecutableId
+import org.utbot.framework.plugin.api.MethodId
+import org.utbot.framework.plugin.api.UtAssembleModel
+import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtModel
+import org.utbot.framework.plugin.api.UtStatementModel
+import org.utbot.framework.plugin.api.util.id
+import org.utbot.framework.plugin.api.util.jClass
+import org.utbot.fuzzer.FuzzedMethodDescription
+import org.utbot.fuzzer.ModelProvider
+import org.utbot.fuzzer.ModelProvider.Companion.consumeAll
+import java.util.function.BiConsumer
+import java.util.function.IntSupplier
+
+/**
+ * Provides different collection for concrete classes.
+ *
+ * For example, ArrayList, LinkedList, Collections.singletonList can be passed to check
+ * if that parameter breaks anything. For example, in case method doesn't expect
+ * a non-modifiable collection and tries to add values.
+ */
+class CollectionModelProvider(
+    private val idGenerator: IntSupplier
+) : ModelProvider {
+
+    private val generators = mapOf(
+        java.util.List::class.java to ::createListModels,
+        java.util.Set::class.java to ::createSetModels,
+        java.util.Map::class.java to ::createMapModels,
+        java.util.Collection::class.java to ::createCollectionModels,
+        java.lang.Iterable::class.java to ::createCollectionModels,
+        java.util.Iterator::class.java to ::createIteratorModels,
+    )
+
+    override fun generate(description: FuzzedMethodDescription, consumer: BiConsumer<Int, UtModel>) {
+        description.parametersMap
+            .asSequence()
+            .forEach { (classId, indices) ->
+                 generators[classId.jClass]?.let { createModels ->
+                     consumer.consumeAll(indices, createModels())
+                 }
+            }
+    }
+
+    private fun createListModels(): List<UtAssembleModel> {
+        return listOf(
+            java.util.List::class.java.createdBy(java.util.ArrayList::class.java.asConstructor()),
+            java.util.List::class.java.createdBy(java.util.LinkedList::class.java.asConstructor()),
+            java.util.List::class.java.createdBy(java.util.Collections::class.java.methodCall("emptyList", java.util.List::class.java)),
+            java.util.List::class.java.createdBy(java.util.Collections::class.java.methodCall("synchronizedList", java.util.List::class.java, params = listOf(java.util.List::class.java)), listOf(
+                java.util.List::class.java.createdBy(java.util.ArrayList::class.java.asConstructor())
+            )),
+        )
+    }
+
+    private fun createSetModels(): List<UtAssembleModel> {
+        return listOf(
+            java.util.Set::class.java.createdBy(java.util.HashSet::class.java.asConstructor()),
+            java.util.Set::class.java.createdBy(java.util.TreeSet::class.java.asConstructor()),
+            java.util.Set::class.java.createdBy(java.util.Collections::class.java.methodCall("emptySet", java.util.Set::class.java))
+        )
+    }
+
+    private fun createMapModels(): List<UtAssembleModel> {
+        return listOf(
+            java.util.Map::class.java.createdBy(java.util.HashMap::class.java.asConstructor()),
+            java.util.Map::class.java.createdBy(java.util.TreeMap::class.java.asConstructor()),
+            java.util.Map::class.java.createdBy(java.util.Collections::class.java.methodCall("emptyMap", java.util.Map::class.java)),
+        )
+    }
+
+    private fun createCollectionModels(): List<UtAssembleModel> {
+        return listOf(
+            java.util.Collection::class.java.createdBy(java.util.ArrayList::class.java.asConstructor()),
+            java.util.Collection::class.java.createdBy(java.util.HashSet::class.java.asConstructor()),
+            java.util.Collection::class.java.createdBy(java.util.Collections::class.java.methodCall("emptySet", java.util.Set::class.java)),
+        )
+    }
+
+    private fun createIteratorModels(): List<UtAssembleModel> {
+        return listOf(
+            java.util.Iterator::class.java.createdBy(java.util.Collections::class.java.methodCall("emptyIterator", java.util.Iterator::class.java)),
+        )
+    }
+
+    private fun Class<*>.asConstructor() = ConstructorId(id, emptyList())
+
+    private fun Class<*>.methodCall(methodName: String, returnType: Class<*>, params: List<Class<*>> = emptyList()) = MethodId(id, methodName, returnType.id, params.map { it.id })
+
+    private fun Class<*>.createdBy(init: ExecutableId, params: List<UtModel> = emptyList()): UtAssembleModel {
+        val instantiationChain = mutableListOf<UtStatementModel>()
+        val genId = idGenerator.asInt
+        return UtAssembleModel(
+            genId,
+            id,
+            "${init.classId.name}${init.parameters}#" + genId.toString(16),
+            instantiationChain
+        ).apply {
+            instantiationChain += UtExecutableCallModel(null, init, params, this)
+        }
+    }
+}

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/EnumModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/EnumModelProvider.kt
@@ -1,0 +1,24 @@
+package org.utbot.fuzzer.providers
+
+import org.utbot.framework.plugin.api.UtEnumConstantModel
+import org.utbot.framework.plugin.api.UtModel
+import org.utbot.framework.plugin.api.util.id
+import org.utbot.framework.plugin.api.util.isSubtypeOf
+import org.utbot.framework.plugin.api.util.jClass
+import org.utbot.fuzzer.FuzzedMethodDescription
+import org.utbot.fuzzer.ModelProvider
+import org.utbot.fuzzer.ModelProvider.Companion.consumeAll
+import java.util.function.BiConsumer
+
+object EnumModelProvider : ModelProvider {
+    override fun generate(description: FuzzedMethodDescription, consumer: BiConsumer<Int, UtModel>) {
+        description.parametersMap
+            .asSequence()
+            .filter { (classId, _) -> classId.isSubtypeOf(Enum::class.java.id) }
+            .forEach { (classId, indices) ->
+                consumer.consumeAll(indices, classId.jClass.enumConstants.filterIsInstance<Enum<*>>().map {
+                    UtEnumConstantModel(classId, it)
+                })
+            }
+    }
+}

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/NullModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/NullModelProvider.kt
@@ -13,11 +13,12 @@ import java.util.function.BiConsumer
 @Suppress("unused") // disabled until fuzzer breaks test with null/nonnull annotations
 object NullModelProvider : ModelProvider {
     override fun generate(description: FuzzedMethodDescription, consumer: BiConsumer<Int, UtModel>) {
-        description.parameters
+        description.parametersMap
             .asSequence()
-            .filter { classId ->  classId.isRefType }
-            .forEachIndexed { index, classId ->
-                consumer.accept(index, UtNullModel(classId))
+            .filter { (classId, _) ->  classId.isRefType }
+            .forEach { (classId, indices) ->
+                val model = UtNullModel(classId)
+                indices.forEach { consumer.accept(it, model) }
             }
     }
 }

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/ObjectModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/ObjectModelProvider.kt
@@ -7,39 +7,73 @@ import org.utbot.framework.plugin.api.UtExecutableCallModel
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtStatementModel
 import org.utbot.framework.plugin.api.util.id
+import org.utbot.framework.plugin.api.util.isPrimitiveWrapper
 import org.utbot.framework.plugin.api.util.jClass
+import org.utbot.framework.plugin.api.util.stringClassId
 import org.utbot.fuzzer.FuzzedMethodDescription
 import org.utbot.fuzzer.ModelProvider
+import org.utbot.fuzzer.exceptIsInstance
 import org.utbot.fuzzer.fuzz
+import org.utbot.fuzzer.objectModelProviders
 import java.lang.reflect.Constructor
 import java.lang.reflect.Modifier
 import java.lang.reflect.Parameter
 import java.util.function.BiConsumer
-import java.util.function.ToIntFunction
+import java.util.function.IntSupplier
 
 /**
  * Creates [UtAssembleModel] for objects which have public constructors with primitives types and String as parameters.
  */
-class ObjectModelProvider(
-    private val idGenerator: ToIntFunction<ClassId>
-) : ModelProvider {
+class ObjectModelProvider : ModelProvider {
 
-    var modelProvider: ModelProvider = ModelProvider.of(ConstantsModelProvider, StringConstantModelProvider, PrimitivesModelProvider)
+    var modelProvider: ModelProvider
+
+    private val idGenerator: IntSupplier
+    private val recursion: Int
+    private val limit: Int
+
+    constructor(idGenerator: IntSupplier) : this(idGenerator, Int.MAX_VALUE)
+
+    constructor(idGenerator: IntSupplier, limit: Int) : this(idGenerator, limit, 1)
+
+    private constructor(idGenerator: IntSupplier, limit: Int, recursion: Int) {
+        this.idGenerator = idGenerator
+        this.recursion = recursion
+        this.limit = limit
+        this.modelProvider = objectModelProviders(idGenerator)
+    }
 
     override fun generate(description: FuzzedMethodDescription, consumer: BiConsumer<Int, UtModel>) {
         val assembleModels = with(description) {
             parameters.asSequence()
+                .filterNot { it == stringClassId || it.isPrimitiveWrapper }
                 .flatMap { classId ->
                     collectConstructors(classId) { javaConstructor ->
-                        isPublic(javaConstructor) && javaConstructor.parameters.all(Companion::isPrimitiveOrString)
-                    }
+                        isPublic(javaConstructor) && (recursion > 0 || javaConstructor.parameters.all(Companion::isPrimitiveOrString))
+                    }.sortedBy {
+                        // prefer constructors with fewer parameters
+                        it.parameters.size
+                    }.take(limit)
                 }
-                .associateWith {
-                    fuzzParameters(it, modelProvider)
+                .associateWith { constructorId ->
+                    val modelProviderWithoutRecursion = modelProvider.exceptIsInstance<ObjectModelProvider>()
+                    fuzzParameters(
+                        constructorId,
+                        if (recursion > 0) {
+                            ObjectModelProvider(idGenerator, limit = 1, recursion - 1).with(modelProviderWithoutRecursion)
+                        } else {
+                            modelProviderWithoutRecursion
+                        }
+                    )
                 }
                 .flatMap { (constructorId, fuzzedParameters) ->
-                    fuzzedParameters.map { params ->
-                        assembleModel(idGenerator.applyAsInt(constructorId.classId), constructorId, params)
+                    if (constructorId.parameters.isEmpty()) {
+                        sequenceOf(assembleModel(idGenerator.asInt, constructorId, emptyList()))
+                    }
+                    else {
+                        fuzzedParameters.map { params ->
+                            assembleModel(idGenerator.asInt, constructorId, params)
+                        }
                     }
                 }
         }

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/PrimitiveDefaultsModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/PrimitiveDefaultsModelProvider.kt
@@ -1,0 +1,45 @@
+package org.utbot.fuzzer.providers
+
+import org.utbot.framework.plugin.api.ClassId
+import org.utbot.framework.plugin.api.UtModel
+import org.utbot.framework.plugin.api.UtPrimitiveModel
+import org.utbot.framework.plugin.api.util.booleanClassId
+import org.utbot.framework.plugin.api.util.byteClassId
+import org.utbot.framework.plugin.api.util.charClassId
+import org.utbot.framework.plugin.api.util.doubleClassId
+import org.utbot.framework.plugin.api.util.floatClassId
+import org.utbot.framework.plugin.api.util.intClassId
+import org.utbot.framework.plugin.api.util.longClassId
+import org.utbot.framework.plugin.api.util.shortClassId
+import org.utbot.framework.plugin.api.util.stringClassId
+import org.utbot.fuzzer.FuzzedMethodDescription
+import org.utbot.fuzzer.ModelProvider
+import java.util.function.BiConsumer
+
+/**
+ * Provides default values for primitive types.
+ */
+object PrimitiveDefaultsModelProvider : ModelProvider {
+    override fun generate(description: FuzzedMethodDescription, consumer: BiConsumer<Int, UtModel>) {
+        description.parametersMap.forEach { (classId, parameterIndices) ->
+            valueOf(classId)?.let { model ->
+                parameterIndices.forEach { index ->
+                    consumer.accept(index, model)
+                }
+            }
+        }
+    }
+
+    fun valueOf(classId: ClassId): UtPrimitiveModel? = when (classId) {
+        booleanClassId -> UtPrimitiveModel(false)
+        byteClassId -> UtPrimitiveModel(0.toByte())
+        charClassId -> UtPrimitiveModel('\u0000')
+        shortClassId -> UtPrimitiveModel(0.toShort())
+        intClassId -> UtPrimitiveModel(0)
+        longClassId -> UtPrimitiveModel(0L)
+        floatClassId -> UtPrimitiveModel(0.0f)
+        doubleClassId -> UtPrimitiveModel(0.0)
+        stringClassId -> UtPrimitiveModel("")
+        else -> null
+    }
+}

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/PrimitiveWrapperModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/PrimitiveWrapperModelProvider.kt
@@ -1,0 +1,64 @@
+package org.utbot.fuzzer.providers
+
+import org.utbot.framework.plugin.api.ClassId
+import org.utbot.framework.plugin.api.UtModel
+import org.utbot.framework.plugin.api.util.isPrimitiveWrapper
+import org.utbot.framework.plugin.api.util.primitiveByWrapper
+import org.utbot.framework.plugin.api.util.stringClassId
+import org.utbot.framework.plugin.api.util.voidClassId
+import org.utbot.framework.plugin.api.util.wrapperByPrimitive
+import org.utbot.fuzzer.FuzzedMethodDescription
+import org.utbot.fuzzer.ModelProvider
+import org.utbot.fuzzer.ModelProvider.Companion.consumeAll
+import java.util.function.BiConsumer
+
+object PrimitiveWrapperModelProvider: ModelProvider {
+
+    private val constantModels = ModelProvider.of(
+        PrimitiveDefaultsModelProvider,
+        ConstantsModelProvider,
+        StringConstantModelProvider
+    )
+
+    override fun generate(description: FuzzedMethodDescription, consumer: BiConsumer<Int, UtModel>) {
+        val primitiveWrapperTypesAsPrimitiveTypes = description.parametersMap
+            .keys
+            .asSequence()
+            .filter {
+                it == stringClassId || it.isPrimitiveWrapper
+            }
+            .mapNotNull { classId ->
+                when {
+                    classId == stringClassId -> stringClassId
+                    classId.isPrimitiveWrapper -> primitiveByWrapper[classId]
+                    else -> null
+                }
+            }.toList()
+
+        if (primitiveWrapperTypesAsPrimitiveTypes.isEmpty()) {
+            return
+        }
+
+        val constants = mutableMapOf<ClassId, MutableList<UtModel>>()
+        constantModels.generate(FuzzedMethodDescription(
+            name = this::class.simpleName + " constant generation ",
+            returnType = voidClassId,
+            parameters = primitiveWrapperTypesAsPrimitiveTypes,
+            concreteValues = description.concreteValues
+        )) { index, value ->
+            val primitiveWrapper = wrapperByPrimitive[primitiveWrapperTypesAsPrimitiveTypes[index]]
+            if (primitiveWrapper != null) {
+                constants.computeIfAbsent(primitiveWrapper) { mutableListOf() }.add(value)
+            }
+        }
+
+        description.parametersMap
+            .asSequence()
+            .filter { (classId, _) -> classId == stringClassId || classId.isPrimitiveWrapper }
+            .forEach { (classId, indices) ->
+                constants[classId]?.let { models ->
+                    consumer.consumeAll(indices, models)
+                }
+            }
+    }
+}

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/PrimitivesModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/PrimitivesModelProvider.kt
@@ -8,7 +8,7 @@ import org.utbot.fuzzer.ModelProvider
 import java.util.function.BiConsumer
 
 /**
- * Creates models of primitives from the method parameters list.
+ * Produces bound values for primitive types.
  */
 object PrimitivesModelProvider : ModelProvider {
     override fun generate(description: FuzzedMethodDescription, consumer: BiConsumer<Int, UtModel>) {
@@ -70,6 +70,9 @@ object PrimitivesModelProvider : ModelProvider {
                 )
                 stringClassId -> listOf(
                     UtPrimitiveModel(""),
+                    UtPrimitiveModel("   "),
+                    UtPrimitiveModel("string"),
+                    UtPrimitiveModel("\n\t\r"),
                 )
                 else -> listOf()
             }

--- a/utbot-fuzzers/src/test/kotlin/org/utbot/framework/plugin/api/ModelProviderTest.kt
+++ b/utbot-fuzzers/src/test/kotlin/org/utbot/framework/plugin/api/ModelProviderTest.kt
@@ -23,6 +23,8 @@ import org.utbot.fuzzer.providers.PrimitivesModelProvider
 import org.utbot.fuzzer.providers.StringConstantModelProvider
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import org.utbot.fuzzer.defaultModelProviders
+import org.utbot.fuzzer.providers.PrimitiveDefaultsModelProvider
 import java.util.Date
 
 class ModelProviderTest {
@@ -181,7 +183,7 @@ class ModelProviderTest {
             val classId = A::class.java.id
             val models = collect(
                 ObjectModelProvider { 0 }.apply {
-                    modelProvider = ModelProvider.of(ConstantsModelProvider, StringConstantModelProvider)
+                    modelProvider = ModelProvider.of(PrimitiveDefaultsModelProvider)
                 },
                 parameters = listOf(classId)
             )
@@ -212,7 +214,8 @@ class ModelProviderTest {
                 parameters = listOf(classId)
             )
 
-            assertEquals(0, models.size)
+            assertEquals(1, models.size)
+            assertEquals(1, models[0]!!.size)
         }
     }
 
@@ -257,6 +260,18 @@ class ModelProviderTest {
         assertEquals(1, result[0]!!.size)
         assertTrue(result[1]!!.size > 1)
         assertEquals(UtPrimitiveModel(-123), result[0]!![0])
+    }
+
+    @Test
+    fun `test collection model can produce basic values with assembled model`() {
+        withUtContext(UtContext(this::class.java.classLoader)) {
+            val result = collect(
+                defaultModelProviders { 0 },
+                parameters = listOf(java.util.List::class.java.id)
+            )
+
+            assertEquals(1, result.size)
+        }
     }
 
     private fun collect(

--- a/utbot-fuzzers/src/test/kotlin/org/utbot/framework/plugin/api/ModelProviderTest.kt
+++ b/utbot-fuzzers/src/test/kotlin/org/utbot/framework/plugin/api/ModelProviderTest.kt
@@ -23,7 +23,11 @@ import org.utbot.fuzzer.providers.PrimitivesModelProvider
 import org.utbot.fuzzer.providers.StringConstantModelProvider
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import org.utbot.framework.plugin.api.util.primitiveByWrapper
+import org.utbot.framework.plugin.api.util.primitiveWrappers
+import org.utbot.framework.plugin.api.util.voidWrapperClassId
 import org.utbot.fuzzer.defaultModelProviders
+import org.utbot.fuzzer.providers.EnumModelProvider
 import org.utbot.fuzzer.providers.PrimitiveDefaultsModelProvider
 import java.util.Date
 
@@ -274,6 +278,158 @@ class ModelProviderTest {
         }
     }
 
+    @Test
+    fun `test enum model provider`() {
+        withUtContext(UtContext(this::class.java.classLoader)) {
+            val result = collect(EnumModelProvider, parameters = listOf(OneTwoThree::class.java.id))
+            assertEquals(1, result.size)
+            assertEquals(3, result[0]!!.size)
+            OneTwoThree.values().forEachIndexed { index: Int, value ->
+                assertEquals(UtEnumConstantModel(OneTwoThree::class.java.id, value), result[0]!![index])
+            }
+        }
+    }
+
+    @Test
+    fun `test string value generates only primitive models`() {
+        withUtContext(UtContext(this::class.java.classLoader)) {
+            val result = collect(defaultModelProviders { 0 }, parameters = listOf(stringClassId))
+            assertEquals(1, result.size)
+            result[0]!!.forEach {
+                assertInstanceOf(UtPrimitiveModel::class.java, it)
+                assertEquals(stringClassId, it.classId)
+            }
+        }
+    }
+
+    @Test
+    fun `test wrapper primitives generate only primitive models`() {
+        withUtContext(UtContext(this::class.java.classLoader)) {
+            primitiveWrappers.asSequence().filterNot { it == voidWrapperClassId }.forEach { classId ->
+                val result = collect(defaultModelProviders { 0 }, parameters = listOf(classId))
+                assertEquals(1, result.size)
+                result[0]!!.forEach {
+                    assertInstanceOf(UtPrimitiveModel::class.java, it)
+                    val expectPrimitiveBecauseItShouldBeGeneratedByDefaultProviders = primitiveByWrapper[classId]
+                    assertEquals(expectPrimitiveBecauseItShouldBeGeneratedByDefaultProviders, it.classId)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `test at least one string is created if characters exist as constants`() {
+        withUtContext(UtContext(this::class.java.classLoader)) {
+            val result = collect(
+                defaultModelProviders { 0 },
+                parameters = listOf(stringClassId),
+                constants = listOf(
+                    FuzzedConcreteValue(charClassId, 'a'),
+                    FuzzedConcreteValue(charClassId, 'b'),
+                    FuzzedConcreteValue(charClassId, 'c'),
+                )
+            )
+            assertEquals(1, result.size)
+            assertTrue(result[0]!!.any {
+                it is UtPrimitiveModel && it.value == "abc"
+            })
+        }
+    }
+
+    @Test
+    @Suppress("unused", "UNUSED_PARAMETER", "ConvertSecondaryConstructorToPrimary")
+    fun `test complex object is constructed and it is not null`() {
+        class A {
+            constructor(some: Any)
+        }
+
+        withUtContext(UtContext(this::class.java.classLoader)) {
+            val result = collect(ObjectModelProvider { 0 }, parameters = listOf(A::class.java.id))
+            assertEquals(1, result.size)
+            assertEquals(1, result[0]!!.size)
+            assertInstanceOf(UtAssembleModel::class.java, result[0]!![0])
+            assertEquals(A::class.java.id, result[0]!![0].classId)
+            (result[0]!![0] as UtAssembleModel).instantiationChain.forEach {
+                assertTrue(it is UtExecutableCallModel)
+                assertEquals(1, (it as UtExecutableCallModel).params.size)
+                val objectParamInConstructor = it.params[0]
+                assertInstanceOf(UtAssembleModel::class.java, objectParamInConstructor)
+                val innerAssembledModel = objectParamInConstructor as UtAssembleModel
+                assertEquals(Any::class.java.id, innerAssembledModel.classId)
+                assertEquals(1, innerAssembledModel.instantiationChain.size)
+                val objectCreation = innerAssembledModel.instantiationChain.first() as UtExecutableCallModel
+                assertEquals(0, objectCreation.params.size)
+                assertInstanceOf(ConstructorId::class.java, objectCreation.executable)
+            }
+        }
+    }
+
+    @Test
+    @Suppress("unused", "UNUSED_PARAMETER", "ConvertSecondaryConstructorToPrimary")
+    fun `test recursive constructor calls and can pass null into inner if no other values exist`() {
+        class MyA {
+            constructor(some: MyA?)
+        }
+
+        withUtContext(UtContext(this::class.java.classLoader)) {
+            val result = collect(ObjectModelProvider { 0 }, parameters = listOf(MyA::class.java.id))
+            assertEquals(1, result.size)
+            assertEquals(1, result[0]!!.size)
+            val outerModel = result[0]!![0] as UtAssembleModel
+            outerModel.instantiationChain.forEach {
+                val constructorParameters = (it as UtExecutableCallModel).params
+                assertEquals(1, constructorParameters.size)
+                val innerModel = (constructorParameters[0] as UtAssembleModel)
+                assertEquals(MyA::class.java.id, innerModel.classId)
+                assertEquals(1, innerModel.instantiationChain.size)
+                val innerConstructorParameters = innerModel.instantiationChain[0] as UtExecutableCallModel
+                assertEquals(1, innerConstructorParameters.params.size)
+                assertInstanceOf(UtNullModel::class.java, innerConstructorParameters.params[0])
+            }
+        }
+    }
+
+    @Test
+    @Suppress("unused", "UNUSED_PARAMETER", "ConvertSecondaryConstructorToPrimary")
+    fun `test complex object is constructed with the simplest inner object constructor`() {
+
+        class Inner {
+            constructor(some: Inner?)
+
+            constructor(some: Inner?, other: Any)
+
+            // this constructor should be chosen
+            constructor(int: Int, double: Double)
+
+            constructor(other: Any, int: Int)
+
+            constructor(some: Inner?, other: Double)
+        }
+
+        class Outer {
+            constructor(inner: Inner)
+        }
+
+        withUtContext(UtContext(this::class.java.classLoader)) {
+            val result = collect(ObjectModelProvider { 0 }, parameters = listOf(Outer::class.java.id))
+            assertEquals(1, result.size)
+            assertEquals(1, result[0]!!.size)
+            val outerModel = result[0]!![0] as UtAssembleModel
+            outerModel.instantiationChain.forEach {
+                val constructorParameters = (it as UtExecutableCallModel).params
+                assertEquals(1, constructorParameters.size)
+                val innerModel = (constructorParameters[0] as UtAssembleModel)
+                assertEquals(Inner::class.java.id, innerModel.classId)
+                assertEquals(1, innerModel.instantiationChain.size)
+                val innerConstructorParameters = innerModel.instantiationChain[0] as UtExecutableCallModel
+                assertEquals(2, innerConstructorParameters.params.size)
+                assertTrue(innerConstructorParameters.params.all { param -> param is UtPrimitiveModel })
+                assertEquals(intClassId, innerConstructorParameters.params[0].classId)
+                assertEquals(doubleClassId, innerConstructorParameters.params[1].classId)
+            }
+        }
+    }
+
     private fun collect(
         modelProvider: ModelProvider,
         name: String = "testMethod",
@@ -288,4 +444,7 @@ class ModelProviderTest {
         }
     }
 
+    private enum class OneTwoThree {
+        ONE, TWO, THREE
+    }
 }


### PR DESCRIPTION
# Description

* collection model provider creates some empty collections of set, list, map, etc.
* array model provider creates empty and not-empty arrays
* char to string model which combines constants into string
* enum model providers creates values of enums
* added extra primitive model providers: default values and values of wrappers
* object model provider now can generate objects with another types as a parameter

Bug fixes and workarounds:

* UtAssembleModel fails to generate test with java.lang.String()
* Several NPEs because of generating null values for unknown types
* NullModelProvider generates models for the primitive parameter

## Type of Change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Automated Testing

- org.utbot.framework.plugin.api.ModelProviderTest
- org.utbot.examples.manual.PredefinedGeneratorParameters.testFuzzingSimple

# Checklist:

- [ ] The change followed the style guidelines of the UTBot project
- [ ] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [ ] No new warnings
- [ ] Tests that prove my change is effective
- [ ] All tests pass locally with my changes