### PR TITLE
Fix bug in FeatureProcessor

### DIFF
--- a/utbot-analytics/src/main/kotlin/org/utbot/features/FeatureProcessorWithStatesRepetition.kt
+++ b/utbot-analytics/src/main/kotlin/org/utbot/features/FeatureProcessorWithStatesRepetition.kt
@@ -52,7 +52,7 @@ class FeatureProcessorWithStatesRepetition(
         val states = mutableListOf<Pair<Int, Long>>()
         var newCoverage = 0
 
-        generateSequence(executionState) { currentState ->
+        generateSequence(executionState) { it.parent }.forEach { currentState ->
             val stateHashCode = currentState.hashCode()
 
             if (currentState.features.isEmpty()) {
@@ -68,8 +68,6 @@ class FeatureProcessorWithStatesRepetition(
                     newCoverage++
                 }
             }
-
-            currentState.parent
         }
 
         generatedTestCases++

--- a/utbot-analytics/src/test/java/org/utbot/features/OnePath.java
+++ b/utbot-analytics/src/test/java/org/utbot/features/OnePath.java
@@ -1,5 +1,8 @@
 package org.utbot.features;
 
+/**
+ * Class that have one execution path
+ */
 public class OnePath {
     int onePath() {
         return 1;

--- a/utbot-analytics/src/test/java/org/utbot/features/OnePath.java
+++ b/utbot-analytics/src/test/java/org/utbot/features/OnePath.java
@@ -1,0 +1,7 @@
+package org.utbot.features;
+
+public class OnePath {
+    int onePath() {
+        return 1;
+    }
+}

--- a/utbot-analytics/src/test/kotlin/org/utbot/features/FeatureProcessorWithRepetitionTest.kt
+++ b/utbot-analytics/src/test/kotlin/org/utbot/features/FeatureProcessorWithRepetitionTest.kt
@@ -11,7 +11,7 @@ import org.utbot.examples.withFeaturePath
 import java.io.File
 import java.io.FileInputStream
 
-class FeatureProcessorWithRepetitionTest : AbstractTestCaseGeneratorTest(OnePath::class) {
+class FeatureProcessorWithRepetitionTest : AbstractTestCaseGeneratorTest(OnePath::class, false) {
     companion object {
         const val featureDir = "src/test/resources/features"
         fun reward(coverage: Double, time: Double) = RewardEstimator.reward(coverage, time)

--- a/utbot-analytics/src/test/kotlin/org/utbot/features/FeatureProcessorWithRepetitionTest.kt
+++ b/utbot-analytics/src/test/kotlin/org/utbot/features/FeatureProcessorWithRepetitionTest.kt
@@ -1,15 +1,38 @@
 package org.utbot.features
 
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.utbot.analytics.EngineAnalyticsContext
+import org.utbot.examples.AbstractTestCaseGeneratorTest
+import org.utbot.examples.eq
+import org.utbot.examples.withFeaturePath
+import java.io.File
+import java.io.FileInputStream
 
-class FeatureProcessorWithRepetitionTest {
+class FeatureProcessorWithRepetitionTest : AbstractTestCaseGeneratorTest(OnePath::class) {
     companion object {
+        const val featureDir = "src/test/resources/features"
         fun reward(coverage: Double, time: Double) = RewardEstimator.reward(coverage, time)
+
+        @JvmStatic
+        @BeforeAll
+        fun beforeAll() {
+            File(featureDir).mkdir()
+            EngineAnalyticsContext.featureProcessorFactory = FeatureProcessorWithStatesRepetitionFactory()
+            EngineAnalyticsContext.featureExtractorFactory = FeatureExtractorFactoryImpl()
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun afterAll() {
+            File(featureDir).deleteRecursively()
+        }
     }
 
     @Test
-    fun testDumpFeatures() {
+    fun testCalculateRewards() {
         val statesToInt = mapOf(
             "a0" to 1,
             "c0" to 2,
@@ -68,6 +91,18 @@ class FeatureProcessorWithRepetitionTest {
         Assertions.assertEquals(9, rewards.size)
         expectedRewards.forEach {
             Assertions.assertEquals(it.value, rewards[statesToInt[it.key]])
+        }
+    }
+
+    @Test
+    fun addTestCaseTest() {
+        withFeaturePath(featureDir) {
+            check(
+                OnePath::onePath,
+                eq(1)
+            )
+
+            Assertions.assertTrue(FileInputStream("$featureDir/0.csv").bufferedReader().readLines().size > 1)
         }
     }
 }

--- a/utbot-analytics/src/test/kotlin/org/utbot/features/FeatureProcessorWithRepetitionTest.kt
+++ b/utbot-analytics/src/test/kotlin/org/utbot/features/FeatureProcessorWithRepetitionTest.kt
@@ -94,6 +94,9 @@ class FeatureProcessorWithRepetitionTest : AbstractTestCaseGeneratorTest(OnePath
         }
     }
 
+    /**
+     * Test, that we correctly add test cases and dump them into file
+     */
     @Test
     fun addTestCaseTest() {
         withFeaturePath(featureDir) {

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/AbstractTestCaseGeneratorTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/AbstractTestCaseGeneratorTest.kt
@@ -2811,3 +2811,18 @@ inline fun <reified T> withPathSelectorType(pathSelectorType: PathSelectorType, 
         UtSettings.pathSelectorType = prev
     }
 }
+
+inline fun <reified T> withFeaturePath(featurePath: String, block: () -> T): T {
+    val prevFeaturePath = UtSettings.featurePath
+    val prevEnableFeatureProcess = UtSettings.enableFeatureProcess
+
+    UtSettings.featurePath = featurePath
+    UtSettings.enableFeatureProcess = true
+
+    try {
+        return block()
+    } finally {
+        UtSettings.featurePath = prevFeaturePath
+        UtSettings.enableFeatureProcess = prevEnableFeatureProcess
+    }
+}


### PR DESCRIPTION
# Description

Add `forEach` after `generateSequence`.

Fixes #223

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

org.utbot.features.FeatureProcessorWithRepetitionsTest

## Manual Scenario 

1. `UtSettings.enableFeatureProcess = true`
2. Run ContestEstimator
3. `UtSettings.featurePath` contains files with feature rows
