### PR TITLE
Publish Java CLI docker images on GitHub Packages

### DIFF
--- a/.github/workflows/publish-cli-image.yml
+++ b/.github/workflows/publish-cli-image.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Docker Buildx (build and push)
         run: |
           docker buildx build \
-            -f docker/Dockerfile_java_cli \
+            -f docker/${{ env.IMAGE_NAME }} \
             --cache-from "type=local,src=/tmp/.buildx-cache" \
             --cache-to "type=local,dest=/tmp/.buildx-cache-new" \
             --tag ${{ steps.meta.outputs.tags }} \

--- a/.github/workflows/publish-cli-image.yml
+++ b/.github/workflows/publish-cli-image.yml
@@ -36,7 +36,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
  
       - name: Set up Docker Buildx
-        id: buildx
         uses: docker/setup-buildx-action@v1
                  
       - name: Cache Docker layers

--- a/.github/workflows/publish-cli-image.yml
+++ b/.github/workflows/publish-cli-image.yml
@@ -1,0 +1,73 @@
+name: "CLI: publish image"
+on:
+  push:
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: utbot_java_cli
+
+jobs:
+  build-and-publish-docker:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        
+      - name: Set timezone
+        uses: szenius/set-timezone@v1.0
+        with:
+          timezoneLinux: "Europe/Moscow"
+        
+      - name: Set environment variables
+        run:
+          echo "COMMIT_SHORT_SHA="$(git rev-parse --short HEAD)"" >> $GITHUB_ENV
+          
+      - name: Set docker tag
+        run:
+          echo "DOCKER_TAG="$(date +%Y).$(date +%-m).$(date +%-d)-${{ env.COMMIT_SHORT_SHA }}"" >> $GITHUB_ENV
+ 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+ 
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+                 
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+            
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ env.DOCKER_TAG }}
+            
+      - name: Docker Buildx (build and push)
+        run: |
+          docker buildx build \
+            -f docker/Dockerfile_java_cli \
+            --cache-from "type=local,src=/tmp/.buildx-cache" \
+            --cache-to "type=local,dest=/tmp/.buildx-cache-new" \
+            --tag ${{ steps.meta.outputs.tags }} \
+            --build-arg ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+            --push .       
+
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/publish-cli-image.yml
+++ b/.github/workflows/publish-cli-image.yml
@@ -6,6 +6,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: utbot_java_cli
+  DOCKERFILE_PATH: docker/Dockerfile_java_cli
 
 jobs:
   build-and-publish-docker:
@@ -57,7 +58,7 @@ jobs:
       - name: Docker Buildx (build and push)
         run: |
           docker buildx build \
-            -f docker/${{ env.IMAGE_NAME }} \
+            -f ${{ env.DOCKERFILE_PATH }} \
             --cache-from "type=local,src=/tmp/.buildx-cache" \
             --cache-to "type=local,dest=/tmp/.buildx-cache-new" \
             --tag ${{ steps.meta.outputs.tags }} \

--- a/docker/Dockerfile_java_cli
+++ b/docker/Dockerfile_java_cli
@@ -6,7 +6,6 @@ WORKDIR /usr/src/
 
 RUN apt-get update \
     && apt-get install -y curl \
-        jq \
         unzip \
         python3 \
         python3-requests \

--- a/docker/Dockerfile_java_cli
+++ b/docker/Dockerfile_java_cli
@@ -1,0 +1,27 @@
+FROM openjdk:8
+
+ARG ACCESS_TOKEN
+
+WORKDIR /usr/src/
+
+RUN apt-get update \
+    && apt-get install -y curl \
+        jq \
+        unzip \
+        python3 \
+        python3-requests \
+    && apt-get clean
+
+# Install UTBot Java CLI
+COPY docker/get_java_cli_download_url.py .
+
+ENV JAVA_CLI_ZIP_NAME "utbot_java_cli.zip"
+    
+RUN curl -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+    -L "$(python3 get_java_cli_download_url.py)" \
+    -o "${JAVA_CLI_ZIP_NAME}"
+    RUN unzip "${JAVA_CLI_ZIP_NAME}" \
+    && rm "${JAVA_CLI_ZIP_NAME}"
+
+ENV JAVA_CLI_PATH="$(find $pwd -type f -name "utbot-cli*")"
+RUN ln -s "${JAVA_CLI_PATH}" $pwd/utbot-cli.jar

--- a/docker/Dockerfile_java_cli
+++ b/docker/Dockerfile_java_cli
@@ -18,9 +18,9 @@ COPY docker/get_java_cli_download_url.py .
 ENV JAVA_CLI_ZIP_NAME "utbot_java_cli.zip"
     
 RUN curl -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-    -L "$(python3 get_java_cli_download_url.py)" \
-    -o "${JAVA_CLI_ZIP_NAME}"
-    RUN unzip "${JAVA_CLI_ZIP_NAME}" \
+        -L "$(python3 get_java_cli_download_url.py)" \
+        -o "${JAVA_CLI_ZIP_NAME}" \
+    && unzip "${JAVA_CLI_ZIP_NAME}" \
     && rm "${JAVA_CLI_ZIP_NAME}"
 
 ENV JAVA_CLI_PATH="$(find $pwd -type f -name "utbot-cli*")"

--- a/docker/get_java_cli_download_url.py
+++ b/docker/get_java_cli_download_url.py
@@ -1,0 +1,14 @@
+import json
+import requests
+
+JAVA_ARTIFACTS_URL="https://api.github.com/repos/UnitTestBot/UTBotJava/actions/artifacts"
+
+request = requests.get(url = JAVA_ARTIFACTS_URL)
+data = request.json()
+artifacts = data['artifacts']
+
+for artifact in artifacts:
+    if "utbot-cli" in artifact['name']:
+        print(artifact['archive_download_url'])
+        break
+        


### PR DESCRIPTION
# Description

There were added scripts allowing to publish Java CLI images on GitHub Packages.

Fixes #263 

## Type of Change

Not applicable.

# How Has This Been Tested?

## Automated Testing

Not applicable.

## Manual Scenario 

Scripts were tested on fork.

# Checklist (remove irrelevant options):

Not applicable.