### PR TITLE
Add summary publication on GitHub Packages 

### DIFF
--- a/utbot-summary/build.gradle
+++ b/utbot-summary/build.gradle
@@ -14,3 +14,16 @@ dependencies {
 
     implementation group: 'com.github.javaparser', name: 'javaparser-core', version: '3.22.1'
 }
+
+publishing {
+  repositories {
+    maven {
+      name = "GitHubPackages"
+      url = "https://maven.pkg.github.com/UnitTestBot/UTBotJava"
+      credentials {
+        username = System.getenv("GITHUB_ACTOR")
+        password = System.getenv("GITHUB_TOKEN")
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Description

The script publishing on GitHub Packages and corresponding build.gradle files were updated. Now it can publish utbot-summary too.

Fixes #274

## Type of Change

Not applicable.

# How Has This Been Tested?

## Automated Testing

Not applicable.

## Manual Scenario 

The script was tested on fork.

# Checklist (remove irrelevant options):

Not applicable.
