### PR TITLE
Add utbot-framework-api publications on GitHub Packages

### DIFF
--- a/.github/workflows/publish-on-github-packages.yml
+++ b/.github/workflows/publish-on-github-packages.yml
@@ -40,7 +40,7 @@ jobs:
 
   publish_framework-api_and_dependencies:
     needs:  build_and_run_tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/publish-on-github-packages.yml
+++ b/.github/workflows/publish-on-github-packages.yml
@@ -18,6 +18,11 @@ jobs:
     - uses: gradle/gradle-build-action@v2
       with:
         gradle-version: 6.8
+    
+    - name: "UTBot Java: build and run tests"
+      run: |
+        export KOTLIN_HOME="/usr"
+        gradle clean build --no-daemon
 
     - name: Upload utbot-framework logs
       if: ${{ failure() }}

--- a/.github/workflows/publish-on-github-packages.yml
+++ b/.github/workflows/publish-on-github-packages.yml
@@ -1,0 +1,75 @@
+name: "[M] Publish on GitHub Packages"
+
+on: workflow_dispatch
+
+jobs:
+  build_and_run_tests:
+    if: ${{ github.actor == 'korifey' || github.actor == 'denis-fokin' || github.actor == 'victoriafomina' || 
+          github.actor == 'bissquit' }}
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        java-version: '8'
+        distribution: 'zulu'
+        java-package: jdk+fx
+        cache: gradle
+    - uses: gradle/gradle-build-action@v2
+      with:
+        gradle-version: 6.8
+
+    - name: Upload utbot-framework logs
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: utbot_framework_logs
+        path: utbot-framework/logs/*
+      
+    - name: Upload utbot-framework tests report artifacts if tests have failed
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: utbot_framework_tests_report
+        path: utbot-framework/build/reports/tests/test/*
+
+  publish_framework-api_and_dependencies:
+    needs:  build_and_run_tests
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        java-version: '8'
+        distribution: 'zulu'
+        java-package: jdk+fx
+        cache: gradle
+    - uses: gradle/gradle-build-action@v2
+      with:
+        gradle-version: 6.8
+        arguments: publish
+      env:
+        GITHUB_ACTOR: ${{ github.actor }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        
+    - name: Set project version
+      run:    
+        echo "VERSION="$(date +%Y).$(date +%-m)"" >> $GITHUB_ENV
+  
+    - name: "utbot-framework-api: build and run tests"
+      run: |
+        cd utbot-framework-api
+        gradle clean build --no-daemon -PsemVer=${{ env.VERSION }}-SNAPSHOT
+        
+    - name: "utbot-api: build"
+      run: |
+        cd utbot-api
+        gradle clean build --no-daemon -PsemVer=${{ env.VERSION }}-SNAPSHOT
+    
+    - name: "utbot-core: build"
+      run: |
+        cd utbot-core
+        gradle clean build --no-daemon -PsemVer=${{ env.VERSION }}-SNAPSHOT

--- a/utbot-api/build.gradle
+++ b/utbot-api/build.gradle
@@ -1,1 +1,18 @@
+plugins {
+  id 'maven-publish'
+}
+
 apply from: "${parent.projectDir}/gradle/include/jvm-project.gradle"
+
+publishing {
+  repositories {
+    maven {
+      name = "GitHubPackages"
+      url = "https://maven.pkg.github.com/UnitTestBot/UTBotJava"
+      credentials {
+        username = System.getenv("GITHUB_ACTOR")
+        password = System.getenv("GITHUB_TOKEN")
+      }
+    }
+  }
+}

--- a/utbot-core/build.gradle
+++ b/utbot-core/build.gradle
@@ -1,6 +1,23 @@
+plugins {
+  id 'maven-publish'
+}
+
 apply from: "${parent.projectDir}/gradle/include/jvm-project.gradle"
 
 dependencies {
     implementation group: 'io.github.microutils', name: 'kotlin-logging', version: kotlin_logging_version
     implementation group: 'net.java.dev.jna', name: 'jna-platform', version: '5.5.0'
+}
+
+publishing {
+  repositories {
+    maven {
+      name = "GitHubPackages"
+      url = "https://maven.pkg.github.com/UnitTestBot/UTBotJava"
+      credentials {
+        username = System.getenv("GITHUB_ACTOR")
+        password = System.getenv("GITHUB_TOKEN")
+      }
+    }
+  }
 }

--- a/utbot-framework-api/build.gradle
+++ b/utbot-framework-api/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+  id 'maven-publish'
+}
+
 apply from: "${parent.projectDir}/gradle/include/jvm-project.gradle"
 
 
@@ -9,4 +13,17 @@ dependencies {
     // TODO do we really need apache commons?
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: commons_lang_version
     implementation group: 'io.github.microutils', name: 'kotlin-logging', version: kotlin_logging_version
+}
+
+publishing {
+  repositories {
+    maven {
+      name = "GitHubPackages"
+      url = "https://maven.pkg.github.com/UnitTestBot/UTBotJava"
+      credentials {
+        username = System.getenv("GITHUB_ACTOR")
+        password = System.getenv("GITHUB_TOKEN")
+      }
+    }
+  }
 }


### PR DESCRIPTION
# Description

Add possibility to publish utbot-framework-api and its dependencies on GitHub Packages.

Fixes #142

## Type of Change

Not applicable.

# How Has This Been Tested?

## Automated Testing

Not applicable.

## Manual Scenario 

It was tested in personal fork.

# Checklist:

Not applicable.