### PR TITLE
Rename merged SARIF report file

### DIFF
--- a/utbot-gradle/src/main/kotlin/org/utbot/gradle/plugin/wrappers/GradleProjectWrapper.kt
+++ b/utbot-gradle/src/main/kotlin/org/utbot/gradle/plugin/wrappers/GradleProjectWrapper.kt
@@ -59,7 +59,7 @@ class GradleProjectWrapper(
     val sarifReportFile: File by lazy {
         Paths.get(
             generatedSarifDirectory.path,
-            "${project.name}-utbot.sarif"
+            "${project.name}Report.sarif"
         ).toFile().apply {
             createNewFileWithParentDirectories()
         }

--- a/utbot-gradle/src/main/kotlin/org/utbot/gradle/plugin/wrappers/SourceSetWrapper.kt
+++ b/utbot-gradle/src/main/kotlin/org/utbot/gradle/plugin/wrappers/SourceSetWrapper.kt
@@ -97,10 +97,10 @@ class SourceSetWrapper(
 
     /**
      * Creates and returns a file for a future SARIF report.
-     * For example, ".../main/com/qwerty/Main-utbot.sarif".
+     * For example, ".../main/com/qwerty/MainReport.sarif".
      */
     private fun createSarifReportFile(classFqn: String): File {
-        val relativePath = "${sourceSet.name}/${classFqnToPath(classFqn)}-utbot.sarif"
+        val relativePath = "${sourceSet.name}/${classFqnToPath(classFqn)}Report.sarif"
         val absolutePath = Paths.get(parentProject.generatedSarifDirectory.path, relativePath)
         return absolutePath.toFile().apply { createNewFileWithParentDirectories() }
     }

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/TestGenerator.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/TestGenerator.kt
@@ -103,7 +103,7 @@ object TestGenerator {
             .toList()
 
         val mergedReport = SarifReport.mergeReports(sarifReports)
-        val mergedReportPath = sarifReportsPath.resolve("${model.project.name}-utbot-merged.sarif")
+        val mergedReportPath = sarifReportsPath.resolve("${model.project.name}Report.sarif")
         mergedReportPath.toFile().writeText(mergedReport)
 
         // notifying the user

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/sarif/SarifReportIdea.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/sarif/SarifReportIdea.kt
@@ -22,7 +22,7 @@ object SarifReportIdea {
         // building the path to the report file
         val classFqn = testCases.firstOrNull()?.method?.clazz?.qualifiedName ?: return
         val sarifReportsPath = model.testModule.getOrCreateSarifReportsPath(model.testSourceRoot)
-        val reportFilePath = sarifReportsPath.resolve("${classFqnToPath(classFqn)}-utbot.sarif")
+        val reportFilePath = sarifReportsPath.resolve("${classFqnToPath(classFqn)}Report.sarif")
 
         // creating report related directory
         VfsUtil.createDirectoryIfMissing(reportFilePath.parent.toString())

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/ModuleUtils.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/ModuleUtils.kt
@@ -74,7 +74,7 @@ fun Module.getOrCreateTestResourcesPath(testSourceRoot: VirtualFile?): Path {
  */
 fun Module.getOrCreateSarifReportsPath(testSourceRoot: VirtualFile?): Path {
     val testResourcesPath = this.getOrCreateTestResourcesPath(testSourceRoot)
-    return "$testResourcesPath/sarif/".toPath()
+    return "$testResourcesPath/utbot-sarif-report/".toPath()
 }
 
 /**

--- a/utbot-maven/src/main/kotlin/org/utbot/maven/plugin/wrappers/MavenProjectWrapper.kt
+++ b/utbot-maven/src/main/kotlin/org/utbot/maven/plugin/wrappers/MavenProjectWrapper.kt
@@ -51,7 +51,7 @@ class MavenProjectWrapper(
     val sarifReportFile: File by lazy {
         Paths.get(
             generatedSarifDirectory.path,
-            "${mavenProject.name}-utbot.sarif"
+            "${mavenProject.name}Report.sarif"
         ).toFile().apply {
             createNewFileWithParentDirectories()
         }
@@ -131,10 +131,10 @@ class MavenProjectWrapper(
 
     /**
      * Creates and returns a file for a future SARIF report.
-     * For example, ".../main/com/qwerty/Main-utbot.sarif".
+     * For example, ".../main/com/qwerty/MainReport.sarif".
      */
     private fun createSarifReportFile(classFqn: String): File {
-        val relativePath = "${PathUtil.classFqnToPath(classFqn)}-utbot.sarif"
+        val relativePath = "${PathUtil.classFqnToPath(classFqn)}Report.sarif"
         val absolutePath = Paths.get(generatedSarifDirectory.path, relativePath)
         return absolutePath.toFile().apply { createNewFileWithParentDirectories() }
     }


### PR DESCRIPTION
# Description

- Rename all SARIF report files: suffixes `...-utbot.sarif` or `...-utbot-merged.sarif` → suffix `...Report.sarif`
- Rename the directory with SARIF reports: `test\resources\sarif` → `test\resources\utbot-sarif-report`

Fixes #242

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

- IDEA plugin:
  1. Execute `runIde` gradle task
  2. Open any project
  3. Run test generation using plugin UI
  4. Check the name of the directory with SARIF reports
  5. Check the names of the SARIF reports
- Gradle plugin:
  1. Execute `utbot-gradle/publishToMavenLocal` gradle task
  2. Open any Gradle project
  3. Run test generation using gradle plugin (How to use: [utbot-gradle/docs/utbot-gradle.md](https://github.com/UnitTestBot/UTBotJava/blob/main/utbot-gradle/docs/utbot-gradle.md))
  4. Check the names of the SARIF reports
- Maven plugin:
  1. Execute `utbot/publishToMavenLocal` gradle task
  2. Execute `utbot-maven/other/install` gradle task
  3. Open any Maven project
  4. Run test generation using maven plugin (How to use: [utbot-maven/docs/utbot-maven.md](https://github.com/UnitTestBot/UTBotJava/blob/main/utbot-maven/docs/utbot-maven.md))
  5. Check the names of the SARIF reports

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] All tests pass locally with my changes
