### PR TITLE
Forgotten archive makes the plugin archive twice big

### DIFF
--- a/.github/workflows/publish-plugin-and-cli-from-branch.yml
+++ b/.github/workflows/publish-plugin-and-cli-from-branch.yml
@@ -45,6 +45,7 @@ jobs:
           gradle buildPlugin --no-daemon -PsemVer=${{ env.VERSION }}
           cd utbot-intellij/build/distributions
           unzip utbot-intellij-${{ env.VERSION }}.zip
+          rm utbot-intellij-${{ env.VERSION }}.zip
           
       - name: Archive UTBot IntelliJ IDEA plugin
         uses: actions/upload-artifact@v2

--- a/.github/workflows/publish-plugin-and-cli.yml
+++ b/.github/workflows/publish-plugin-and-cli.yml
@@ -28,6 +28,7 @@ jobs:
           gradle buildPlugin --no-daemon -PsemVer=${{ env.VERSION }}
           cd utbot-intellij/build/distributions
           unzip utbot-intellij-${{ env.VERSION }}.zip
+          rm utbot-intellij-${{ env.VERSION }}.zip
           
       - name: Archive UTBot IntelliJ IDEA plugin
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
# Description

It seems that in publish-plugin-and-cli.yml we forget removing the source archive.

