### PR TITLE
Turn on disabled tests

### DIFF
--- a/utbot-framework/src/test/kotlin/org/utbot/examples/mock/MockWithSideEffectExampleTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/mock/MockWithSideEffectExampleTest.kt
@@ -8,7 +8,6 @@ import org.utbot.examples.isException
 import org.utbot.framework.plugin.api.MockStrategyApi
 import org.junit.Test
 
-@Ignore
 internal class MockWithSideEffectExampleTest : AbstractTestCaseGeneratorTest(testClass = MockWithSideEffectExample::class) {
     @Test
     fun testSideEffect() {

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/objects/ModelMinimizationExamplesTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/objects/ModelMinimizationExamplesTest.kt
@@ -6,7 +6,6 @@ import org.utbot.examples.DoNotCalculate
 import org.utbot.examples.eq
 import org.junit.Test
 
-@Ignore
 internal class ModelMinimizationExamplesTest : AbstractTestCaseGeneratorTest(testClass = ModelMinimizationExamples::class) {
     @Test
     fun singleValueComparisonTest() {

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/objects/SimpleClassMultiInstanceExampleTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/objects/SimpleClassMultiInstanceExampleTest.kt
@@ -6,7 +6,6 @@ import org.utbot.examples.DoNotCalculate
 import org.utbot.examples.eq
 import org.junit.Test
 
-@Ignore
 internal class SimpleClassMultiInstanceExampleTest : AbstractTestCaseGeneratorTest(testClass = SimpleClassMultiInstanceExample::class) {
     @Test
     fun singleObjectChangeTest() {


### PR DESCRIPTION
# Description

Several tests were disabled during the migration on GitHub. In this request, I enable them back.

Fixes #3

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

Tests from the issue:
* MockWithSideEffectExampleTest.testSideEffectElimination
* MockWithSideEffectExampleTest.testSideEffectWithoutMocks
* MockWithSideEffectExampleTest.testStaticMethodSideEffectEliminationWithoutMocks
* MockWithSideEffectExampleTest.testSideEffect
* MockWithSideEffectExampleTest.testStaticMethodSideEffectElimination
* ModelMinimizationExamplesTest.conditionCheckAEqTest
* ModelMinimizationExamplesTest.conditionCheckANeTest
* ModelMinimizationExamplesTest.conditionCheckBEqTest
* ModelMinimizationExamplesTest.conditionCheckBNeTest
* ModelMinimizationExamplesTest.conditionCheckNoNullabilityConstraintTest
* ModelMinimizationExamplesTest.firstArrayElementContainsSentinelTest
* ModelMinimizationExamplesTest.multipleConstraintsTest
* ModelMinimizationExamplesTest.singleValueComparisonNotNullTest
* ModelMinimizationExamplesTest.singleValueComparisonTest
* SimpleClassMultiInstanceExampleTest.singleObjectChangeTest

## Manual Scenario 

Not applicable. 

# Checklist:

- [ ] The change followed the style guidelines of the UTBot project
- [ ] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [ ] No new warnings
- [ ] Tests that prove my change is effective
- [ ] All tests pass locally with my changes