### PR TITLE
Temporary directories should be removed on exit #167

### DIFF
--- a/utbot-core/src/main/kotlin/org/utbot/common/FileUtil.kt
+++ b/utbot-core/src/main/kotlin/org/utbot/common/FileUtil.kt
@@ -75,12 +75,8 @@ object FileUtil {
         }.forEach { it.deleteRecursively() }
     }
 
-    private fun createTempDirectory(): Path {
-        val tempFolderPath = Paths.get(tempDirectoryPath + File.separator + utBotTempFolderPrefix)
-
-        tempFolderPath.toFile().mkdirs()
-
-        return createTempDirectory(tempFolderPath, "generated-")
+    fun createTempDirectory(prefix: String): Path {
+        return createTempDirectory(utBotTempDirectory, prefix)
     }
 
     /**
@@ -88,7 +84,7 @@ object FileUtil {
      * It can be used for Soot analysis.
      */
     fun isolateClassFiles(vararg classes: KClass<*>): File {
-        val tempDir = createTempDirectory().toFile()
+        val tempDir = createTempDirectory("generated-").toFile()
 
         for (clazz in classes) {
             val path = clazz.toClassFilePath()

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/z3/Z3initializer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/z3/Z3initializer.kt
@@ -2,6 +2,7 @@ package org.utbot.engine.z3
 
 import com.microsoft.z3.Context
 import com.microsoft.z3.Global
+import org.utbot.common.FileUtil
 import java.io.File
 import java.nio.file.Files.createTempDirectory
 
@@ -41,7 +42,7 @@ abstract class Z3Initializer : AutoCloseable {
 
             val libFolder: String?
             if (libZ3DllUrl.toURI().scheme == "jar") {
-                val tempDir = createTempDirectory(null).toFile().apply { deleteOnExit() }
+                val tempDir = FileUtil.createTempDirectory("libs-").toFile()
 
                 allLibraries.forEach { name ->
                     Z3Initializer::class.java

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/Settings.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/Settings.kt
@@ -32,6 +32,8 @@ import com.intellij.openapi.components.Storage
 import com.intellij.openapi.project.Project
 import com.intellij.util.xmlb.Converter
 import com.intellij.util.xmlb.annotations.OptionTag
+import org.utbot.common.FileUtil
+import java.util.concurrent.CompletableFuture
 import kotlin.reflect.KClass
 
 @State(
@@ -152,6 +154,11 @@ class Settings(val project: Project) : PersistentStateComponent<Settings.State> 
     }
 
     override fun getState(): State = state
+
+    override fun initializeComponent() {
+        super.initializeComponent()
+        CompletableFuture.runAsync { FileUtil.clearTempDirectory(UtSettings.daysLimitForTempFiles) }
+    }
 
     override fun loadState(state: State) {
         this.state = state

--- a/utbot-intellij/src/main/resources/META-INF/plugin.xml
+++ b/utbot-intellij/src/main/resources/META-INF/plugin.xml
@@ -30,7 +30,8 @@
         <projectConfigurable parentId="tools" instance="org.utbot.intellij.plugin.settings.Configurable"
                                  id="org.utbot.intellij.plugin.settings.Configurable"
                                  displayName="UtBot"/>
-        <projectService serviceImplementation="org.utbot.intellij.plugin.settings.Settings"/>
+        <!--suppress PluginXmlValidity -->
+        <projectService serviceImplementation="org.utbot.intellij.plugin.settings.Settings" preload="true"/>
         <registryKey defaultValue="false" description="Enable editing Kotlin test files" key="kotlin.ultra.light.classes.empty.text.range"/>
     </extensions>
 


### PR DESCRIPTION
# Description

We don't delete some of temporary directories because deleteOnExit doesn't work for them.
The solution is to use existing FileUtil.clearTempDirectory and delete outdated files later at the next startup.

Fixes #167

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

Start IntelliJ with plugin, generate some tests. All temporary directories and files should be inside $tmpDir/UTBot.
Default 'expiration period' is 3 days by default. For testing purposes create $homeDir/.utbot/settings.properties with the following line inside: `daysLimitForTempFiles=-1`.
After restart all 'old' files should be deleted automatically.

# Checklist:

- [ ] The change followed the style guidelines of the UTBot project
- [ ] Self-review of the code is passed
- [ ] No new warnings
- [ ] Tests that prove my change is effective
