### PR TITLE
Wrapper for basic Stream

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/impl/FieldIdStrategies.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/impl/FieldIdStrategies.kt
@@ -47,7 +47,7 @@ class FieldIdReflectionStrategy(val fieldId: FieldId) : FieldIdStrategy {
         get() = Modifier.isStatic(fieldId.field.modifiers)
 
     override val isSynthetic: Boolean
-        get() = false
+        get() = fieldId.field.isSynthetic
 
     override val type: ClassId
         get() = fieldId.field.type.id

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/Collection.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/Collection.java
@@ -1,0 +1,27 @@
+package org.utbot.engine.overrides.collections;
+
+import org.utbot.api.annotation.UtClassMock;
+import org.utbot.engine.overrides.stream.UtStream;
+
+import java.util.stream.Stream;
+
+@UtClassMock(target = java.util.Collection.class, internalUsage = true)
+public interface Collection<E> extends java.util.Collection<E> {
+    @SuppressWarnings("unchecked")
+    @Override
+    default Stream<E> parallelStream() {
+        Object[] data = toArray();
+        int size = data.length;
+
+        return new UtStream<>((E[]) data, size);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    default Stream<E> stream() {
+        Object[] data = toArray();
+        int size = data.length;
+
+        return new UtStream<>((E[]) data, size);
+    }
+}

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtArrayList.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtArrayList.java
@@ -13,7 +13,10 @@ import java.util.RandomAccess;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
+
 import org.jetbrains.annotations.NotNull;
+import org.utbot.engine.overrides.stream.UtStream;
 
 import static org.utbot.api.mock.UtMock.assume;
 import static org.utbot.engine.ResolverKt.MAX_LIST_SIZE;
@@ -359,6 +362,28 @@ public class UtArrayList<E> extends AbstractList<E>
         for (int i = 0; i < elementData.end; i++) {
             elementData.set(i, operator.apply(elementData.get(i)));
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Stream<E> stream() {
+        preconditionCheck();
+
+        int size = elementData.end;
+        Object[] data = elementData.toArray(0, size);
+
+        return new UtStream<>((E[]) data, size);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Stream<E> parallelStream() {
+        preconditionCheck();
+
+        int size = elementData.end;
+        Object[] data = elementData.toArray(0, size);
+
+        return new UtStream<>((E[]) data, size);
     }
 
     /**

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtHashSet.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtHashSet.java
@@ -8,7 +8,10 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
+
 import org.jetbrains.annotations.NotNull;
+import org.utbot.engine.overrides.stream.UtStream;
 
 import static org.utbot.api.mock.UtMock.assume;
 import static org.utbot.engine.overrides.UtOverrideMock.alreadyVisited;
@@ -261,6 +264,28 @@ public class UtHashSet<E> extends AbstractSet<E> implements UtGenericStorage<E> 
     public Iterator<E> iterator() {
         preconditionCheck();
         return new UtHashSetIterator();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Stream<E> stream() {
+        preconditionCheck();
+
+        int size = elementData.end;
+        Object[] data = elementData.toArray(0, size);
+
+        return new UtStream<>((E[]) data, size);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Stream<E> parallelStream() {
+        preconditionCheck();
+
+        int size = elementData.end;
+        Object[] data = elementData.toArray(0, size);
+
+        return new UtStream<>((E[]) data, size);
     }
 
     public class UtHashSetIterator implements Iterator<E> {

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtLinkedList.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtLinkedList.java
@@ -13,7 +13,10 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
+
 import org.jetbrains.annotations.NotNull;
+import org.utbot.engine.overrides.stream.UtStream;
 
 import static org.utbot.api.mock.UtMock.assume;
 import static org.utbot.engine.ResolverKt.MAX_LIST_SIZE;
@@ -448,6 +451,29 @@ public class UtLinkedList<E> extends AbstractSequentialList<E>
         preconditionCheck();
         return new ReverseIteratorWrapper(elementData.end);
     }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Stream<E> stream() {
+        preconditionCheck();
+
+        int size = elementData.end;
+        Object[] data = elementData.toArray(0, size);
+
+        return new UtStream<>((E[]) data, size);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Stream<E> parallelStream() {
+        preconditionCheck();
+
+        int size = elementData.end;
+        Object[] data = elementData.toArray(0, size);
+
+        return new UtStream<>((E[]) data, size);
+    }
+
     public class ReverseIteratorWrapper implements ListIterator<E> {
 
         int index;

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/stream/Arrays.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/stream/Arrays.java
@@ -1,0 +1,20 @@
+package org.utbot.engine.overrides.stream;
+
+import org.utbot.api.annotation.UtClassMock;
+
+import java.util.stream.Stream;
+
+@UtClassMock(target = java.util.Arrays.class, internalUsage = true)
+public class Arrays {
+    public static <T> Stream<T> stream(T[] array, int startInclusive, int endExclusive) {
+        int size = array.length;
+
+        if (startInclusive < 0 || endExclusive < startInclusive || endExclusive > size) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+
+        return new UtStream<>(array, startInclusive, endExclusive);
+    }
+
+    // TODO primitive arrays https://github.com/UnitTestBot/UTBotJava/issues/146
+}

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/stream/Stream.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/stream/Stream.java
@@ -1,0 +1,54 @@
+package org.utbot.engine.overrides.stream;
+
+import org.utbot.api.annotation.UtClassMock;
+
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+import java.util.stream.BaseStream;
+
+import static org.utbot.engine.overrides.UtOverrideMock.executeConcretely;
+
+@SuppressWarnings({"UnnecessaryInterfaceModifier", "unused"})
+@UtClassMock(target = java.util.stream.Stream.class, internalUsage = true)
+public interface Stream<E> extends BaseStream<E, Stream<E>> {
+    @SuppressWarnings("unchecked")
+    public static <E> java.util.stream.Stream<E> of(E element) {
+        Object[] data = new Object[1];
+        data[0] = element;
+
+        return new UtStream<>((E[]) data, 1);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <E> java.util.stream.Stream<E> of(E... elements) {
+        int size = elements.length;
+
+        return new UtStream<>(elements, size);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <E> java.util.stream.Stream<E> empty() {
+        return new UtStream<>((E[]) new Object[]{}, 0);
+    }
+
+    public static <E> java.util.stream.Stream<E> generate(Supplier<E> s) {
+        // as "generate" method produces an infinite stream, we cannot analyze it symbolically
+        executeConcretely();
+        return null;
+    }
+
+    public static <E> java.util.stream.Stream<E> iterate(final E seed, final UnaryOperator<E> f) {
+        // as "iterate" method produces an infinite stream, we cannot analyze it symbolically
+        executeConcretely();
+        return null;
+    }
+    
+    public static <E> java.util.stream.Stream<E> concat(
+            java.util.stream.Stream<? extends E> a, 
+            java.util.stream.Stream<? extends E> b
+    ) {
+        // as provided streams might be infinite, we cannot analyze this method symbolically
+        executeConcretely();
+        return null;
+    }
+}

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/stream/Stream.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/stream/Stream.java
@@ -8,11 +8,11 @@ import java.util.stream.BaseStream;
 
 import static org.utbot.engine.overrides.UtOverrideMock.executeConcretely;
 
-@SuppressWarnings({"UnnecessaryInterfaceModifier", "unused"})
+@SuppressWarnings("unused")
 @UtClassMock(target = java.util.stream.Stream.class, internalUsage = true)
 public interface Stream<E> extends BaseStream<E, Stream<E>> {
     @SuppressWarnings("unchecked")
-    public static <E> java.util.stream.Stream<E> of(E element) {
+    static <E> java.util.stream.Stream<E> of(E element) {
         Object[] data = new Object[1];
         data[0] = element;
 
@@ -20,30 +20,30 @@ public interface Stream<E> extends BaseStream<E, Stream<E>> {
     }
 
     @SuppressWarnings("unchecked")
-    public static <E> java.util.stream.Stream<E> of(E... elements) {
+    static <E> java.util.stream.Stream<E> of(E... elements) {
         int size = elements.length;
 
         return new UtStream<>(elements, size);
     }
 
     @SuppressWarnings("unchecked")
-    public static <E> java.util.stream.Stream<E> empty() {
+    static <E> java.util.stream.Stream<E> empty() {
         return new UtStream<>((E[]) new Object[]{}, 0);
     }
 
-    public static <E> java.util.stream.Stream<E> generate(Supplier<E> s) {
+    static <E> java.util.stream.Stream<E> generate(Supplier<E> s) {
         // as "generate" method produces an infinite stream, we cannot analyze it symbolically
         executeConcretely();
         return null;
     }
 
-    public static <E> java.util.stream.Stream<E> iterate(final E seed, final UnaryOperator<E> f) {
+    static <E> java.util.stream.Stream<E> iterate(final E seed, final UnaryOperator<E> f) {
         // as "iterate" method produces an infinite stream, we cannot analyze it symbolically
         executeConcretely();
         return null;
     }
     
-    public static <E> java.util.stream.Stream<E> concat(
+     static <E> java.util.stream.Stream<E> concat(
             java.util.stream.Stream<? extends E> a, 
             java.util.stream.Stream<? extends E> b
     ) {

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/stream/UtStream.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/stream/UtStream.java
@@ -4,7 +4,12 @@ import org.utbot.engine.overrides.UtArrayMock;
 import org.utbot.engine.overrides.collections.RangeModifiableUnlimitedArray;
 import org.utbot.engine.overrides.collections.UtGenericStorage;
 
-import java.util.*;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
@@ -24,6 +29,7 @@ import java.util.stream.Stream;
 import org.jetbrains.annotations.NotNull;
 
 import static org.utbot.api.mock.UtMock.assume;
+import static org.utbot.api.mock.UtMock.assumeOrExecuteConcretely;
 import static org.utbot.engine.ResolverKt.HARD_MAX_ARRAY_SIZE;
 import static org.utbot.engine.overrides.UtOverrideMock.alreadyVisited;
 import static org.utbot.engine.overrides.UtOverrideMock.executeConcretely;
@@ -313,7 +319,8 @@ public class UtStream<E> implements Stream<E>, UtGenericStorage<E> {
             throw new IllegalArgumentException();
         }
 
-        // TODO how to process long value correctly - assumeOrExecuteConcretely?
+        assumeOrExecuteConcretely(maxSize <= Integer.MAX_VALUE);
+
         int newSize = (int) maxSize;
         int curSize = elementData.end;
 
@@ -346,7 +353,7 @@ public class UtStream<E> implements Stream<E>, UtGenericStorage<E> {
             return new UtStream<>();
         }
 
-        // TODO how to process long value correctly - assumeOrExecuteConcretely?
+        // n is 1...Integer.MAX_VALUE here
         int newSize = (int) (curSize - n);
 
         return new UtStream<>((E[]) elementData.toArray((int) n, newSize), newSize);

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/stream/UtStream.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/stream/UtStream.java
@@ -1,0 +1,682 @@
+package org.utbot.engine.overrides.stream;
+
+import org.utbot.engine.overrides.UtArrayMock;
+import org.utbot.engine.overrides.collections.RangeModifiableUnlimitedArray;
+import org.utbot.engine.overrides.collections.UtGenericStorage;
+
+import java.util.*;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.function.ToDoubleFunction;
+import java.util.function.ToIntFunction;
+import java.util.function.ToLongFunction;
+import java.util.stream.Collector;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+import org.jetbrains.annotations.NotNull;
+
+import static org.utbot.api.mock.UtMock.assume;
+import static org.utbot.engine.ResolverKt.HARD_MAX_ARRAY_SIZE;
+import static org.utbot.engine.overrides.UtOverrideMock.alreadyVisited;
+import static org.utbot.engine.overrides.UtOverrideMock.executeConcretely;
+import static org.utbot.engine.overrides.UtOverrideMock.parameter;
+import static org.utbot.engine.overrides.UtOverrideMock.visit;
+
+public class UtStream<E> implements Stream<E>, UtGenericStorage<E> {
+    private final RangeModifiableUnlimitedArray<E> elementData;
+
+    private final RangeModifiableUnlimitedArray<Runnable> closeHandlers = new RangeModifiableUnlimitedArray<>();
+
+    private boolean isParallel = false;
+
+    /**
+     * {@code false} by default, assigned to {@code true} after performing any operation on this stream. Any operation,
+     * performed on a closed UtStream, throws the {@link IllegalStateException}.
+     */
+    private boolean isClosed = false;
+
+    public UtStream() {
+        visit(this);
+        elementData = new RangeModifiableUnlimitedArray<>();
+    }
+
+    public UtStream(E[] data, int length) {
+        visit(this);
+        elementData = new RangeModifiableUnlimitedArray<>();
+        elementData.setRange(0, data, 0, length);
+        elementData.end = length;
+    }
+
+    public UtStream(E[] data, int startInclusive, int endExclusive) {
+        visit(this);
+
+        int size = endExclusive - startInclusive;
+
+        elementData = new RangeModifiableUnlimitedArray<>();
+        elementData.setRange(0, data, startInclusive, size);
+        elementData.end = size;
+    }
+
+    /**
+     * Precondition check is called only once by object,
+     * if it was passed as parameter to method under test.
+     * <p>
+     * Preconditions that are must be satisfied:
+     * <li> elementData.size in 0..HARD_MAX_ARRAY_SIZE. </li>
+     * <li> elementData is marked as parameter </li>
+     * <li> elementData.storage and it's elements are marked as parameters </li>
+     */
+    @SuppressWarnings("DuplicatedCode")
+    void preconditionCheck() {
+        if (alreadyVisited(this)) {
+            return;
+        }
+        setEqualGenericType(elementData);
+
+        assume(elementData != null);
+        assume(elementData.storage != null);
+
+        parameter(elementData);
+        parameter(elementData.storage);
+
+        assume(elementData.begin == 0);
+
+        assume(elementData.end >= 0);
+        // we can create a stream for an array using Stream.of
+        assume(elementData.end <= HARD_MAX_ARRAY_SIZE);
+
+        visit(this);
+    }
+
+    private void preconditionCheckWithClosingStream() {
+        preconditionCheck();
+
+        if (isClosed) {
+            throw new IllegalStateException();
+        }
+
+        // Even if exception occurs in the body of a stream operation, this stream could not be used later.
+        isClosed = true;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Stream<E> filter(Predicate<? super E> predicate) {
+        preconditionCheckWithClosingStream();
+
+        int size = elementData.end;
+        Object[] filtered = new Object[size];
+        int j = 0;
+        for (int i = 0; i < size; i++) {
+            E element = elementData.get(i);
+            if (predicate.test(element)) {
+                filtered[j++] = element;
+            }
+        }
+
+        return new UtStream<>((E[]) filtered, j);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <R> Stream<R> map(Function<? super E, ? extends R> mapper) {
+        preconditionCheckWithClosingStream();
+
+        int size = elementData.end;
+        Object[] mapped = new Object[size];
+        for (int i = 0; i < size; i++) {
+            mapped[i] = mapper.apply(elementData.get(i));
+        }
+
+        return new UtStream<>((R[]) mapped, size);
+    }
+
+    @Override
+    public IntStream mapToInt(ToIntFunction<? super E> mapper) {
+        preconditionCheckWithClosingStream();
+        // TODO https://github.com/UnitTestBot/UTBotJava/issues/146
+        executeConcretely();
+        return null;
+    }
+
+    @Override
+    public LongStream mapToLong(ToLongFunction<? super E> mapper) {
+        preconditionCheckWithClosingStream();
+        // TODO https://github.com/UnitTestBot/UTBotJava/issues/146
+        executeConcretely();
+        return null;
+    }
+
+    @Override
+    public DoubleStream mapToDouble(ToDoubleFunction<? super E> mapper) {
+        preconditionCheckWithClosingStream();
+        // TODO https://github.com/UnitTestBot/UTBotJava/issues/146
+        executeConcretely();
+        return null;
+    }
+
+    @Override
+    public <R> Stream<R> flatMap(Function<? super E, ? extends Stream<? extends R>> mapper) {
+        preconditionCheckWithClosingStream();
+        // as mapper can produce infinite streams, we cannot process it symbolically
+        executeConcretely();
+        return null;
+    }
+
+    @Override
+    public IntStream flatMapToInt(Function<? super E, ? extends IntStream> mapper) {
+        preconditionCheckWithClosingStream();
+        // TODO https://github.com/UnitTestBot/UTBotJava/issues/146
+        executeConcretely();
+        return null;
+    }
+
+    @Override
+    public LongStream flatMapToLong(Function<? super E, ? extends LongStream> mapper) {
+        preconditionCheckWithClosingStream();
+        // TODO https://github.com/UnitTestBot/UTBotJava/issues/146
+        executeConcretely();
+        return null;
+    }
+
+    @Override
+    public DoubleStream flatMapToDouble(Function<? super E, ? extends DoubleStream> mapper) {
+        preconditionCheckWithClosingStream();
+        // TODO https://github.com/UnitTestBot/UTBotJava/issues/146
+        executeConcretely();
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Stream<E> distinct() {
+        preconditionCheckWithClosingStream();
+
+        int size = elementData.end;
+        Object[] distinctElements = new Object[size];
+        int distinctSize = 0;
+        for (int i = 0; i < size; i++) {
+            E element = elementData.get(i);
+            boolean isDuplicate = false;
+
+            if (element == null) {
+                for (int j = 0; j < distinctSize; j++) {
+                    Object alreadyProcessedElement = distinctElements[j];
+                    if (alreadyProcessedElement == null) {
+                        isDuplicate = true;
+                        break;
+                    }
+                }
+            } else {
+                for (int j = 0; j < distinctSize; j++) {
+                    Object alreadyProcessedElement = distinctElements[j];
+                    if (element.equals(alreadyProcessedElement)) {
+                        isDuplicate = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!isDuplicate) {
+                distinctElements[distinctSize++] = element;
+            }
+        }
+
+        return new UtStream<>((E[]) distinctElements, distinctSize);
+    }
+
+    // TODO choose the best sorting https://github.com/UnitTestBot/UTBotJava/issues/188
+    @SuppressWarnings("unchecked")
+    @Override
+    public Stream<E> sorted() {
+        preconditionCheckWithClosingStream();
+
+        int size = elementData.end;
+
+        if (size == 0) {
+            return new UtStream<>();
+        }
+
+        Object[] sortedElements = UtArrayMock.copyOf(elementData.toArray(0, size), size);
+
+        // bubble sort
+        for (int i = 0; i < size - 1; i++) {
+            for (int j = 0; j < size - i - 1; j++) {
+                if (((Comparable<E>) sortedElements[j]).compareTo((E) sortedElements[j + 1]) > 0) {
+                    Object tmp = sortedElements[j];
+                    sortedElements[j] = sortedElements[j + 1];
+                    sortedElements[j + 1] = tmp;
+                }
+            }
+        }
+
+        return new UtStream<>((E[]) sortedElements, size);
+    }
+
+    // TODO choose the best sorting https://github.com/UnitTestBot/UTBotJava/issues/188
+    @SuppressWarnings("unchecked")
+    @Override
+    public Stream<E> sorted(Comparator<? super E> comparator) {
+        preconditionCheckWithClosingStream();
+
+        int size = elementData.end;
+
+        if (size == 0) {
+            return new UtStream<>();
+        }
+
+        Object[] sortedElements = UtArrayMock.copyOf(elementData.toArray(0, size), size);
+
+        // bubble sort
+        for (int i = 0; i < size - 1; i++) {
+            for (int j = 0; j < size - i - 1; j++) {
+                if (comparator.compare((E) sortedElements[j], (E) sortedElements[j + 1]) > 0) {
+                    Object tmp = sortedElements[j];
+                    sortedElements[j] = sortedElements[j + 1];
+                    sortedElements[j + 1] = tmp;
+                }
+            }
+        }
+
+        return new UtStream<>((E[]) sortedElements, size);
+    }
+
+    @Override
+    public Stream<E> peek(Consumer<? super E> action) {
+        preconditionCheckWithClosingStream();
+
+        int size = elementData.end;
+        for (int i = 0; i < size; i++) {
+            action.accept(elementData.get(i));
+        }
+
+        // returned stream should be opened, so we "reopen" this stream to return it
+        isClosed = false;
+
+        return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Stream<E> limit(long maxSize) {
+        preconditionCheckWithClosingStream();
+
+        if (maxSize < 0) {
+            throw new IllegalArgumentException();
+        }
+
+        // TODO how to process long value correctly - assumeOrExecuteConcretely?
+        int newSize = (int) maxSize;
+        int curSize = elementData.end;
+
+        if (newSize == curSize) {
+            return this;
+        }
+
+        if (newSize > curSize) {
+            newSize = curSize;
+        }
+
+        return new UtStream<>((E[]) elementData.toArray(0, newSize), newSize);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Stream<E> skip(long n) {
+        preconditionCheckWithClosingStream();
+
+        if (n < 0) {
+            throw new IllegalArgumentException();
+        }
+
+        if (n == 0) {
+            return this;
+        }
+
+        int curSize = elementData.end;
+        if (n > curSize) {
+            return new UtStream<>();
+        }
+
+        // TODO how to process long value correctly - assumeOrExecuteConcretely?
+        int newSize = (int) (curSize - n);
+
+        return new UtStream<>((E[]) elementData.toArray((int) n, newSize), newSize);
+    }
+
+    @Override
+    public void forEach(Consumer<? super E> action) {
+        peek(action);
+    }
+
+    @Override
+    public void forEachOrdered(Consumer<? super E> action) {
+        peek(action);
+    }
+
+    @NotNull
+    @Override
+    public Object[] toArray() {
+        preconditionCheckWithClosingStream();
+
+        return elementData.toArray(0, elementData.end);
+    }
+
+    @NotNull
+    @Override
+    public <A> A[] toArray(IntFunction<A[]> generator) {
+        preconditionCheckWithClosingStream();
+
+        // TODO untracked ArrayStoreException - JIRA:1089
+        int size = elementData.end;
+        A[] array = generator.apply(size);
+
+        UtArrayMock.arraycopy(elementData.toArray(0, size), 0, array, 0, size);
+
+        return array;
+    }
+
+    @Override
+    public E reduce(E identity, BinaryOperator<E> accumulator) {
+        preconditionCheckWithClosingStream();
+
+        int size = elementData.end;
+        E result = identity;
+        for (int i = 0; i < size; i++) {
+            result = accumulator.apply(result, elementData.get(i));
+        }
+
+        return result;
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    @NotNull
+    @Override
+    public Optional<E> reduce(BinaryOperator<E> accumulator) {
+        preconditionCheckWithClosingStream();
+
+        int size = elementData.end;
+        if (size == 0) {
+            return Optional.empty();
+        }
+
+        E result = null;
+        for (int i = 0; i < size; i++) {
+            E element = elementData.get(i);
+            if (result == null) {
+                result = element;
+            } else {
+                result = accumulator.apply(result, element);
+            }
+        }
+
+        return Optional.of(result);
+    }
+
+    @Override
+    public <U> U reduce(U identity, BiFunction<U, ? super E, U> accumulator, BinaryOperator<U> combiner) {
+        preconditionCheckWithClosingStream();
+
+        // since this implementation is always sequential, we do not need to use the combiner
+        int size = elementData.end;
+        U result = identity;
+        for (int i = 0; i < size; i++) {
+            result = accumulator.apply(result, elementData.get(i));
+        }
+
+        return result;
+    }
+
+    @Override
+    public <R> R collect(Supplier<R> supplier, BiConsumer<R, ? super E> accumulator, BiConsumer<R, R> combiner) {
+        preconditionCheckWithClosingStream();
+
+        // since this implementation is always sequential, we do not need to use the combiner
+        int size = elementData.end;
+        R result = supplier.get();
+        for (int i = 0; i < size; i++) {
+            accumulator.accept(result, elementData.get(i));
+        }
+
+        return result;
+    }
+
+    @Override
+    public <R, A> R collect(Collector<? super E, A, R> collector) {
+        preconditionCheckWithClosingStream();
+
+        // since this implementation is always sequential, we do not need to use the combiner
+        int size = elementData.end;
+        A result = collector.supplier().get();
+        for (int i = 0; i < size; i++) {
+            collector.accumulator().accept(result, elementData.get(i));
+        }
+
+        return collector.finisher().apply(result);
+    }
+
+    @NotNull
+    @Override
+    public Optional<E> min(Comparator<? super E> comparator) {
+        preconditionCheckWithClosingStream();
+
+        int size = elementData.end;
+        if (size == 0) {
+            return Optional.empty();
+        }
+
+        E min = elementData.get(0);
+        for (int i = 1; i < size; i++) {
+            E element = elementData.get(i);
+            if (comparator.compare(min, element) > 0) {
+                min = element;
+            }
+        }
+
+        return Optional.of(min);
+    }
+
+    @NotNull
+    @Override
+    public Optional<E> max(Comparator<? super E> comparator) {
+        preconditionCheckWithClosingStream();
+
+        int size = elementData.end;
+        if (size == 0) {
+            return Optional.empty();
+        }
+
+        E max = elementData.get(0);
+        for (int i = 1; i < size; i++) {
+            E element = elementData.get(i);
+            if (comparator.compare(max, element) < 0) {
+                max = element;
+            }
+        }
+
+        return Optional.of(max);
+    }
+
+    @Override
+    public long count() {
+        preconditionCheckWithClosingStream();
+
+        return elementData.end;
+    }
+
+    @Override
+    public boolean anyMatch(Predicate<? super E> predicate) {
+        preconditionCheckWithClosingStream();
+
+        int size = elementData.end;
+        for (int i = 0; i < size; i++) {
+            if (predicate.test(elementData.get(i))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean allMatch(Predicate<? super E> predicate) {
+        preconditionCheckWithClosingStream();
+
+        int size = elementData.end;
+        for (int i = 0; i < size; i++) {
+            if (!predicate.test(elementData.get(i))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean noneMatch(Predicate<? super E> predicate) {
+        preconditionCheckWithClosingStream();
+
+        return !anyMatch(predicate);
+    }
+
+    @NotNull
+    @Override
+    public Optional<E> findFirst() {
+        preconditionCheckWithClosingStream();
+
+        if (elementData.end == 0) {
+            return Optional.empty();
+        }
+
+        E first = elementData.get(0);
+
+        return Optional.of(first);
+    }
+
+    @NotNull
+    @Override
+    public Optional<E> findAny() {
+        preconditionCheckWithClosingStream();
+
+        // since this implementation is always sequential, we can just return the first element
+        return findFirst();
+    }
+
+    @NotNull
+    @Override
+    public Iterator<E> iterator() {
+        preconditionCheckWithClosingStream();
+
+        return new UtStreamIterator(0);
+    }
+
+    @NotNull
+    @Override
+    public Spliterator<E> spliterator() {
+        preconditionCheckWithClosingStream();
+        // implementation from AbstractList
+        return Spliterators.spliterator(elementData.toArray(0, elementData.end), Spliterator.ORDERED);
+    }
+
+    @Override
+    public boolean isParallel() {
+        // this method does not "close" this stream
+        preconditionCheck();
+
+        return isParallel;
+    }
+
+    @NotNull
+    @Override
+    public Stream<E> sequential() {
+        // this method does not "close" this stream
+        preconditionCheck();
+
+        isParallel = false;
+
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public Stream<E> parallel() {
+        // this method does not "close" this stream
+        preconditionCheck();
+
+        isParallel = true;
+
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public Stream<E> unordered() {
+        // this method does not "close" this stream
+        preconditionCheck();
+
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public Stream<E> onClose(Runnable closeHandler) {
+        // this method does not "close" this stream
+        preconditionCheck();
+
+        // adds closeHandler to existing
+        closeHandlers.set(closeHandlers.end++, closeHandler);
+
+        return this;
+    }
+
+    @Override
+    public void close() {
+        // Stream can be closed via this method many times
+        preconditionCheck();
+
+        // TODO resources closing https://github.com/UnitTestBot/UTBotJava/issues/189
+
+        // NOTE: this implementation does not care about suppressing and throwing exceptions produced by handlers
+        for (int i = 0; i < closeHandlers.end; i++) {
+            closeHandlers.get(i).run();
+        }
+    }
+
+    public class UtStreamIterator implements Iterator<E> {
+        int index;
+
+        UtStreamIterator(int index) {
+            if (index < 0 || index > elementData.end) {
+                throw new IndexOutOfBoundsException();
+            }
+
+            this.index = index;
+        }
+
+        @Override
+        public boolean hasNext() {
+            preconditionCheck();
+
+            return index != elementData.end;
+        }
+
+        @Override
+        public E next() {
+            preconditionCheck();
+
+            if (index == elementData.end) {
+                throw new NoSuchElementException();
+            }
+
+            return elementData.get(index++);
+        }
+    }
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ArrayObjectWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ArrayObjectWrappers.kt
@@ -33,10 +33,6 @@ import soot.Scene
 import soot.SootClass
 import soot.SootField
 import soot.SootMethod
-import sun.reflect.generics.reflectiveObjects.GenericArrayTypeImpl
-import sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl
-import sun.reflect.generics.reflectiveObjects.TypeVariableImpl
-import sun.reflect.generics.reflectiveObjects.WildcardTypeImpl
 
 val rangeModifiableArrayId: ClassId = RangeModifiableUnlimitedArray::class.id
 
@@ -250,8 +246,7 @@ class RangeModifiableUnlimitedArrayWrapper : WrapperInterface {
 
         // try to retrieve type storage for the single type parameter
         val typeStorage =
-            resolver.typeRegistry.getObjectParameterTypeStorages(wrapper.addr)?.singleOrNull() ?: TypeStorage(OBJECT_TYPE)
-
+            resolver.typeRegistry.getTypeStoragesForObjectTypeParameters(wrapper.addr)?.singleOrNull() ?: TypeRegistry.objectTypeStorage
 
         (0 until sizeValue).associateWithTo(resultModel.stores) { i ->
             val addr = UtAddrExpression(arrayExpression.select(mkInt(i + firstValue)))

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ArrayObjectWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ArrayObjectWrappers.kt
@@ -248,7 +248,9 @@ class RangeModifiableUnlimitedArrayWrapper : WrapperInterface {
         // the constructed model to avoid infinite recursion below
         resolver.addConstructedModel(concreteAddr, resultModel)
 
-        val typeStorage = resolver.typeRegistry.genericTypeStorageByAddr[wrapper.addr]?.singleOrNull() ?: TypeStorage(OBJECT_TYPE)
+        // try to retrieve type storage for the single type parameter
+        val typeStorage =
+            resolver.typeRegistry.getObjectParameterTypeStorages(wrapper.addr)?.singleOrNull() ?: TypeStorage(OBJECT_TYPE)
 
 
         (0 until sizeValue).associateWithTo(resultModel.stores) { i ->

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ArrayObjectWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ArrayObjectWrappers.kt
@@ -26,18 +26,21 @@ import org.utbot.framework.plugin.api.UtNullModel
 import org.utbot.framework.plugin.api.UtPrimitiveModel
 import org.utbot.framework.plugin.api.UtReferenceModel
 import org.utbot.framework.plugin.api.util.id
+import org.utbot.framework.plugin.api.util.objectArrayClassId
 import org.utbot.framework.plugin.api.util.objectClassId
+import soot.ArrayType
 import soot.Scene
+import soot.SootClass
+import soot.SootField
 import soot.SootMethod
+import sun.reflect.generics.reflectiveObjects.GenericArrayTypeImpl
+import sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl
+import sun.reflect.generics.reflectiveObjects.TypeVariableImpl
+import sun.reflect.generics.reflectiveObjects.WildcardTypeImpl
 
 val rangeModifiableArrayId: ClassId = RangeModifiableUnlimitedArray::class.id
 
 class RangeModifiableUnlimitedArrayWrapper : WrapperInterface {
-    private val rangeModifiableArrayClass = Scene.v().getSootClass(rangeModifiableArrayId.name)
-    private val beginField = rangeModifiableArrayClass.getField("int begin")
-    private val endField = rangeModifiableArrayClass.getField("int end")
-    private val storageField = rangeModifiableArrayClass.getField("java.lang.Object[] storage")
-
     override fun UtBotSymbolicEngine.invoke(
         wrapper: ObjectValue,
         method: SootMethod,
@@ -168,13 +171,15 @@ class RangeModifiableUnlimitedArrayWrapper : WrapperInterface {
                 val typeStorage = typeResolver.constructTypeStorage(OBJECT_TYPE.arrayType, useConcreteType = false)
                 val array = ArrayValue(typeStorage, arrayAddr)
 
+                val hardConstraints = setOf(
+                    Eq(memory.findArrayLength(arrayAddr), length),
+                    typeRegistry.typeConstraint(arrayAddr, array.typeStorage).all(),
+                ).asHardConstraint()
+
                 listOf(
                     MethodResult(
                         SymbolicSuccess(array),
-                        hardConstraints = setOf(
-                            Eq(memory.findArrayLength(arrayAddr), length),
-                            typeRegistry.typeConstraint(array.addr, array.typeStorage).all()
-                        ).asHardConstraint(),
+                        hardConstraints = hardConstraints,
                         memoryUpdates = arrayUpdateWithValue(arrayAddr, OBJECT_TYPE.arrayType, value)
                     )
                 )
@@ -233,7 +238,7 @@ class RangeModifiableUnlimitedArrayWrapper : WrapperInterface {
 
         val resultModel = UtArrayModel(
             concreteAddr,
-            objectClassId,
+            objectArrayClassId,
             sizeValue,
             UtNullModel(objectClassId),
             mutableMapOf()
@@ -243,16 +248,33 @@ class RangeModifiableUnlimitedArrayWrapper : WrapperInterface {
         // the constructed model to avoid infinite recursion below
         resolver.addConstructedModel(concreteAddr, resultModel)
 
+        val typeStorage = resolver.typeRegistry.genericTypeStorageByAddr[wrapper.addr]?.singleOrNull() ?: TypeStorage(OBJECT_TYPE)
+
+
         (0 until sizeValue).associateWithTo(resultModel.stores) { i ->
-            resolver.resolveModel(
-                ObjectValue(
-                    TypeStorage(OBJECT_TYPE),
-                    UtAddrExpression(arrayExpression.select(mkInt(i + firstValue)))
-                )
-            )
+            val addr = UtAddrExpression(arrayExpression.select(mkInt(i + firstValue)))
+
+            val value = if (typeStorage.leastCommonType is ArrayType) {
+                ArrayValue(typeStorage, addr)
+            } else {
+                ObjectValue(typeStorage, addr)
+            }
+
+            resolver.resolveModel(value)
         }
 
         return resultModel
+    }
+
+    companion object {
+        internal val rangeModifiableArrayClass: SootClass
+            get() = Scene.v().getSootClass(rangeModifiableArrayId.name)
+        internal val beginField: SootField
+            get() = rangeModifiableArrayClass.getFieldByName("begin")
+        internal val endField: SootField
+            get() = rangeModifiableArrayClass.getFieldByName("end")
+        internal val storageField: SootField
+            get() = rangeModifiableArrayClass.getFieldByName("storage")
     }
 }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Memory.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Memory.kt
@@ -431,7 +431,6 @@ class TypeRegistry {
 
     private val genericAddrToNumDimensionsArrays = mutableMapOf<Int, UtArrayExpressionBase>()
 
-    @Suppress("unused")
     private fun genericAddrToNumDimensions(i: Int) = genericAddrToNumDimensionsArrays.getOrPut(i) {
         mkArrayConst(
             "genericAddrToNumDimensions_$i",
@@ -561,6 +560,8 @@ class TypeRegistry {
      * Returns symbolic representation for a number of dimensions corresponding to the given address
      */
     fun symNumDimensions(addr: UtAddrExpression) = addrToNumDimensions.select(addr)
+
+    fun genericNumDimensions(addr: UtAddrExpression, i: Int) = genericAddrToNumDimensions(i).select(addr)
 
     /**
      * Returns a constraint stating that number of dimensions for the given address is zero

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Memory.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Memory.kt
@@ -722,7 +722,7 @@ class TypeRegistry {
         secondAddr: UtAddrExpression,
         parameterSize: Int
     ) : UtEqGenericTypeParametersExpression {
-        val injections = (0 until parameterSize).associateWith { it }.toList().toTypedArray()
+        val injections = Array(parameterSize) { it to it }
 
         return eqGenericTypeParametersConstraint(firstAddr, secondAddr, *injections)
     }
@@ -745,7 +745,7 @@ class TypeRegistry {
     /**
      * Retrieves parameter type storages of an object with the given [addr] if present, or null otherwise.
      */
-    fun getObjectParameterTypeStorages(addr: UtAddrExpression): List<TypeStorage>? = genericTypeStorageByAddr[addr]
+    fun getTypeStoragesForObjectTypeParameters(addr: UtAddrExpression): List<TypeStorage>? = genericTypeStorageByAddr[addr]
 
     /**
      * Set types storages for [firstAddr]'s type parameters equal to type storages for [secondAddr]'s type parameters
@@ -756,22 +756,22 @@ class TypeRegistry {
         secondAddr: UtAddrExpression,
         indexInjection: Array<out Pair<Int, Int>>
     ) {
-        genericTypeStorageByAddr[secondAddr]?.let { existingGenericTypes ->
-            val currentGenericTypes = mutableMapOf<Int, TypeStorage>()
+        val existingGenericTypes = genericTypeStorageByAddr[secondAddr] ?: return
 
-            indexInjection.forEach { (from, to) ->
-                require(from >= 0 && from < existingGenericTypes.size) {
-                    "Type injection is out of bounds: should be in [0; ${existingGenericTypes.size}) but is $from"
-                }
+        val currentGenericTypes = mutableMapOf<Int, TypeStorage>()
 
-                currentGenericTypes[to] = existingGenericTypes[from]
+        indexInjection.forEach { (from, to) ->
+            require(from >= 0 && from < existingGenericTypes.size) {
+                "Type injection is out of bounds: should be in [0; ${existingGenericTypes.size}) but is $from"
             }
 
-            genericTypeStorageByAddr[firstAddr] = currentGenericTypes
-                .entries
-                .sortedBy { it.key }
-                .mapTo(mutableListOf()) { it.value }
+            currentGenericTypes[to] = existingGenericTypes[from]
         }
+
+        genericTypeStorageByAddr[firstAddr] = currentGenericTypes
+            .entries
+            .sortedBy { it.key }
+            .mapTo(mutableListOf()) { it.value }
     }
 
     /**

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Mocks.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Mocks.kt
@@ -176,8 +176,14 @@ class Mocker(
         if (!isEngineClass(type) && type.sootClass.isPrivate) return false // could not mock private classes (even if it is in mock always list)
         if (mockAlways(type)) return true // always mock randoms and loggers
         if (mockInfo is UtFieldMockInfo) {
+            val declaringClass = mockInfo.fieldId.declaringClass
+
+            if (Scene.v().getSootClass(declaringClass.name).isArtificialEntity) {
+                return false // see BaseStreamExample::minExample for an example; cannot load java class for such class
+            }
+
             return when {
-                mockInfo.fieldId.declaringClass.packageName.startsWith("java.lang") -> false
+                declaringClass.packageName.startsWith("java.lang") -> false
                 !mockInfo.fieldId.type.isRefType -> false  // mocks are allowed for ref fields only
                 else -> return strategy.eligibleToMock(mockInfo.fieldId.type, classUnderTest) // if we have a field with Integer type, we should not mock it
             }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ObjectWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ObjectWrappers.kt
@@ -8,6 +8,7 @@ import org.utbot.engine.UtOptionalClass.UT_OPTIONAL
 import org.utbot.engine.UtOptionalClass.UT_OPTIONAL_DOUBLE
 import org.utbot.engine.UtOptionalClass.UT_OPTIONAL_INT
 import org.utbot.engine.UtOptionalClass.UT_OPTIONAL_LONG
+import org.utbot.engine.UtStreamClass.UT_STREAM
 import org.utbot.engine.overrides.collections.AssociativeArray
 import org.utbot.engine.overrides.collections.RangeModifiableUnlimitedArray
 import org.utbot.engine.overrides.collections.UtHashMap
@@ -27,16 +28,16 @@ import org.utbot.framework.plugin.api.util.constructorId
 import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.stringClassId
 import org.utbot.framework.util.nextModelName
+import soot.RefType
+import soot.Scene
+import soot.SootClass
+import soot.SootMethod
 import java.util.Optional
 import java.util.OptionalDouble
 import java.util.OptionalInt
 import java.util.OptionalLong
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.reflect.KClass
-import soot.RefType
-import soot.Scene
-import soot.SootClass
-import soot.SootMethod
 
 typealias TypeToBeWrapped = RefType
 typealias WrapperType = RefType
@@ -81,6 +82,10 @@ val classToWrapper: MutableMap<TypeToBeWrapped, WrapperType> =
         putSootClass(java.util.AbstractMap::class, UtHashMap::class)
         putSootClass(java.util.LinkedHashMap::class, UtHashMap::class)
         putSootClass(java.util.HashMap::class, UtHashMap::class)
+
+        putSootClass(java.util.stream.BaseStream::class, UT_STREAM.className)
+        putSootClass(java.util.stream.Stream::class, UT_STREAM.className)
+        // TODO primitive streams https://github.com/UnitTestBot/UTBotJava/issues/146
     }
 
 /**
@@ -176,7 +181,12 @@ private val wrappers = mapOf(
     wrap(java.util.Map::class) { _, addr -> objectValue(LINKED_HASH_MAP_TYPE, addr, MapWrapper()) },
     wrap(java.util.AbstractMap::class) { _, addr -> objectValue(LINKED_HASH_MAP_TYPE, addr, MapWrapper()) },
     wrap(java.util.LinkedHashMap::class) { _, addr -> objectValue(LINKED_HASH_MAP_TYPE, addr, MapWrapper()) },
-    wrap(java.util.HashMap::class) { _, addr -> objectValue(HASH_MAP_TYPE, addr, MapWrapper()) }
+    wrap(java.util.HashMap::class) { _, addr -> objectValue(HASH_MAP_TYPE, addr, MapWrapper()) },
+
+    // stream wrappers
+    wrap(java.util.stream.BaseStream::class) { _, addr -> objectValue(STREAM_TYPE, addr, CommonStreamWrapper()) },
+    wrap(java.util.stream.Stream::class) { _, addr -> objectValue(STREAM_TYPE, addr, CommonStreamWrapper()) },
+    // TODO primitive streams https://github.com/UnitTestBot/UTBotJava/issues/146
 ).also {
     // check every `wrapped` class has a corresponding value in [classToWrapper]
     it.keys.all { key ->
@@ -187,7 +197,7 @@ private val wrappers = mapOf(
 private fun wrap(kClass: KClass<*>, implementation: (RefType, UtAddrExpression) -> ObjectValue) =
     kClass.id to implementation
 
-internal fun wrapper(type: RefType, addr: UtAddrExpression) =
+internal fun wrapper(type: RefType, addr: UtAddrExpression): ObjectValue? =
     wrappers[type.id]?.invoke(type, addr)
 
 interface WrapperInterface {

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/OptionalWrapper.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/OptionalWrapper.kt
@@ -29,7 +29,7 @@ import soot.Scene
 import soot.SootMethod
 
 /**
- * Auxiliary enum class for specifying an implementation for [ListWrapper], that it will use.
+ * Auxiliary enum class for specifying an implementation for [OptionalWrapper], that it will use.
  */
 enum class UtOptionalClass {
     UT_OPTIONAL,
@@ -58,7 +58,8 @@ class OptionalWrapper(private val utOptionalClass: UtOptionalClass) : BaseOverri
     private val AS_OPTIONAL_METHOD_SIGNATURE =
         overriddenClass.getMethodByName(UtOptional<*>::asOptional.name).signature
 
-    override fun UtBotSymbolicEngine.overrideInvoke(
+    override fun overrideInvoke(
+        engine: UtBotSymbolicEngine,
         wrapper: ObjectValue,
         method: SootMethod,
         parameters: List<SymbolicValue>
@@ -71,7 +72,7 @@ class OptionalWrapper(private val utOptionalClass: UtOptionalClass) : BaseOverri
                 return listOf(
                     MethodResult(
                         parameters.first(),
-                        typeRegistry.typeConstraintToGenericTypeParameter(
+                        engine.typeRegistry.typeConstraintToGenericTypeParameter(
                             parameters.first().addr,
                             wrapper.addr,
                             i = 0

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/OptionalWrapper.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/OptionalWrapper.kt
@@ -58,8 +58,7 @@ class OptionalWrapper(private val utOptionalClass: UtOptionalClass) : BaseOverri
     private val AS_OPTIONAL_METHOD_SIGNATURE =
         overriddenClass.getMethodByName(UtOptional<*>::asOptional.name).signature
 
-    override fun overrideInvoke(
-        engine: UtBotSymbolicEngine,
+    override fun UtBotSymbolicEngine.overrideInvoke(
         wrapper: ObjectValue,
         method: SootMethod,
         parameters: List<SymbolicValue>
@@ -72,7 +71,7 @@ class OptionalWrapper(private val utOptionalClass: UtOptionalClass) : BaseOverri
                 return listOf(
                     MethodResult(
                         parameters.first(),
-                        engine.typeRegistry.typeConstraintToGenericTypeParameter(
+                        typeRegistry.typeConstraintToGenericTypeParameter(
                             parameters.first().addr,
                             wrapper.addr,
                             i = 0
@@ -82,6 +81,7 @@ class OptionalWrapper(private val utOptionalClass: UtOptionalClass) : BaseOverri
             }
 
         }
+
         return null
     }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/StreamWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/StreamWrappers.kt
@@ -1,0 +1,127 @@
+package org.utbot.engine
+
+import org.utbot.engine.overrides.stream.UtStream
+import org.utbot.framework.plugin.api.ClassId
+import org.utbot.framework.plugin.api.FieldId
+import org.utbot.framework.plugin.api.MethodId
+import org.utbot.framework.plugin.api.UtArrayModel
+import org.utbot.framework.plugin.api.UtAssembleModel
+import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtStatementModel
+import org.utbot.framework.plugin.api.classId
+import org.utbot.framework.plugin.api.util.id
+import org.utbot.framework.plugin.api.util.methodId
+import org.utbot.framework.plugin.api.util.objectArrayClassId
+import org.utbot.framework.plugin.api.util.objectClassId
+import org.utbot.framework.util.nextModelName
+import soot.BooleanType
+import soot.RefType
+import soot.Scene
+import soot.SootField
+import soot.Type
+
+/**
+ * Auxiliary enum class for specifying an implementation for [CommonStreamWrapper], that it will use.
+ */
+// TODO introduce a base interface for all such enums after https://github.com/UnitTestBot/UTBotJava/issues/146?
+enum class UtStreamClass {
+    UT_STREAM;
+    // TODO primitive streams https://github.com/UnitTestBot/UTBotJava/issues/146
+//    UT_STREAM_INT,
+//    UT_STREAM_LONG,
+//    UT_STREAM_DOUBLE;
+
+    val className: String
+        get() = when (this) {
+            UT_STREAM -> UtStream::class.java.canonicalName
+            // TODO primitive streams https://github.com/UnitTestBot/UTBotJava/issues/146
+//            UT_STREAM_INT -> UtStreamInt::class.java.canonicalName
+//            UT_STREAM_LONG -> UtStreamLong::class.java.canonicalName
+//            UT_STREAM_DOUBLE -> UtStreamDouble::class.java.canonicalName
+        }
+
+    val elementClassId: ClassId
+        get() = when (this) {
+            UT_STREAM -> objectClassId
+            // TODO primitive streams https://github.com/UnitTestBot/UTBotJava/issues/146
+//            UT_STREAM_INT -> intClassId
+//            UT_STREAM_LONG -> longClassId
+//            UT_STREAM_DOUBLE -> doubleClassId
+        }
+
+    val overriddenStreamClassId: ClassId
+        get() = when (this) {
+            UT_STREAM -> java.util.stream.Stream::class.java.id
+            // TODO primitive streams https://github.com/UnitTestBot/UTBotJava/issues/146
+        }
+}
+
+abstract class StreamWrapper(
+    private val utStreamClass: UtStreamClass
+) : BaseGenericStorageBasedContainerWrapper(utStreamClass.className) {
+    override fun value(resolver: Resolver, wrapper: ObjectValue): UtAssembleModel = resolver.run {
+        val addr = holder.concreteAddr(wrapper.addr)
+        val modelName = nextModelName(baseModelName)
+        val parametersArrayModel = resolveElementAsArrayModel(wrapper)
+
+        val instantiationChain = mutableListOf<UtStatementModel>()
+        val modificationsChain = emptyList<UtStatementModel>()
+
+        UtAssembleModel(addr, utStreamClass.overriddenStreamClassId, modelName, instantiationChain, modificationsChain)
+            .apply {
+                val (builder, params) = if (parametersArrayModel.length == 0) {
+                    streamEmptyMethodId to emptyList()
+                } else {
+                    streamOfMethodId to listOf(parametersArrayModel)
+                }
+
+                instantiationChain += UtExecutableCallModel(
+                    instance = null,
+                    executable = builder,
+                    params = params,
+                    returnValue = this
+                )
+            }
+    }
+
+    override fun chooseClassIdWithConstructor(classId: ClassId): ClassId = error("No constructor for Stream")
+
+    override val modificationMethodId: MethodId
+        get() = error("No modification method for Stream")
+
+    private fun Resolver.resolveElementAsArrayModel(wrapper: ObjectValue): UtArrayModel {
+        val elementDataFieldId = FieldId(overriddenClass.type.classId, "elementData")
+
+        return collectFieldModels(wrapper.addr, overriddenClass.type)[elementDataFieldId] as UtArrayModel
+    }
+
+    private val streamOfMethodId: MethodId = methodId(
+        classId = utStreamClass.overriddenStreamClassId,
+        name = "of",
+        returnType = utStreamClass.overriddenStreamClassId,
+        arguments = arrayOf(objectArrayClassId) // vararg
+    )
+
+    private val streamEmptyMethodId: MethodId = methodId(
+        classId = utStreamClass.overriddenStreamClassId,
+        name = "empty",
+        returnType = utStreamClass.overriddenStreamClassId,
+        arguments = emptyArray()
+    )
+}
+
+class CommonStreamWrapper : StreamWrapper(UtStreamClass.UT_STREAM) {
+    override val baseModelName: String = "stream"
+
+    companion object {
+        internal val utStreamType: RefType
+            get() = Scene.v().getSootClass(UtStream::class.java.canonicalName).type
+        private val booleanType: Type
+            get() = BooleanType.v()
+
+        internal val isParallelStreamFieldId: SootField
+            get() = SootField("isParallel", booleanType)
+        internal val isClosedStreamFieldId: SootField
+            get() = SootField("isClosed", booleanType)
+    }
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Strings.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Strings.kt
@@ -67,85 +67,83 @@ class StringWrapper : BaseOverriddenWrapper(utStringClass.name) {
     private fun UtBotSymbolicEngine.getValueArray(addr: UtAddrExpression) =
         getArrayField(addr, overriddenClass, STRING_VALUE)
 
-    override fun overrideInvoke(
-        engine: UtBotSymbolicEngine,
+    override fun UtBotSymbolicEngine.overrideInvoke(
         wrapper: ObjectValue,
         method: SootMethod,
         parameters: List<SymbolicValue>
-    ): List<InvokeResult>? =
-        with(engine) {
-            when (method.subSignature) {
-                toStringMethodSignature -> {
-                    return listOf(MethodResult(wrapper.copy(typeStorage = TypeStorage(method.returnType))))
-                }
-                matchesMethodSignature -> {
-                    val arg = parameters[0] as ObjectValue
-                    val matchingLengthExpr = getIntFieldValue(arg, STRING_LENGTH).accept(RewritingVisitor())
-
-                    if (!matchingLengthExpr.isConcrete) return null
-
-                    val matchingValueExpr =
-                        selectArrayExpressionFromMemory(getValueArray(arg.addr)).accept(RewritingVisitor())
-                    val matchingLength = matchingLengthExpr.toConcrete() as Int
-                    val matchingValue = CharArray(matchingLength)
-
-                    for (i in 0 until matchingLength) {
-                        val charExpr = matchingValueExpr.select(mkInt(i)).accept(RewritingVisitor())
-
-                        if (!charExpr.isConcrete) return null
-
-                        matchingValue[i] = (charExpr.toConcrete() as Number).toChar()
-                    }
-
-                    val rgxGen = RgxGen(String(matchingValue))
-                    val matching = (rgxGen.generate())
-                    val notMatching = rgxGen.generateNotMatching()
-
-                    val thisLength = getIntFieldValue(wrapper, STRING_LENGTH)
-                    val thisValue = selectArrayExpressionFromMemory(getValueArray(wrapper.addr))
-
-                    val matchingConstraints = mutableSetOf<UtBoolExpression>()
-                    matchingConstraints += mkEq(thisLength, mkInt(matching.length))
-                    for (i in matching.indices) {
-                        matchingConstraints += mkEq(thisValue.select(mkInt(i)), mkChar(matching[i]))
-                    }
-
-                    val notMatchingConstraints = mutableSetOf<UtBoolExpression>()
-                    notMatchingConstraints += mkEq(thisLength, mkInt(notMatching.length))
-                    for (i in notMatching.indices) {
-                        notMatchingConstraints += mkEq(thisValue.select(mkInt(i)), mkChar(notMatching[i]))
-                    }
-
-                    return listOf(
-                        MethodResult(UtTrue.toBoolValue(), matchingConstraints.asHardConstraint()),
-                        MethodResult(UtFalse.toBoolValue(), notMatchingConstraints.asHardConstraint())
-                    )
-                }
-                charAtMethodSignature -> {
-                    val index = parameters[0] as PrimitiveValue
-                    val lengthExpr = getIntFieldValue(wrapper, STRING_LENGTH)
-                    val inBoundsCondition = mkAnd(Le(0.toPrimitiveValue(), index), Lt(index, lengthExpr.toIntValue()))
-                    val failMethodResult =
-                        MethodResult(
-                            explicitThrown(
-                                StringIndexOutOfBoundsException(),
-                                findNewAddr(),
-                                isInNestedMethod()
-                            ),
-                            hardConstraints = mkNot(inBoundsCondition).asHardConstraint()
-                        )
-
-                    val valueExpr = selectArrayExpressionFromMemory(getValueArray(wrapper.addr))
-
-                    val returnResult = MethodResult(
-                        valueExpr.select(index.expr).toCharValue(),
-                        hardConstraints = inBoundsCondition.asHardConstraint()
-                    )
-                    return listOf(returnResult, failMethodResult)
-                }
-                else -> return null
+    ): List<InvokeResult>? {
+        return when (method.subSignature) {
+            toStringMethodSignature -> {
+                listOf(MethodResult(wrapper.copy(typeStorage = TypeStorage(method.returnType))))
             }
+            matchesMethodSignature -> {
+                val arg = parameters[0] as ObjectValue
+                val matchingLengthExpr = getIntFieldValue(arg, STRING_LENGTH).accept(RewritingVisitor())
+
+                if (!matchingLengthExpr.isConcrete) return null
+
+                val matchingValueExpr =
+                    selectArrayExpressionFromMemory(getValueArray(arg.addr)).accept(RewritingVisitor())
+                val matchingLength = matchingLengthExpr.toConcrete() as Int
+                val matchingValue = CharArray(matchingLength)
+
+                for (i in 0 until matchingLength) {
+                    val charExpr = matchingValueExpr.select(mkInt(i)).accept(RewritingVisitor())
+
+                    if (!charExpr.isConcrete) return null
+
+                    matchingValue[i] = (charExpr.toConcrete() as Number).toChar()
+                }
+
+                val rgxGen = RgxGen(String(matchingValue))
+                val matching = (rgxGen.generate())
+                val notMatching = rgxGen.generateNotMatching()
+
+                val thisLength = getIntFieldValue(wrapper, STRING_LENGTH)
+                val thisValue = selectArrayExpressionFromMemory(getValueArray(wrapper.addr))
+
+                val matchingConstraints = mutableSetOf<UtBoolExpression>()
+                matchingConstraints += mkEq(thisLength, mkInt(matching.length))
+                for (i in matching.indices) {
+                    matchingConstraints += mkEq(thisValue.select(mkInt(i)), mkChar(matching[i]))
+                }
+
+                val notMatchingConstraints = mutableSetOf<UtBoolExpression>()
+                notMatchingConstraints += mkEq(thisLength, mkInt(notMatching.length))
+                for (i in notMatching.indices) {
+                    notMatchingConstraints += mkEq(thisValue.select(mkInt(i)), mkChar(notMatching[i]))
+                }
+
+                return listOf(
+                    MethodResult(UtTrue.toBoolValue(), matchingConstraints.asHardConstraint()),
+                    MethodResult(UtFalse.toBoolValue(), notMatchingConstraints.asHardConstraint())
+                )
+            }
+            charAtMethodSignature -> {
+                val index = parameters[0] as PrimitiveValue
+                val lengthExpr = getIntFieldValue(wrapper, STRING_LENGTH)
+                val inBoundsCondition = mkAnd(Le(0.toPrimitiveValue(), index), Lt(index, lengthExpr.toIntValue()))
+                val failMethodResult =
+                    MethodResult(
+                        explicitThrown(
+                            StringIndexOutOfBoundsException(),
+                            findNewAddr(),
+                            isInNestedMethod()
+                        ),
+                        hardConstraints = mkNot(inBoundsCondition).asHardConstraint()
+                    )
+
+                val valueExpr = selectArrayExpressionFromMemory(getValueArray(wrapper.addr))
+
+                val returnResult = MethodResult(
+                    valueExpr.select(index.expr).toCharValue(),
+                    hardConstraints = inBoundsCondition.asHardConstraint()
+                )
+                return listOf(returnResult, failMethodResult)
+            }
+            else -> return null
         }
+    }
 
     override fun value(resolver: Resolver, wrapper: ObjectValue): UtModel = resolver.run {
         val classId = STRING_TYPE.id
@@ -294,8 +292,7 @@ sealed class UtAbstractStringBuilderWrapper(className: String) : BaseOverriddenW
     private val asStringBuilderMethodSignature =
         overriddenClass.getMethodByName("asStringBuilder").subSignature
 
-    override fun overrideInvoke(
-        engine: UtBotSymbolicEngine,
+    override fun UtBotSymbolicEngine.overrideInvoke(
         wrapper: ObjectValue,
         method: SootMethod,
         parameters: List<SymbolicValue>

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/TypeResolver.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/TypeResolver.kt
@@ -110,12 +110,32 @@ class TypeResolver(private val typeRegistry: TypeRegistry, private val hierarchy
     fun constructTypeStorage(type: Type, possibleTypes: Collection<Type>): TypeStorage {
         val concretePossibleTypes = possibleTypes
             .map { (if (it is ArrayType) it.baseType else it) to it.numDimensions }
-            .filterNot { (baseType, numDimensions) -> numDimensions == 0 && baseType is RefType && baseType.sootClass.isInappropriate }
+            .filterNot { (baseType, numDimensions) -> isInappropriateOrArrayOfMocksOrLocals(numDimensions, baseType) }
             .mapTo(mutableSetOf()) { (baseType, numDimensions) ->
                 if (numDimensions == 0) baseType else baseType.makeArrayType(numDimensions)
             }
 
         return TypeStorage(type, concretePossibleTypes).filterInappropriateClassesForCodeGeneration()
+    }
+
+    private fun isInappropriateOrArrayOfMocksOrLocals(numDimensions: Int, baseType: Type?): Boolean {
+        if (baseType !is RefType) {
+            return false
+        }
+
+        val baseSootClass = baseType.sootClass
+
+        if (numDimensions == 0 && baseSootClass.isInappropriate) {
+            // interface, abstract class, or local, or mock could not be constructed
+            return true
+        }
+
+        if (numDimensions > 0 && (baseSootClass.isLocal || baseSootClass.findMockAnnotationOrNull != null)) {
+            // array of mocks or locals could not be constructed, but array of interfaces or abstract classes could be
+            return true
+        }
+
+        return false
     }
 
     /**

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/TypeResolver.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/TypeResolver.kt
@@ -110,7 +110,7 @@ class TypeResolver(private val typeRegistry: TypeRegistry, private val hierarchy
     fun constructTypeStorage(type: Type, possibleTypes: Collection<Type>): TypeStorage {
         val concretePossibleTypes = possibleTypes
             .map { (if (it is ArrayType) it.baseType else it) to it.numDimensions }
-            .filterNot { (baseType, _) -> baseType is RefType && baseType.sootClass.isInappropriate }
+            .filterNot { (baseType, numDimensions) -> numDimensions == 0 && baseType is RefType && baseType.sootClass.isInappropriate }
             .mapTo(mutableSetOf()) { (baseType, numDimensions) ->
                 if (numDimensions == 0) baseType else baseType.makeArrayType(numDimensions)
             }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
@@ -1360,7 +1360,8 @@ class UtBotSymbolicEngine(
 
             queuedSymbolicStateUpdates += typeRegistry.genericTypeParameterConstraint(value.addr, typeStorages).asHardConstraint()
             parameterAddrToGenericType += value.addr to type
-            typeRegistry.genericTypeStorageByAddr += value.addr to typeStorages
+
+            typeRegistry.saveObjectParameterTypeStorages(value.addr, typeStorages)
         }
     }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/pc/Z3TranslatorVisitor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/pc/Z3TranslatorVisitor.kt
@@ -242,10 +242,10 @@ open class Z3TranslatorVisitor(
                     )
                 }.toTypedArray()
             )
-            constraints += typeConstraint
 
-            z3Context.mkAnd(*constraints.toTypedArray())
+            constraints += typeConstraint
         }
+
         z3Context.mkOr(
             z3Context.mkAnd(*constraints.toTypedArray()),
             z3Context.mkEq(translate(expr.addr), translate(nullObjectAddr))
@@ -259,12 +259,17 @@ open class Z3TranslatorVisitor(
         val genericSymType = translate(typeRegistry.genericTypeId(baseAddr, parameterTypeIndex))
         val genericNumDimensions = translate(typeRegistry.genericNumDimensions(baseAddr, parameterTypeIndex))
 
-        val typeConstraint = z3Context.mkOr(
+        val dimensionsConstraint = z3Context.mkEq(symNumDimensions, genericNumDimensions)
+
+        val equalTypeConstraint = z3Context.mkAnd(
             z3Context.mkEq(symType, genericSymType),
-            z3Context.mkEq(translate(expr.addr), translate(nullObjectAddr))
+            dimensionsConstraint
         )
 
-        val dimensionsConstraint = z3Context.mkEq(symNumDimensions, genericNumDimensions)
+        val typeConstraint = z3Context.mkOr(
+            equalTypeConstraint,
+            z3Context.mkEq(translate(expr.addr), translate(nullObjectAddr))
+        )
 
         z3Context.mkAnd(typeConstraint, dimensionsConstraint)
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/pc/Z3TranslatorVisitor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/pc/Z3TranslatorVisitor.kt
@@ -226,7 +226,6 @@ open class Z3TranslatorVisitor(
     override fun visit(expr: UtGenericExpression): Expr = expr.run {
         val constraints = mutableListOf<BoolExpr>()
         for (i in types.indices) {
-            val symNumDimensions = translate(typeRegistry.genericNumDimensions(addr, i)) as BitVecExpr
             val symType = translate(typeRegistry.genericTypeId(addr, i))
 
             if (types[i].leastCommonType.isJavaLangObject()) {
@@ -244,20 +243,6 @@ open class Z3TranslatorVisitor(
                 }.toTypedArray()
             )
             constraints += typeConstraint
-
-            val numDimensionsConstraint = z3Context.mkAnd(
-                *possibleBaseTypes.map {
-                    val numDimensions = z3Context.mkBV(it.numDimensions, Int.SIZE_BITS)
-
-                    if (it.isJavaLangObject()) {
-                        z3Context.mkBVSGE(symNumDimensions, numDimensions)
-                    } else {
-                        z3Context.mkEq(symNumDimensions, numDimensions)
-                    }
-                }.toTypedArray()
-            )
-
-            constraints += numDimensionsConstraint
 
             z3Context.mkAnd(*constraints.toTypedArray())
         }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/builtin/UtilMethodBuiltins.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/builtin/UtilMethodBuiltins.kt
@@ -33,6 +33,7 @@ internal val ClassId.possibleUtilMethodIds: Set<MethodId>
         deepEqualsMethodId,
         arraysDeepEqualsMethodId,
         iterablesDeepEqualsMethodId,
+        streamsDeepEqualsMethodId,
         mapsDeepEqualsMethodId,
         hasCustomEqualsMethodId,
         getArrayLengthMethodId
@@ -115,6 +116,13 @@ internal val ClassId.iterablesDeepEqualsMethodId: MethodId
         name = "iterablesDeepEquals",
         returnType = booleanClassId,
         arguments = arrayOf(java.lang.Iterable::class.id, java.lang.Iterable::class.id)
+    )
+
+internal val ClassId.streamsDeepEqualsMethodId: MethodId
+    get() = utilMethodId(
+        name = "streamsDeepEquals",
+        returnType = booleanClassId,
+        arguments = arrayOf(java.util.stream.Stream::class.id, java.util.stream.Stream::class.id)
     )
 
 internal val ClassId.mapsDeepEqualsMethodId: MethodId

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/context/CgContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/context/CgContext.kt
@@ -54,6 +54,7 @@ import kotlinx.collections.immutable.PersistentSet
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.collections.immutable.persistentSetOf
+import org.utbot.framework.codegen.model.constructor.builtin.streamsDeepEqualsMethodId
 
 /**
  * Interface for all code generation context aware entities
@@ -350,6 +351,9 @@ internal interface CgContextOwner {
 
     val iterablesDeepEquals: MethodId
         get() = currentTestClass.iterablesDeepEqualsMethodId
+
+    val streamsDeepEquals: MethodId
+        get() = currentTestClass.streamsDeepEqualsMethodId
 
     val mapsDeepEquals: MethodId
         get() = currentTestClass.mapsDeepEqualsMethodId

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgCallableAccessManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgCallableAccessManager.kt
@@ -26,6 +26,7 @@ import org.utbot.framework.codegen.model.constructor.builtin.newInstance
 import org.utbot.framework.codegen.model.constructor.builtin.setAccessible
 import org.utbot.framework.codegen.model.constructor.builtin.setFieldMethodId
 import org.utbot.framework.codegen.model.constructor.builtin.setStaticFieldMethodId
+import org.utbot.framework.codegen.model.constructor.builtin.streamsDeepEqualsMethodId
 import org.utbot.framework.codegen.model.constructor.context.CgContext
 import org.utbot.framework.codegen.model.constructor.context.CgContextOwner
 import org.utbot.framework.codegen.model.constructor.util.CgComponents
@@ -173,6 +174,7 @@ internal class CgCallableAccessManagerImpl(val context: CgContext) : CgCallableA
                 deepEqualsMethodId,
                 arraysDeepEqualsMethodId,
                 iterablesDeepEqualsMethodId,
+                streamsDeepEqualsMethodId,
                 mapsDeepEqualsMethodId,
                 hasCustomEqualsMethodId,
                 getArrayLengthMethodId -> emptySet()

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgTestClassConstructor.kt
@@ -162,8 +162,8 @@ internal class CgTestClassConstructor(val context: CgContext) :
      */
     private fun MethodId.dependencies(): List<MethodId> = when (this) {
         createInstance -> listOf(getUnsafeInstance)
-        deepEquals -> listOf(arraysDeepEquals, iterablesDeepEquals, mapsDeepEquals, hasCustomEquals)
-        arraysDeepEquals, iterablesDeepEquals, mapsDeepEquals -> listOf(deepEquals)
+        deepEquals -> listOf(arraysDeepEquals, iterablesDeepEquals, streamsDeepEquals, mapsDeepEquals, hasCustomEquals)
+        arraysDeepEquals, iterablesDeepEquals, streamsDeepEquals, mapsDeepEquals -> listOf(deepEquals)
         else -> emptyList()
     }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/TestFrameworkManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/TestFrameworkManager.kt
@@ -9,6 +9,7 @@ import org.utbot.framework.codegen.model.constructor.builtin.forName
 import org.utbot.framework.codegen.model.constructor.builtin.hasCustomEqualsMethodId
 import org.utbot.framework.codegen.model.constructor.builtin.iterablesDeepEqualsMethodId
 import org.utbot.framework.codegen.model.constructor.builtin.mapsDeepEqualsMethodId
+import org.utbot.framework.codegen.model.constructor.builtin.streamsDeepEqualsMethodId
 import org.utbot.framework.codegen.model.constructor.context.CgContext
 import org.utbot.framework.codegen.model.constructor.context.CgContextOwner
 import org.utbot.framework.codegen.model.constructor.util.CgComponents
@@ -103,6 +104,7 @@ internal abstract class TestFrameworkManager(val context: CgContext)
         requiredUtilMethods += currentTestClass.deepEqualsMethodId
         requiredUtilMethods += currentTestClass.arraysDeepEqualsMethodId
         requiredUtilMethods += currentTestClass.iterablesDeepEqualsMethodId
+        requiredUtilMethods += currentTestClass.streamsDeepEqualsMethodId
         requiredUtilMethods += currentTestClass.mapsDeepEqualsMethodId
         requiredUtilMethods += currentTestClass.hasCustomEqualsMethodId
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/UtilMethods.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/UtilMethods.kt
@@ -858,17 +858,17 @@ private fun ClassId.regularImportsByUtilMethod(id: MethodId, codegenLanguage: Co
         }
         iterablesDeepEqualsMethodId -> when (codegenLanguage) {
             CodegenLanguage.JAVA -> listOf(Iterable::class.id, Iterator::class.id, Set::class.id)
-            CodegenLanguage.KOTLIN -> listOf()
+            CodegenLanguage.KOTLIN -> emptyList()
         }
         streamsDeepEqualsMethodId -> when (codegenLanguage) {
-            CodegenLanguage.JAVA -> listOf(java.util.stream.Stream::class.id, java.util.stream.Stream::class.id, Set::class.id)
-            CodegenLanguage.KOTLIN -> listOf()
+            CodegenLanguage.JAVA -> listOf(java.util.stream.Stream::class.id, Set::class.id)
+            CodegenLanguage.KOTLIN -> emptyList()
         }
         mapsDeepEqualsMethodId -> when (codegenLanguage) {
             CodegenLanguage.JAVA -> listOf(Map::class.id, Iterator::class.id, Set::class.id)
-            CodegenLanguage.KOTLIN -> listOf()
+            CodegenLanguage.KOTLIN -> emptyList()
         }
-        hasCustomEqualsMethodId -> listOf()
+        hasCustomEqualsMethodId -> emptyList()
         getArrayLengthMethodId -> listOf(java.lang.reflect.Array::class.id)
         else -> error("Unknown util method for class $this: $id")
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/SootUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/SootUtils.kt
@@ -25,11 +25,14 @@ import org.utbot.engine.overrides.collections.UtHashMap
 import org.utbot.engine.overrides.collections.UtHashSet
 import org.utbot.engine.overrides.collections.UtLinkedList
 import org.utbot.engine.overrides.UtOverrideMock
+import org.utbot.engine.overrides.collections.Collection
 import org.utbot.engine.overrides.collections.UtGenericStorage
 import org.utbot.engine.overrides.collections.UtOptional
 import org.utbot.engine.overrides.collections.UtOptionalDouble
 import org.utbot.engine.overrides.collections.UtOptionalInt
 import org.utbot.engine.overrides.collections.UtOptionalLong
+import org.utbot.engine.overrides.stream.Stream
+import org.utbot.engine.overrides.stream.UtStream
 import java.io.File
 import java.nio.file.Path
 import kotlin.reflect.KClass
@@ -127,5 +130,9 @@ private val classesToLoad = arrayOf(
     UtNativeStringWrapper::class,
     UtString::class,
     UtStringBuilder::class,
-    UtStringBuffer::class
+    UtStringBuffer::class,
+    Stream::class,
+    Collection::class,
+    UtStream::class,
+    UtStream.UtStreamIterator::class
 )

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/AbstractTestCaseGeneratorTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/AbstractTestCaseGeneratorTest.kt
@@ -2564,7 +2564,7 @@ internal fun invokeMatcher(matcher: Function<Boolean>, params: List<Any?>) = whe
 fun ge(count: Int) = ExecutionsNumberMatcher("ge $count") { it >= count }
 fun eq(count: Int) = ExecutionsNumberMatcher("eq $count") { it == count }
 fun between(bounds: IntRange) = ExecutionsNumberMatcher("$bounds") { it in bounds }
-val ignoreExecutionsNumber = ExecutionsNumberMatcher("Do not calculate") { true }
+val ignoreExecutionsNumber = ExecutionsNumberMatcher("Do not calculate") { it > 0 }
 
 fun atLeast(percents: Int) = AtLeast(percents)
 
@@ -2618,6 +2618,17 @@ class AtLeast(percents: Int) : CoverageMatcher("at least $percents% coverage",
     { it.counters.all { 100 * it.covered >= percents * it.total } })
 
 object DoNotCalculate : CoverageMatcher("Do not calculate", { true })
+
+class FullWithAssumptions(assumeCallsNumber: Int) : CoverageMatcher(
+    "full coverage except failed assume calls",
+    { it.instructionCounter.let { it.covered >= it.total - assumeCallsNumber } }
+) {
+    init {
+        require(assumeCallsNumber > 0) {
+            "Non-positive number of assume calls $assumeCallsNumber passed (for zero calls use Full coverage matcher"
+        }
+    }
+}
 
 // simple matchers
 fun withResult(ex: UtValueExecution<*>) = ex.paramsBefore + ex.evaluatedResult
@@ -2704,7 +2715,7 @@ fun keyMatch(keyStmt: List<DocStatement>) = { summary: List<DocStatement>? ->
 fun Map<FieldId, UtConcreteValue<*>>.findByName(name: String) = entries.single { name == it.key.name }.value.value
 fun Map<FieldId, UtConcreteValue<*>>.singleValue() = values.single().value
 
-private typealias StaticsType = Map<FieldId, UtConcreteValue<*>>
+internal typealias StaticsType = Map<FieldId, UtConcreteValue<*>>
 private typealias Mocks = List<MockInfo>
 private typealias Instrumentation = List<UtInstrumentation>
 

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/lambda/SimpleLambdaExamplesTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/lambda/SimpleLambdaExamplesTest.kt
@@ -1,0 +1,32 @@
+package org.utbot.examples.lambda
+
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.utbot.examples.AbstractTestCaseGeneratorTest
+import org.utbot.examples.DoNotCalculate
+import org.utbot.examples.eq
+import org.utbot.examples.isException
+
+class SimpleLambdaExamplesTest : AbstractTestCaseGeneratorTest(testClass = SimpleLambdaExamples::class) {
+    @Test
+    fun testBiFunctionLambdaExample() {
+        checkWithException(
+            SimpleLambdaExamples::biFunctionLambdaExample,
+            eq(2),
+            { a, b, r -> b == 0 && r.isException<ArithmeticException>() },
+            { a, b, r -> b != 0 && r.getOrThrow() == a / b },
+        )
+    }
+
+    @Test
+    @Disabled("TODO 0 executions https://github.com/UnitTestBot/UTBotJava/issues/192")
+    fun testChoosePredicate() {
+        check(
+            SimpleLambdaExamples::choosePredicate,
+            eq(2),
+            { b, r -> b && !r!!.test(null) && r.test(0) },
+            { b, r -> !b && r!!.test(null) && !r.test(0) },
+            // TODO coverage calculation fails https://github.com/UnitTestBot/UTBotJava/issues/192
+        )
+    }
+}

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/lambda/SimpleLambdaExamplesTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/lambda/SimpleLambdaExamplesTest.kt
@@ -3,7 +3,6 @@ package org.utbot.examples.lambda
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.utbot.examples.AbstractTestCaseGeneratorTest
-import org.utbot.examples.DoNotCalculate
 import org.utbot.examples.eq
 import org.utbot.examples.isException
 
@@ -13,7 +12,7 @@ class SimpleLambdaExamplesTest : AbstractTestCaseGeneratorTest(testClass = Simpl
         checkWithException(
             SimpleLambdaExamples::biFunctionLambdaExample,
             eq(2),
-            { a, b, r -> b == 0 && r.isException<ArithmeticException>() },
+            { _, b, r -> b == 0 && r.isException<ArithmeticException>() },
             { a, b, r -> b != 0 && r.getOrThrow() == a / b },
         )
     }

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/stream/BaseStreamExampleTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/stream/BaseStreamExampleTest.kt
@@ -330,6 +330,18 @@ class BaseStreamExampleTest : AbstractTestCaseGeneratorTest(
     }
 
     @Test
+    @Disabled("TODO unsat type constraints https://github.com/UnitTestBot/UTBotJava/issues/253")
+    fun testCustomCollectionStreamExample() {
+        check(
+            BaseStreamExample::customCollectionStreamExample,
+            ignoreExecutionsNumber,
+            { c, r -> c.isEmpty() && r == 0L },
+            { c, r -> c.isNotEmpty() && c.size.toLong() == r },
+            coverage = DoNotCalculate
+        )
+    }
+
+    @Test
     fun testGenerateExample() {
         check(
             BaseStreamExample::generateExample,

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/stream/BaseStreamExampleTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/stream/BaseStreamExampleTest.kt
@@ -1,0 +1,372 @@
+package org.utbot.examples.stream
+
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.utbot.examples.AbstractTestCaseGeneratorTest
+import org.utbot.examples.DoNotCalculate
+import org.utbot.examples.Full
+import org.utbot.examples.FullWithAssumptions
+import org.utbot.examples.StaticsType
+import org.utbot.examples.eq
+import org.utbot.examples.ignoreExecutionsNumber
+import org.utbot.examples.isException
+import org.utbot.examples.withoutConcrete
+import org.utbot.framework.codegen.CodeGeneration
+import org.utbot.framework.plugin.api.CodegenLanguage
+import java.util.Optional
+import java.util.stream.Stream
+import kotlin.streams.toList
+
+// TODO 1 instruction is always uncovered https://github.com/UnitTestBot/UTBotJava/issues/193
+// TODO failed Kotlin compilation (generics) JIRA:1332
+class BaseStreamExampleTest : AbstractTestCaseGeneratorTest(
+    testClass = BaseStreamExample::class,
+    testCodeGeneration = true,
+    languagePipelines = listOf(
+        CodeGenerationLanguageLastStage(CodegenLanguage.JAVA),
+        CodeGenerationLanguageLastStage(CodegenLanguage.KOTLIN, CodeGeneration)
+    )
+) {
+    @Test
+    fun testReturningStreamExample() {
+        withoutConcrete {
+            check(
+                BaseStreamExample::returningStreamExample,
+                eq(2),
+                // NOTE: the order of the matchers is important because Stream could be used only once
+                { c, r -> c.isNotEmpty() && c == r!!.toList() },
+                { c, r -> c.isEmpty() && c == r!!.toList() },
+                coverage = FullWithAssumptions(assumeCallsNumber = 1)
+            )
+        }
+    }
+
+    @Test
+    fun testFilterExample() {
+        check(
+            BaseStreamExample::filterExample,
+            ignoreExecutionsNumber,
+            { c, r -> null !in c && r == false },
+            { c, r -> null in c && r == true },
+            coverage = FullWithAssumptions(assumeCallsNumber = 1)
+        )
+    }
+
+    @Test
+    fun testMapExample() {
+        checkWithException(
+            BaseStreamExample::mapExample,
+            eq(2),
+            { c, r -> null in c && r.isException<NullPointerException>() },
+            { c, r -> r.getOrThrow().contentEquals(c.map { it * 2 }.toTypedArray()) },
+            coverage = DoNotCalculate
+        )
+    }
+
+    @Test
+    fun testFlatMapExample() {
+        check(
+            BaseStreamExample::flatMapExample,
+            ignoreExecutionsNumber,
+            { c, r -> r.contentEquals(c.flatMap { listOf(it, it) }.toTypedArray()) },
+            coverage = FullWithAssumptions(assumeCallsNumber = 1)
+        )
+    }
+
+    @Test
+    fun testDistinctExample() {
+        check(
+            BaseStreamExample::distinctExample,
+            ignoreExecutionsNumber,
+            { c, r -> c == c.distinct() && r == false },
+            { c, r -> c != c.distinct() && r == true },
+            coverage = FullWithAssumptions(assumeCallsNumber = 1)
+        )
+    }
+
+    @Test
+    @Tag("slow")
+    // TODO slow sorting https://github.com/UnitTestBot/UTBotJava/issues/188
+    fun testSortedExample() {
+        check(
+            BaseStreamExample::sortedExample,
+            ignoreExecutionsNumber,
+            { c, r -> c.last() < c.first() && r!!.asSequence().isSorted() },
+            coverage = FullWithAssumptions(assumeCallsNumber = 2)
+        )
+    }
+
+    @Test
+    fun testPeekExample() {
+        checkThisAndStaticsAfter(
+            BaseStreamExample::peekExample,
+            ignoreExecutionsNumber,
+            *streamConsumerStaticsMatchers,
+            coverage = FullWithAssumptions(assumeCallsNumber = 1)
+        )
+    }
+
+    @Test
+    fun testLimitExample() {
+        check(
+            BaseStreamExample::limitExample,
+            ignoreExecutionsNumber,
+            { c, r -> c.size <= 5 && c.toTypedArray().contentEquals(r) },
+            { c, r -> c.size > 5 && c.take(5).toTypedArray().contentEquals(r) },
+            coverage = FullWithAssumptions(assumeCallsNumber = 1)
+        )
+    }
+
+    @Test
+    fun testSkipExample() {
+        check(
+            BaseStreamExample::skipExample,
+            ignoreExecutionsNumber,
+            { c, r -> c.size > 5 && c.drop(5).toTypedArray().contentEquals(r) },
+            { c, r -> c.size <= 5 && r!!.isEmpty() },
+            coverage = FullWithAssumptions(assumeCallsNumber = 1)
+        )
+    }
+
+    @Test
+    fun testForEachExample() {
+        checkThisAndStaticsAfter(
+            BaseStreamExample::forEachExample,
+            eq(2),
+            *streamConsumerStaticsMatchers,
+            coverage = DoNotCalculate
+        )
+    }
+
+    @Test
+    fun testToArrayExample() {
+        check(
+            BaseStreamExample::toArrayExample,
+            ignoreExecutionsNumber,
+            { c, r -> c.toTypedArray().contentEquals(r) },
+            coverage = FullWithAssumptions(assumeCallsNumber = 1)
+        )
+    }
+
+    @Test
+    fun testReduceExample() {
+        check(
+            BaseStreamExample::reduceExample,
+            ignoreExecutionsNumber,
+            { c, r -> c.isEmpty() && r == 42 },
+            { c, r -> c.isNotEmpty() && r == c.sum() + 42 },
+            coverage = FullWithAssumptions(assumeCallsNumber = 1)
+        )
+    }
+
+    @Test
+    fun testOptionalReduceExample() {
+        checkWithException(
+            BaseStreamExample::optionalReduceExample,
+            ignoreExecutionsNumber,
+            { c, r -> c.isEmpty() && r.getOrThrow() == Optional.empty<Int>() },
+            { c, r -> c.isNotEmpty() && c.single() == null && r.isException<NullPointerException>() },
+            { c, r -> c.isNotEmpty() && r.getOrThrow() == Optional.of<Int>(c.sum()) },
+            coverage = DoNotCalculate // TODO 2 instructions are uncovered https://github.com/UnitTestBot/UTBotJava/issues/193
+        )
+    }
+
+    @Test
+    fun testComplexReduceExample() {
+        check(
+            BaseStreamExample::complexReduceExample,
+            ignoreExecutionsNumber,
+            { c, r -> c.isEmpty() && c.sumOf { it.toDouble() } + 42.0 == r },
+            { c: List<Int?>, r -> c.isNotEmpty() && c.sumOf { it?.toDouble() ?: 0.0 } + 42.0 == r },
+            coverage = FullWithAssumptions(assumeCallsNumber = 1)
+        )
+    }
+
+    @Test
+    @Disabled("TODO zero executions https://github.com/UnitTestBot/UTBotJava/issues/207")
+    fun testCollectorExample() {
+        check(
+            BaseStreamExample::collectorExample,
+            ignoreExecutionsNumber,
+            { c, r -> c.toSet() == r },
+            coverage = FullWithAssumptions(assumeCallsNumber = 1)
+        )
+    }
+
+    @Test
+    fun testCollectExample() {
+        checkWithException(
+            BaseStreamExample::collectExample,
+            ignoreExecutionsNumber, // 3 executions instead of 2 expected
+            { c, r -> null in c && r.isException<NullPointerException>() },
+            { c, r -> null !in c && c.sum() == r.getOrThrow() },
+            coverage = DoNotCalculate // TODO 2 instructions are uncovered https://github.com/UnitTestBot/UTBotJava/issues/193
+        )
+    }
+
+    @Test
+    fun testMinExample() {
+        checkWithException(
+            BaseStreamExample::minExample,
+            ignoreExecutionsNumber,
+            { c, r -> c.isEmpty() && r.getOrThrow() == Optional.empty<Int>() },
+            { c, r -> c.isNotEmpty() && c.all { it == null } && r.isException<NullPointerException>() },
+            { c, r -> c.isNotEmpty() && r.getOrThrow() == Optional.of<Int>(c.minOrNull()!!) },
+            coverage = DoNotCalculate // TODO 2 instructions are uncovered https://github.com/UnitTestBot/UTBotJava/issues/193
+        )
+    }
+
+    @Test
+    fun testMaxExample() {
+        checkWithException(
+            BaseStreamExample::maxExample,
+            ignoreExecutionsNumber,
+            { c, r -> c.isEmpty() && r.getOrThrow() == Optional.empty<Int>() },
+            { c, r -> c.isNotEmpty() && c.all { it == null } && r.isException<NullPointerException>() },
+            { c, r -> c.isNotEmpty() && r.getOrThrow() == Optional.of<Int>(c.maxOrNull()!!) },
+            coverage = DoNotCalculate // TODO 2 instructions are uncovered https://github.com/UnitTestBot/UTBotJava/issues/193
+        )
+    }
+
+    @Test
+    fun testCountExample() {
+        check(
+            BaseStreamExample::countExample,
+            ignoreExecutionsNumber,
+            { c, r -> c.isEmpty() && r == 0L },
+            { c, r -> c.isNotEmpty() && c.size.toLong() == r },
+            coverage = FullWithAssumptions(assumeCallsNumber = 1)
+        )
+    }
+
+    @Test
+    fun testAnyMatchExample() {
+        check(
+            BaseStreamExample::anyMatchExample,
+            ignoreExecutionsNumber,
+            { c, r -> c.isEmpty() && r == false },
+            { c, r -> c.isNotEmpty() && c.all { it == null } && r == true },
+            { c, r -> c.isNotEmpty() && c.first() != null && c.last() == null && r == true },
+            { c, r -> c.isNotEmpty() && c.first() == null && c.last() != null && r == true },
+            { c, r -> c.isNotEmpty() && c.none { it == null } && r == false },
+            coverage = FullWithAssumptions(assumeCallsNumber = 2)
+        )
+    }
+
+    @Test
+    fun testAllMatchExample() {
+        check(
+            BaseStreamExample::allMatchExample,
+            ignoreExecutionsNumber,
+            { c, r -> c.isEmpty() && r == true },
+            { c, r -> c.isNotEmpty() && c.all { it == null } && r == true },
+            { c, r -> c.isNotEmpty() && c.first() != null && c.last() == null && r == false },
+            { c, r -> c.isNotEmpty() && c.first() == null && c.last() != null && r == false },
+            { c, r -> c.isNotEmpty() && c.none { it == null } && r == false },
+            coverage = FullWithAssumptions(assumeCallsNumber = 2)
+        )
+    }
+
+    @Test
+    fun testNoneMatchExample() {
+        check(
+            BaseStreamExample::noneMatchExample,
+            ignoreExecutionsNumber,
+            { c, r -> c.isEmpty() && r == true },
+            { c, r -> c.isNotEmpty() && c.all { it == null } && r == false },
+            { c, r -> c.isNotEmpty() && c.first() != null && c.last() == null && r == false },
+            { c, r -> c.isNotEmpty() && c.first() == null && c.last() != null && r == false },
+            { c, r -> c.isNotEmpty() && c.none { it == null } && r == true },
+            coverage = FullWithAssumptions(assumeCallsNumber = 2)
+        )
+    }
+
+    @Test
+    fun testFindFirstExample() {
+        checkWithException(
+            BaseStreamExample::findFirstExample,
+            eq(3),
+            { c, r -> c.isEmpty() && r.getOrThrow() == Optional.empty<Int>() },
+            { c: List<Int?>, r -> c.isNotEmpty() && c.first() == null && r.isException<NullPointerException>() },
+            { c, r -> c.isNotEmpty() && r.getOrThrow() == Optional.of(c.first()) },
+            coverage = DoNotCalculate
+        )
+    }
+
+    @Test
+    fun testIteratorExample() {
+        checkWithException(
+            BaseStreamExample::iteratorSumExample,
+            eq(2),
+            { c, r -> null in c && r.isException<NullPointerException>() },
+            { c, r -> null !in c && r.getOrThrow() == c.sum() },
+            coverage = DoNotCalculate
+        )
+    }
+
+    @Test
+    fun testStreamOfExample() {
+        withoutConcrete {
+            check(
+                BaseStreamExample::streamOfExample,
+                ignoreExecutionsNumber,
+                // NOTE: the order of the matchers is important because Stream could be used only once
+                { c, r -> c.isNotEmpty() && c.contentEquals(r!!.toArray()) },
+                { c, r -> c.isEmpty() && Stream.empty<Int>().toArray().contentEquals(r!!.toArray()) },
+                coverage = FullWithAssumptions(assumeCallsNumber = 1)
+            )
+        }
+    }
+
+    @Test
+    fun testClosedStreamExample() {
+        checkWithException(
+            BaseStreamExample::closedStreamExample,
+            eq(1),
+            { _, r -> r.isException<IllegalStateException>() },
+            coverage = DoNotCalculate
+        )
+    }
+
+    @Test
+    fun testGenerateExample() {
+        check(
+            BaseStreamExample::generateExample,
+            ignoreExecutionsNumber,
+            { r -> r!!.contentEquals(Array(10) { 42 }) },
+            coverage = Full
+        )
+    }
+
+    @Test
+    fun testIterateExample() {
+        check(
+            BaseStreamExample::iterateExample,
+            ignoreExecutionsNumber,
+            { r -> r!!.contentEquals(Array(10) { i -> 42 + i }) },
+            coverage = Full
+        )
+    }
+
+    @Test
+    fun testConcatExample() {
+        check(
+            BaseStreamExample::concatExample,
+            ignoreExecutionsNumber,
+            { r -> r!!.contentEquals(Array(10) { 42 } + Array(10) { i -> 42 + i }) },
+            coverage = Full
+        )
+    }
+
+    private val streamConsumerStaticsMatchers = arrayOf(
+        { _: BaseStreamExample, c: List<Int?>, _: StaticsType, _: Int? -> null in c },
+        { _: BaseStreamExample, c: List<Int?>, statics: StaticsType, r: Int? ->
+            val x = statics.values.single().value as Int
+
+            r!! + c.sumOf { it ?: 0 } == x
+        }
+    )
+}
+
+private fun <E : Comparable<E>> Sequence<E>.isSorted(): Boolean = zipWithNext { a, b -> a <= b }.all { it }

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/stream/BaseStreamExampleTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/stream/BaseStreamExampleTest.kt
@@ -342,6 +342,17 @@ class BaseStreamExampleTest : AbstractTestCaseGeneratorTest(
     }
 
     @Test
+    fun testAnyCollectionStreamExample() {
+        check(
+            BaseStreamExample::anyCollectionStreamExample,
+            ignoreExecutionsNumber,
+            { c, r -> c.isEmpty() && r == 0L },
+            { c, r -> c.isNotEmpty() && c.size.toLong() == r },
+            coverage = FullWithAssumptions(assumeCallsNumber = 1)
+        )
+    }
+
+    @Test
     fun testGenerateExample() {
         check(
             BaseStreamExample::generateExample,

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/stream/BaseStreamExampleTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/stream/BaseStreamExampleTest.kt
@@ -43,6 +43,18 @@ class BaseStreamExampleTest : AbstractTestCaseGeneratorTest(
     }
 
     @Test
+    fun testReturningStreamAsParameterExample() {
+        withoutConcrete {
+            check(
+                BaseStreamExample::returningStreamAsParameterExample,
+                eq(1),
+                { s, r -> s != null && s.toList() == r!!.toList() },
+                coverage = FullWithAssumptions(assumeCallsNumber = 1)
+            )
+        }
+    }
+
+    @Test
     fun testFilterExample() {
         check(
             BaseStreamExample::filterExample,

--- a/utbot-sample/src/main/java/org/utbot/examples/lambda/SimpleLambdaExamples.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/lambda/SimpleLambdaExamples.java
@@ -1,0 +1,21 @@
+package org.utbot.examples.lambda;
+
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+
+public class SimpleLambdaExamples {
+    public int biFunctionLambdaExample(int a, int b) {
+        BiFunction<Integer, Integer, Integer> division = (numerator, divisor) -> numerator / divisor;
+
+        return division.apply(a, b);
+    }
+
+    @SuppressWarnings("Convert2MethodRef")
+    public Predicate<Object> choosePredicate(boolean isNotNullPredicate) {
+        if (isNotNullPredicate) {
+            return (o -> o != null);
+        } else {
+            return (o -> o == null);
+        }
+    }
+}

--- a/utbot-sample/src/main/java/org/utbot/examples/stream/BaseStreamExample.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/stream/BaseStreamExample.java
@@ -1,8 +1,10 @@
 package org.utbot.examples.stream;
 
+import org.jetbrains.annotations.NotNull;
 import org.utbot.api.mock.UtMock;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -402,6 +404,25 @@ public class BaseStreamExample {
         return stream.count();
     }
 
+    @SuppressWarnings({"ReplaceInefficientStreamCount", "ConstantConditions"})
+    long customCollectionStreamExample(CustomCollection<Integer> customCollection) {
+        UtMock.assume(customCollection != null && customCollection.data != null);
+
+        if (customCollection.isEmpty()) {
+            return customCollection.stream().count();
+
+            // simplified example, does not generate branch too
+            /*customCollection.removeIf(Objects::isNull);
+            return customCollection.toArray().length;*/
+        } else {
+            return customCollection.stream().count();
+
+            // simplified example, does not generate branch too
+            /*customCollection.removeIf(Objects::isNull);
+            return customCollection.toArray().length;*/
+        }
+    }
+
     Integer[] generateExample() {
         return Stream.generate(() -> 42).limit(10).toArray(Integer[]::new);
     }
@@ -453,6 +474,115 @@ public class BaseStreamExample {
 
         void plus(IntWrapper other) {
             value += other.value;
+        }
+    }
+
+    public static class CustomCollection<E> implements Collection<E> {
+        private E[] data;
+
+        public CustomCollection(@NotNull E[] data) {
+            this.data = data;
+        }
+
+        @Override
+        public int size() {
+            return data.length;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return size() == 0;
+        }
+
+        @Override
+        public boolean contains(Object o) {
+            return Arrays.asList(data).contains(o);
+        }
+
+        @NotNull
+        @Override
+        public Iterator<E> iterator() {
+            return Arrays.asList(data).iterator();
+        }
+
+        @SuppressWarnings({"ManualArrayCopy", "unchecked"})
+        @NotNull
+        @Override
+        public Object[] toArray() {
+            final int size = size();
+            E[] arr = (E[]) new Object[size];
+            for (int i = 0; i < size; i++) {
+                arr[i] = data[i];
+            }
+
+            return arr;
+        }
+
+        @NotNull
+        @Override
+        public <T> T[] toArray(@NotNull T[] a) {
+            return Arrays.asList(data).toArray(a);
+        }
+
+        @Override
+        public boolean add(E e) {
+            final int size = size();
+            E[] newData = Arrays.copyOf(data, size + 1);
+            newData[size] = e;
+            data = newData;
+
+            return true;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public boolean remove(Object o) {
+            final List<E> es = Arrays.asList(data);
+            final boolean removed = es.remove(o);
+            data = (E[]) es.toArray();
+
+            return removed;
+        }
+
+        @Override
+        public boolean containsAll(@NotNull Collection<?> c) {
+            return Arrays.asList(data).containsAll(c);
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public boolean addAll(@NotNull Collection<? extends E> c) {
+            final List<E> es = Arrays.asList(data);
+            final boolean added = es.addAll(c);
+            data = (E[]) es.toArray();
+
+            return added;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public boolean removeAll(@NotNull Collection<?> c) {
+            final List<E> es = Arrays.asList(data);
+            final boolean removed = es.removeAll(c);
+            data = (E[]) es.toArray();
+
+            return removed;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public boolean retainAll(@NotNull Collection<?> c) {
+            final List<E> es = Arrays.asList(data);
+            final boolean retained = es.retainAll(c);
+            data = (E[]) es.toArray();
+
+            return retained;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public void clear() {
+            data = (E[]) new Object[0];
         }
     }
 }

--- a/utbot-sample/src/main/java/org/utbot/examples/stream/BaseStreamExample.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/stream/BaseStreamExample.java
@@ -423,6 +423,16 @@ public class BaseStreamExample {
         }
     }
 
+    long anyCollectionStreamExample(Collection<Integer> c) {
+        UtMock.assume(c != null);
+
+        if (c.isEmpty()) {
+            return c.stream().count();
+        } else {
+            return c.stream().count();
+        }
+    }
+
     Integer[] generateExample() {
         return Stream.generate(() -> 42).limit(10).toArray(Integer[]::new);
     }

--- a/utbot-sample/src/main/java/org/utbot/examples/stream/BaseStreamExample.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/stream/BaseStreamExample.java
@@ -28,6 +28,11 @@ public class BaseStreamExample {
         }
     }
 
+    Stream<Integer> returningStreamAsParameterExample(Stream<Integer> s) {
+        UtMock.assume(s != null);
+        return s;
+    }
+
     @SuppressWarnings("Convert2MethodRef")
     boolean filterExample(List<Integer> list) {
         UtMock.assume(list != null && !list.isEmpty());
@@ -423,6 +428,7 @@ public class BaseStreamExample {
         }
     }
 
+    @SuppressWarnings({"ConstantConditions", "ReplaceInefficientStreamCount"})
     long anyCollectionStreamExample(Collection<Integer> c) {
         UtMock.assume(c != null);
 

--- a/utbot-sample/src/main/java/org/utbot/examples/stream/BaseStreamExample.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/stream/BaseStreamExample.java
@@ -1,0 +1,458 @@
+package org.utbot.examples.stream;
+
+import org.utbot.api.mock.UtMock;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@SuppressWarnings({"IfStatementWithIdenticalBranches", "RedundantOperationOnEmptyContainer"})
+public class BaseStreamExample {
+    Stream<Integer> returningStreamExample(List<Integer> list) {
+        UtMock.assume(list != null);
+
+        if (list.isEmpty()) {
+            return list.stream();
+        } else {
+            return list.stream();
+        }
+    }
+
+    @SuppressWarnings("Convert2MethodRef")
+    boolean filterExample(List<Integer> list) {
+        UtMock.assume(list != null && !list.isEmpty());
+
+        int prevSize = list.size();
+
+        int newSize = list.stream().filter(value -> value != null).toArray().length;
+
+        return prevSize != newSize;
+    }
+
+    Integer[] mapExample(List<Integer> list) {
+        UtMock.assume(list != null && !list.isEmpty());
+
+        final Function<Integer, Integer> mapper = value -> value * 2;
+        if (list.contains(null)) {
+            return list.stream().map(mapper).toArray(Integer[]::new);
+        } else {
+            return list.stream().map(mapper).toArray(Integer[]::new);
+        }
+    }
+
+    // TODO mapToInt, etc https://github.com/UnitTestBot/UTBotJava/issues/146
+
+    Object[] flatMapExample(List<Integer> list) {
+        UtMock.assume(list != null && !list.isEmpty());
+
+        return list.stream().flatMap(value -> Arrays.stream(new Object[]{value, value})).toArray(Object[]::new);
+    }
+
+    boolean distinctExample(List<Integer> list) {
+        UtMock.assume(list != null && !list.isEmpty());
+
+        int prevSize = list.size();
+
+        int newSize = list.stream().distinct().toArray().length;
+
+        return prevSize != newSize;
+    }
+
+    Integer[] sortedExample(List<Integer> list) {
+        UtMock.assume(list != null && list.size() >= 2);
+
+        Integer first = list.get(0);
+
+        int lastIndex = list.size() - 1;
+        Integer last = list.get(lastIndex);
+
+        UtMock.assume(last < first);
+
+        return list.stream().sorted().toArray(Integer[]::new);
+    }
+
+    // TODO sorted with custom Comparator
+
+    static int x = 0;
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    int peekExample(List<Integer> list) {
+        UtMock.assume(list != null && !list.isEmpty());
+
+        int beforeStaticValue = x;
+
+        final Consumer<Integer> action = value -> x += value;
+        if (list.contains(null)) {
+            list.stream().peek(action);
+        } else {
+            list.stream().peek(action);
+        }
+
+        return beforeStaticValue;
+    }
+
+    @SuppressWarnings("IfStatementWithIdenticalBranches")
+    Integer[] limitExample(List<Integer> list) {
+        UtMock.assume(list != null && !list.isEmpty());
+
+        if (list.size() <= 5) {
+            return list.stream().limit(5).toArray(Integer[]::new);
+        } else {
+            return list.stream().limit(5).toArray(Integer[]::new);
+        }
+    }
+
+    @SuppressWarnings("IfStatementWithIdenticalBranches")
+    Integer[] skipExample(List<Integer> list) {
+        UtMock.assume(list != null && !list.isEmpty());
+
+        if (list.size() > 5) {
+            return list.stream().skip(5).toArray(Integer[]::new);
+        } else {
+            return list.stream().skip(5).toArray(Integer[]::new);
+        }
+    }
+
+    @SuppressWarnings("SimplifyStreamApiCallChains")
+    int forEachExample(List<Integer> list) {
+        UtMock.assume(list != null && !list.isEmpty());
+
+        int beforeStaticValue = x;
+
+        final Consumer<Integer> action = value -> x += value;
+        if (list.contains(null)) {
+            list.stream().forEach(action);
+        } else {
+            list.stream().forEach(action);
+        }
+
+        return beforeStaticValue;
+    }
+
+    @SuppressWarnings("SimplifyStreamApiCallChains")
+    Object[] toArrayExample(List<Integer> list) {
+        UtMock.assume(list != null);
+
+        int size = list.size();
+        if (size <= 1) {
+            return list.stream().toArray();
+        } else {
+            return list.stream().toArray(Integer[]::new);
+        }
+    }
+
+    Integer reduceExample(List<Integer> list) {
+        UtMock.assume(list != null);
+
+        final int identity = 42;
+        if (list.isEmpty()) {
+            return list.stream().reduce(identity, this::nullableSum);
+        } else {
+            return list.stream().reduce(identity, this::nullableSum);
+        }
+    }
+
+    Optional<Integer> optionalReduceExample(List<Integer> list) {
+        UtMock.assume(list != null);
+
+        int size = list.size();
+
+        if (size == 0) {
+            return list.stream().reduce(this::nullableSum);
+        }
+
+        if (size == 1 && list.get(0) == null) {
+            return list.stream().reduce(this::nullableSum);
+        }
+
+        return list.stream().reduce(this::nullableSum);
+    }
+
+    Double complexReduceExample(List<Integer> list) {
+        UtMock.assume(list != null);
+
+        final double identity = 42.0;
+        final BiFunction<Double, Integer, Double> accumulator = (Double a, Integer b) -> a + (b != null ? b.doubleValue() : 0.0);
+        if (list.isEmpty()) {
+            return list.stream().reduce(identity, accumulator, Double::sum);
+        }
+
+        // TODO this branch leads to almost infinite analysis
+//        if (list.contains(null)) {
+//            return list.stream().reduce(42.0, (Double a, Integer b) -> a + b.doubleValue(), Double::sum);
+//        }
+
+        return list.stream().reduce(
+                identity,
+                accumulator,
+                Double::sum
+        );
+    }
+
+    Integer collectExample(List<Integer> list) {
+        UtMock.assume(list != null);
+
+        if (list.contains(null)) {
+            return list.stream().collect(IntWrapper::new, IntWrapper::plus, IntWrapper::plus).value;
+        } else {
+            return list.stream().collect(IntWrapper::new, IntWrapper::plus, IntWrapper::plus).value;
+        }
+    }
+
+    @SuppressWarnings("SimplifyStreamApiCallChains")
+    Set<Integer> collectorExample(List<Integer> list) {
+        UtMock.assume(list != null);
+
+        return list.stream().collect(Collectors.toSet());
+    }
+
+    @SuppressWarnings("RedundantOperationOnEmptyContainer")
+    Optional<Integer> minExample(List<Integer> list) {
+        UtMock.assume(list != null);
+
+        int size = list.size();
+
+        if (size == 0) {
+            return list.stream().min(this::nullableCompareTo);
+        }
+
+        if (size == 1 && list.get(0) == null) {
+            return list.stream().min(this::nullableCompareTo);
+        }
+
+        return list.stream().min(this::nullableCompareTo);
+    }
+
+    @SuppressWarnings("RedundantOperationOnEmptyContainer")
+    Optional<Integer> maxExample(List<Integer> list) {
+        UtMock.assume(list != null);
+
+        int size = list.size();
+
+        if (size == 0) {
+            return list.stream().max(this::nullableCompareTo);
+        }
+
+        if (size == 1 && list.get(0) == null) {
+            return list.stream().max(this::nullableCompareTo);
+        }
+
+        return list.stream().max(this::nullableCompareTo);
+    }
+
+    @SuppressWarnings({"ReplaceInefficientStreamCount", "ConstantConditions"})
+    long countExample(List<Integer> list) {
+        UtMock.assume(list != null);
+
+        if (list.isEmpty()) {
+            return list.stream().count();
+        } else {
+            return list.stream().count();
+        }
+    }
+
+    @SuppressWarnings({"Convert2MethodRef", "ConstantConditions", "RedundantOperationOnEmptyContainer"})
+    boolean anyMatchExample(List<Integer> list) {
+        UtMock.assume(list != null);
+
+        final Predicate<Integer> predicate = value -> value == null;
+        if (list.isEmpty()) {
+            return list.stream().anyMatch(predicate);
+        }
+
+        UtMock.assume(list.size() == 2);
+
+        Integer first = list.get(0);
+        Integer second = list.get(1);
+
+        if (first == null && second == null) {
+            return list.stream().anyMatch(predicate);
+        }
+
+        if (first == null) {
+            return list.stream().anyMatch(predicate);
+        }
+
+        if (second == null) {
+            return list.stream().anyMatch(predicate);
+        }
+
+        return list.stream().anyMatch(predicate);
+    }
+
+    @SuppressWarnings({"Convert2MethodRef", "ConstantConditions", "RedundantOperationOnEmptyContainer"})
+    boolean allMatchExample(List<Integer> list) {
+        UtMock.assume(list != null);
+
+        final Predicate<Integer> predicate = value -> value == null;
+        if (list.isEmpty()) {
+            return list.stream().allMatch(predicate);
+        }
+
+        UtMock.assume(list.size() == 2);
+
+        Integer first = list.get(0);
+        Integer second = list.get(1);
+
+        if (first == null && second == null) {
+            return list.stream().allMatch(predicate);
+        }
+
+        if (first == null) {
+            return list.stream().allMatch(predicate);
+        }
+
+        if (second == null) {
+            return list.stream().allMatch(predicate);
+        }
+
+        return list.stream().allMatch(predicate);
+    }
+
+    @SuppressWarnings({"Convert2MethodRef", "ConstantConditions", "RedundantOperationOnEmptyContainer"})
+    boolean noneMatchExample(List<Integer> list) {
+        UtMock.assume(list != null);
+
+        final Predicate<Integer> predicate = value -> value == null;
+        if (list.isEmpty()) {
+            return list.stream().noneMatch(predicate);
+        }
+
+        UtMock.assume(list.size() == 2);
+
+        Integer first = list.get(0);
+        Integer second = list.get(1);
+
+        if (first == null && second == null) {
+            return list.stream().noneMatch(predicate);
+        }
+
+        if (first == null) {
+            return list.stream().noneMatch(predicate);
+        }
+
+        if (second == null) {
+            return list.stream().noneMatch(predicate);
+        }
+
+        return list.stream().noneMatch(predicate);
+    }
+
+    @SuppressWarnings("RedundantOperationOnEmptyContainer")
+    Optional<Integer> findFirstExample(List<Integer> list) {
+        UtMock.assume(list != null);
+
+        if (list.isEmpty()) {
+            return list.stream().findFirst();
+        }
+
+        if (list.get(0) == null) {
+            return list.stream().findFirst();
+        } else {
+            return list.stream().findFirst();
+        }
+    }
+
+    Integer iteratorSumExample(List<Integer> list) {
+        UtMock.assume(list != null && !list.isEmpty());
+
+        int sum = 0;
+        Iterator<Integer> streamIterator = list.stream().iterator();
+
+        if (list.isEmpty()) {
+            while (streamIterator.hasNext()) {
+                Integer value = streamIterator.next();
+                sum += value;
+            }
+        } else {
+            while (streamIterator.hasNext()) {
+                Integer value = streamIterator.next();
+                sum += value;
+            }
+        }
+
+        return sum;
+    }
+
+    Stream<Integer> streamOfExample(Integer[] values) {
+        UtMock.assume(values != null);
+
+        if (values.length == 0) {
+            return Stream.empty();
+        } else {
+            return Stream.of(values);
+        }
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    long closedStreamExample(List<Integer> values) {
+        UtMock.assume(values != null);
+
+        Stream<Integer> stream = values.stream();
+        stream.count();
+
+        return stream.count();
+    }
+
+    Integer[] generateExample() {
+        return Stream.generate(() -> 42).limit(10).toArray(Integer[]::new);
+    }
+
+    Integer[] iterateExample() {
+        return Stream.iterate(42, x -> x + 1).limit(10).toArray(Integer[]::new);
+    }
+
+    Integer[] concatExample() {
+        final int identity = 42;
+        Stream<Integer> first = Stream.generate(() -> identity).limit(10);
+        Stream<Integer> second = Stream.iterate(identity, x -> x + 1).limit(10);
+
+        return Stream.concat(first, second).toArray(Integer[]::new);
+    }
+
+    // avoid NPE
+    private int nullableSum(Integer a, Integer b) {
+        if (b == null) {
+            return a;
+        }
+
+        return a + b;
+    }
+
+    // avoid NPE
+    private int nullableCompareTo(Integer a, Integer b) {
+        if (a == null && b == null) {
+            return 0;
+        }
+
+        if (a == null) {
+            return -1;
+        }
+
+        if (b == null) {
+            return 1;
+        }
+
+        return a.compareTo(b);
+    }
+
+    private static class IntWrapper {
+        int value = 0;
+
+        void plus(int other) {
+            value += other;
+        }
+
+        void plus(IntWrapper other) {
+            value += other.value;
+        }
+    }
+}


### PR DESCRIPTION
# Description

Added wrapper `UtStream` based on `RangeModifiableUnlimitedArray` for `java.util.streams.Stream` with all its methods implemented (as easy for the symbolic analysis as possible). Added `UtClassMock` for static methods of `java.util.streams.Stream` (`of`, `empty`, `generate`, `iterate`, and `concat`) - with using `UtStream` wrapper for finite streams and concrete execution for infinite streams (from `generate`, `iterate`, and `concat`).

Closes #145.

## Type of Change

New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Automated Testing

See `org.utbot.examples.stream.BaseStreamExampleTest`

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] Tests that prove my change is effective
- [x] All tests pass locally with my changes
