### PR TITLE
Add framework, instrumentation, fuzzers pubications on GitHub Packages

### DIFF
--- a/.github/workflows/publish-on-github-packages.yml
+++ b/.github/workflows/publish-on-github-packages.yml
@@ -9,43 +9,9 @@ on:
         description: "commit SHA: e.g. cab4799c"
 
 jobs:
-  build_and_run_tests:
+  publish_on_github_packages:
     if: ${{ github.actor == 'korifey' || github.actor == 'denis-fokin' || github.actor == 'victoriafomina' || 
           github.actor == 'bissquit' }}
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-java@v3
-      with:
-        java-version: '8'
-        distribution: 'zulu'
-        java-package: jdk+fx
-        cache: gradle
-    - uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: 6.8
-    
-    - name: "UTBot Java: build and run tests"
-      run: |
-        export KOTLIN_HOME="/usr"
-        gradle clean build --no-daemon
-
-    - name: Upload utbot-framework logs
-      if: ${{ failure() }}
-      uses: actions/upload-artifact@v2
-      with:
-        name: utbot_framework_logs
-        path: utbot-framework/logs/*
-      
-    - name: Upload utbot-framework tests report artifacts if tests have failed
-      if: ${{ failure() }}
-      uses: actions/upload-artifact@v2
-      with:
-        name: utbot_framework_tests_report
-        path: utbot-framework/build/reports/tests/test/*
-
-  publish_utbot:
-    needs:  build_and_run_tests
     runs-on: ubuntu-20.04
     permissions:
       packages: write
@@ -61,27 +27,35 @@ jobs:
     - uses: gradle/gradle-build-action@v2
       with:
         gradle-version: 6.8
-        arguments: publish
-      env:
-        GITHUB_ACTOR: ${{ github.actor }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
     - name: Check out ${{ github.event.inputs.commit-sha }} commit
       run: |
         git fetch
         git checkout ${{ github.event.inputs.commit-sha }}
-        
-    - name: "utbot-framework-api: build and run tests"
+          
+    - name: "UTBot Java: build and run tests"
       run: |
-        cd utbot-framework-api
+        export KOTLIN_HOME="/usr"
         gradle clean build --no-daemon
         
-    - name: "utbot-api: build"
-      run: |
-        cd utbot-api
-        gradle clean build --no-daemon
-    
-    - name: "utbot-core: build"
-      run: |
-        cd utbot-core
-        gradle clean build --no-daemon
+    - name: Upload utbot-framework logs
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: utbot_framework_logs
+        path: utbot-framework/logs/*
+      
+    - name: Upload utbot-framework tests report artifacts if tests have failed
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: utbot_framework_tests_report
+        path: utbot-framework/build/reports/tests/test/*
+        
+    - uses: gradle/gradle-build-action@v2
+      with:
+        gradle-version: 6.8
+        arguments: publish
+      env:
+        GITHUB_ACTOR: ${{ github.actor }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/utbot-framework/build.gradle
+++ b/utbot-framework/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+  id 'maven-publish'
+}
+
 apply from: "${parent.projectDir}/gradle/include/jvm-project.gradle"
 
 repositories {
@@ -74,4 +78,17 @@ test {
     if (System.getProperty('DEBUG', 'false') == 'true') {
         jvmArgs '-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=9009'
     }
+}
+
+publishing {
+  repositories {
+    maven {
+      name = "GitHubPackages"
+      url = "https://maven.pkg.github.com/UnitTestBot/UTBotJava"
+      credentials {
+        username = System.getenv("GITHUB_ACTOR")
+        password = System.getenv("GITHUB_TOKEN")
+      }
+    }
+  }
 }

--- a/utbot-fuzzers/build.gradle
+++ b/utbot-fuzzers/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+  id 'maven-publish'
+}
+
 apply from: "${parent.projectDir}/gradle/include/jvm-project.gradle"
 
 dependencies {
@@ -8,4 +12,17 @@ dependencies {
 
 compileJava {
     options.compilerArgs = []
+}
+
+publishing {
+  repositories {
+    maven {
+      name = "GitHubPackages"
+      url = "https://maven.pkg.github.com/UnitTestBot/UTBotJava"
+      credentials {
+        username = System.getenv("GITHUB_ACTOR")
+        password = System.getenv("GITHUB_TOKEN")
+      }
+    }
+  }
 }

--- a/utbot-instrumentation/build.gradle
+++ b/utbot-instrumentation/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+  id 'maven-publish'
+}
+
 apply from: "${parent.projectDir}/gradle/include/jvm-project.gradle"
 
 dependencies {
@@ -32,4 +36,17 @@ configurations {
 
 artifacts {
     instrumentationArchive jar
+}
+
+publishing {
+  repositories {
+    maven {
+      name = "GitHubPackages"
+      url = "https://maven.pkg.github.com/UnitTestBot/UTBotJava"
+      credentials {
+        username = System.getenv("GITHUB_ACTOR")
+        password = System.getenv("GITHUB_TOKEN")
+      }
+    }
+  }
 }


### PR DESCRIPTION
# Description

The script publishing on GitHub Packages and corresponding build.gradle files were updated. Now it can publish utbot-framework, utbot-instrumentation, utbot-fuzzers too.

Fixes #257

## Type of Change

Not applicable.

# How Has This Been Tested?

## Automated Testing

Not applicable.

## Manual Scenario 

The script was tested on fork.

# Checklist (remove irrelevant options):

Not applicable.
