### PR TITLE
Fix incorrect analysis steps in the SARIF report

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/sarif/SarifReport.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/sarif/SarifReport.kt
@@ -254,10 +254,12 @@ class SarifReport(
             return null
 
         // searching needed method call
+        val publicMethodCall = "$methodName("
+        val privateMethodCall = Regex("""$methodName.*\.invoke\(""") // using reflection
         val methodCallLineNumber = testsBodyLines
             .drop(testMethodStartsAt + 1) // for search after it
             .indexOfFirst { line ->
-                line.contains("$methodName(")
+                line.contains(publicMethodCall) || line.contains(privateMethodCall)
             }
         if (methodCallLineNumber == -1)
             return null

--- a/utbot-framework/src/main/kotlin/org/utbot/sarif/SarifReport.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/sarif/SarifReport.kt
@@ -254,12 +254,12 @@ class SarifReport(
             return null
 
         // searching needed method call
-        val publicMethodCall = "$methodName("
-        val privateMethodCall = Regex("""$methodName.*\.invoke\(""") // using reflection
+        val publicMethodCallPattern = "$methodName("
+        val privateMethodCallPattern = Regex("""$methodName.*\.invoke\(""") // using reflection
         val methodCallLineNumber = testsBodyLines
             .drop(testMethodStartsAt + 1) // for search after it
             .indexOfFirst { line ->
-                line.contains(publicMethodCall) || line.contains(privateMethodCall)
+                line.contains(publicMethodCallPattern) || line.contains(privateMethodCallPattern)
             }
         if (methodCallLineNumber == -1)
             return null


### PR DESCRIPTION
# Description

Fix incorrect analysis steps in the SARIF report generated for the class with a private function.

Fixes #247

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Automated Testing

`org.utbot.sarif.SarifReportTest`

## Manual Scenario 

Repeat the steps from the issue #247

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] No new warnings
- [x] All tests pass locally with my changes
