### PR TITLE
Existing test framework should be pre-selected at the very first start

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -773,18 +773,17 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
             ParametrizedTestSource.DO_NOT_PARAMETRIZE -> TestFramework.allItems
             ParametrizedTestSource.PARAMETRIZE -> TestFramework.allItems.filterNot { it == Junit4 }
         }
-
-        enabledTestFrameworks.forEach {
-            it.isInstalled = findFrameworkLibrary(model.project, model.testModule, it) != null
-        }
-
-        val defaultItem = when (parametrizedTestSource) {
+        var defaultItem = when (parametrizedTestSource) {
             ParametrizedTestSource.DO_NOT_PARAMETRIZE -> TestFramework.defaultItem
             ParametrizedTestSource.PARAMETRIZE -> TestFramework.parametrizedDefaultItem
         }
+        enabledTestFrameworks.forEach {
+            it.isInstalled = findFrameworkLibrary(model.project, model.testModule, it) != null
+            if (it.isInstalled && !defaultItem.isInstalled) defaultItem = it
+        }
 
         testFrameworks.model = DefaultComboBoxModel(enabledTestFrameworks.toTypedArray())
-        testFrameworks.item = if (currentFrameworkItem in enabledTestFrameworks) currentFrameworkItem else defaultItem
+        testFrameworks.item = if (currentFrameworkItem in enabledTestFrameworks && currentFrameworkItem.isInstalled) currentFrameworkItem else defaultItem
         testFrameworks.renderer = object : ColoredListCellRenderer<TestFramework>() {
             override fun customizeCellRenderer(
                 list: JList<out TestFramework>, value: TestFramework?,


### PR DESCRIPTION
# Description

In case 'current' framework and 'default' framework both not installed we pre-select the installed one (if any)

Fixes #155

## Type of Change

- Usability bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

1. Generate some tests with JUnit 4 or TestNG
2. Shutdown IDE, delete .idea\utbot-settings.xml
3. Start again, open "Gennerate..." dialog
4. Existing test framework should be selected (instead of 'default' JUnit 5)
5. Remove JUnit 4 or/and TestTG library from project dependency (Go to Project Structure > Modules > Depencencies > Remove)
6. Open "Generate..." dialog, now JUnit 5 is pre-selected again as default.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [ ] No new warnings