### PR TITLE
First time use we may help user with "Got It" tooltip

### DIFF
--- a/utbot-intellij/src/main/resources/META-INF/plugin.xml
+++ b/utbot-intellij/src/main/resources/META-INF/plugin.xml
@@ -33,6 +33,7 @@
         <!--suppress PluginXmlValidity -->
         <projectService serviceImplementation="org.utbot.intellij.plugin.settings.Settings" preload="true"/>
         <registryKey defaultValue="false" description="Enable editing Kotlin test files" key="kotlin.ultra.light.classes.empty.text.range"/>
+        <postStartupActivity implementation="org.utbot.intellij.plugin.ui.GotItTooltipActivity"/>
     </extensions>
 
     <!-- Minimum and maximum build of IDE compatible with the plugin -->


### PR DESCRIPTION
# Description

First time the plugin shown a hint, "Got it message" to promote the plugin and especially its actual shortcut

Fixes #157 

## Type of Change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Manual Scenario 

1. Start IDE with plugin and clean config (to get the config clean in terms of this issue you may delete a line     `<property name="UTBot.GotItMessageWasShown" value="true" />` in config/options/other.xml

2. Check if the message appears after some initial activity (loading/indexing etc.), don't press 'Got it' button.
3. Restart IDE, the message has to appear again, now press 'Got it button'
4. Restart IDE, ensure the message doesn't appear again.


# Checklist (remove irrelevant options):

- [ ] The change followed the style guidelines of the UTBot project
- [ ] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [ ] No new warnings
- [ ] Tests that prove my change is effective
- [ ] All tests pass locally with my changes

## Visual proof
![image](https://user-images.githubusercontent.com/4101410/175263382-031e9fc9-0ac3-48d7-8603-d3a1ffc66c93.png)