### PR TITLE
Force mocking without mock framework installed fix

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Mocks.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Mocks.kt
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlin.reflect.KFunction2
 import kotlin.reflect.KFunction5
 import kotlinx.collections.immutable.persistentListOf
+import org.utbot.engine.util.mockListeners.MockListenerController
 import soot.BooleanType
 import soot.RefType
 import soot.Scene
@@ -133,7 +134,8 @@ class Mocker(
     private val strategy: MockStrategy,
     private val classUnderTest: ClassId,
     private val hierarchy: Hierarchy,
-    chosenClassesToMockAlways: Set<ClassId>
+    chosenClassesToMockAlways: Set<ClassId>,
+    internal val mockListenerController: MockListenerController? = null,
 ) {
     /**
      * Creates mocked instance of the [type] using mock info if it should be mocked by the mocker,
@@ -164,6 +166,11 @@ class Mocker(
      * For others, if mock is not a new instance mock, asks mock strategy for decision.
      */
     fun shouldMock(
+        type: RefType,
+        mockInfo: UtMockInfo,
+    ): Boolean = checkIfShouldMock(type, mockInfo).also { if (it) mockListenerController?.onShouldMock(strategy) }
+
+    private fun checkIfShouldMock(
         type: RefType,
         mockInfo: UtMockInfo
     ): Boolean {

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/util/mockListeners/ForceMockListener.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/util/mockListeners/ForceMockListener.kt
@@ -1,0 +1,21 @@
+package org.utbot.engine.util.mockListeners
+import org.utbot.engine.EngineController
+import org.utbot.engine.MockStrategy
+import org.utbot.engine.util.mockListeners.exceptions.ForceMockCancellationException
+
+/**
+ * Listener for mocker events in [org.utbot.engine.UtBotSymbolicEngine].
+ * If forced mock happened, cancels the engine job.
+ *
+ * Supposed to be created only if Mockito is not installed.
+ */
+class ForceMockListener: MockListener {
+    var forceMockHappened = false
+        private set
+
+    override fun onShouldMock(controller: EngineController, strategy: MockStrategy) {
+        // If force mocking happened -- сancel engine job
+        controller.job?.cancel(ForceMockCancellationException())
+        forceMockHappened = true
+    }
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/util/mockListeners/MockListener.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/util/mockListeners/MockListener.kt
@@ -1,0 +1,11 @@
+package org.utbot.engine.util.mockListeners
+
+import org.utbot.engine.EngineController
+import org.utbot.engine.MockStrategy
+
+/**
+ * Listener that can be attached using [MockListenerController] to mocker in [org.utbot.engine.UtBotSymbolicEngine].
+ */
+interface MockListener {
+    fun onShouldMock(controller: EngineController, strategy: MockStrategy)
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/util/mockListeners/MockListenerController.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/util/mockListeners/MockListenerController.kt
@@ -1,0 +1,19 @@
+package org.utbot.engine.util.mockListeners
+
+import org.utbot.engine.EngineController
+import org.utbot.engine.MockStrategy
+
+/**
+ * Controller that allows to attach listeners to mocker in [org.utbot.engine.UtBotSymbolicEngine].
+ */
+class MockListenerController(private val controller: EngineController) {
+    val listeners = mutableListOf<MockListener>()
+
+    fun attach(listener: MockListener) {
+        listeners += listener
+    }
+
+    fun onShouldMock(strategy: MockStrategy) {
+        listeners.map { it.onShouldMock(controller, strategy) }
+    }
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/util/mockListeners/exceptions/ForceMockCancellationException.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/util/mockListeners/exceptions/ForceMockCancellationException.kt
@@ -1,0 +1,8 @@
+package org.utbot.engine.util.mockListeners.exceptions
+
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Exception used in [org.utbot.engine.util.mockListeners.ForceMockListener].
+ */
+class ForceMockCancellationException: CancellationException("Forced mocks without Mockito")

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgTestClassConstructor.kt
@@ -188,6 +188,9 @@ data class TestsGenerationReport(
     val classUnderTest: KClass<*>
         get() = executables.firstOrNull()?.clazz ?: error("No executables found in test report")
 
+    // Initial message is generated lazily to avoid evaluation of classUnderTest
+    var initialMessage: () -> String = { "Unit tests for $classUnderTest were generated successfully." }
+
     fun addMethodErrors(testCase: UtTestCase, errors: Map<String, Int>) {
         this.errors[testCase.method] = errors
     }
@@ -212,7 +215,8 @@ data class TestsGenerationReport(
     }
 
     override fun toString(): String = buildString {
-        appendHtmlLine("Unit tests for $classUnderTest were generated successfully.")
+        appendHtmlLine(initialMessage())
+        appendHtmlLine()
         val testMethodsStatistic = executables.map { it.countTestMethods() }
         val errors = executables.map { it.countErrors() }
         val overallTestMethods = testMethodsStatistic.sumBy { it.count }

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/ConfigureWindowCommon.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/ConfigureWindowCommon.kt
@@ -1,0 +1,47 @@
+package org.utbot.intellij.plugin.ui
+
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.DependencyScope
+import com.intellij.openapi.roots.ExternalLibraryDescriptor
+import com.intellij.openapi.roots.JavaProjectModelModificationService
+import com.intellij.openapi.ui.Messages
+import org.jetbrains.concurrency.Promise
+import org.utbot.framework.plugin.api.MockFramework
+import org.utbot.intellij.plugin.ui.utils.LibrarySearchScope
+import org.utbot.intellij.plugin.ui.utils.findFrameworkLibrary
+import org.utbot.intellij.plugin.ui.utils.parseVersion
+
+fun createMockFrameworkNotificationDialog(title: String) = Messages.showYesNoDialog(
+    """Mock framework ${MockFramework.MOCKITO.displayName} is not installed into current module. 
+            |Would you like to install it now?""".trimMargin(),
+    title,
+    "Yes",
+    "No",
+    Messages.getQuestionIcon(),
+)
+
+fun configureMockFramework(project: Project, module: Module) {
+    val selectedMockFramework = MockFramework.MOCKITO
+
+    val libraryInProject =
+        findFrameworkLibrary(project, module, selectedMockFramework, LibrarySearchScope.Project)
+    val versionInProject = libraryInProject?.libraryName?.parseVersion()
+
+    selectedMockFramework.isInstalled = true
+    addDependency(project, module, mockitoCoreLibraryDescriptor(versionInProject))
+        .onError { selectedMockFramework.isInstalled = false }
+}
+
+/**
+ * Adds the dependency for selected framework via [JavaProjectModelModificationService].
+ *
+ * Note that version restrictions will be applied only if they are present on target machine
+ * Otherwise latest release version will be installed.
+ */
+fun addDependency(project: Project, module: Module, libraryDescriptor: ExternalLibraryDescriptor): Promise<Void> {
+    return JavaProjectModelModificationService
+        .getInstance(project)
+        //this method returns JetBrains internal Promise that is difficult to deal with, but it is our way
+        .addDependency(module, libraryDescriptor, DependencyScope.TEST)
+}

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsModel.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsModel.kt
@@ -26,7 +26,8 @@ data class GenerateTestsModel(
     var srcClasses: Set<PsiClass>,
     var selectedMethods: Set<MemberInfo>?,
     var timeout:Long,
-    var generateWarningsForStaticMocking: Boolean = false
+    var generateWarningsForStaticMocking: Boolean = false,
+    var forceMockHappened: Boolean = false
 ) {
     var testSourceRoot: VirtualFile? = null
     var testPackageName: String? = null

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/Notifications.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/Notifications.kt
@@ -1,6 +1,7 @@
 package org.utbot.intellij.plugin.ui
 
 import com.intellij.ide.util.PropertiesComponent
+import com.intellij.notification.Notification
 import com.intellij.notification.NotificationDisplayType
 import com.intellij.notification.NotificationGroup
 import com.intellij.notification.NotificationListener
@@ -11,12 +12,14 @@ import com.intellij.openapi.keymap.KeymapUtil
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.StartupActivity
+import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.ui.popup.Balloon
 import com.intellij.openapi.wm.WindowManager
 import com.intellij.ui.GotItMessage
 import com.intellij.ui.awt.RelativePoint
 import com.intellij.util.ui.JBFont
 import java.awt.Point
+import javax.swing.event.HyperlinkEvent
 
 abstract class Notifier {
     protected abstract val notificationType: NotificationType
@@ -76,6 +79,7 @@ object UnsupportedTestFrameworkNotifier : ErrorNotifier() {
 abstract class UrlNotifier : Notifier() {
 
     protected abstract val titleText: String
+    protected abstract val urlOpeningListener: NotificationListener
 
     override fun notify(info: String, project: Project?, module: Module?) {
         notificationGroup
@@ -83,7 +87,7 @@ abstract class UrlNotifier : Notifier() {
                 titleText,
                 content(project, module, info),
                 notificationType,
-                NotificationListener.UrlOpeningListener(false)
+                urlOpeningListener,
             ).notify(project)
     }
 }
@@ -98,6 +102,8 @@ object SarifReportNotifier : InformationUrlNotifier() {
 
     override val titleText: String = "" // no title
 
+    override val urlOpeningListener: NotificationListener = NotificationListener.UrlOpeningListener(false)
+
     override fun content(project: Project?, module: Module?, info: String): String = info
 }
 
@@ -106,7 +112,54 @@ object TestsReportNotifier : InformationUrlNotifier() {
 
     override val titleText: String = "Report of the unit tests generation via UtBot"
 
-    override fun content(project: Project?, module: Module?, info: String): String = info
+    override val urlOpeningListener: TestReportUrlOpeningListener = TestReportUrlOpeningListener()
+
+    override fun content(project: Project?, module: Module?, info: String): String {
+        // Remember last project and module to use them for configurations.
+        urlOpeningListener.project = project
+        urlOpeningListener.module = module
+        return info
+    }
+}
+
+/**
+ * Listener that handles URLs starting with [prefix], like "#utbot/configure-mockito".
+ *
+ * Current implementation
+ */
+class TestReportUrlOpeningListener: NotificationListener.Adapter() {
+    companion object {
+        const val prefix = "#utbot/"
+        const val mockitoSuffix = "configure-mockito"
+    }
+    private val defaultListener = NotificationListener.UrlOpeningListener(false)
+
+    // Last project and module to be able to use them when activated for configuration tasks.
+    var project: Project? = null
+    var module: Module? = null
+
+    override fun hyperlinkActivated(notification: Notification, e: HyperlinkEvent) {
+        val description = e.description
+        if (description.startsWith(prefix)) {
+            handleDescription(description.removePrefix(prefix))
+        } else {
+            return defaultListener.hyperlinkUpdate(notification, e)
+        }
+    }
+
+    private fun handleDescription(descriptionSuffix: String) {
+        when {
+            descriptionSuffix.startsWith(mockitoSuffix) -> {
+                project?.let { project -> module?.let { module ->
+                        if (createMockFrameworkNotificationDialog("Configure mock framework") == Messages.YES) {
+                            configureMockFramework(project, module)
+                        }
+                    } ?: error("Could not configure mock framework: module is null for project $project")
+                } ?: error("Could not configure mock framework: project is null")
+            }
+            else -> error("No such command with #utbot prefix: $descriptionSuffix")
+        }
+    }
 }
 
 object GotItTooltipActivity : StartupActivity {


### PR DESCRIPTION
# Description

Added mock listeners for engine to make it abstract from external events.
Added force mock listener.
Added url handler for urls like "#utbot/..." to launch configuration tasks from popups.
Added message with link to mock framework configuration to test reports if force mocking happened.

Fixes #190

## Type of Change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

Launched project without mockito installed.
Generated tests for Sort.quickSort without mocks -> mocks for Random were forced.
Checked that message suggesting mockito installation appeared in test report.
Verified that link in that message leads to the window for mockito configuration, and it installs correctly.
After installation, tests with force-mocks were generated correctly.

# Checklist (remove irrelevant options):

- [ ] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] Tests that prove my change is effective
- [ ] All tests pass locally with my changes
