### PR TITLE
#151: macOS support

### DIFF
--- a/utbot-analytics/build.gradle
+++ b/utbot-analytics/build.gradle
@@ -6,7 +6,10 @@ configurations {
 }
 
 
-String classifier = System.getProperty('os.name').toLowerCase().split()[0] + "-x86_64"
+def osName = System.getProperty('os.name').toLowerCase().split()[0]
+if (osName == "mac") osName = "macosx"
+String classifier = osName + "-x86_64"
+
 evaluationDependsOn(':utbot-framework')
 compileTestJava.dependsOn tasks.getByPath(':utbot-framework:testClasses')
 dependencies {

--- a/utbot-framework/build.gradle
+++ b/utbot-framework/build.gradle
@@ -53,6 +53,7 @@ dependencies {
 
     z3native group: 'com.microsoft.z3', name: 'z3-native-win64', version: z3_version, ext: 'zip'
     z3native group: 'com.microsoft.z3', name: 'z3-native-linux64', version: z3_version, ext: 'zip'
+    z3native group: 'com.microsoft.z3', name: 'z3-native-osx', version: z3_version, ext: 'zip'
 }
 
 processResources {

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/z3/Z3initializer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/z3/Z3initializer.kt
@@ -20,22 +20,23 @@ abstract class Z3Initializer : AutoCloseable {
     companion object {
         private val libraries = listOf("libz3", "libz3java")
         private val vcWinLibrariesToLoadBefore = listOf("vcruntime140", "vcruntime140_1")
-        private const val supportedArch = "amd64"
+        private val supportedArchs = setOf("amd64", "x86_64")
         private val initializeCallback by lazy {
             System.setProperty("z3.skipLibraryLoad", "true")
             val arch = System.getProperty("os.arch")
-            require(supportedArch == arch) { "Not supported arch: $arch" }
+            require(arch in supportedArchs) { "Not supported arch: $arch" }
 
-            val osProperty = System.getProperty("os.name")
+            val osProperty = System.getProperty("os.name").toLowerCase()
             val (ext, allLibraries) = when {
-                osProperty.startsWith("Windows") -> ".dll" to vcWinLibrariesToLoadBefore + libraries
-                osProperty.startsWith("Linux") -> ".so" to libraries
+                osProperty.startsWith("windows") -> ".dll" to vcWinLibrariesToLoadBefore + libraries
+                osProperty.startsWith("linux") -> ".so" to libraries
+                osProperty.startsWith("mac") -> ".dylib" to libraries
                 else -> error("Unknown OS: $osProperty")
             }
             val libZ3DllUrl = Z3Initializer::class.java
                 .classLoader
                 .getResource("lib/x64/libz3.dll") ?: error("Can't find native library folder")
-            //can't take resource of parent folder right here because in obfuscated jar parent folder
+            // can't take resource of parent folder right here because in obfuscated jar parent folder
             // can be missed (e.g., in case if obfuscation was applied)
 
             val libFolder: String?


### PR DESCRIPTION
# Description

Created macOS binaries with independent libz3.dylib and libz3java.dylib.
Changed Z3Initializer to support macOS binaries.
Changed utbot-analytics/build.gradle to use correct os name for macOS.

Fixes #151 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

Run any test in the sample tests suite.

## Manual Scenario 

Run Intellij IDEA with UTBot plugin on macOS, open any example, like Triangle, generate test for it.

# Checklist:

- [ ] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [ ] No new warnings
- [ ] Tests that prove my change is effective
- [ ] All tests pass locally with my changes