### PR TITLE
Extract Traverser from UtBotSymbolicEngine

### DIFF
--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/UtArrayMock.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/UtArrayMock.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 
 /**
  * Auxiliary class with static methods without implementation.
- * These static methods are just markers for {@link org.utbot.engine.UtBotSymbolicEngine}.,
+ * These static methods are just markers for {@link org.utbot.engine.Traverser}.,
  * to do some corresponding behavior, that can't be represent
  * with java instructions.
  * <p>

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/UtArrayMock.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/UtArrayMock.java
@@ -15,7 +15,7 @@ import java.util.Arrays;
 @SuppressWarnings("unused")
 public class UtArrayMock {
     /**
-     * Traversing this instruction by {@link org.utbot.engine.UtBotSymbolicEngine} should
+     * Traversing this instruction by {@link org.utbot.engine.Traverser} should
      * behave similar to call of {@link java.util.Arrays#copyOf(Object[], int)}
      * if length is less or equals to src.length, otherwise first
      * src.length elements are equal to src, but the rest are undefined.
@@ -45,7 +45,7 @@ public class UtArrayMock {
     }
 
     /**
-     * Traversing this instruction by {@link org.utbot.engine.UtBotSymbolicEngine} should
+     * Traversing this instruction by {@link org.utbot.engine.Traverser} should
      * behave similar to call of
      * {@link java.lang.System#arraycopy(Object, int, Object, int, int)}
      * if all the arguments are valid.
@@ -67,7 +67,7 @@ public class UtArrayMock {
     }
 
     /**
-     * Traversing this instruction by {@link org.utbot.engine.UtBotSymbolicEngine} should
+     * Traversing this instruction by {@link org.utbot.engine.Traverser} should
      * behave similar to call of
      * {@link java.lang.System#arraycopy(Object, int, Object, int, int)}
      * if all the arguments are valid.
@@ -83,7 +83,7 @@ public class UtArrayMock {
     }
 
     /**
-     * Traversing this instruction by {@link org.utbot.engine.UtBotSymbolicEngine} should
+     * Traversing this instruction by {@link org.utbot.engine.Traverser} should
      * behave similar to call of
      * {@link java.lang.System#arraycopy(Object, int, Object, int, int)}
      * if all the arguments are valid.
@@ -99,7 +99,7 @@ public class UtArrayMock {
     }
 
     /**
-     * Traversing this instruction by {@link org.utbot.engine.UtBotSymbolicEngine} should
+     * Traversing this instruction by {@link org.utbot.engine.Traverser} should
      * behave similar to call of
      * {@link java.lang.System#arraycopy(Object, int, Object, int, int)}
      * if all the arguments are valid.
@@ -115,7 +115,7 @@ public class UtArrayMock {
     }
 
     /**
-     * Traversing this instruction by {@link org.utbot.engine.UtBotSymbolicEngine} should
+     * Traversing this instruction by {@link org.utbot.engine.Traverser} should
      * behave similar to call of
      * {@link java.lang.System#arraycopy(Object, int, Object, int, int)}
      * if all the arguments are valid.
@@ -131,7 +131,7 @@ public class UtArrayMock {
     }
 
     /**
-     * Traversing this instruction by {@link org.utbot.engine.UtBotSymbolicEngine} should
+     * Traversing this instruction by {@link org.utbot.engine.Traverser} should
      * behave similar to call of
      * {@link java.lang.System#arraycopy(Object, int, Object, int, int)}
      * if all the arguments are valid.
@@ -147,7 +147,7 @@ public class UtArrayMock {
     }
 
     /**
-     * Traversing this instruction by {@link org.utbot.engine.UtBotSymbolicEngine} should
+     * Traversing this instruction by {@link org.utbot.engine.Traverser} should
      * behave similar to call of
      * {@link java.lang.System#arraycopy(Object, int, Object, int, int)}
      * if all the arguments are valid.
@@ -163,7 +163,7 @@ public class UtArrayMock {
     }
 
     /**
-     * Traversing this instruction by {@link org.utbot.engine.UtBotSymbolicEngine} should
+     * Traversing this instruction by {@link org.utbot.engine.Traverser} should
      * behave similar to call of
      * {@link java.lang.System#arraycopy(Object, int, Object, int, int)}
      * if all the arguments are valid.
@@ -179,7 +179,7 @@ public class UtArrayMock {
     }
 
     /**
-     * Traversing this instruction by {@link org.utbot.engine.UtBotSymbolicEngine} should
+     * Traversing this instruction by {@link org.utbot.engine.Traverser} should
      * behave similar to call of
      * {@link java.lang.System#arraycopy(Object, int, Object, int, int)}
      * if all the arguments are valid.

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/UtArrayMock.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/UtArrayMock.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 
 /**
  * Auxiliary class with static methods without implementation.
- * These static methods are just markers for <code>UtBotSymbolicEngine</code>,
+ * These static methods are just markers for {@link org.utbot.engine.UtBotSymbolicEngine}.,
  * to do some corresponding behavior, that can't be represent
  * with java instructions.
  * <p>
@@ -15,7 +15,7 @@ import java.util.Arrays;
 @SuppressWarnings("unused")
 public class UtArrayMock {
     /**
-     * Traversing this instruction by <code>UtBotSymbolicEngine</code> should
+     * Traversing this instruction by {@link org.utbot.engine.UtBotSymbolicEngine} should
      * behave similar to call of {@link java.util.Arrays#copyOf(Object[], int)}
      * if length is less or equals to src.length, otherwise first
      * src.length elements are equal to src, but the rest are undefined.
@@ -45,7 +45,7 @@ public class UtArrayMock {
     }
 
     /**
-     * Traversing this instruction by <code>UtBotSymbolicEngine</code> should
+     * Traversing this instruction by {@link org.utbot.engine.UtBotSymbolicEngine} should
      * behave similar to call of
      * {@link java.lang.System#arraycopy(Object, int, Object, int, int)}
      * if all the arguments are valid.
@@ -67,7 +67,7 @@ public class UtArrayMock {
     }
 
     /**
-     * Traversing this instruction by <code>UtBotSymbolicEngine</code> should
+     * Traversing this instruction by {@link org.utbot.engine.UtBotSymbolicEngine} should
      * behave similar to call of
      * {@link java.lang.System#arraycopy(Object, int, Object, int, int)}
      * if all the arguments are valid.
@@ -83,7 +83,7 @@ public class UtArrayMock {
     }
 
     /**
-     * Traversing this instruction by <code>UtBotSymbolicEngine</code> should
+     * Traversing this instruction by {@link org.utbot.engine.UtBotSymbolicEngine} should
      * behave similar to call of
      * {@link java.lang.System#arraycopy(Object, int, Object, int, int)}
      * if all the arguments are valid.
@@ -99,7 +99,7 @@ public class UtArrayMock {
     }
 
     /**
-     * Traversing this instruction by <code>UtBotSymbolicEngine</code> should
+     * Traversing this instruction by {@link org.utbot.engine.UtBotSymbolicEngine} should
      * behave similar to call of
      * {@link java.lang.System#arraycopy(Object, int, Object, int, int)}
      * if all the arguments are valid.
@@ -115,7 +115,7 @@ public class UtArrayMock {
     }
 
     /**
-     * Traversing this instruction by <code>UtBotSymbolicEngine</code> should
+     * Traversing this instruction by {@link org.utbot.engine.UtBotSymbolicEngine} should
      * behave similar to call of
      * {@link java.lang.System#arraycopy(Object, int, Object, int, int)}
      * if all the arguments are valid.
@@ -131,7 +131,7 @@ public class UtArrayMock {
     }
 
     /**
-     * Traversing this instruction by <code>UtBotSymbolicEngine</code> should
+     * Traversing this instruction by {@link org.utbot.engine.UtBotSymbolicEngine} should
      * behave similar to call of
      * {@link java.lang.System#arraycopy(Object, int, Object, int, int)}
      * if all the arguments are valid.
@@ -147,7 +147,7 @@ public class UtArrayMock {
     }
 
     /**
-     * Traversing this instruction by <code>UtBotSymbolicEngine</code> should
+     * Traversing this instruction by {@link org.utbot.engine.UtBotSymbolicEngine} should
      * behave similar to call of
      * {@link java.lang.System#arraycopy(Object, int, Object, int, int)}
      * if all the arguments are valid.
@@ -163,7 +163,7 @@ public class UtArrayMock {
     }
 
     /**
-     * Traversing this instruction by <code>UtBotSymbolicEngine</code> should
+     * Traversing this instruction by {@link org.utbot.engine.UtBotSymbolicEngine} should
      * behave similar to call of
      * {@link java.lang.System#arraycopy(Object, int, Object, int, int)}
      * if all the arguments are valid.
@@ -179,7 +179,7 @@ public class UtArrayMock {
     }
 
     /**
-     * Traversing this instruction by <code>UtBotSymbolicEngine</code> should
+     * Traversing this instruction by {@link org.utbot.engine.UtBotSymbolicEngine} should
      * behave similar to call of
      * {@link java.lang.System#arraycopy(Object, int, Object, int, int)}
      * if all the arguments are valid.

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/UtLogicMock.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/UtLogicMock.java
@@ -2,7 +2,7 @@ package org.utbot.engine.overrides;
 
 /**
  * Auxiliary class with static methods without implementation.
- * These static methods are just markers for <code>UtBotSymbolicEngine</code>,
+ * These static methods are just markers for {@link org.utbot.engine.UtBotSymbolicEngine},
  * to do some corresponding behavior, that can be represented with smt expressions.
  * <p>
  * <code>UtLogicMock</code> is used to store bool smt bool expressions in

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/UtLogicMock.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/UtLogicMock.java
@@ -2,7 +2,7 @@ package org.utbot.engine.overrides;
 
 /**
  * Auxiliary class with static methods without implementation.
- * These static methods are just markers for {@link org.utbot.engine.UtBotSymbolicEngine},
+ * These static methods are just markers for {@link org.utbot.engine.Traverser},
  * to do some corresponding behavior, that can be represented with smt expressions.
  * <p>
  * <code>UtLogicMock</code> is used to store bool smt bool expressions in

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/UtOverrideMock.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/UtOverrideMock.java
@@ -2,13 +2,13 @@ package org.utbot.engine.overrides;
 
 /**
  * Auxiliary class with static methods without implementation.
- * These static methods are just markers for UtBotSymbolicEngine,
+ * These static methods are just markers for {@link org.utbot.engine.UtBotSymbolicEngine},
  * to do some corresponding behavior, that can't be represent
  * with java instructions.
  *
  * Set of methods in UtOverrideMock is used in code of classes,
  * that override implementation of some standard class by new implementation,
- * that is more simple for UtBotSymbolicEngine to traverse.
+ * that is more simple for {@link org.utbot.engine.UtBotSymbolicEngine} to traverse.
  */
 @SuppressWarnings("unused")
 public class UtOverrideMock {
@@ -25,7 +25,7 @@ public class UtOverrideMock {
     }
 
     /**
-     * If UtBotSymbolicEngine meets invoke of this method in code,
+     * If {@link org.utbot.engine.UtBotSymbolicEngine} meets invoke of this method in code,
      * then it marks the address of object o in memory as visited
      * and creates new MemoryUpdate with parameter isVisited, equal to o.addr
      * @param o parameter, that need to be marked as visited.
@@ -34,7 +34,7 @@ public class UtOverrideMock {
     }
 
     /**
-     * If UtBotSymbolicEngine meets invoke of this method in code,
+     * If {@link org.utbot.engine.UtBotSymbolicEngine} meets invoke of this method in code,
      * then it marks the method, where met instruction is placed,
      * and all the methods that will be traversed in nested invokes
      * as methods that couldn't throw exceptions.
@@ -44,7 +44,7 @@ public class UtOverrideMock {
     }
 
     /**
-     * If UtBotSymbolicEngine meets invoke of this method in code,
+     * If {@link org.utbot.engine.UtBotSymbolicEngine} meets invoke of this method in code,
      * then it assumes that the specified object is parameter,
      * and need to be marked as parameter.
      * As address space of parameters in engine is non-positive, while
@@ -63,7 +63,7 @@ public class UtOverrideMock {
     }
 
     /**
-     * If UtBotSymbolicEngine meets invoke of this method in code,
+     * If {@link org.utbot.engine.UtBotSymbolicEngine} meets invoke of this method in code,
      * then it starts concrete execution from this point.
      */
     public static void executeConcretely() {

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/UtOverrideMock.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/UtOverrideMock.java
@@ -2,13 +2,13 @@ package org.utbot.engine.overrides;
 
 /**
  * Auxiliary class with static methods without implementation.
- * These static methods are just markers for {@link org.utbot.engine.UtBotSymbolicEngine},
+ * These static methods are just markers for {@link org.utbot.engine.Traverser},
  * to do some corresponding behavior, that can't be represent
  * with java instructions.
  *
  * Set of methods in UtOverrideMock is used in code of classes,
  * that override implementation of some standard class by new implementation,
- * that is more simple for {@link org.utbot.engine.UtBotSymbolicEngine} to traverse.
+ * that is more simple for {@link org.utbot.engine.Traverser} to traverse.
  */
 @SuppressWarnings("unused")
 public class UtOverrideMock {
@@ -25,7 +25,7 @@ public class UtOverrideMock {
     }
 
     /**
-     * If {@link org.utbot.engine.UtBotSymbolicEngine} meets invoke of this method in code,
+     * If {@link org.utbot.engine.Traverser} meets invoke of this method in code,
      * then it marks the address of object o in memory as visited
      * and creates new MemoryUpdate with parameter isVisited, equal to o.addr
      * @param o parameter, that need to be marked as visited.
@@ -34,7 +34,7 @@ public class UtOverrideMock {
     }
 
     /**
-     * If {@link org.utbot.engine.UtBotSymbolicEngine} meets invoke of this method in code,
+     * If {@link org.utbot.engine.Traverser} meets invoke of this method in code,
      * then it marks the method, where met instruction is placed,
      * and all the methods that will be traversed in nested invokes
      * as methods that couldn't throw exceptions.
@@ -44,7 +44,7 @@ public class UtOverrideMock {
     }
 
     /**
-     * If {@link org.utbot.engine.UtBotSymbolicEngine} meets invoke of this method in code,
+     * If {@link org.utbot.engine.Traverser} meets invoke of this method in code,
      * then it assumes that the specified object is parameter,
      * and need to be marked as parameter.
      * As address space of parameters in engine is non-positive, while
@@ -63,7 +63,7 @@ public class UtOverrideMock {
     }
 
     /**
-     * If {@link org.utbot.engine.UtBotSymbolicEngine} meets invoke of this method in code,
+     * If {@link org.utbot.engine.Traverser} meets invoke of this method in code,
      * then it starts concrete execution from this point.
      */
     public static void executeConcretely() {

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtArrayList.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtArrayList.java
@@ -28,7 +28,7 @@ import static org.utbot.engine.overrides.UtOverrideMock.visit;
 
 
 /**
- * Class represents hybrid implementation (java + engine instructions) of List interface for {@link org.utbot.engine.UtBotSymbolicEngine}.
+ * Class represents hybrid implementation (java + engine instructions) of List interface for {@link org.utbot.engine.Traverser}.
  * <p>
  * Implementation is based on org.utbot.engine.overrides.collections.RangeModifiableArray.
  * Should behave similar to {@link java.util.ArrayList}.

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtArrayList.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtArrayList.java
@@ -28,7 +28,7 @@ import static org.utbot.engine.overrides.UtOverrideMock.visit;
 
 
 /**
- * Class represents hybrid implementation (java + engine instructions) of List interface for UtBotSymbolicEngine.
+ * Class represents hybrid implementation (java + engine instructions) of List interface for {@link org.utbot.engine.UtBotSymbolicEngine}.
  * <p>
  * Implementation is based on org.utbot.engine.overrides.collections.RangeModifiableArray.
  * Should behave similar to {@link java.util.ArrayList}.

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtHashMap.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtHashMap.java
@@ -23,7 +23,7 @@ import static org.utbot.engine.overrides.UtOverrideMock.visit;
 
 
 /**
- * Class represents hybrid implementation (java + engine instructions) of Map interface for UtBotSymbolicEngine.
+ * Class represents hybrid implementation (java + engine instructions) of Map interface for {@link org.utbot.engine.UtBotSymbolicEngine}.
  * <p>
  * Implementation is based on using org.utbot.engine.overrides.collections.RangeModifiableArray as keySet
  * and org.utbot.engine.overrides.collections.UtArray as associative array from keys to values.

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtHashMap.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtHashMap.java
@@ -23,7 +23,7 @@ import static org.utbot.engine.overrides.UtOverrideMock.visit;
 
 
 /**
- * Class represents hybrid implementation (java + engine instructions) of Map interface for {@link org.utbot.engine.UtBotSymbolicEngine}.
+ * Class represents hybrid implementation (java + engine instructions) of Map interface for {@link org.utbot.engine.Traverser}.
  * <p>
  * Implementation is based on using org.utbot.engine.overrides.collections.RangeModifiableArray as keySet
  * and org.utbot.engine.overrides.collections.UtArray as associative array from keys to values.

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtHashSet.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtHashSet.java
@@ -20,7 +20,7 @@ import static org.utbot.engine.overrides.UtOverrideMock.parameter;
 import static org.utbot.engine.overrides.UtOverrideMock.visit;
 
 /**
- * Class represents hybrid implementation (java + engine instructions) of Set interface for UtBotSymbolicEngine.
+ * Class represents hybrid implementation (java + engine instructions) of Set interface for {@link org.utbot.engine.UtBotSymbolicEngine}.
  * <p>
  * Implementation is based on RangedModifiableArray, and all operations are linear.
  * Should behave similar to

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtHashSet.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtHashSet.java
@@ -20,7 +20,7 @@ import static org.utbot.engine.overrides.UtOverrideMock.parameter;
 import static org.utbot.engine.overrides.UtOverrideMock.visit;
 
 /**
- * Class represents hybrid implementation (java + engine instructions) of Set interface for {@link org.utbot.engine.UtBotSymbolicEngine}.
+ * Class represents hybrid implementation (java + engine instructions) of Set interface for {@link org.utbot.engine.Traverser}.
  * <p>
  * Implementation is based on RangedModifiableArray, and all operations are linear.
  * Should behave similar to

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtOptional.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtOptional.java
@@ -13,7 +13,7 @@ import static org.utbot.engine.overrides.UtOverrideMock.alreadyVisited;
 import static org.utbot.engine.overrides.UtOverrideMock.visit;
 
 /**
- * Class represents hybrid implementation (java + engine instructions) of Optional for UtBotSymbolicEngine.
+ * Class represents hybrid implementation (java + engine instructions) of Optional for {@link org.utbot.engine.UtBotSymbolicEngine}.
  * <p>
  * Should behave the same as {@link java.util.Optional}.
  * @see org.utbot.engine.OptionalWrapper

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtOptional.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtOptional.java
@@ -13,7 +13,7 @@ import static org.utbot.engine.overrides.UtOverrideMock.alreadyVisited;
 import static org.utbot.engine.overrides.UtOverrideMock.visit;
 
 /**
- * Class represents hybrid implementation (java + engine instructions) of Optional for {@link org.utbot.engine.UtBotSymbolicEngine}.
+ * Class represents hybrid implementation (java + engine instructions) of Optional for {@link org.utbot.engine.Traverser}.
  * <p>
  * Should behave the same as {@link java.util.Optional}.
  * @see org.utbot.engine.OptionalWrapper

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtOptionalDouble.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtOptionalDouble.java
@@ -11,7 +11,7 @@ import static org.utbot.engine.overrides.UtOverrideMock.alreadyVisited;
 import static org.utbot.engine.overrides.UtOverrideMock.visit;
 
 /**
- * Class represents hybrid implementation (java + engine instructions) of OptionalDouble for {@link org.utbot.engine.UtBotSymbolicEngine}.
+ * Class represents hybrid implementation (java + engine instructions) of OptionalDouble for {@link org.utbot.engine.Traverser}.
  * <p>
  * Should behave the same as {@link java.util.OptionalDouble}.
  * @see org.utbot.engine.OptionalWrapper

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtOptionalDouble.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtOptionalDouble.java
@@ -11,7 +11,7 @@ import static org.utbot.engine.overrides.UtOverrideMock.alreadyVisited;
 import static org.utbot.engine.overrides.UtOverrideMock.visit;
 
 /**
- * Class represents hybrid implementation (java + engine instructions) of OptionalDouble for UtBotSymbolicEngine.
+ * Class represents hybrid implementation (java + engine instructions) of OptionalDouble for {@link org.utbot.engine.UtBotSymbolicEngine}.
  * <p>
  * Should behave the same as {@link java.util.OptionalDouble}.
  * @see org.utbot.engine.OptionalWrapper

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtOptionalInt.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtOptionalInt.java
@@ -11,7 +11,7 @@ import static org.utbot.engine.overrides.UtOverrideMock.alreadyVisited;
 import static org.utbot.engine.overrides.UtOverrideMock.visit;
 
 /**
- * Class represents hybrid implementation (java + engine instructions) of OptionalInt for UtBotSymbolicEngine.
+ * Class represents hybrid implementation (java + engine instructions) of OptionalInt for {@link org.utbot.engine.UtBotSymbolicEngine}.
  * <p>
  * Should behave the same as {@link java.util.OptionalInt}.
  * @see org.utbot.engine.OptionalWrapper

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtOptionalInt.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtOptionalInt.java
@@ -11,7 +11,7 @@ import static org.utbot.engine.overrides.UtOverrideMock.alreadyVisited;
 import static org.utbot.engine.overrides.UtOverrideMock.visit;
 
 /**
- * Class represents hybrid implementation (java + engine instructions) of OptionalInt for {@link org.utbot.engine.UtBotSymbolicEngine}.
+ * Class represents hybrid implementation (java + engine instructions) of OptionalInt for {@link org.utbot.engine.Traverser}.
  * <p>
  * Should behave the same as {@link java.util.OptionalInt}.
  * @see org.utbot.engine.OptionalWrapper

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtOptionalLong.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtOptionalLong.java
@@ -10,7 +10,7 @@ import static org.utbot.engine.overrides.UtOverrideMock.alreadyVisited;
 import static org.utbot.engine.overrides.UtOverrideMock.visit;
 
 /**
- * Class represents hybrid implementation (java + engine instructions) of Optional for UtBotSymbolicEngine.
+ * Class represents hybrid implementation (java + engine instructions) of Optional for {@link org.utbot.engine.UtBotSymbolicEngine}.
  * <p>
  * Should behave the same as {@link java.util.Optional}.
  * @see org.utbot.engine.OptionalWrapper

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtOptionalLong.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtOptionalLong.java
@@ -10,7 +10,7 @@ import static org.utbot.engine.overrides.UtOverrideMock.alreadyVisited;
 import static org.utbot.engine.overrides.UtOverrideMock.visit;
 
 /**
- * Class represents hybrid implementation (java + engine instructions) of Optional for {@link org.utbot.engine.UtBotSymbolicEngine}.
+ * Class represents hybrid implementation (java + engine instructions) of Optional for {@link org.utbot.engine.Traverser}.
  * <p>
  * Should behave the same as {@link java.util.Optional}.
  * @see org.utbot.engine.OptionalWrapper

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ArrayObjectWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ArrayObjectWrappers.kt
@@ -37,7 +37,7 @@ import soot.SootMethod
 val rangeModifiableArrayId: ClassId = RangeModifiableUnlimitedArray::class.id
 
 class RangeModifiableUnlimitedArrayWrapper : WrapperInterface {
-    override fun UtBotSymbolicEngine.invoke(
+    override fun Traverser.invoke(
         wrapper: ObjectValue,
         method: SootMethod,
         parameters: List<SymbolicValue>
@@ -203,10 +203,10 @@ class RangeModifiableUnlimitedArrayWrapper : WrapperInterface {
         }
     }
 
-    private fun UtBotSymbolicEngine.getStorageArrayField(addr: UtAddrExpression) =
+    private fun Traverser.getStorageArrayField(addr: UtAddrExpression) =
         getArrayField(addr, rangeModifiableArrayClass, storageField)
 
-    private fun UtBotSymbolicEngine.getStorageArrayExpression(
+    private fun Traverser.getStorageArrayExpression(
         wrapper: ObjectValue
     ): UtExpression = selectArrayExpressionFromMemory(getStorageArrayField(wrapper.addr))
 
@@ -285,7 +285,7 @@ class AssociativeArrayWrapper : WrapperInterface {
     private val storageField = associativeArrayClass.getField("java.lang.Object[] storage")
 
 
-    override fun UtBotSymbolicEngine.invoke(
+    override fun Traverser.invoke(
         wrapper: ObjectValue,
         method: SootMethod,
         parameters: List<SymbolicValue>
@@ -414,16 +414,16 @@ class AssociativeArrayWrapper : WrapperInterface {
         return model
     }
 
-    private fun UtBotSymbolicEngine.getStorageArrayField(addr: UtAddrExpression) =
+    private fun Traverser.getStorageArrayField(addr: UtAddrExpression) =
         getArrayField(addr, associativeArrayClass, storageField)
 
-    private fun UtBotSymbolicEngine.getTouchedArrayField(addr: UtAddrExpression) =
+    private fun Traverser.getTouchedArrayField(addr: UtAddrExpression) =
         getArrayField(addr, associativeArrayClass, touchedField)
 
-    private fun UtBotSymbolicEngine.getTouchedArrayExpression(wrapper: ObjectValue): UtExpression =
+    private fun Traverser.getTouchedArrayExpression(wrapper: ObjectValue): UtExpression =
         selectArrayExpressionFromMemory(getTouchedArrayField(wrapper.addr))
 
-    private fun UtBotSymbolicEngine.getStorageArrayExpression(
+    private fun Traverser.getStorageArrayExpression(
         wrapper: ObjectValue
     ): UtExpression = selectArrayExpressionFromMemory(getStorageArrayField(wrapper.addr))
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/CollectionWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/CollectionWrappers.kt
@@ -50,7 +50,7 @@ abstract class BaseOverriddenWrapper(protected val overriddenClassName: String) 
      *
      * @see invoke
      */
-    protected abstract fun UtBotSymbolicEngine.overrideInvoke(
+    protected abstract fun Traverser.overrideInvoke(
         wrapper: ObjectValue,
         method: SootMethod,
         parameters: List<SymbolicValue>
@@ -65,11 +65,11 @@ abstract class BaseOverriddenWrapper(protected val overriddenClassName: String) 
      *
      * Multiple GraphResults are returned because, we shouldn't substitute invocation of specified
      * that was called inside substituted method of object with the same address as specified [wrapper].
-     * (For example UtArrayList.<init> invokes AbstractList.<init> that also leads to [UtBotSymbolicEngine.invoke],
+     * (For example UtArrayList.<init> invokes AbstractList.<init> that also leads to [Traverser.invoke],
      * and shouldn't be substituted with UtArrayList.<init> again). Only one GraphResult is valid, that is
      * guaranteed by contradictory to each other sets of constraints, added to them.
      */
-    override fun UtBotSymbolicEngine.invoke(
+    override fun Traverser.invoke(
         wrapper: ObjectValue,
         method: SootMethod,
         parameters: List<SymbolicValue>
@@ -162,7 +162,7 @@ abstract class BaseContainerWrapper(containerClassName: String) : BaseOverridden
 }
 
 abstract class BaseGenericStorageBasedContainerWrapper(containerClassName: String) : BaseContainerWrapper(containerClassName) {
-    override fun UtBotSymbolicEngine.overrideInvoke(
+    override fun Traverser.overrideInvoke(
         wrapper: ObjectValue,
         method: SootMethod,
         parameters: List<SymbolicValue>
@@ -283,7 +283,7 @@ class SetWrapper : BaseGenericStorageBasedContainerWrapper(UtHashSet::class.qual
  * entries, then real behavior of generated test can differ from expected and undefined.
  */
 class MapWrapper : BaseContainerWrapper(UtHashMap::class.qualifiedName!!) {
-    override fun UtBotSymbolicEngine.overrideInvoke(
+    override fun Traverser.overrideInvoke(
         wrapper: ObjectValue,
         method: SootMethod,
         parameters: List<SymbolicValue>
@@ -418,14 +418,14 @@ val HASH_MAP_TYPE: RefType
 val STREAM_TYPE: RefType
     get() = Scene.v().getSootClass(java.util.stream.Stream::class.java.canonicalName).type
 
-internal fun UtBotSymbolicEngine.getArrayField(
+internal fun Traverser.getArrayField(
     addr: UtAddrExpression,
     wrapperClass: SootClass,
     field: SootField
 ): ArrayValue =
     createFieldOrMock(wrapperClass.type, addr, field, mockInfoGenerator = null) as ArrayValue
 
-internal fun UtBotSymbolicEngine.getIntFieldValue(wrapper: ObjectValue, field: SootField): UtExpression {
+internal fun Traverser.getIntFieldValue(wrapper: ObjectValue, field: SootField): UtExpression {
     val chunkId = hierarchy.chunkIdForField(field.declaringClass.type, field)
     val descriptor = MemoryChunkDescriptor(chunkId, field.declaringClass.type, IntType.v())
     val array = memory.findArray(descriptor, MemoryState.CURRENT)

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/CollectionWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/CollectionWrappers.kt
@@ -65,7 +65,7 @@ abstract class BaseOverriddenWrapper(protected val overriddenClassName: String) 
      *
      * Multiple GraphResults are returned because, we shouldn't substitute invocation of specified
      * that was called inside substituted method of object with the same address as specified [wrapper].
-     * (For example UtArrayList.<init> invokes AbstractList.<init> that also leads to UtBotSymbolicEngine.invoke,
+     * (For example UtArrayList.<init> invokes AbstractList.<init> that also leads to [UtBotSymbolicEngine.invoke],
      * and shouldn't be substituted with UtArrayList.<init> again). Only one GraphResult is valid, that is
      * guaranteed by contradictory to each other sets of constraints, added to them.
      */

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/DataClasses.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/DataClasses.kt
@@ -184,7 +184,7 @@ data class OverrideResult(
  * there is only one usage of it: to support instanceof for arrays we have to update them in the memory.
  *
  * @see UtInstanceOfExpression
- * @see UtBotSymbolicEngine.resolveIfCondition
+ * @see Traverser.resolveIfCondition
  */
 data class ResolvedCondition(
     val condition: UtBoolExpression,

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ExecutionState.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ExecutionState.kt
@@ -252,7 +252,7 @@ data class ExecutionState(
         )
     }
 
-    fun updateMemory(
+    fun update(
         stateUpdate: SymbolicStateUpdate
     ): ExecutionState {
         val last = executionStack.last()

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ExecutionState.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ExecutionState.kt
@@ -17,6 +17,8 @@ import org.utbot.framework.plugin.api.Step
 import soot.SootMethod
 import soot.jimple.Stmt
 import java.util.Objects
+import org.utbot.engine.symbolic.Assumption
+import org.utbot.framework.plugin.api.UtExecution
 
 const val RETURN_DECISION_NUM = -1
 const val CALL_DECISION_NUM = -2
@@ -29,11 +31,11 @@ data class Edge(val src: Stmt, val dst: Stmt, val decisionNum: Int)
  * [INTERMEDIATE] is a label for an intermediate state which is suitable for further symbolic analysis.
  *
  * [TERMINAL] is a label for a terminal state from which we might (or might not) execute concretely and construct
- * UtExecution. This state represents the final state of the program execution, that is a throw or return from the outer
+ * [UtExecution]. This state represents the final state of the program execution, that is a throw or return from the outer
  * method.
  *
  * [CONCRETE] is a label for a state which is not suitable for further symbolic analysis and it is also not a terminal
- * state. Such states are only suitable for a concrete execution and may appear from Assumptions constraints
+ * state. Such states are only suitable for a concrete execution and may appear from [Assumption]s.
  */
 enum class StateLabel {
     INTERMEDIATE,

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ExecutionState.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ExecutionState.kt
@@ -160,6 +160,9 @@ data class ExecutionState(
     val isThrowException: Boolean
         get() = (lastEdge?.decisionNum ?: 0) < CALL_DECISION_NUM
 
+    val isInsideStaticInitializer
+        get() = executionStack.any { it.method.isStaticInitializer }
+
     fun createExceptionState(
         exception: SymbolicFailure,
         update: SymbolicStateUpdate

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ExecutionState.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ExecutionState.kt
@@ -34,8 +34,8 @@ data class Edge(val src: Stmt, val dst: Stmt, val decisionNum: Int)
  * [UtExecution]. This state represents the final state of the program execution, that is a throw or return from the outer
  * method.
  *
- * [CONCRETE] is a label for a state which is not suitable for further symbolic analysis and it is also not a terminal
- * state. Such states are only suitable for a concrete execution and may appear from [Assumption]s.
+ * [CONCRETE] is a label for a state which is not suitable for further symbolic analysis, and it is also not a terminal
+ * state. Such states are only suitable for a concrete execution and may result from [Assumption]s.
  */
 enum class StateLabel {
     INTERMEDIATE,

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Extensions.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Extensions.kt
@@ -111,6 +111,7 @@ fun SootMethod.canRetrieveBody() =
  */
 fun SootMethod.jimpleBody(): JimpleBody {
     declaringClass.adjustLevel(BODIES)
+    require(canRetrieveBody()) { "Can't retrieve body for $this"}
     return retrieveActiveBody() as JimpleBody
 }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Extensions.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Extensions.kt
@@ -201,7 +201,7 @@ val Type.numDimensions get() = if (this is ArrayType) numDimensions else 0
 /**
  * Invocation. Can generate multiple targets.
  *
- * @see UtBotSymbolicEngine.virtualAndInterfaceInvoke
+ * @see Traverser.virtualAndInterfaceInvoke
  */
 data class Invocation(
     val instance: ReferenceValue?,
@@ -220,7 +220,7 @@ data class Invocation(
 /**
  * Invocation target. Contains constraints to be satisfied for this instance class (related to virtual invoke).
  *
- * @see UtBotSymbolicEngine.virtualAndInterfaceInvoke
+ * @see Traverser.virtualAndInterfaceInvoke
  */
 data class InvocationTarget(
     val instance: ReferenceValue?,
@@ -243,11 +243,11 @@ data class MethodInvocationTarget(
 )
 
 /**
- * Used in the [UtBotSymbolicEngine.findLibraryTargets] to substitute common types
+ * Used in the [Traverser.findLibraryTargets] to substitute common types
  * like [Iterable] with the types that have corresponding wrappers.
  *
- * @see UtBotSymbolicEngine.findLibraryTargets
- * @see UtBotSymbolicEngine.findInvocationTargets
+ * @see Traverser.findLibraryTargets
+ * @see Traverser.findInvocationTargets
  */
 val libraryTargets: Map<String, List<String>> = mapOf(
     Iterable::class.java.name to listOf(ArrayList::class.java.name, HashSet::class.java.name),

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Memory.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Memory.kt
@@ -539,17 +539,6 @@ class TypeRegistry {
         finalCost
     }
 
-    private val objectCounter = AtomicInteger(objectCounterInitialValue)
-    fun findNewAddr(insideStaticInitializer: Boolean): UtAddrExpression {
-        val newAddr = objectCounter.getAndIncrement()
-        // return negative address for objects created inside static initializer
-        // to make their address space be intersected with address space of
-        // parameters of method under symbolic execution
-        // @see ObjectWithFinalStaticTest::testParameterEqualsFinalStatic
-        val signedAddr = if (insideStaticInitializer) -newAddr else newAddr
-        return UtAddrExpression(signedAddr)
-    }
-
     private val classRefCounter = AtomicInteger(classRefAddrsInitialValue)
     private fun nextClassRefAddr() = UtAddrExpression(classRefCounter.getAndIncrement())
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Memory.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Memory.kt
@@ -242,7 +242,7 @@ data class Memory( // TODO: split purely symbolic memory and information about s
          * sometimes we want to change initial memory states of fields of a certain class, so we erase all the
          * information about previous states and update it with the current state. For now, this processing only takes
          * place after receiving MethodResult from [STATIC_INITIALIZER] method call at the end of
-         * [UtBotSymbolicEngine.processStaticInitializer]. The value of `update.classIdToClearStatics` is equal to the
+         * [Traverser.processStaticInitializer]. The value of `update.classIdToClearStatics` is equal to the
          * class for which the static initialization has performed.
          * TODO: JIRA:1610 -- refactor working with statics later
          */

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Memory.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Memory.kt
@@ -238,12 +238,14 @@ data class Memory( // TODO: split purely symbolic memory and information about s
         val previousMemoryStates = staticFieldsStates.toMutableMap()
 
 
-        // sometimes we want to change initial memory states of fields of a certain class, so we erase all the
-        // information about previous states and update it with the current state. For now, this processing only takes
-        // place after receiving MethodResult from [STATIC_INITIALIZER] method call at the end of
-        // [UtBotSymbolicEngine.processStaticInitializer]. The value of `update.classIdToClearStatics` is equal to the
-        // class for which the static initialization has performed.
-        // TODO: JIRA:1610 -- refactor working with statics later
+        /**
+         * sometimes we want to change initial memory states of fields of a certain class, so we erase all the
+         * information about previous states and update it with the current state. For now, this processing only takes
+         * place after receiving MethodResult from [STATIC_INITIALIZER] method call at the end of
+         * [UtBotSymbolicEngine.processStaticInitializer]. The value of `update.classIdToClearStatics` is equal to the
+         * class for which the static initialization has performed.
+         * TODO: JIRA:1610 -- refactor working with statics later
+         */
         update.classIdToClearStatics?.let { classId ->
             Scene.v().getSootClass(classId.name).fields.forEach { sootField ->
                 previousMemoryStates.remove(sootField.fieldId)

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Mocks.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Mocks.kt
@@ -46,7 +46,7 @@ class UtMockInfoGenerator(private val generator: (UtAddrExpression) -> UtMockInf
  * Contains mock class id and mock address to work with object cache.
  *
  * Note: addr for static method mocks contains addr of the "host" object
- * received by [UtBotSymbolicEngine.locateStaticObject].
+ * received by [Traverser.locateStaticObject].
  *
  * @property classId classId of the object this mock represents.
  * @property addr address of the mock object.
@@ -90,9 +90,9 @@ data class UtObjectMockInfo(
 
 /**
  * Mock for the "host" object for static methods and fields with [classId] declaringClass.
- * [addr] is a value received by [UtBotSymbolicEngine.locateStaticObject].
+ * [addr] is a value received by [Traverser.locateStaticObject].
  *
- * @see UtBotSymbolicEngine.locateStaticObject
+ * @see Traverser.locateStaticObject
  */
 data class UtStaticObjectMockInfo(
     override val classId: ClassId,
@@ -115,12 +115,12 @@ data class UtNewInstanceMockInfo(
  * Represents mocks for static methods.
  * Contains the methodId.
  *
- * Used only in [UtBotSymbolicEngine.mockStaticMethod] method to pass information into [Mocker] about the method.
+ * Used only in [Traverser.mockStaticMethod] method to pass information into [Mocker] about the method.
  * All the executables will be stored in executables of the object with [UtStaticObjectMockInfo] and the same addr.
  *
  * Note: we use non null addr here because of [createMockObject] method. We have to know address of the object
  * that we want to make. Although static method doesn't have "caller", we still can use address of the object
- * received by [UtBotSymbolicEngine.locateStaticObject].
+ * received by [Traverser.locateStaticObject].
  */
 data class UtStaticMethodMockInfo(
     override val addr: UtAddrExpression,
@@ -265,7 +265,7 @@ class UtMockWrapper(
     private val mockInfo: UtMockInfo
 ) : WrapperInterface {
 
-    override fun UtBotSymbolicEngine.invoke(
+    override fun Traverser.invoke(
         wrapper: ObjectValue,
         method: SootMethod,
         parameters: List<SymbolicValue>

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ObjectWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ObjectWrappers.kt
@@ -204,7 +204,7 @@ interface WrapperInterface {
     /**
      * Returns list of invocation results
      */
-    operator fun UtBotSymbolicEngine.invoke(
+    operator fun Traverser.invoke(
         wrapper: ObjectValue,
         method: SootMethod,
         parameters: List<SymbolicValue>
@@ -215,7 +215,7 @@ interface WrapperInterface {
 
 // TODO: perhaps we have to have wrapper around concrete value here
 data class ThrowableWrapper(val throwable: Throwable) : WrapperInterface {
-    override fun UtBotSymbolicEngine.invoke(wrapper: ObjectValue, method: SootMethod, parameters: List<SymbolicValue>) =
+    override fun Traverser.invoke(wrapper: ObjectValue, method: SootMethod, parameters: List<SymbolicValue>) =
         workaround(MAKE_SYMBOLIC) {
             listOf(
                 MethodResult(

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/OptionalWrapper.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/OptionalWrapper.kt
@@ -58,7 +58,7 @@ class OptionalWrapper(private val utOptionalClass: UtOptionalClass) : BaseOverri
     private val AS_OPTIONAL_METHOD_SIGNATURE =
         overriddenClass.getMethodByName(UtOptional<*>::asOptional.name).signature
 
-    override fun UtBotSymbolicEngine.overrideInvoke(
+    override fun Traverser.overrideInvoke(
         wrapper: ObjectValue,
         method: SootMethod,
         parameters: List<SymbolicValue>

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Resolver.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Resolver.kt
@@ -346,10 +346,9 @@ class Resolver(
     /**
      * Resolves current result (return value).
      */
-    fun resolveResult(symResult: SymbolicResult?): UtExecutionResult =
+    fun resolveResult(symResult: SymbolicResult): UtExecutionResult =
         withMemoryState(CURRENT) {
             when (symResult) {
-                null -> UtExecutionSuccess(UtVoidModel)
                 is SymbolicSuccess -> {
                     collectMocksAndInstrumentation()
                     val model = resolveModel(symResult.value)

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Resolver.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Resolver.kt
@@ -683,7 +683,7 @@ class Resolver(
      * the method returns null as the result.
      *
      * @see Memory.touchedAddresses
-     * @see UtBotSymbolicEngine.touchAddress
+     * @see Traverser.touchAddress
      */
     private fun UtSolverStatusSAT.constructTypeOrNull(addr: UtAddrExpression, defaultType: Type): Type? {
         return constructTypeOrNull(addr, defaultType, isTouched(addr))
@@ -1032,7 +1032,7 @@ val typesOfObjectsToRecreate = listOf(
  * * we have to determine, which null values must be constructed;
  * * we must distinguish primitives and wrappers, but because of kotlin types we cannot do it without the [sootType];
  */
-fun UtBotSymbolicEngine.toMethodResult(value: Any?, sootType: Type): MethodResult {
+fun Traverser.toMethodResult(value: Any?, sootType: Type): MethodResult {
     if (sootType is PrimType) return MethodResult(value.primitiveToSymbolic())
 
     return when (value) {
@@ -1107,7 +1107,7 @@ fun UtBotSymbolicEngine.toMethodResult(value: Any?, sootType: Type): MethodResul
     }
 }
 
-private fun UtBotSymbolicEngine.arrayToMethodResult(
+private fun Traverser.arrayToMethodResult(
     size: Int,
     elementType: Type,
     takeElement: (Int) -> UtExpression
@@ -1143,7 +1143,7 @@ private fun UtBotSymbolicEngine.arrayToMethodResult(
     )
 }
 
-fun UtBotSymbolicEngine.constructEnumStaticFieldResult(
+fun Traverser.constructEnumStaticFieldResult(
     fieldName: String,
     fieldType: Type,
     declaringClass: SootClass,

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Strings.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Strings.kt
@@ -128,7 +128,7 @@ class StringWrapper : BaseOverriddenWrapper(utStringClass.name) {
                         explicitThrown(
                             StringIndexOutOfBoundsException(),
                             findNewAddr(),
-                            isInNestedMethod()
+                            environment.state.isInNestedMethod()
                         ),
                         hardConstraints = mkNot(inBoundsCondition).asHardConstraint()
                     )

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Strings.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Strings.kt
@@ -64,10 +64,10 @@ class StringWrapper : BaseOverriddenWrapper(utStringClass.name) {
     private val charAtMethodSignature =
         overriddenClass.getMethodByName(UtString::charAtImpl.name).subSignature
 
-    private fun UtBotSymbolicEngine.getValueArray(addr: UtAddrExpression) =
+    private fun Traverser.getValueArray(addr: UtAddrExpression) =
         getArrayField(addr, overriddenClass, STRING_VALUE)
 
-    override fun UtBotSymbolicEngine.overrideInvoke(
+    override fun Traverser.overrideInvoke(
         wrapper: ObjectValue,
         method: SootMethod,
         parameters: List<SymbolicValue>
@@ -200,7 +200,7 @@ private fun nextStringName() = "\$string${stringNameIndex++}"
 
 class UtNativeStringWrapper : WrapperInterface {
     private val valueDescriptor = NATIVE_STRING_VALUE_DESCRIPTOR
-    override fun UtBotSymbolicEngine.invoke(
+    override fun Traverser.invoke(
         wrapper: ObjectValue,
         method: SootMethod,
         parameters: List<SymbolicValue>
@@ -292,7 +292,7 @@ sealed class UtAbstractStringBuilderWrapper(className: String) : BaseOverriddenW
     private val asStringBuilderMethodSignature =
         overriddenClass.getMethodByName("asStringBuilder").subSignature
 
-    override fun UtBotSymbolicEngine.overrideInvoke(
+    override fun Traverser.overrideInvoke(
         wrapper: ObjectValue,
         method: SootMethod,
         parameters: List<SymbolicValue>

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/SymbolicValue.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/SymbolicValue.kt
@@ -88,7 +88,7 @@ sealed class ReferenceValue(open val addr: UtAddrExpression) : SymbolicValue()
  * otherwise it is possible for an object to have inappropriate or incorrect typeId and dimensionNum.
  *
  * @see TypeRegistry.typeConstraint
- * @see UtBotSymbolicEngine.createObject
+ * @see Traverser.createObject
  */
 data class ObjectValue(
     override val typeStorage: TypeStorage,
@@ -127,7 +127,7 @@ data class ObjectValue(
  * otherwise it is possible for an object to have inappropriate or incorrect typeId and dimensionNum.
  *
  * @see TypeRegistry.typeConstraint
- * @see UtBotSymbolicEngine.createObject
+ * @see Traverser.createObject
  */
 data class ArrayValue(
     override val typeStorage: TypeStorage,

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/TraversalContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/TraversalContext.kt
@@ -1,0 +1,30 @@
+package org.utbot.engine
+
+/**
+ * Represents a mutable _Context_ during the [ExecutionState] traversing. This _Context_ consists of all mutable and
+ * immutable properties and fields which are created and updated during analysis of **one** Jimple instruction.
+ *
+ * Traverser functions should be implemented as an extension functions with [TraversalContext] as a receiver.
+ *
+ * TODO: extend this class with other properties, such as [Environment], which is [Traverser] mutable property now.
+ */
+class TraversalContext {
+    // TODO: move properties from [UtBotSymbolicEngine] here
+
+
+    // TODO: Q: maybe it's better to pass stateConsumer as an argument to constructor?
+    private val states = mutableListOf<ExecutionState>()
+
+    /**
+     * Offers new [ExecutionState] which can be obtained later with [nextStates].
+     */
+    fun offerState(state: ExecutionState) {
+        states.add(state)
+    }
+
+    /**
+     * New states from traversal.
+     */
+    val nextStates: Collection<ExecutionState>
+        get() = states
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/TraversalContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/TraversalContext.kt
@@ -2,7 +2,7 @@ package org.utbot.engine
 
 /**
  * Represents a mutable _Context_ during the [ExecutionState] traversing. This _Context_ consists of all mutable and
- * immutable properties and fields which are created and updated during analysis of **one** Jimple instruction.
+ * immutable properties and fields which are created and updated during analysis of a **single** Jimple instruction.
  *
  * Traverser functions should be implemented as an extension functions with [TraversalContext] as a receiver.
  *
@@ -23,7 +23,7 @@ class TraversalContext {
     }
 
     /**
-     * New states from traversal.
+     * New states obtained from the traversal.
      */
     val nextStates: Collection<ExecutionState>
         get() = states

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -389,10 +389,6 @@ class Traverser(
     private val featureProcessor: FeatureProcessor? =
         if (enableFeatureProcess) EngineAnalyticsContext.featureProcessorFactory(globalGraph) else null
 
-    private val insideStaticInitializer
-        get() = environment.state.executionStack.any { it.method.isStaticInitializer }
-
-
     private val objectCounter = AtomicInteger(TypeRegistry.objectCounterInitialValue)
     private fun findNewAddr(insideStaticInitializer: Boolean): UtAddrExpression {
         val newAddr = objectCounter.getAndIncrement()

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -1356,7 +1356,7 @@ class Traverser(
      * Returns null if mock is not allowed - Engine traverses nested method call or parameter type is not RefType.
      */
     private fun parameterMockInfoGenerator(parameterRef: IdentityRef): UtMockInfoGenerator? {
-        if (isInNestedMethod()) return null
+        if (environment.state.isInNestedMethod()) return null
         if (parameterRef !is ParameterRef) return null
         val type = parameterRef.type
         if (type !is RefType) return null
@@ -1568,7 +1568,7 @@ class Traverser(
     }
 
     private suspend fun FlowCollector<UtResult>.traverseThrowStmt(current: JThrowStmt) {
-        val symException = explicitThrown(resolve(current.op), isInNestedMethod())
+        val symException = explicitThrown(resolve(current.op), environment.state.isInNestedMethod())
         traverseException(current, symException)
     }
 
@@ -3628,7 +3628,7 @@ class Traverser(
     ) {
         if (environment.state.executionStack.last().doesntThrow) return
 
-        val symException = implicitThrown(exception, findNewAddr(), isInNestedMethod())
+        val symException = implicitThrown(exception, findNewAddr(), environment.state.isInNestedMethod())
         if (!traverseCatchBlock(environment.state.stmt, symException, conditions)) {
             environment.state.expectUndefined()
             val nextState = environment.state.createExceptionState(
@@ -3755,7 +3755,9 @@ class Traverser(
 
             workaround(REMOVE_ANONYMOUS_CLASSES) {
                 val sootClass = returnValue.type.sootClass
-                if (!isInNestedMethod() && (sootClass.isAnonymous || sootClass.isArtificialEntity)) return
+                if (!environment.state.isInNestedMethod() && (sootClass.isAnonymous || sootClass.isArtificialEntity)) {
+                    return
+                }
             }
         }
 
@@ -3776,7 +3778,7 @@ class Traverser(
         val updatedMemory = memory.update(queuedSymbolicStateUpdates.memoryUpdates)
 
         //no need to respect soft constraints in NestedMethod
-        val holder = newSolver.check(respectSoft = !isInNestedMethod())
+        val holder = newSolver.check(respectSoft = !environment.state.isInNestedMethod())
 
         if (holder !is UtSolverStatusSAT) {
             logger.trace { "processResult<${environment.method.signature}> UNSAT" }
@@ -3784,7 +3786,7 @@ class Traverser(
         }
 
         //execution frame from level 2 or above
-        if (isInNestedMethod()) {
+        if (environment.state.isInNestedMethod()) {
             // static fields substitution
             // TODO: JIRA:1610 -- better way of working with statics
             val updates = if (environment.method.name == STATIC_INITIALIZER && substituteStaticsWithSymbolicVariable) {
@@ -3880,8 +3882,6 @@ class Traverser(
             emitFailedConcreteExecutionResult(stateBefore, e)
         }
     }
-
-    internal fun isInNestedMethod() = environment.state.isInNestedMethod()
 
     private fun ReturnStmt.symbolicSuccess(): SymbolicSuccess {
         val type = environment.method.returnType

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -313,7 +313,7 @@ private fun pathSelector(graph: InterProceduralUnitGraph, typeRegistry: TypeRegi
         }
     }
 
-class UtBotSymbolicEngine(
+class Traverser(
     private val controller: EngineController,
     private val methodUnderTest: UtMethod<*>,
     private val graph: ExceptionalUnitGraph,
@@ -3377,7 +3377,7 @@ class UtBotSymbolicEngine(
      * different object addresses in such case
      * - We do not compare null addresses here, it happens in resolveIfCondition
      *
-     * @see UtBotSymbolicEngine.resolveIfCondition
+     * @see Traverser.resolveIfCondition
      */
     private fun compareReferenceValues(
         lhs: ReferenceValue,
@@ -3877,7 +3877,7 @@ class UtBotSymbolicEngine(
         return SymbolicSuccess(value)
     }
 
-    internal fun asMethodResult(function: UtBotSymbolicEngine.() -> SymbolicValue): MethodResult {
+    internal fun asMethodResult(function: Traverser.() -> SymbolicValue): MethodResult {
         val prevSymbolicStateUpdate = queuedSymbolicStateUpdates.copy()
         // TODO: refactor this `try` with `finally` later
         queuedSymbolicStateUpdates = SymbolicStateUpdate()

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -266,6 +266,7 @@ import sun.reflect.generics.reflectiveObjects.TypeVariableImpl
 import sun.reflect.generics.reflectiveObjects.WildcardTypeImpl
 import java.lang.reflect.Method
 import java.util.concurrent.atomic.AtomicInteger
+import org.utbot.framework.plugin.api.jimpleBody
 
 private val logger = KotlinLogging.logger {}
 val pathLogger = KotlinLogging.logger(logger.name + ".path")
@@ -317,13 +318,16 @@ private fun pathSelector(graph: InterProceduralUnitGraph, typeRegistry: TypeRegi
 class Traverser(
     private val controller: EngineController,
     private val methodUnderTest: UtMethod<*>,
-    private val graph: ExceptionalUnitGraph,
     classpath: String,
     dependencyPaths: String,
     mockStrategy: MockStrategy = NO_MOCKS,
     chosenClassesToMockAlways: Set<ClassId>,
     private val solverTimeoutInMillis: Int = checkSolverTimeoutMillis
 ) : UtContextInitializer() {
+
+    private val graph = jimpleBody(methodUnderTest).also {
+        logger.trace { "JIMPLE for $methodUnderTest:\n$this" }
+    }.graph()
 
     private val methodUnderAnalysisStmts: Set<Stmt> = graph.stmts.toSet()
     private val visitedStmts: MutableSet<Stmt> = mutableSetOf()

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -6,7 +6,6 @@ import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 import kotlinx.collections.immutable.toPersistentSet
-import kotlinx.coroutines.CancellationException
 import org.utbot.common.WorkaroundReason.HACK
 import org.utbot.common.WorkaroundReason.REMOVE_ANONYMOUS_CLASSES
 import org.utbot.common.findField
@@ -213,6 +212,7 @@ class Traverser(
     private val classLoader: ClassLoader
         get() = utContext.classLoader
 
+    // TODO: move this and other mutable fields to [TraversalContext]
     lateinit var environment: Environment
     private val solver: UtSolver
         get() = environment.state.solver
@@ -281,13 +281,9 @@ class Traverser(
         } catch (ex: Throwable) {
             environment.state.close()
 
-            if (ex !is CancellationException) {
-                logger.error(ex) { "Test generation failed on stmt $currentStmt, symbolic stack trace:\n$symbolicStackTrace" }
-                // TODO: enrich with nice description for known issues
-                throw ex
-            } else {
-                logger.debug(ex) { "Cancellation happened" }
-            }
+            logger.error(ex) { "Test generation failed on stmt $currentStmt, symbolic stack trace:\n$symbolicStackTrace" }
+            // TODO: enrich with nice description for known issues
+            throw ex
         }
         queuedSymbolicStateUpdates = SymbolicStateUpdate()
         return context.nextStates
@@ -2991,7 +2987,8 @@ class Traverser(
             implicitlyThrowException(NullPointerException(), setOf(notMarkedAndNull))
         }
 
-        queuedSymbolicStateUpdates += canNotBeNull.asHardConstraint()    }
+        queuedSymbolicStateUpdates += canNotBeNull.asHardConstraint()
+    }
 
     private fun TraversalContext.divisionByZeroCheck(denom: PrimitiveValue) {
         val equalsToZero = Eq(denom, 0)
@@ -3363,7 +3360,8 @@ class Traverser(
             return
         }
 
-        //toplevel method
+        // toplevel method
+        // TODO: investigate very strange behavior when some constraints are not added leading to failing CodegenExampleTest::firstExampleTest fails
         val terminalExecutionState = environment.state.copy(
             symbolicState = symbolicState,
             methodResult = methodResult, // the way to put SymbolicResult into terminal state

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -728,7 +728,7 @@ class Traverser(
             is JInvokeStmt -> traverseInvokeStmt(current)
             is SwitchStmt -> traverseSwitchStmt(current)
             is JReturnStmt -> processResult(current.symbolicSuccess())
-            is JReturnVoidStmt -> processResult(null)
+            is JReturnVoidStmt -> processResult(SymbolicSuccess(voidValue))
             is JRetStmt -> error("This one should be already removed by Soot: $current")
             is JThrowStmt -> traverseThrowStmt(current)
             is JBreakpointStmt -> pathSelector.offer(environment.state.updateQueued(globalGraph.succ(current)))
@@ -3737,7 +3737,7 @@ class Traverser(
         )
     }
 
-    private suspend fun FlowCollector<UtResult>.processResult(symbolicResult: SymbolicResult? /* null for void only: strange hack */) {
+    private suspend fun FlowCollector<UtResult>.processResult(symbolicResult: SymbolicResult) {
         val resolvedParameters = environment.state.parameters.map { it.value }
 
         //choose types that have biggest priority
@@ -3791,9 +3791,8 @@ class Traverser(
             } else {
                 MemoryUpdate() // all memory updates are already added in [environment.state]
             }
-            val symbolicResultOrVoid = symbolicResult ?: SymbolicSuccess(typeResolver.nullObject(VoidType.v()))
             val methodResult = MethodResult(
-                symbolicResultOrVoid,
+                symbolicResult,
                 queuedSymbolicStateUpdates + updates
             )
             val stateToOffer = environment.state.pop(methodResult)

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -3660,9 +3660,9 @@ class Traverser(
      * Collects entry method statement path for ML. Eliminates duplicated statements, e.g. assignment with invocation
      * in right part.
      */
-    private fun entryMethodPath(): MutableList<Step> {
+    private fun entryMethodPath(state: ExecutionState): MutableList<Step> {
         val entryPath = mutableListOf<Step>()
-        environment.state.fullPath().forEach { step ->
+        state.fullPath().forEach { step ->
             // TODO: replace step.stmt in methodUnderAnalysisStmts with step.depth == 0
             //  when fix SAT-812: [JAVA] Wrong depth when exception thrown
             if (step.stmt in methodUnderAnalysisStmts && step.stmt !== entryPath.lastOrNull()?.stmt) {
@@ -3848,7 +3848,7 @@ class Traverser(
             stateAfter,
             symbolicExecutionResult,
             instrumentation,
-            entryMethodPath(),
+            entryMethodPath(environment.state),
             state.fullPath()
         )
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -1733,6 +1733,7 @@ class Traverser(
             is JNewArrayExpr -> {
                 val size = (resolve(expr.size) as PrimitiveValue).align()
                 val type = expr.type as ArrayType
+                negativeArraySizeCheck(size)
                 createNewArray(size, type, type.elementType).also {
                     val defaultValue = type.defaultSymValue
                     queuedSymbolicStateUpdates += arrayUpdateWithValue(it.addr, type, defaultValue as UtArrayExpressionBase)
@@ -2015,8 +2016,11 @@ class Traverser(
         return castedArray
     }
 
+    /**
+     * @param size [SymbolicValue] representing size of an array. It's caller responsibility to handle negative
+     * size.
+     */
     internal fun createNewArray(size: PrimitiveValue, type: ArrayType, elementType: Type): ArrayValue {
-        negativeArraySizeCheck(size)
         val addr = findNewAddr()
         val length = memory.findArrayLength(addr)
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -3330,12 +3330,12 @@ class Traverser(
             queuedSymbolicStateUpdates += mkNot(mkEq(symbolicResult.value.addr, nullObjectAddr)).asHardConstraint()
         }
 
-        val state = environment.state.update(queuedSymbolicStateUpdates)
-        val memory = state.memory
-        val solver = state.solver
+        val symbolicState = environment.state.symbolicState + queuedSymbolicStateUpdates
+        val memory = symbolicState.memory
+        val solver = symbolicState.solver
 
         //no need to respect soft constraints in NestedMethod
-        val holder = solver.check(respectSoft = !state.isInNestedMethod())
+        val holder = solver.check(respectSoft = !environment.state.isInNestedMethod())
 
         if (holder !is UtSolverStatusSAT) {
             logger.trace { "processResult<${environment.method.signature}> UNSAT" }
@@ -3344,7 +3344,7 @@ class Traverser(
         val methodResult = MethodResult(symbolicResult)
 
         //execution frame from level 2 or above
-        if (state.isInNestedMethod()) {
+        if (environment.state.isInNestedMethod()) {
             // static fields substitution
             // TODO: JIRA:1610 -- better way of working with statics
             val updates = if (environment.method.name == STATIC_INITIALIZER && substituteStaticsWithSymbolicVariable) {
@@ -3355,7 +3355,8 @@ class Traverser(
             } else {
                 MemoryUpdate() // all memory updates are already added in [environment.state]
             }
-            val stateToOffer = state.pop(methodResult.copy(symbolicStateUpdate = updates.asUpdate()))
+            val methodResultWithUpdates = methodResult.copy(symbolicStateUpdate = queuedSymbolicStateUpdates + updates)
+            val stateToOffer = environment.state.pop(methodResultWithUpdates)
             offerState(stateToOffer)
 
             logger.trace { "processResult<${environment.method.signature}> return from nested method" }
@@ -3363,7 +3364,8 @@ class Traverser(
         }
 
         //toplevel method
-        val terminalExecutionState = state.copy(
+        val terminalExecutionState = environment.state.copy(
+            symbolicState = symbolicState,
             methodResult = methodResult, // the way to put SymbolicResult into terminal state
             label = StateLabel.TERMINAL
         )

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -3829,8 +3829,8 @@ class Traverser(
         // it's free to make a check, because in the result is SAT, it should be already cached
         val holder = requireNotNull(solver.check(respectSoft = true) as? UtSolverStatusSAT) { "The state must be SAT!" }
 
-        val predictedTestName = Predictors.testName.predict(environment.state.path)
-        Predictors.testName.provide(environment.state.path, predictedTestName, "")
+        val predictedTestName = Predictors.testName.predict(state.path)
+        Predictors.testName.provide(state.path, predictedTestName, "")
 
         val resolver =
             Resolver(hierarchy, memory, typeRegistry, typeResolver, holder, methodUnderTest, softMaxArraySize)
@@ -3849,10 +3849,10 @@ class Traverser(
             symbolicExecutionResult,
             instrumentation,
             entryMethodPath(),
-            environment.state.fullPath()
+            state.fullPath()
         )
 
-        globalGraph.traversed(environment.state)
+        globalGraph.traversed(state)
 
         if (!UtSettings.useConcreteExecution ||
             // Can't execute concretely because overflows do not cause actual exceptions.

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
@@ -351,6 +351,8 @@ class UtBotSymbolicEngine(
                         // So we need to make it throw CancelledException by method below:
                         currentCoroutineContext().job.ensureActive()
                     }
+
+                    // TODO: think about concise modifying globalGraph in Traverser and UtBotSymbolicEngine
                     globalGraph.visitNode(state)
                 }
             }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
@@ -1,0 +1,654 @@
+package org.utbot.engine
+
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.job
+import kotlinx.coroutines.yield
+import mu.KotlinLogging
+import org.utbot.analytics.EngineAnalyticsContext
+import org.utbot.analytics.FeatureProcessor
+import org.utbot.analytics.Predictors
+import org.utbot.common.WorkaroundReason.REMOVE_ANONYMOUS_CLASSES
+import org.utbot.common.bracket
+import org.utbot.common.debug
+import org.utbot.common.workaround
+import org.utbot.engine.MockStrategy.NO_MOCKS
+import org.utbot.engine.pc.UtArraySelectExpression
+import org.utbot.engine.pc.UtBoolExpression
+import org.utbot.engine.pc.UtContextInitializer
+import org.utbot.engine.pc.UtSolver
+import org.utbot.engine.pc.UtSolverStatusSAT
+import org.utbot.engine.pc.findTheMostNestedAddr
+import org.utbot.engine.pc.mkEq
+import org.utbot.engine.pc.mkInt
+import org.utbot.engine.selectors.PathSelector
+import org.utbot.engine.selectors.StrategyOption
+import org.utbot.engine.selectors.coveredNewSelector
+import org.utbot.engine.selectors.cpInstSelector
+import org.utbot.engine.selectors.forkDepthSelector
+import org.utbot.engine.selectors.inheritorsSelector
+import org.utbot.engine.selectors.nnRewardGuidedSelector
+import org.utbot.engine.selectors.nurs.NonUniformRandomSearch
+import org.utbot.engine.selectors.pollUntilFastSAT
+import org.utbot.engine.selectors.randomPathSelector
+import org.utbot.engine.selectors.randomSelector
+import org.utbot.engine.selectors.strategies.GraphViz
+import org.utbot.engine.selectors.subpathGuidedSelector
+import org.utbot.engine.symbolic.SymbolicState
+import org.utbot.engine.symbolic.asHardConstraint
+import org.utbot.engine.util.mockListeners.MockListener
+import org.utbot.engine.util.mockListeners.MockListenerController
+import org.utbot.framework.PathSelectorType
+import org.utbot.framework.UtSettings
+import org.utbot.framework.UtSettings.checkSolverTimeoutMillis
+import org.utbot.framework.UtSettings.enableFeatureProcess
+import org.utbot.framework.UtSettings.pathSelectorStepsLimit
+import org.utbot.framework.UtSettings.pathSelectorType
+import org.utbot.framework.UtSettings.processUnknownStatesDuringConcreteExecution
+import org.utbot.framework.UtSettings.useDebugVisualization
+import org.utbot.framework.concrete.UtConcreteExecutionData
+import org.utbot.framework.concrete.UtConcreteExecutionResult
+import org.utbot.framework.concrete.UtExecutionInstrumentation
+import org.utbot.framework.plugin.api.ClassId
+import org.utbot.framework.plugin.api.ConcreteExecutionFailureException
+import org.utbot.framework.plugin.api.EnvironmentModels
+import org.utbot.framework.plugin.api.Instruction
+import org.utbot.framework.plugin.api.MissingState
+import org.utbot.framework.plugin.api.Step
+import org.utbot.framework.plugin.api.UtConcreteExecutionFailure
+import org.utbot.framework.plugin.api.UtError
+import org.utbot.framework.plugin.api.UtExecution
+import org.utbot.framework.plugin.api.UtInstrumentation
+import org.utbot.framework.plugin.api.UtMethod
+import org.utbot.framework.plugin.api.UtNullModel
+import org.utbot.framework.plugin.api.UtOverflowFailure
+import org.utbot.framework.plugin.api.UtResult
+import org.utbot.framework.plugin.api.graph
+import org.utbot.framework.plugin.api.jimpleBody
+import org.utbot.framework.plugin.api.onSuccess
+import org.utbot.framework.plugin.api.util.executableId
+import org.utbot.framework.plugin.api.util.id
+import org.utbot.framework.plugin.api.util.utContext
+import org.utbot.framework.plugin.api.util.description
+import org.utbot.fuzzer.FallbackModelProvider
+import org.utbot.fuzzer.FuzzedMethodDescription
+import org.utbot.fuzzer.ModelProvider
+import org.utbot.fuzzer.collectConstantsForFuzzer
+import org.utbot.fuzzer.defaultModelProviders
+import org.utbot.fuzzer.fuzz
+import org.utbot.fuzzer.names.MethodBasedNameSuggester
+import org.utbot.fuzzer.names.ModelBasedNameSuggester
+import org.utbot.instrumentation.ConcreteExecutor
+import soot.jimple.Stmt
+import soot.tagkit.ParamNamesTag
+import java.lang.reflect.Method
+import kotlin.system.measureTimeMillis
+
+val logger = KotlinLogging.logger {}
+val pathLogger = KotlinLogging.logger(logger.name + ".path")
+
+//in future we should put all timeouts here
+class EngineController {
+    var paused: Boolean = false
+    var executeConcretely: Boolean = false
+    var stop: Boolean = false
+    var job: Job? = null
+}
+
+//for debugging purpose only
+private var stateSelectedCount = 0
+
+//all id values of synthetic default models must be greater that for real ones
+private var nextDefaultModelId = 1500_000_000
+
+private fun pathSelector(graph: InterProceduralUnitGraph, typeRegistry: TypeRegistry) =
+    when (pathSelectorType) {
+        PathSelectorType.COVERED_NEW_SELECTOR -> coveredNewSelector(graph) {
+            withStepsLimit(pathSelectorStepsLimit)
+        }
+        PathSelectorType.INHERITORS_SELECTOR -> inheritorsSelector(graph, typeRegistry) {
+            withStepsLimit(pathSelectorStepsLimit)
+        }
+        PathSelectorType.SUBPATH_GUIDED_SELECTOR -> subpathGuidedSelector(graph, StrategyOption.DISTANCE) {
+            withStepsLimit(pathSelectorStepsLimit)
+        }
+        PathSelectorType.CPI_SELECTOR -> cpInstSelector(graph, StrategyOption.DISTANCE) {
+            withStepsLimit(pathSelectorStepsLimit)
+        }
+        PathSelectorType.FORK_DEPTH_SELECTOR -> forkDepthSelector(graph, StrategyOption.DISTANCE) {
+            withStepsLimit(pathSelectorStepsLimit)
+        }
+        PathSelectorType.NN_REWARD_GUIDED_SELECTOR -> nnRewardGuidedSelector(graph, StrategyOption.DISTANCE) {
+            withStepsLimit(pathSelectorStepsLimit)
+        }
+        PathSelectorType.RANDOM_SELECTOR -> randomSelector(graph, StrategyOption.DISTANCE) {
+            withStepsLimit(pathSelectorStepsLimit)
+        }
+        PathSelectorType.RANDOM_PATH_SELECTOR -> randomPathSelector(graph, StrategyOption.DISTANCE) {
+            withStepsLimit(pathSelectorStepsLimit)
+        }
+    }
+
+class UtBotSymbolicEngine(
+    private val controller: EngineController,
+    private val methodUnderTest: UtMethod<*>,
+    classpath: String,
+    dependencyPaths: String,
+    mockStrategy: MockStrategy = NO_MOCKS,
+    chosenClassesToMockAlways: Set<ClassId>,
+    private val solverTimeoutInMillis: Int = checkSolverTimeoutMillis
+) : UtContextInitializer() {
+
+    private val graph = jimpleBody(methodUnderTest).also {
+        logger.trace { "JIMPLE for $methodUnderTest:\n$this" }
+    }.graph()
+
+    private val methodUnderAnalysisStmts: Set<Stmt> = graph.stmts.toSet()
+    private val globalGraph = InterProceduralUnitGraph(graph)
+    private val typeRegistry: TypeRegistry = TypeRegistry()
+    private val pathSelector: PathSelector = pathSelector(globalGraph, typeRegistry)
+
+    internal val hierarchy: Hierarchy = Hierarchy(typeRegistry)
+
+    // TODO HACK violation of encapsulation
+    internal val typeResolver: TypeResolver = TypeResolver(typeRegistry, hierarchy)
+
+    private val classUnderTest: ClassId = methodUnderTest.clazz.id
+
+    private val mocker: Mocker = Mocker(
+        mockStrategy,
+        classUnderTest,
+        hierarchy,
+        chosenClassesToMockAlways,
+        MockListenerController(controller)
+    )
+
+    fun attachMockListener(mockListener: MockListener) = mocker.mockListenerController?.attach(mockListener)
+
+    private val statesForConcreteExecution: MutableList<ExecutionState> = mutableListOf()
+
+    private val traverser = Traverser(
+        methodUnderTest,
+        typeRegistry,
+        hierarchy,
+        typeResolver,
+        globalGraph,
+        mocker,
+    )
+
+    //HACK (long strings)
+    internal var softMaxArraySize = 40
+
+    private val concreteExecutor =
+        ConcreteExecutor(
+            UtExecutionInstrumentation,
+            classpath,
+            dependencyPaths
+        ).apply { this.classLoader = utContext.classLoader }
+
+    private val featureProcessor: FeatureProcessor? =
+        if (enableFeatureProcess) EngineAnalyticsContext.featureProcessorFactory(globalGraph) else null
+
+
+    private val trackableResources: MutableSet<AutoCloseable> = mutableSetOf()
+
+    private fun postTraverse() {
+        for (r in trackableResources)
+            try {
+                r.close()
+            } catch (e: Throwable) {
+                logger.error(e) { "Closing resource failed" }
+            }
+        trackableResources.clear()
+        featureProcessor?.dumpFeatures()
+    }
+
+    private suspend fun preTraverse() {
+        //fixes leak in useless Context() created in AutoCloseable()
+        close()
+        if (!currentCoroutineContext().isActive) return
+        stateSelectedCount = 0
+    }
+
+    fun traverse(): Flow<UtResult> = traverseImpl()
+        .onStart { preTraverse() }
+        .onCompletion { postTraverse() }
+
+    private fun traverseImpl(): Flow<UtResult> = flow {
+
+        require(trackableResources.isEmpty())
+
+        if (useDebugVisualization) GraphViz(globalGraph, pathSelector)
+
+        val initStmt = graph.head
+        val initState = ExecutionState(
+            initStmt,
+            SymbolicState(UtSolver(typeRegistry, trackableResources, solverTimeoutInMillis)),
+            executionStack = persistentListOf(ExecutionStackElement(null, method = graph.body.method))
+        )
+
+        pathSelector.offer(initState)
+
+        pathSelector.use {
+
+            while (currentCoroutineContext().isActive) {
+                if (controller.stop)
+                    break
+
+                if (controller.paused) {
+                    try {
+                        yield()
+                    } catch (e: CancellationException) { //todo in future we should just throw cancellation
+                        break
+                    }
+                    continue
+                }
+
+                stateSelectedCount++
+                pathLogger.trace {
+                    "traverse<$methodUnderTest>: choosing next state($stateSelectedCount), " +
+                            "queue size=${(pathSelector as? NonUniformRandomSearch)?.size ?: -1}"
+                }
+
+                if (controller.executeConcretely || statesForConcreteExecution.isNotEmpty()) {
+                    val state = pathSelector.pollUntilFastSAT()
+                        ?: statesForConcreteExecution.pollUntilSat(processUnknownStatesDuringConcreteExecution)
+                        ?: break
+                    // This state can contain inconsistent wrappers - for example, Map with keys but missing values.
+                    // We cannot use withWrapperConsistencyChecks here because it needs solver to work.
+                    // So, we have to process such cases accurately in wrappers resolving.
+
+                    logger.trace { "executing $state concretely..." }
+
+
+                    logger.debug().bracket("concolicStrategy<$methodUnderTest>: execute concretely") {
+                        val resolver = Resolver(
+                            hierarchy,
+                            state.memory,
+                            typeRegistry,
+                            typeResolver,
+                            state.solver.lastStatus as UtSolverStatusSAT,
+                            methodUnderTest,
+                            softMaxArraySize
+                        )
+
+                        val resolvedParameters = state.methodUnderTestParameters
+                        val (modelsBefore, _, instrumentation) = resolver.resolveModels(resolvedParameters)
+                        val stateBefore = modelsBefore.constructStateForMethod(methodUnderTest)
+
+                        try {
+                            val concreteExecutionResult =
+                                concreteExecutor.executeConcretely(methodUnderTest, stateBefore, instrumentation)
+
+                            val concreteUtExecution = UtExecution(
+                                stateBefore,
+                                concreteExecutionResult.stateAfter,
+                                concreteExecutionResult.result,
+                                instrumentation,
+                                mutableListOf(),
+                                listOf(),
+                                concreteExecutionResult.coverage
+                            )
+                            emit(concreteUtExecution)
+
+                            logger.debug { "concolicStrategy<${methodUnderTest}>: returned $concreteUtExecution" }
+                        } catch (e: CancellationException) {
+                            logger.debug(e) { "Cancellation happened" }
+                        } catch (e: ConcreteExecutionFailureException) {
+                            emitFailedConcreteExecutionResult(stateBefore, e)
+                        } catch (e: Throwable) {
+                            emit(UtError("Concrete execution failed", e))
+                        }
+                    }
+
+                } else {
+                    val state = pathSelector.poll()
+
+                    // state is null in case states queue is empty
+                    // or path selector exceed some limits (steps limit, for example)
+                    if (state == null) {
+                        // check do we have remaining states that we can execute concretely
+                        val pathSelectorStatesForConcreteExecution = pathSelector
+                            .remainingStatesForConcreteExecution
+                            .map { it.withWrapperConsistencyChecks() }
+                        if (pathSelectorStatesForConcreteExecution.isNotEmpty()) {
+                            statesForConcreteExecution += pathSelectorStatesForConcreteExecution
+                            logger.debug {
+                                "${pathSelectorStatesForConcreteExecution.size} remaining states " +
+                                        "were moved from path selector for concrete execution"
+                            }
+                            continue // the next step in while loop processes concrete states
+                        } else {
+                            break
+                        }
+                    }
+
+                    state.executingTime += measureTimeMillis {
+                        val newStates = try {
+                            traverser.traverse(state)
+                        } catch (ex: Throwable) {
+                            emit(UtError(ex.description, ex))
+                            return@measureTimeMillis
+                        }
+                        for (newState in newStates) {
+                            when (newState.label) {
+                                StateLabel.INTERMEDIATE -> pathSelector.offer(newState)
+                                StateLabel.CONCRETE -> statesForConcreteExecution.add(newState)
+                                StateLabel.TERMINAL -> consumeTerminalState(newState)
+                            }
+                        }
+
+                        // Here job can be cancelled from within traverse, e.g. by using force mocking without Mockito.
+                        // So we need to make it throw CancelledException by method below:
+                        currentCoroutineContext().job.ensureActive()
+                    }
+                    globalGraph.visitNode(state)
+                }
+            }
+        }
+    }
+
+
+    /**
+     * Run fuzzing flow.
+     *
+     * @param until is used by fuzzer to cancel all tasks if the current time is over this value
+     * @param modelProvider provides model values for a method
+     */
+    fun fuzzing(until: Long = Long.MAX_VALUE, modelProvider: (ModelProvider) -> ModelProvider = { it }) = flow {
+        val executableId = if (methodUnderTest.isConstructor) {
+            methodUnderTest.javaConstructor!!.executableId
+        } else {
+            methodUnderTest.javaMethod!!.executableId
+        }
+
+        val isFuzzable = executableId.parameters.all { classId ->
+            classId != Method::class.java.id && // causes the child process crash at invocation
+                classId != Class::class.java.id  // causes java.lang.IllegalAccessException: java.lang.Class at sun.misc.Unsafe.allocateInstance(Native Method)
+        }
+        if (!isFuzzable) {
+            return@flow
+        }
+
+        val fallbackModelProvider = FallbackModelProvider { nextDefaultModelId++ }
+
+        val thisInstance = when {
+            methodUnderTest.isStatic -> null
+            methodUnderTest.isConstructor -> if (
+                methodUnderTest.clazz.isAbstract ||  // can't instantiate abstract class
+                methodUnderTest.clazz.java.isEnum    // can't reflectively create enum objects
+            ) {
+                return@flow
+            } else {
+                null
+            }
+            else -> {
+                fallbackModelProvider.toModel(methodUnderTest.clazz).apply {
+                    if (this is UtNullModel) { // it will definitely fail because of NPE,
+                        return@flow
+                    }
+                }
+            }
+        }
+
+        val methodUnderTestDescription = FuzzedMethodDescription(executableId, collectConstantsForFuzzer(graph)).apply {
+            compilableName = if (methodUnderTest.isMethod) executableId.name else null
+            val names = graph.body.method.tags.filterIsInstance<ParamNamesTag>().firstOrNull()?.names
+            parameterNameMap = { index -> names?.getOrNull(index) }
+        }
+        val modelProviderWithFallback = modelProvider(defaultModelProviders { nextDefaultModelId++ }).withFallback(fallbackModelProvider::toModel)
+        val coveredInstructionTracker = mutableSetOf<Instruction>()
+        var attempts = UtSettings.fuzzingMaxAttempts
+        fuzz(methodUnderTestDescription, modelProviderWithFallback).forEach { values ->
+            if (System.currentTimeMillis() >= until) {
+                logger.info { "Fuzzing overtime: $methodUnderTest" }
+                return@flow
+            }
+
+            val initialEnvironmentModels = EnvironmentModels(thisInstance, values.map { it.model }, mapOf())
+
+            try {
+                val concreteExecutionResult =
+                    concreteExecutor.executeConcretely(methodUnderTest, initialEnvironmentModels, listOf())
+
+                workaround(REMOVE_ANONYMOUS_CLASSES) {
+                    concreteExecutionResult.result.onSuccess {
+                        if (it.classId.isAnonymous) {
+                            logger.debug("Anonymous class found as a concrete result, symbolic one will be returned")
+                            return@flow
+                        }
+                    }
+                }
+
+                if (!coveredInstructionTracker.addAll(concreteExecutionResult.coverage.coveredInstructions)) {
+                    if (--attempts < 0) {
+                        return@flow
+                    }
+                }
+
+                val nameSuggester = sequenceOf(ModelBasedNameSuggester(), MethodBasedNameSuggester())
+                val testMethodName = try {
+                    nameSuggester.flatMap { it.suggest(methodUnderTestDescription, values, concreteExecutionResult.result) }.firstOrNull()
+                } catch (t: Throwable) {
+                    logger.error(t) { "Cannot create suggested test name for ${methodUnderTest.displayName}" }
+                    null
+                }
+
+                emit(
+                    UtExecution(
+                        stateBefore = initialEnvironmentModels,
+                        stateAfter = concreteExecutionResult.stateAfter,
+                        result = concreteExecutionResult.result,
+                        instrumentation = emptyList(),
+                        path = mutableListOf(),
+                        fullPath = emptyList(),
+                        coverage = concreteExecutionResult.coverage,
+                        testMethodName = testMethodName?.testName,
+                        displayName = testMethodName?.displayName
+                    )
+                )
+            } catch (e: CancellationException) {
+                logger.debug { "Cancelled by timeout" }
+            } catch (e: ConcreteExecutionFailureException) {
+                emitFailedConcreteExecutionResult(initialEnvironmentModels, e)
+            } catch (e: Throwable) {
+                emit(UtError("Default concrete execution failed", e))
+            }
+        }
+    }
+
+    private suspend fun FlowCollector<UtResult>.emitFailedConcreteExecutionResult(
+        stateBefore: EnvironmentModels,
+        e: ConcreteExecutionFailureException
+    ) {
+        val failedConcreteExecution = UtExecution(
+            stateBefore = stateBefore,
+            stateAfter = MissingState,
+            result = UtConcreteExecutionFailure(e),
+            instrumentation = emptyList(),
+            path = mutableListOf(),
+            fullPath = listOf()
+        )
+
+        emit(failedConcreteExecution)
+    }
+
+    private suspend fun FlowCollector<UtResult>.consumeTerminalState(
+        state: ExecutionState,
+    ) {
+        // some checks to be sure the state is correct
+        require(state.label == StateLabel.TERMINAL) { "Can't process non-terminal state!" }
+        require(!state.isInNestedMethod()) { "The state has to correspond to the MUT" }
+
+        val memory = state.memory
+        val solver = state.solver
+        val parameters = state.parameters.map { it.value }
+        val symbolicResult = requireNotNull(state.methodResult?.symbolicResult) { "The state must have symbolicResult" }
+        // it's free to make a check, because in the result is SAT, it should be already cached
+        val holder = requireNotNull(solver.check(respectSoft = true) as? UtSolverStatusSAT) { "The state must be SAT!" }
+
+        val predictedTestName = Predictors.testName.predict(state.path)
+        Predictors.testName.provide(state.path, predictedTestName, "")
+
+        // resolving
+        val resolver =
+            Resolver(hierarchy, memory, typeRegistry, typeResolver, holder, methodUnderTest, softMaxArraySize)
+
+        val (modelsBefore, modelsAfter, instrumentation) = resolver.resolveModels(parameters)
+
+        val symbolicExecutionResult = resolver.resolveResult(symbolicResult)
+
+        val stateBefore = modelsBefore.constructStateForMethod(methodUnderTest)
+        val stateAfter = modelsAfter.constructStateForMethod(methodUnderTest)
+        require(stateBefore.parameters.size == stateAfter.parameters.size)
+
+        val symbolicUtExecution = UtExecution(
+            stateBefore,
+            stateAfter,
+            symbolicExecutionResult,
+            instrumentation,
+            entryMethodPath(state),
+            state.fullPath()
+        )
+
+        globalGraph.traversed(state)
+
+        if (!UtSettings.useConcreteExecution ||
+            // Can't execute concretely because overflows do not cause actual exceptions.
+            // Still, we need overflows to act as implicit exceptions.
+            (UtSettings.treatOverflowAsError && symbolicExecutionResult is UtOverflowFailure)
+        ) {
+            logger.debug {
+                "processResult<${methodUnderTest}>: no concrete execution allowed, " +
+                        "emit purely symbolic result $symbolicUtExecution"
+            }
+            emit(symbolicUtExecution)
+            return
+        }
+
+        //It's possible that symbolic and concrete stateAfter/results are diverged.
+        //So we trust concrete results more.
+        try {
+            logger.debug().bracket("processResult<$methodUnderTest>: concrete execution") {
+
+                //this can throw CancellationException
+                val concreteExecutionResult = concreteExecutor.executeConcretely(
+                    methodUnderTest,
+                    stateBefore,
+                    instrumentation
+                )
+
+                workaround(REMOVE_ANONYMOUS_CLASSES) {
+                    concreteExecutionResult.result.onSuccess {
+                        if (it.classId.isAnonymous) {
+                            logger.debug("Anonymous class found as a concrete result, symbolic one will be returned")
+                            emit(symbolicUtExecution)
+                            return
+                        }
+                    }
+                }
+
+                val concolicUtExecution = symbolicUtExecution.copy(
+                    stateAfter = concreteExecutionResult.stateAfter,
+                    result = concreteExecutionResult.result,
+                    coverage = concreteExecutionResult.coverage
+                )
+
+                emit(concolicUtExecution)
+                logger.debug { "processResult<${methodUnderTest}>: returned $concolicUtExecution" }
+            }
+        } catch (e: ConcreteExecutionFailureException) {
+            emitFailedConcreteExecutionResult(stateBefore, e)
+        }
+    }
+
+    /**
+     * Collects entry method statement path for ML. Eliminates duplicated statements, e.g. assignment with invocation
+     * in right part.
+     */
+    private fun entryMethodPath(state: ExecutionState): MutableList<Step> {
+        val entryPath = mutableListOf<Step>()
+        state.fullPath().forEach { step ->
+            // TODO: replace step.stmt in methodUnderAnalysisStmts with step.depth == 0
+            //  when fix SAT-812: [JAVA] Wrong depth when exception thrown
+            if (step.stmt in methodUnderAnalysisStmts && step.stmt !== entryPath.lastOrNull()?.stmt) {
+                entryPath += step
+            }
+        }
+        return entryPath
+    }
+}
+
+private fun ResolvedModels.constructStateForMethod(methodUnderTest: UtMethod<*>): EnvironmentModels {
+    val (thisInstanceBefore, paramsBefore) = when {
+        methodUnderTest.isStatic -> null to parameters
+        methodUnderTest.isConstructor -> null to parameters.drop(1)
+        else -> parameters.first() to parameters.drop(1)
+    }
+    return EnvironmentModels(thisInstanceBefore, paramsBefore, statics)
+}
+
+private suspend fun ConcreteExecutor<UtConcreteExecutionResult, UtExecutionInstrumentation>.executeConcretely(
+    methodUnderTest: UtMethod<*>,
+    stateBefore: EnvironmentModels,
+    instrumentation: List<UtInstrumentation>
+): UtConcreteExecutionResult = executeAsync(
+    methodUnderTest.callable,
+    arrayOf(),
+    parameters = UtConcreteExecutionData(stateBefore, instrumentation)
+).convertToAssemble(methodUnderTest)
+
+/**
+ * Before pushing our states for concrete execution, we have to be sure that every state is consistent.
+ * For now state could be inconsistent in case MUT parameters are wrappers that are not fully visited.
+ * For example, not fully visited map can contain duplicate keys that leads to incorrect behaviour.
+ * To prevent it, we need to add visited constraint for each MUT parameter-wrapper in state.
+ */
+private fun ExecutionState.withWrapperConsistencyChecks(): ExecutionState {
+    val visitedConstraints = mutableSetOf<UtBoolExpression>()
+    val methodUnderTestWrapperParameters = methodUnderTestParameters.filterNot { it.asWrapperOrNull == null }
+    val methodUnderTestWrapperParametersAddresses = methodUnderTestWrapperParameters.map { it.addr }.toSet()
+
+    if (methodUnderTestWrapperParameters.isEmpty()) {
+        return this
+    }
+
+    // make consistency checks for parameters-wrappers ...
+    methodUnderTestWrapperParameters.forEach { symbolicValue ->
+        symbolicValue.asWrapperOrNull?.let {
+            makeWrapperConsistencyCheck(symbolicValue, memory, visitedConstraints)
+        }
+    }
+
+    // ... and all locals that depends on these parameters-wrappers
+    val localReferenceValues = localVariableMemory
+        .localValues
+        .filterIsInstance<ReferenceValue>()
+        .filter { it.addr.internal is UtArraySelectExpression }
+    localReferenceValues.forEach {
+        val theMostNestedAddr = findTheMostNestedAddr(it.addr.internal as UtArraySelectExpression)
+        if (theMostNestedAddr in methodUnderTestWrapperParametersAddresses) {
+            makeWrapperConsistencyCheck(it, memory, visitedConstraints)
+        }
+    }
+
+    return copy(symbolicState = symbolicState + visitedConstraints.asHardConstraint())
+}
+
+private fun makeWrapperConsistencyCheck(
+    symbolicValue: SymbolicValue,
+    memory: Memory,
+    visitedConstraints: MutableSet<UtBoolExpression>
+) {
+    val visitedSelectExpression = memory.isVisited(symbolicValue.addr)
+    visitedConstraints += mkEq(visitedSelectExpression, mkInt(1))
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
@@ -493,8 +493,7 @@ class UtBotSymbolicEngine(
         val solver = state.solver
         val parameters = state.parameters.map { it.value }
         val symbolicResult = requireNotNull(state.methodResult?.symbolicResult) { "The state must have symbolicResult" }
-        // it's free to make a check, because in the result is SAT, it should be already cached
-        val holder = requireNotNull(solver.check(respectSoft = true) as? UtSolverStatusSAT) { "The state must be SAT!" }
+        val holder = requireNotNull(solver.lastStatus as? UtSolverStatusSAT) { "The state must be SAT!" }
 
         val predictedTestName = Predictors.testName.predict(state.path)
         Predictors.testName.provide(state.path, predictedTestName, "")

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/pc/UtExpression.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/pc/UtExpression.kt
@@ -243,7 +243,7 @@ data class UtArraySelectExpression(val arrayExpression: UtExpression, val index:
 }
 
 /**
- * Uses in [org.utbot.engine.UtBotSymbolicEngine.classCastExceptionCheck].
+ * Uses in [org.utbot.engine.Traverser.classCastExceptionCheck].
  * Returns the most nested index in the [UtArraySelectExpression].
  *
  * I.e. for (select a i) it returns i, for (select (select (select a i) j) k) it still returns i

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/util/statics/concrete/EnumConcreteUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/util/statics/concrete/EnumConcreteUtils.kt
@@ -20,7 +20,7 @@ import soot.jimple.StaticFieldRef
 import soot.jimple.Stmt
 import soot.jimple.internal.JAssignStmt
 
-fun UtBotSymbolicEngine.makeSymbolicValuesFromEnumConcreteValues(
+fun Traverser.makeSymbolicValuesFromEnumConcreteValues(
     type: Type,
     enumConstantRuntimeValues: List<Enum<*>>
 ): Pair<List<ObjectValue>, Map<String, MethodResult>> {
@@ -62,7 +62,7 @@ fun associateEnumSootFieldsWithConcreteValues(
 /**
  * Construct symbolic updates for enum static fields and a symbolic value for a local in the left part of the assignment.
  */
-fun UtBotSymbolicEngine.makeEnumStaticFieldsUpdates(
+fun Traverser.makeEnumStaticFieldsUpdates(
     staticFields: List<Pair<SootField, List<Any>>>,
     declaringClass: SootClass,
     enumConstantSymbolicResultsByName: Map<String, MethodResult>,
@@ -109,7 +109,7 @@ fun UtBotSymbolicEngine.makeEnumStaticFieldsUpdates(
     return staticFieldsUpdates to symbolicValueForLocal
 }
 
-fun UtBotSymbolicEngine.makeEnumNonStaticFieldsUpdates(
+fun Traverser.makeEnumNonStaticFieldsUpdates(
     enumConstantSymbolicValues: List<ObjectValue>,
     nonStaticFields: List<Pair<SootField, List<Any>>>
 ): SymbolicStateUpdate {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/UtBotTestCaseGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/UtBotTestCaseGenerator.kt
@@ -8,7 +8,6 @@ import org.utbot.common.trace
 import org.utbot.engine.EngineController
 import org.utbot.engine.MockStrategy
 import org.utbot.engine.Mocker
-import org.utbot.engine.Traverser
 import org.utbot.engine.jimpleBody
 import org.utbot.engine.pureJavaSignature
 import org.utbot.framework.TestSelectionStrategyType
@@ -48,6 +47,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.yield
 import mu.KotlinLogging
+import org.utbot.engine.UtBotSymbolicEngine
 import soot.Scene
 import soot.jimple.JimpleBody
 import soot.toolkits.graph.ExceptionalUnitGraph
@@ -198,10 +198,10 @@ object UtBotTestCaseGenerator : TestCaseGenerator {
         mockStrategy: MockStrategyApi,
         chosenClassesToMockAlways: Set<ClassId>,
         executionTimeEstimator: ExecutionTimeEstimator
-    ): Traverser {
+    ): UtBotSymbolicEngine {
         // TODO: create classLoader from buildDir/classpath and migrate from UtMethod to MethodId?
         logger.debug("Starting symbolic execution for $method  --$mockStrategy--")
-        return Traverser(
+        return UtBotSymbolicEngine(
             controller,
             method,
             classpathForEngine,
@@ -212,7 +212,7 @@ object UtBotTestCaseGenerator : TestCaseGenerator {
         )
     }
 
-    private fun createDefaultFlow(engine: Traverser): Flow<UtResult> {
+    private fun createDefaultFlow(engine: UtBotSymbolicEngine): Flow<UtResult> {
         var flow = engine.traverse()
         if (UtSettings.useFuzzing) {
             flow = flowOf(
@@ -261,7 +261,7 @@ object UtBotTestCaseGenerator : TestCaseGenerator {
         mockStrategy: MockStrategyApi,
         chosenClassesToMockAlways: Set<ClassId> = Mocker.javaDefaultClasses.mapTo(mutableSetOf()) { it.id },
         methodsGenerationTimeout: Long = utBotGenerationTimeoutInMillis,
-        generate: (engine: Traverser) -> Flow<UtResult> = ::createDefaultFlow
+        generate: (engine: UtBotSymbolicEngine) -> Flow<UtResult> = ::createDefaultFlow
     ): List<UtTestCase> {
         if (isCanceled()) return methods.map { UtTestCase(it) }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/UtBotTestCaseGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/UtBotTestCaseGenerator.kt
@@ -8,7 +8,7 @@ import org.utbot.common.trace
 import org.utbot.engine.EngineController
 import org.utbot.engine.MockStrategy
 import org.utbot.engine.Mocker
-import org.utbot.engine.UtBotSymbolicEngine
+import org.utbot.engine.Traverser
 import org.utbot.engine.jimpleBody
 import org.utbot.engine.pureJavaSignature
 import org.utbot.framework.TestSelectionStrategyType
@@ -199,12 +199,12 @@ object UtBotTestCaseGenerator : TestCaseGenerator {
         mockStrategy: MockStrategyApi,
         chosenClassesToMockAlways: Set<ClassId>,
         executionTimeEstimator: ExecutionTimeEstimator
-    ): UtBotSymbolicEngine {
+    ): Traverser {
         // TODO: create classLoader from buildDir/classpath and migrate from UtMethod to MethodId?
         logger.debug("Starting symbolic execution for $method  --$mockStrategy--")
         val graph = graph(method)
 
-        return UtBotSymbolicEngine(
+        return Traverser(
             controller,
             method,
             graph,
@@ -216,7 +216,7 @@ object UtBotTestCaseGenerator : TestCaseGenerator {
         )
     }
 
-    private fun createDefaultFlow(engine: UtBotSymbolicEngine): Flow<UtResult> {
+    private fun createDefaultFlow(engine: Traverser): Flow<UtResult> {
         var flow = engine.traverse()
         if (UtSettings.useFuzzing) {
             flow = flowOf(
@@ -265,7 +265,7 @@ object UtBotTestCaseGenerator : TestCaseGenerator {
         mockStrategy: MockStrategyApi,
         chosenClassesToMockAlways: Set<ClassId> = Mocker.javaDefaultClasses.mapTo(mutableSetOf()) { it.id },
         methodsGenerationTimeout: Long = utBotGenerationTimeoutInMillis,
-        generate: (engine: UtBotSymbolicEngine) -> Flow<UtResult> = ::createDefaultFlow
+        generate: (engine: Traverser) -> Flow<UtResult> = ::createDefaultFlow
     ): List<UtTestCase> {
         if (isCanceled()) return methods.map { UtTestCase(it) }
 

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/AbstractTestCaseGeneratorTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/AbstractTestCaseGeneratorTest.kt
@@ -68,6 +68,7 @@ import kotlin.reflect.KFunction5
 import mu.KotlinLogging
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.utbot.framework.PathSelectorType
+import org.utbot.framework.plugin.api.jimpleBody
 
 val logger = KotlinLogging.logger {}
 
@@ -2343,7 +2344,7 @@ abstract class AbstractTestCaseGeneratorTest(
                 walk(utMethod, mockStrategy, additionalDependenciesClassPath)
             }
             testCase.summarize(searchDirectory)
-            val valueTestCase = testCase.toValueTestCase(UtBotTestCaseGenerator.jimpleBody(utMethod))
+            val valueTestCase = testCase.toValueTestCase(jimpleBody(utMethod))
 
             assertTrue(testCase.errors.isEmpty()) {
                 "We have errors: ${
@@ -2478,7 +2479,7 @@ abstract class AbstractTestCaseGeneratorTest(
         additionalDependenciesClassPath: String = ""
     ): MethodResult {
         val testCase = executions(method, mockStrategy, additionalDependenciesClassPath)
-        val jimpleBody = UtBotTestCaseGenerator.jimpleBody(method)
+        val jimpleBody = jimpleBody(method)
         val methodCoverage = methodCoverage(
             method,
             testCase.toValueTestCase(jimpleBody).executions,

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/exceptions/ExceptionExamplesTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/exceptions/ExceptionExamplesTest.kt
@@ -93,7 +93,7 @@ internal class ExceptionExamplesTest : AbstractTestCaseGeneratorTest(
     }
 
     /**
-     * Used for path generation check in [org.utbot.engine.UtBotSymbolicEngine.fullPath]
+     * Used for path generation check in [org.utbot.engine.Traverser.fullPath]
      */
     @Test
     fun testCatchDeepNestedThrow() {
@@ -107,7 +107,7 @@ internal class ExceptionExamplesTest : AbstractTestCaseGeneratorTest(
     }
 
     /**
-     * Used for path generation check in [org.utbot.engine.UtBotSymbolicEngine.fullPath]
+     * Used for path generation check in [org.utbot.engine.Traverser.fullPath]
      */
     @Test
     fun testDontCatchDeepNestedThrow() {

--- a/utbot-framework/src/test/resources/log4j2.xml
+++ b/utbot-framework/src/test/resources/log4j2.xml
@@ -17,7 +17,7 @@
     </Appenders>
     <Loggers>
         <!--        Uncomment this logger to see path -->
-        <Logger name="org.utbot.engine.UtBotSymbolicEngine.path" level="debug"/>
+        <Logger name="org.utbot.engine.Traverser.path" level="debug"/>
 
 
         <!-- Set this logger level to TRACE to see SMT requests, and SAT/UNSAT/UNKNOWN responses -->

--- a/utbot-framework/src/test/resources/log4j2.xml
+++ b/utbot-framework/src/test/resources/log4j2.xml
@@ -17,7 +17,7 @@
     </Appenders>
     <Loggers>
         <!--        Uncomment this logger to see path -->
-        <Logger name="org.utbot.engine.Traverser.path" level="debug"/>
+        <Logger name="org.utbot.engine.UtBotSymbolicEngine.path" level="debug"/>
 
 
         <!-- Set this logger level to TRACE to see SMT requests, and SAT/UNSAT/UNKNOWN responses -->

--- a/utbot-junit-contest/src/main/resources/log4j2.xml
+++ b/utbot-junit-contest/src/main/resources/log4j2.xml
@@ -19,7 +19,7 @@
         </Logger>
 
 
-        <Logger name="org.utbot.engine.Traverser" level="debug"/>
+        <Logger name="org.utbot.engine.UtBotSymbolicEngine" level="debug"/>
         <Logger name="org.utbot.instrumentation" level="trace"/>
 
         <Logger name="org.utbot.engine.selectors.strategies.GraphViz" level="debug">

--- a/utbot-junit-contest/src/main/resources/log4j2.xml
+++ b/utbot-junit-contest/src/main/resources/log4j2.xml
@@ -19,7 +19,7 @@
         </Logger>
 
 
-        <Logger name="org.utbot.engine.UtBotSymbolicEngine" level="debug"/>
+        <Logger name="org.utbot.engine.Traverser" level="debug"/>
         <Logger name="org.utbot.instrumentation" level="trace"/>
 
         <Logger name="org.utbot.engine.selectors.strategies.GraphViz" level="debug">


### PR DESCRIPTION
# Description

Split the logic of `UtBotSymbolicEngine` into two classes:
- `UtBotSymbolicEngine`
- `Traverser`

Introduced new classes and some TODO stubs:
- `StateLabel` is used for marking `ExecutionState` accordingly to their status (INTERMIDIATE, CONCRETE, TERMINAL). See the comments in the code for more information.
- `TraversalContext` is a context during one Jimple instruction traversal. Now there are some TODO stubs for the future work.

Refactored several relevant places with non-functional changes:
- Changed signatures of some traversal functions
- Moved some functions to more convenient places
- Fixed hack on nullable `SymbolicResult` in `processResult`
- Other minor refactorings

Fixes [#259](https://github.com/UnitTestBot/UTBotJava/issues/259)

## Details

Previously `UtBotSymbolicEngine` had the complex logic of different types:
- setting up everything
- working with the states queue
- Jimple travesal
- working with the symbolic state
- processing final states

The idea is to split some of the aspects of the engine logic into different classes. In this MR the extraction of Jimple traversal was done. Now we have two classes:

### UtBotSymbolicEngine

Now `UtBotSymbolicEngine` is a manager class. It's created once for one method analysis process. We can't reuse it for different methods. It sets up everything for `Traverser`, controls the flow of polling states from the queue and pushing new states to the queue and also processes terminal states.

So now the next things are done in `UtBotSymbolicEngine`:
- setting up everything
- working with the states queue
- processing final states

### Traverser

`Traverser` is responsible for traversing the top instruction from the passed `ExecutionState`. It's created inside `UtBotSymbolicEngine` and can't be reused between different methods ("method-under-test"s). The main function is `traverse(state: ExecutionState): Collection<ExecutionState>` which takes an `ExecutionState` and produces next states, so all other extra information needed for traversal should be passed via the constructor of `Traverser`.

Please note, that now it's `Traverser` responsibility to choose the right label for the next `ExecutionState`. Then `UtBotSymbolicEngine` matches on this label and decides what to do with this state.

So now the next things are done in `Traverser`:
- Jimple travesal
- working with the symbolic state

## Type of Change

- Refactoring (non-functional change improving code quality)

# How Has This Been Tested?

## Automated Testing

Ran all tests in IDEA. No new test failures have been detected in this change.

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings (**Except some TODOs for the following MRs**)
- [x] All tests pass locally with my changes
