### PR TITLE
Dedicated test root for auto-generated tests should be provided #159

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -28,7 +28,6 @@ import org.utbot.intellij.plugin.ui.utils.findFrameworkLibrary
 import org.utbot.intellij.plugin.ui.utils.getOrCreateTestResourcesPath
 import org.utbot.intellij.plugin.ui.utils.kotlinTargetPlatform
 import org.utbot.intellij.plugin.ui.utils.parseVersion
-import org.utbot.intellij.plugin.ui.utils.suitableTestSourceRoots
 import org.utbot.intellij.plugin.ui.utils.testResourceRootTypes
 import org.utbot.intellij.plugin.ui.utils.addSourceRootIfAbsent
 import org.utbot.intellij.plugin.ui.utils.testRootType
@@ -37,8 +36,6 @@ import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.components.service
 import com.intellij.openapi.options.ShowSettingsUtil
-import com.intellij.openapi.roots.ContentEntry
-import com.intellij.openapi.projectRoots.JavaSdkVersion
 import com.intellij.openapi.roots.ContentEntry
 import com.intellij.openapi.roots.DependencyScope
 import com.intellij.openapi.roots.ExternalLibraryDescriptor
@@ -51,7 +48,6 @@ import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.openapi.util.Computable
-import com.intellij.openapi.ui.popup.IconButton
 import com.intellij.openapi.vfs.StandardFileSystems
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VfsUtilCore.urlToPath
@@ -79,15 +75,9 @@ import com.intellij.ui.layout.Row
 import com.intellij.ui.layout.panel
 import com.intellij.util.IncorrectOperationException
 import com.intellij.util.io.exists
-import com.intellij.util.lang.JavaVersion
-import com.intellij.util.ui.JBUI
-import com.intellij.util.ui.JBUI.Borders.empty
-import com.intellij.util.ui.JBUI.Borders.merge
-import com.intellij.util.ui.JBUI.scale
 import com.intellij.util.ui.JBUI.size
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
-import com.intellij.util.ui.components.BorderLayoutPanel
 import java.awt.BorderLayout
 import java.nio.file.Files
 import java.nio.file.Path
@@ -461,6 +451,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
         } finally {
             if (modifiableModel.isWritable && !modifiableModel.isDisposed) modifiableModel.dispose()
         }
+    }
 
     private fun createPackageWrapper(packageName: String?): PackageWrapper =
         PackageWrapper(PsiManager.getInstance(model.project), trimPackageName(packageName))

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/ModuleUtils.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/ModuleUtils.kt
@@ -14,16 +14,20 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.JavaSdk
 import com.intellij.openapi.projectRoots.JavaSdkVersion
 import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.roots.ContentEntry
+import com.intellij.openapi.roots.ModifiableRootModel
 import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.SourceFolder
 import com.intellij.openapi.roots.TestModuleProperties
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.newvfs.impl.FakeVirtualFile
 import com.intellij.util.PathUtil.getParentPath
 import java.nio.file.Path
 import mu.KotlinLogging
 import org.jetbrains.android.sdk.AndroidSdkType
+import org.jetbrains.jps.model.module.JpsModuleSourceRootType
 import org.jetbrains.kotlin.config.KotlinFacetSettingsProvider
 import org.jetbrains.kotlin.config.TestResourceKotlinRootType
 import org.jetbrains.kotlin.platform.TargetPlatformVersion
@@ -112,7 +116,7 @@ private fun findPotentialModuleForTests(project: Project, srcModule: Module): Mo
 /**
  * Finds all suitable test root virtual files.
  */
-private fun Module.suitableTestSourceRoots(codegenLanguage: CodegenLanguage): List<VirtualFile> {
+fun Module.suitableTestSourceRoots(codegenLanguage: CodegenLanguage): List<VirtualFile> {
     val sourceRootsInModule = suitableTestSourceFolders(codegenLanguage).mapNotNull { it.file }
 
     if (sourceRootsInModule.isNotEmpty()) {
@@ -141,53 +145,90 @@ private fun Module.suitableTestSourceFolders(codegenLanguage: CodegenLanguage): 
         .sortedBy { it.url.length }
 }
 
+private const val dedicatedTestSourceRootName = "utbot_tests"
+fun Module.addDedicatedTestRoot(testSourceRoots : MutableList<VirtualFile>) : VirtualFile? {
+    // Dedicated test root already exists
+    // OR it looks like standard structure of Gradle project where 'unexpected' test roots won't work
+    if (testSourceRoots.any { file ->
+            file.name == dedicatedTestSourceRootName || file.path.endsWith("src/test/java")
+        }) return null
+
+    val moduleInstance = ModuleRootManager.getInstance(this)
+    val testFolder = moduleInstance.contentEntries.flatMap { it.sourceFolders.toList() }
+        .firstOrNull { it.rootType in testSourceRootTypes }
+    (testFolder?.let { testFolder.file?.parent } ?: (testFolder?.contentEntry
+        ?: moduleInstance.contentEntries.first()).file ?: moduleFile)?.let {
+        val file = FakeVirtualFile(it, dedicatedTestSourceRootName)
+        testSourceRoots.add(file)
+        // We return "true" IFF it's case of not yet created fake directory
+        return if (VfsUtil.findRelativeFile(it, dedicatedTestSourceRootName) == null) file else null
+    }
+    return null
+}
+
 private const val resourcesSuffix = "/resources"
 
 private fun getOrCreateTestResourcesUrl(module: Module, testSourceRoot: VirtualFile?): String {
-    val moduleInstance = ModuleRootManager.getInstance(module)
-    val sourceFolders = moduleInstance.contentEntries.flatMap { it.sourceFolders.toList() }
-
-    val testResourcesFolder = sourceFolders
-        .filter { sourceFolder ->
-            sourceFolder.rootType in testResourceRootTypes && !sourceFolder.isForGeneratedSources()
-        }
-        // taking the source folder that has the maximum common prefix
-        // with `testSourceRoot`, which was selected by the user
-        .maxBy { sourceFolder ->
-            val sourceFolderPath = sourceFolder.file?.path ?: ""
-            val testSourceRootPath = testSourceRoot?.path ?: ""
-            sourceFolderPath.commonPrefixWith(testSourceRootPath).length
-        }
-    if (testResourcesFolder != null) {
-        return testResourcesFolder.url
-    }
-
-    val testFolder = sourceFolders.firstOrNull { it.rootType in testSourceRootTypes }
-    val contentEntry = testFolder?.contentEntry ?: moduleInstance.contentEntries.first()
-
-    val parentFolderUrl = testFolder?.let { getParentPath(testFolder.url) }
-    val testResourcesUrl =
-        if (parentFolderUrl != null) "${parentFolderUrl}$resourcesSuffix" else "${contentEntry.url}$resourcesSuffix"
-
-    val codegenLanguage =
-        if (testFolder?.rootType == TestResourceKotlinRootType) CodegenLanguage.KOTLIN else CodegenLanguage.JAVA
-
+    val rootModel = ModuleRootManager.getInstance(module).modifiableModel
     try {
-        WriteCommandAction.runWriteCommandAction(module.project) {
-            contentEntry.addSourceFolder(testResourcesUrl, codegenLanguage.testResourcesRootType())
-            moduleInstance.modifiableModel.commit()
-            VfsUtil.createDirectoryIfMissing(VfsUtilCore.urlToPath(testResourcesUrl))
-        }
-    }
-    catch (e: java.lang.IllegalStateException) {
-        // Hack to avoid unmodifiable ModuleBridge testModule on Android SAT-1536.
-        workaround(WorkaroundReason.HACK) {
-            logger.info("Error during SARIF report generation: $e")
-            return testFolder!!.url
-        }
-    }
+        val sourceFolders = rootModel.contentEntries.flatMap { it.sourceFolders.toList() }
 
-    return testResourcesUrl
+        val testResourcesFolder = sourceFolders
+            .filter { sourceFolder ->
+                sourceFolder.rootType in testResourceRootTypes && !sourceFolder.isForGeneratedSources()
+            }
+            // taking the source folder that has the maximum common prefix
+            // with `testSourceRoot`, which was selected by the user
+            .maxBy { sourceFolder ->
+                val sourceFolderPath = sourceFolder.file?.path ?: ""
+                val testSourceRootPath = testSourceRoot?.path ?: ""
+                sourceFolderPath.commonPrefixWith(testSourceRootPath).length
+            }
+        if (testResourcesFolder != null) {
+            return testResourcesFolder.url
+        }
+
+        val testFolder = sourceFolders.firstOrNull { it.rootType in testSourceRootTypes }
+        val contentEntry = testFolder?.contentEntry ?: rootModel.contentEntries.first()
+
+        val parentFolderUrl = testFolder?.let { getParentPath(testFolder.url) }
+        val testResourcesUrl =
+            if (parentFolderUrl != null) "${parentFolderUrl}$resourcesSuffix" else "${contentEntry.url}$resourcesSuffix"
+
+        val codegenLanguage =
+            if (testFolder?.rootType == TestResourceKotlinRootType) CodegenLanguage.KOTLIN else CodegenLanguage.JAVA
+
+        try {
+            contentEntry.addSourceRootIfAbsent(rootModel, testResourcesUrl, codegenLanguage.testResourcesRootType())
+        } catch (e: java.lang.IllegalStateException) {
+            // Hack to avoid unmodifiable ModuleBridge testModule on Android SAT-1536.
+            workaround(WorkaroundReason.HACK) {
+                logger.info("Error during SARIF report generation: $e")
+                return testFolder!!.url
+            }
+        }
+
+        return testResourcesUrl
+    } finally {
+        if (!rootModel.isDisposed && rootModel.isWritable) rootModel.dispose()
+    }
+}
+
+fun ContentEntry.addSourceRootIfAbsent(model: ModifiableRootModel, sourceRootUrl : String, type: JpsModuleSourceRootType<*>) {
+    getSourceFolders(type).find { it.url == sourceRootUrl }?.apply {
+        model.dispose()
+        return
+    }
+    VfsUtil.createDirectoryIfMissing(VfsUtilCore.urlToPath(sourceRootUrl))
+    addSourceFolder(sourceRootUrl, type)
+    WriteCommandAction.runWriteCommandAction(rootModel.module.project) {
+        try {
+            model.commit()
+        } catch (e: Exception) {
+            logger.error { e }
+            model.dispose()
+        }
+    }
 }
 
 /**

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/ModuleUtils.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/ModuleUtils.kt
@@ -146,7 +146,7 @@ private fun Module.suitableTestSourceFolders(codegenLanguage: CodegenLanguage): 
 }
 
 private const val dedicatedTestSourceRootName = "utbot_tests"
-fun Module.addDedicatedTestRoot(testSourceRoots : MutableList<VirtualFile>) : VirtualFile? {
+fun Module.addDedicatedTestRoot(testSourceRoots: MutableList<VirtualFile>): VirtualFile? {
     // Dedicated test root already exists
     // OR it looks like standard structure of Gradle project where 'unexpected' test roots won't work
     if (testSourceRoots.any { file ->
@@ -214,7 +214,11 @@ private fun getOrCreateTestResourcesUrl(module: Module, testSourceRoot: VirtualF
     }
 }
 
-fun ContentEntry.addSourceRootIfAbsent(model: ModifiableRootModel, sourceRootUrl : String, type: JpsModuleSourceRootType<*>) {
+fun ContentEntry.addSourceRootIfAbsent(
+    model: ModifiableRootModel,
+    sourceRootUrl: String,
+    type: JpsModuleSourceRootType<*>
+) {
     getSourceFolders(type).find { it.url == sourceRootUrl }?.apply {
         model.dispose()
         return


### PR DESCRIPTION
# Description

We suggest **utbot_tests** root for auto-generated tests
The structure of Gradle project is no so flexible, so we should not suggest extra roots, as soon as root `src/test/java` is found.

Fixes #159 

## Type of Change
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Manual Scenario 

Project with no root: the only item in combobox should look like ".../utbot_tests (will be created)" instead of placeholder text "set test folder".
Project with roots: in addition to actual list we also suggest utbot_tests root to choose or create, at the moment it's not preselected.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] No new warnings
