### PR TITLE
Correct asserts on booleans in parametrized tests

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
@@ -534,10 +534,15 @@ internal class CgMethodConstructor(val context: CgContext) : CgContextOwner by c
                                 doubleDelta
                             )
                         expectedModel.value is Boolean -> {
-                            if (expectedModel.value as Boolean) {
-                                assertions[assertTrue](actual)
-                            } else {
-                                assertions[assertFalse](actual)
+                            when (parameterizedTestSource) {
+                                ParametrizedTestSource.DO_NOT_PARAMETRIZE ->
+                                    if (expectedModel.value as Boolean) {
+                                        assertions[assertTrue](actual)
+                                    } else {
+                                        assertions[assertFalse](actual)
+                                    }
+                                ParametrizedTestSource.PARAMETRIZE ->
+                                    assertions[assertEquals](expected, actual)
                             }
                         }
                         // other primitives and string
@@ -1018,10 +1023,14 @@ internal class CgMethodConstructor(val context: CgContext) : CgContextOwner by c
                     )
                 }
                 expected == nullLiteral() -> testFrameworkManager.assertNull(actual)
-                expected is CgLiteral && expected.value is Boolean -> testFrameworkManager.assertBoolean(
-                    expected.value,
-                    actual
-                )
+                expected is CgLiteral && expected.value is Boolean -> {
+                    when (parameterizedTestSource) {
+                        ParametrizedTestSource.DO_NOT_PARAMETRIZE ->
+                            testFrameworkManager.assertBoolean(expected.value, actual)
+                        ParametrizedTestSource.PARAMETRIZE ->
+                            testFrameworkManager.assertEquals(expected, actual)
+                    }
+                }
                 else -> {
                     if (expected is CgLiteral) {
                         // Literal can only be Primitive or String, can use equals here

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgJavaRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgJavaRenderer.kt
@@ -213,7 +213,7 @@ internal class CgJavaRenderer(context: CgContext, printer: CgPrinter = CgPrinter
         //we do not have a good string representation for two-dimensional array, so this strange if-else is required
         val returnType =
             if (element.returnType.simpleName == "Object[][]") "java.lang.Object[][]" else "${element.returnType}"
-        print("public static $returnType ${element.name}() throws Exception")
+        print("public static $returnType ${element.name}()")
     }
 
     override fun visit(element: CgInnerBlock) {


### PR DESCRIPTION
# Description

Assert booleans equality with assertEquals in parametrized tests

Fixes # ([248](https://github.com/UnitTestBot/UTBotJava/issues/248))

## Type of Change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

`IntExamples.orderCheck` from our utbot-samples project

## Manual Scenario 

Parametrized tests on function that return boolean. Not required if pipline passes.
