### PR TITLE
Exception is thrown on IDE shutdown #211

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -52,6 +52,7 @@ import com.intellij.openapi.ui.DialogPanel
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.ui.popup.IconButton
+import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VfsUtilCore.urlToPath
 import com.intellij.openapi.vfs.VirtualFile
@@ -843,7 +844,9 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
     }
 
     private fun staticsMockingConfigured(): Boolean {
-        val entries = ModuleRootManager.getInstance(model.testModule).modifiableModel.contentEntries
+        val modifiableModel = ModuleRootManager.getInstance(model.testModule).modifiableModel
+        Disposer.register(disposable) { modifiableModel.dispose() }
+        val entries = modifiableModel.contentEntries
         val hasEntriesWithoutResources = entries
             .filterNot { it.sourceFolders.any { f -> f.rootType in testResourceRootTypes } }
             .isNotEmpty()


### PR DESCRIPTION
# Description

Obtained ModifiableRootModel should be disposed or committed, otherwise the resource is considered as 'leaked'

Fixes #211

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 
1. Start IDE with plugin
2. Open "Generate tests with UtBot" dialog
3. Close the dialog, exit IDE
No exception should be seen in log

# Checklist (remove irrelevant options):

- [ ] The change followed the style guidelines of the UTBot project
- [ ] Self-review of the code is passed
- [ ] No new warnings