### PR TITLE
Corrected order of methods under test

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerator.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerator.kt
@@ -57,7 +57,10 @@ class CodeGenerator(
 
 fun findMethodsInClassMatchingSelected(clazz: KClass<*>, selectedMethods: List<MemberInfo>): List<UtMethod<*>> {
     val selectedSignatures = selectedMethods.map { it.signature() }
-    return clazz.functions.filter { it.signature().normalized() in selectedSignatures }.map { UtMethod(it, clazz) }
+    return clazz.functions
+        .sortedWith(compareBy { selectedSignatures.indexOf(it.signature()) })
+        .filter { it.signature().normalized() in selectedSignatures }
+        .map { UtMethod(it, clazz) }
 }
 
 fun findMethodParams(clazz: KClass<*>, methods: List<MemberInfo>): Map<UtMethod<*>, List<String>> {


### PR DESCRIPTION
# Description

Generated tests order does not match the order of the MUTs.

Fixes # ([115](https://github.com/UnitTestBot/UTBotJava/issues/115))

## Type of Change


- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

Generate tests for class with many methods under test, select all and several and check that order of test methods is similar to order of methods under test.
