### PR TITLE
RunTimeException Error in process of test generation #182

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/UtBotTestCaseGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/UtBotTestCaseGenerator.kt
@@ -48,6 +48,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.yield
 import mu.KotlinLogging
+import org.utbot.engine.*
 import soot.Scene
 import soot.jimple.JimpleBody
 import soot.toolkits.graph.ExceptionalUnitGraph
@@ -403,7 +404,9 @@ object UtBotTestCaseGenerator : TestCaseGenerator {
         val signature = method.callable.signature
         val sootMethod = clazz.methods.singleOrNull { it.pureJavaSignature == signature }
             ?: error("No such $signature found")
-
+        if (!sootMethod.canRetrieveBody()) {
+            error("No method body for $sootMethod found")
+        }
         val methodBody = sootMethod.jimpleBody()
         val graph = methodBody.graph()
 

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/actions/GenerateTestsAction.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/actions/GenerateTestsAction.kt
@@ -58,6 +58,7 @@ class GenerateTestsAction : AnAction() {
             e.getData(CommonDataKeys.VIRTUAL_FILE_ARRAY)?.let {
                 srcClasses += getAllClasses(project, it)
             }
+            srcClasses.removeIf { it.isInterface }
             var commonSourceRoot = null as VirtualFile?
             for (srcClass in srcClasses) {
                 if (commonSourceRoot == null) {


### PR DESCRIPTION
# Description

From plugin side we check and skip interfaces, thus we don't try to process them at all
From engine side we throw IllegalStateException with helpful message instead of RuntimeException

Fixes #182

## Type of Change
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## Manual Scenario 
"Generate tests..." action skips interfaces, so it's disabled if there is nothing except interfaces in the context.

# Checklist (remove irrelevant options):

- [ ] The change followed the style guidelines of the UTBot project
- [ ] Self-review of the code is passed
- [ ] No new warnings