### PR TITLE
Remove unnecessary asserts for static fields

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
@@ -848,8 +848,14 @@ internal class CgMethodConstructor(val context: CgContext) : CgContextOwner by c
         depth: Int,
         visitedModels: MutableSet<UtModel>
     ) {
+        // if field is static, it is represents itself in "before" and
+        // "after" state: no need to assert its equality to itself.
+        if (fieldId.isStatic) {
+            return
+        }
+
+        // if model is already processed, so we don't want to add new statements
         if (fieldModel in visitedModels) {
-            // this model is already processed, so we don't want to add new statements
             return
         }
 


### PR DESCRIPTION
# Description

This changes allow to avoid such useless asserts as

```kotlin
int objectWithStaticFieldsClassDefaultValue = ObjectWithStaticFieldsClass.defaultValue;
int actualDefaultValue = ObjectWithStaticFieldsClass.defaultValue;
assertEquals(objectWithStaticFieldsClassDefaultValue, actualDefaultValue);
```

Fixes # [31](https://github.com/UnitTestBot/UTBotJava/issues/31)

## Type of Change

- [ ] Little improvement (non-breaking change which improves functionality)

# How Has This Been Tested?

## Automated Testing

This behavior can be verified on `ObjectWithStaticFieldsExample.readFromStaticArray` function
