### PR TITLE
Add linearStateRewardPredictor and fix names

### DIFF
--- a/docs/jlearch/jlearch-architecture.md
+++ b/docs/jlearch/jlearch-architecture.md
@@ -136,7 +136,7 @@ Interface for reward predictors. Now it has three implementations in `analytics`
 
 * `NNStateRewardPredictorSmile`: it uses our own format to store feedforward neural network, and it uses `Smile` library to do multiplication of matrix.
 * `NNStateRewardPredictorTorch`: it assumed that a model is any type of model in `pt` format. It uses the `Deep Java library` to use such models.
-* `LinearStateRewardPredictor`: it read weights vector as line of doubles, separated by comma.
+* `LinearStateRewardPredictor`: it uses our own format to store weights vector: line of doubles, separated by comma with bias as last weight.
 
 It should be created at the beginning of work and stored at `Predictors` class to be used in `NNRewardGuidedSelector` from the `framework` module.
 

--- a/docs/jlearch/jlearch-architecture.md
+++ b/docs/jlearch/jlearch-architecture.md
@@ -37,7 +37,7 @@ classDiagram
     UtBotSymbolicEngine *-- InterproceduralUnitGraph
 
     class Predictors 
-    class NNStateRewardPredictor
+    class StateRewardPredictor
     class NNRewardGuidedSelector
 
    
@@ -50,12 +50,13 @@ classDiagram
 
     UtBotSymbolicEngine *-- BasePathSelector  
     
-    Predictors o-- NNStateRewardPredictor
+    Predictors o-- StateRewardPredictor
     NNRewardGuidedSelector ..> Predictors
     NNRewardGuidedSelector *-- FeatureExtractor
     
-    NNStateRewardPredictorSmile --|> NNStateRewardPredictor
-    NNStateRewardPredictorTorch --|> NNStateRewardPredictor
+    NNStateRewardPredictorSmile --|> StateRewardPredictor
+    StateRewardPredictorTorch --|> StateRewardPredictor
+    LinearStateRewardPredictor --|> StateRewardPredictor
     
     NNStateRewardGuidedSelectorWithRecalculationWeight --|> NNRewardGuidedSelector
     NNStateRewardGuidedSelectorWithoutRecalculationWeight --|> NNRewardGuidedSelector      
@@ -129,12 +130,13 @@ For creating `FeatureExtractor`, it uses `FeatureExtractorFactory` from `EngineA
 It is interface in framework-module, that allows to use implementation from analytics module.
 * `extractFeatures(state: ExecutionState)` - create features list for state and store it in `state.features`. Now we extract all features, which were described in [paper](https://files.sri.inf.ethz.ch/website/papers/ccs21-learch.pdf). In feature, we can extend the feature list by other features, for example, NeuroSMT.
 
-# NNStateRewardPredictor
+# StateRewardPredictor
 
-Interface for reward predictors. Now it has two implementations in `analytics` module:
+Interface for reward predictors. Now it has three implementations in `analytics` module:
 
 * `NNStateRewardPredictorSmile`: it uses our own format to store feedforward neural network, and it uses `Smile` library to do multiplication of matrix.
 * `NNStateRewardPredictorTorch`: it assumed that a model is any type of model in `pt` format. It uses the `Deep Java library` to use such models.
+* `LinearStateRewardPredictor`: it read weights vector as line of doubles, separated by comma.
 
 It should be created at the beginning of work and stored at `Predictors` class to be used in `NNRewardGuidedSelector` from the `framework` module.
 

--- a/utbot-analytics/src/main/kotlin/org/utbot/predictors/FeedForwardNetwork.kt
+++ b/utbot-analytics/src/main/kotlin/org/utbot/predictors/FeedForwardNetwork.kt
@@ -1,5 +1,6 @@
 package org.utbot.predictors
 
+import org.utbot.predictors.util.ModelBuildingException
 import smile.math.matrix.Matrix
 import kotlin.math.max
 
@@ -26,7 +27,7 @@ internal fun buildModel(nnJson: NNJson): FeedForwardNetwork {
             operations.add {
                 when (nnJson.activationLayers[i]) {
                     ActivationFunctions.ReLU -> reLU(it)
-                    else -> error("Unsupported activation")
+                    else -> throw ModelBuildingException("Unsupported activation")
                 }
             }
         }

--- a/utbot-analytics/src/main/kotlin/org/utbot/predictors/NNJson.kt
+++ b/utbot-analytics/src/main/kotlin/org/utbot/predictors/NNJson.kt
@@ -2,6 +2,7 @@ package org.utbot.predictors
 
 import com.google.gson.Gson
 import org.utbot.framework.UtSettings
+import org.utbot.predictors.util.ModelLoadingException
 import java.io.FileReader
 import java.nio.file.Paths
 
@@ -33,10 +34,16 @@ data class NNJson(
 
 internal fun loadModel(path: String): NNJson {
     val modelFile = Paths.get(UtSettings.rewardModelPath, path).toFile()
-    val nnJson: NNJson =
-        Gson().fromJson(FileReader(modelFile), NNJson::class.java) ?: run {
-            error("Empty model")
-        }
+    lateinit var nnJson: NNJson
+
+    try {
+        nnJson =
+            Gson().fromJson(FileReader(modelFile), NNJson::class.java) ?: run {
+                error("Empty model")
+            }
+    } catch (e: Exception) {
+        throw ModelLoadingException(e)
+    }
 
     return nnJson
 }

--- a/utbot-analytics/src/main/kotlin/org/utbot/predictors/NNStateRewardPredictor.kt
+++ b/utbot-analytics/src/main/kotlin/org/utbot/predictors/NNStateRewardPredictor.kt
@@ -1,8 +1,0 @@
-package org.utbot.predictors
-
-import org.utbot.analytics.UtBotAbstractPredictor
-
-/**
- * Interface, which should predict reward for state by features list.
- */
-interface NNStateRewardPredictor : UtBotAbstractPredictor<List<Double>, Double>

--- a/utbot-analytics/src/main/kotlin/org/utbot/predictors/NNStateRewardPredictorBase.kt
+++ b/utbot-analytics/src/main/kotlin/org/utbot/predictors/NNStateRewardPredictorBase.kt
@@ -4,6 +4,7 @@ import mu.KotlinLogging
 import org.utbot.analytics.StateRewardPredictor
 import org.utbot.framework.PathSelectorType
 import org.utbot.framework.UtSettings
+import org.utbot.predictors.util.PredictorLoadingException
 import smile.math.matrix.Matrix
 
 private const val DEFAULT_MODEL_PATH = "nn.json"
@@ -21,7 +22,7 @@ class NNStateRewardPredictorBase(modelPath: String = DEFAULT_MODEL_PATH, scalerP
         try {
             nn = getModel(modelPath)
             scaler = loadScaler(scalerPath)
-        } catch (e: Exception) {
+        } catch (e: PredictorLoadingException) {
             logger.info(e) {
                 "Error while initialization of NNStateRewardPredictorBase. Changing pathSelectorType on INHERITORS_SELECTOR"
             }

--- a/utbot-analytics/src/main/kotlin/org/utbot/predictors/NNStateRewardPredictorBase.kt
+++ b/utbot-analytics/src/main/kotlin/org/utbot/predictors/NNStateRewardPredictorBase.kt
@@ -1,19 +1,19 @@
 package org.utbot.predictors
 
 import mu.KotlinLogging
+import org.utbot.analytics.StateRewardPredictor
 import org.utbot.framework.PathSelectorType
 import org.utbot.framework.UtSettings
 import smile.math.matrix.Matrix
 
 private const val DEFAULT_MODEL_PATH = "nn.json"
-private const val DEFAULT_SCALER_PATH = "scaler.txt"
 
 private val logger = KotlinLogging.logger {}
 
 private fun getModel(path: String) = buildModel(loadModel(path))
 
 class NNStateRewardPredictorBase(modelPath: String = DEFAULT_MODEL_PATH, scalerPath: String = DEFAULT_SCALER_PATH) :
-    NNStateRewardPredictor {
+    StateRewardPredictor {
     private lateinit var nn: FeedForwardNetwork
     private lateinit var scaler: StandardScaler
 

--- a/utbot-analytics/src/main/kotlin/org/utbot/predictors/StateRewardPredictorFactory.kt
+++ b/utbot-analytics/src/main/kotlin/org/utbot/predictors/StateRewardPredictorFactory.kt
@@ -1,0 +1,16 @@
+package org.utbot.predictors
+
+import org.utbot.analytics.StateRewardPredictorFactory
+import org.utbot.framework.StateRewardPredictorType
+import org.utbot.framework.UtSettings
+
+/**
+ * Creates [StateRewardPredictor], by checking the [UtSettings] configuration.
+ */
+class StateRewardPredictorFactoryImpl : StateRewardPredictorFactory {
+    override operator fun invoke() = when (UtSettings.stateRewardPredictorType) {
+        StateRewardPredictorType.BASE -> NNStateRewardPredictorBase()
+        StateRewardPredictorType.TORCH -> StateRewardPredictorTorch()
+        StateRewardPredictorType.LINEAR -> LinearStateRewardPredictor()
+    }
+}

--- a/utbot-analytics/src/main/kotlin/org/utbot/predictors/StateRewardPredictorTorch.kt
+++ b/utbot-analytics/src/main/kotlin/org/utbot/predictors/StateRewardPredictorTorch.kt
@@ -6,11 +6,12 @@ import ai.djl.ndarray.NDArray
 import ai.djl.ndarray.NDList
 import ai.djl.translate.Translator
 import ai.djl.translate.TranslatorContext
+import org.utbot.analytics.StateRewardPredictor
 import org.utbot.framework.UtSettings
 import java.io.Closeable
 import java.nio.file.Paths
 
-class NNStateRewardPredictorTorch : NNStateRewardPredictor, Closeable {
+class StateRewardPredictorTorch : StateRewardPredictor, Closeable {
     val model: Model = Model.newInstance("model")
 
     init {

--- a/utbot-analytics/src/main/kotlin/org/utbot/predictors/scalers.kt
+++ b/utbot-analytics/src/main/kotlin/org/utbot/predictors/scalers.kt
@@ -1,6 +1,8 @@
 package org.utbot.predictors
 
 import org.utbot.framework.UtSettings
+import org.utbot.predictors.util.ScalerLoadingException
+import org.utbot.predictors.util.splitByCommaIntoDoubleArray
 import smile.math.matrix.Matrix
 import java.nio.file.Paths
 
@@ -10,8 +12,12 @@ internal const val DEFAULT_SCALER_PATH = "scaler.txt"
 data class StandardScaler(val mean: Matrix?, val variance: Matrix?)
 
 internal fun loadScaler(path: String): StandardScaler =
-    Paths.get(UtSettings.rewardModelPath, path).toFile().bufferedReader().use {
-        val mean = it.readLine()?.splitByCommaIntoDoubleArray() ?: error("There is not mean in $path")
-        val variance = it.readLine()?.splitByCommaIntoDoubleArray() ?: error("There is not variance in $path")
-        StandardScaler(Matrix(mean), Matrix(variance))
+    try {
+        Paths.get(UtSettings.rewardModelPath, path).toFile().bufferedReader().use {
+            val mean = it.readLine()?.splitByCommaIntoDoubleArray() ?: error("There is not mean in $path")
+            val variance = it.readLine()?.splitByCommaIntoDoubleArray() ?: error("There is not variance in $path")
+            StandardScaler(Matrix(mean), Matrix(variance))
+        }
+    } catch (e: Exception) {
+        throw ScalerLoadingException(e)
     }

--- a/utbot-analytics/src/main/kotlin/org/utbot/predictors/scalers.kt
+++ b/utbot-analytics/src/main/kotlin/org/utbot/predictors/scalers.kt
@@ -4,6 +4,9 @@ import org.utbot.framework.UtSettings
 import smile.math.matrix.Matrix
 import java.nio.file.Paths
 
+
+internal const val DEFAULT_SCALER_PATH = "scaler.txt"
+
 data class StandardScaler(val mean: Matrix?, val variance: Matrix?)
 
 internal fun loadScaler(path: String): StandardScaler =

--- a/utbot-analytics/src/main/kotlin/org/utbot/predictors/util/PredictorLoadingException.kt
+++ b/utbot-analytics/src/main/kotlin/org/utbot/predictors/util/PredictorLoadingException.kt
@@ -1,0 +1,11 @@
+package org.utbot.predictors.util
+
+sealed class PredictorLoadingException(msg: String?, cause: Throwable? = null) : Exception(msg, cause)
+
+class WeightsLoadingException(e: Throwable) : PredictorLoadingException("Error while loading weights", e)
+
+class ModelLoadingException(e: Throwable) : PredictorLoadingException("Error while loading model", e)
+
+class ScalerLoadingException(e: Throwable) : PredictorLoadingException("Error while loading scaler", e)
+
+class ModelBuildingException(msg: String) : PredictorLoadingException(msg)

--- a/utbot-analytics/src/main/kotlin/org/utbot/predictors/util/StringUtils.kt
+++ b/utbot-analytics/src/main/kotlin/org/utbot/predictors/util/StringUtils.kt
@@ -1,4 +1,4 @@
-package org.utbot.predictors
+package org.utbot.predictors.util
 
 fun String.splitByCommaIntoDoubleArray() =
     try {

--- a/utbot-analytics/src/test/kotlin/org/utbot/predictors/LinearStateRewardPredictorTest.kt
+++ b/utbot-analytics/src/test/kotlin/org/utbot/predictors/LinearStateRewardPredictorTest.kt
@@ -31,4 +31,15 @@ class LinearStateRewardPredictorTest {
             }
         }
     }
+
+    @Test
+    fun simpleTestNotBatch() {
+        withRewardModelPath("src/test/resources") {
+            val pred = LinearStateRewardPredictor()
+
+            val features = listOf(2.0, 3.0)
+
+            assertEquals(6.0, pred.predict(features))
+        }
+    }
 }

--- a/utbot-analytics/src/test/kotlin/org/utbot/predictors/NNStateRewardPredictorTest.kt
+++ b/utbot-analytics/src/test/kotlin/org/utbot/predictors/NNStateRewardPredictorTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.utbot.examples.withPathSelectorType
+import org.utbot.analytics.StateRewardPredictor
 import org.utbot.examples.withRewardModelPath
 import org.utbot.framework.PathSelectorType
 import org.utbot.framework.UtSettings
@@ -32,13 +33,13 @@ class NNStateRewardPredictorTest {
 
 
         withRewardModelPath("models") {
-            val averageTime = calcAverageTimeForModelPredict(::NNStateRewardPredictorTorch, 100, features)
+            val averageTime = calcAverageTimeForModelPredict(::StateRewardPredictorTorch, 100, features)
             println(averageTime)
         }
     }
 
     private fun calcAverageTimeForModelPredict(
-        model: () -> NNStateRewardPredictor,
+        model: () -> StateRewardPredictor,
         iterations: Int,
         features: List<Double>
     ): Double {

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -115,6 +115,11 @@ object UtSettings {
     var nnRewardGuidedSelectorType: NNRewardGuidedSelectorType by getEnumProperty(NNRewardGuidedSelectorType.WITHOUT_RECALCULATION)
 
     /**
+     * Type of [StateRewardPredictor]
+     */
+    var stateRewardPredictorType: StateRewardPredictorType by getEnumProperty(StateRewardPredictorType.BASE)
+
+    /**
      * Steps limit for path selector.
      */
     var pathSelectorStepsLimit by getIntProperty(3500)
@@ -421,4 +426,24 @@ enum class NNRewardGuidedSelectorType {
      * [NNRewardGuidedSelectorWithoutRecalculation]
      */
     WITHOUT_RECALCULATION
+}
+
+/**
+ * Enum to specify [StateRewardPredictor], see implementations for details
+ */
+enum class StateRewardPredictorType {
+    /**
+     * [NNStateRewardPredictorBase]
+     */
+    BASE,
+
+    /**
+     * [StateRewardPredictorTorch]
+     */
+    TORCH,
+
+    /**
+     * [NNStateRewardPredictorBase]
+     */
+    LINEAR
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/analytics/EngineAnalyticsContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/analytics/EngineAnalyticsContext.kt
@@ -32,6 +32,5 @@ object EngineAnalyticsContext {
         override fun invoke(): StateRewardPredictor {
             error("NNStateRewardPredictor factory wasn't provided")
         }
-
     }
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/analytics/EngineAnalyticsContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/analytics/EngineAnalyticsContext.kt
@@ -27,4 +27,11 @@ object EngineAnalyticsContext {
         NNRewardGuidedSelectorType.WITHOUT_RECALCULATION -> NNRewardGuidedSelectorWithoutRecalculationFactory()
         NNRewardGuidedSelectorType.WITH_RECALCULATION -> NNRewardGuidedSelectorWithRecalculationFactory()
     }
+
+    var stateRewardPredictorFactory: StateRewardPredictorFactory = object : StateRewardPredictorFactory {
+        override fun invoke(): StateRewardPredictor {
+            error("NNStateRewardPredictor factory wasn't provided")
+        }
+
+    }
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/analytics/StateRewardPredictor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/analytics/StateRewardPredictor.kt
@@ -1,0 +1,6 @@
+package org.utbot.analytics
+
+/**
+ * Interface, which should predict reward for state by features list.
+ */
+interface StateRewardPredictor : UtBotAbstractPredictor<List<Double>, Double>

--- a/utbot-framework/src/main/kotlin/org/utbot/analytics/StateRewardPredictorFactory.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/analytics/StateRewardPredictorFactory.kt
@@ -1,0 +1,8 @@
+package org.utbot.analytics
+
+/**
+ * Encapsulates creation of [StateRewardPredictor]
+ */
+interface StateRewardPredictorFactory {
+    operator fun invoke(): StateRewardPredictor
+}

--- a/utbot-junit-contest/src/main/kotlin/org/utbot/contest/ContestEstimator.kt
+++ b/utbot-junit-contest/src/main/kotlin/org/utbot/contest/ContestEstimator.kt
@@ -34,6 +34,7 @@ import kotlin.concurrent.thread
 import kotlin.math.min
 import kotlin.system.exitProcess
 import org.utbot.framework.JdkPathService
+import org.utbot.predictors.StateRewardPredictorFactoryImpl
 
 private val logger = KotlinLogging.logger {}
 
@@ -323,9 +324,10 @@ fun runEstimator(
 //    Predictors.smt = UtBotTimePredictor()
 //    Predictors.smtIncremental = UtBotTimePredictorIncremental()
 //    Predictors.testName = StatementUniquenessPredictor()
-//    Predictors.stateRewardPredictor = NNStateRewardPredictorBase()
     EngineAnalyticsContext.featureProcessorFactory = FeatureProcessorWithStatesRepetitionFactory()
     EngineAnalyticsContext.featureExtractorFactory = FeatureExtractorFactoryImpl()
+    EngineAnalyticsContext.stateRewardPredictorFactory = StateRewardPredictorFactoryImpl()
+//    Predictors.stateRewardPredictor = EngineAnalyticsContext.stateRewardPredictorFactory()
 
 
     // fix for CTRL-ALT-SHIFT-C from IDEA, which copies in class#method form

--- a/utbot-junit-contest/src/main/kotlin/org/utbot/contest/ContestEstimator.kt
+++ b/utbot-junit-contest/src/main/kotlin/org/utbot/contest/ContestEstimator.kt
@@ -327,7 +327,12 @@ fun runEstimator(
     EngineAnalyticsContext.featureProcessorFactory = FeatureProcessorWithStatesRepetitionFactory()
     EngineAnalyticsContext.featureExtractorFactory = FeatureExtractorFactoryImpl()
     EngineAnalyticsContext.stateRewardPredictorFactory = StateRewardPredictorFactoryImpl()
-//    Predictors.stateRewardPredictor = EngineAnalyticsContext.stateRewardPredictorFactory()
+
+    /**
+     * Uncomment if you want to use NN_REWARD_GUIDED_SELECTOR
+     *
+     * Predictors.stateRewardPredictor = EngineAnalyticsContext.stateRewardPredictorFactory()
+    */
 
 
     // fix for CTRL-ALT-SHIFT-C from IDEA, which copies in class#method form


### PR DESCRIPTION
# Description

Implemented linearStateRewardPredictor, fix naming and update docs.

Fixes #301

## Type of Change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Automated Testing

org.utbot.predictors.LinearStateRewardPredictorTest

## Manual Scenario 

* Take model from @Atos1337 or @amandelpie
* `UtSettings.pathSelectorType=NN_REWARD_GUIDED_SELECTOR`
* `UtSettings.stateRewardPredictorType=LINEAR`
* `UtSettings.rewardModelPath=path/to/model`
* Run ContestEstimator

