### PR TITLE
Prepare IntelliJ plugin 2022.6-alpha for marketplace #195

### DIFF
--- a/utbot-intellij/src/main/resources/META-INF/plugin.xml
+++ b/utbot-intellij/src/main/resources/META-INF/plugin.xml
@@ -2,11 +2,11 @@
 <idea-plugin>
 
     <id>org.utbot.intellij.plugin.id</id>
-    <name>UTBot</name>
+    <name>UnitTestBot</name>
     <vendor>utbot.org</vendor>
 
     <description>UnitTestBot plugin for IntelliJ IDEA for Java</description>
-    <version>2022.5-alpha</version>
+    <version>2022.6-alpha</version>
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.java</depends>
     <depends>org.jetbrains.kotlin</depends>


### PR DESCRIPTION
# Description

Update version to 2022.6-alpha and plugin name to UnitTestBot in plugin.xml

## Type of Change

Renaming only

# How Has This Been Tested?

## Manual Scenario 

No testing needed until 2022.6-alpha is released as ZIP artefact

# Checklist (remove irrelevant options):

- [ ] Self-review of the code is passed
- [ ] No new warnings
