### PR TITLE
Implement state initialization by fuzzing

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -239,9 +239,14 @@ object UtSettings {
 
 
     /**
-     * Set to true to start fuzzing if symbolic execution haven't return anything
+     * Set to true to start fuzzing if symbolic execution haven't return anything.
      */
     var useFuzzing: Boolean by getBooleanProperty(false)
+
+    /**
+     * Set to true to initialize symbolic parameters by values from fuzzing.
+     */
+    var useFuzzingInitialization: Boolean by getBooleanProperty(false)
 
     /**
      * Set the total attempts to improve coverage by fuzzer.

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ExecutionState.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ExecutionState.kt
@@ -187,7 +187,7 @@ data class ExecutionState(
             pathLength = pathLength + 1,
             lastEdge = edge,
             lastMethod = executionStack.last().method,
-            methodResult,
+            methodResult = methodResult,
             stateAnalyticsProperties = stateAnalyticsProperties.successorProperties(this)
         )
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Extensions.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Extensions.kt
@@ -1,42 +1,23 @@
 package org.utbot.engine
 
 import com.google.common.collect.BiMap
+import kotlinx.collections.immutable.PersistentMap
+import kotlinx.collections.immutable.persistentHashMapOf
 import org.utbot.api.mock.UtMock
-import org.utbot.engine.pc.UtAddrExpression
-import org.utbot.engine.pc.UtArraySort
-import org.utbot.engine.pc.UtBoolExpression
-import org.utbot.engine.pc.UtBoolSort
-import org.utbot.engine.pc.UtBvConst
-import org.utbot.engine.pc.UtByteSort
-import org.utbot.engine.pc.UtCharSort
-import org.utbot.engine.pc.UtExpression
-import org.utbot.engine.pc.UtFp32Sort
-import org.utbot.engine.pc.UtFp64Sort
-import org.utbot.engine.pc.UtIntSort
-import org.utbot.engine.pc.UtLongSort
-import org.utbot.engine.pc.UtSeqSort
-import org.utbot.engine.pc.UtShortSort
-import org.utbot.engine.pc.UtSolverStatusKind
-import org.utbot.engine.pc.UtSolverStatusSAT
-import org.utbot.engine.symbolic.Assumption
-import org.utbot.engine.pc.UtSort
-import org.utbot.engine.pc.mkArrayWithConst
-import org.utbot.engine.pc.mkBool
-import org.utbot.engine.pc.mkByte
-import org.utbot.engine.pc.mkChar
-import org.utbot.engine.pc.mkDouble
-import org.utbot.engine.pc.mkFloat
-import org.utbot.engine.pc.mkInt
-import org.utbot.engine.pc.mkLong
-import org.utbot.engine.pc.mkShort
-import org.utbot.engine.pc.mkString
-import org.utbot.engine.pc.toSort
+import org.utbot.engine.pc.*
 import org.utbot.framework.UtSettings.checkNpeForFinalFields
 import org.utbot.framework.UtSettings.checkNpeInNestedMethods
 import org.utbot.framework.UtSettings.checkNpeInNestedNotPrivateMethods
+import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.FieldId
 import org.utbot.framework.plugin.api.UtMethod
 import org.utbot.framework.plugin.api.id
+import soot.*
+import soot.SootClass.BODIES
+import soot.jimple.*
+import soot.jimple.internal.*
+import soot.tagkit.ArtificialEntityTag
+import sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl
 import java.lang.reflect.Constructor
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
@@ -45,35 +26,6 @@ import kotlin.reflect.KFunction
 import kotlin.reflect.KProperty
 import kotlin.reflect.jvm.javaConstructor
 import kotlin.reflect.jvm.javaMethod
-import kotlinx.collections.immutable.PersistentMap
-import kotlinx.collections.immutable.persistentHashMapOf
-import org.utbot.engine.pc.UtSolverStatusUNDEFINED
-import soot.ArrayType
-import soot.PrimType
-import soot.RefLikeType
-import soot.RefType
-import soot.Scene
-import soot.SootClass
-import soot.SootClass.BODIES
-import soot.SootField
-import soot.SootMethod
-import soot.Type
-import soot.Value
-import soot.jimple.Expr
-import soot.jimple.InvokeExpr
-import soot.jimple.JimpleBody
-import soot.jimple.StaticFieldRef
-import soot.jimple.Stmt
-import soot.jimple.internal.JDynamicInvokeExpr
-import soot.jimple.internal.JIdentityStmt
-import soot.jimple.internal.JInterfaceInvokeExpr
-import soot.jimple.internal.JInvokeStmt
-import soot.jimple.internal.JSpecialInvokeExpr
-import soot.jimple.internal.JStaticInvokeExpr
-import soot.jimple.internal.JVirtualInvokeExpr
-import soot.jimple.internal.JimpleLocal
-import soot.tagkit.ArtificialEntityTag
-import sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl
 
 val JIdentityStmt.lines: String
     get() = tags.joinToString { "$it" }
@@ -469,6 +421,16 @@ fun isOverriddenClass(type: RefType) = type.sootClass.isOverridden
 
 val SootMethod.isSynthetic: Boolean
     get() = soot.Modifier.isSynthetic(modifiers)
+
+/**
+ * Search symbolic ordinal of enum in memory by address [addr].
+ */
+fun Memory.findOrdinal(type: RefType, addr: UtAddrExpression) : PrimitiveValue {
+    val array = findArray(MemoryChunkDescriptor(ENUM_ORDINAL, type, IntType.v()))
+    return array.select(addr).toIntValue()
+}
+
+fun ClassId.toSoot(): SootClass = Scene.v().getSootClass(this.name)
 
 /**
  * Returns true if the [SootMethod]'s signature is equal to [UtMock.assume]'s signature, false otherwise.

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/mvisitors/ConstraintModelVisitor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/mvisitors/ConstraintModelVisitor.kt
@@ -1,0 +1,136 @@
+package org.utbot.engine.mvisitors
+
+import org.utbot.engine.*
+import org.utbot.engine.pc.*
+import org.utbot.engine.symbolic.asHardConstraint
+import org.utbot.framework.plugin.api.*
+import soot.ArrayType
+import soot.RefType
+
+/**
+ * This class builds type and value constraints for equation [symbolicValue] == specific UtModel.
+ *
+ * Note: may create memory updates in [engine] while visiting.
+ */
+class ConstraintModelVisitor(
+    private var symbolicValue: SymbolicValue,
+    private val engine: UtBotSymbolicEngine
+) : UtModelVisitor<List<UtBoolExpression>> {
+
+    private inline fun <reified T> withSymbolicValue(
+        newSymbolicValue: SymbolicValue,
+        block: () -> T
+    ): T {
+        val old = symbolicValue
+        return try {
+            symbolicValue = newSymbolicValue
+            block()
+        } finally {
+            symbolicValue = old
+        }
+    }
+
+    // TODO: must exception be thrown?
+    private fun mismatchTypes(): List<UtBoolExpression> =
+        emptyList()
+
+    override fun visitArray(model: UtArrayModel): List<UtBoolExpression> =
+        when (val value = symbolicValue) {
+            is ArrayValue -> {
+                val constraints = mutableListOf<UtBoolExpression>()
+                constraints += mkNot(mkEq(value.addr, nullObjectAddr))
+                val arrayLength = engine.memory.findArrayLength(value.addr)
+                constraints += mkEq(arrayLength.align(), model.length.primitiveToSymbolic())
+
+                repeat(model.length) { storeIndex ->
+                    val storeModel = model.stores[storeIndex] ?: model.constModel
+                    val selectedExpr = value.addr.select(storeIndex.primitiveToLiteral())
+                    val storeSymbolicValue = when (val elementType = value.type.elementType) {
+                        is RefType -> engine.createObject(
+                            UtAddrExpression(selectedExpr),
+                            elementType,
+                            useConcreteType = false,
+                            mockInfoGenerator = null
+                        )
+                        is ArrayType -> engine.createArray(
+                            UtAddrExpression(selectedExpr),
+                            elementType,
+                            useConcreteType = false
+                        )
+                        else -> PrimitiveValue(elementType, selectedExpr)
+                    }
+                    constraints += withSymbolicValue(storeSymbolicValue) {
+                        storeModel.visit(this)
+                    }
+                }
+                constraints
+            }
+            else -> mismatchTypes()
+        }
+
+    override fun visitAssemble(model: UtAssembleModel): List<UtBoolExpression> {
+        // TODO: not supported
+        return mismatchTypes()
+    }
+
+    override fun visitComposite(model: UtCompositeModel): List<UtBoolExpression> =
+        when (val value = symbolicValue) {
+            is ObjectValue -> {
+                val constraints = mutableListOf<UtBoolExpression>()
+                val type = model.classId.toSoot().type
+                val typeStorage = engine.typeResolver.constructTypeStorage(type, true)
+                constraints += engine.typeRegistry.typeConstraint(value.addr, typeStorage).isConstraint()
+                model.fields.forEach { (field, fieldModel) ->
+                    val sootField = field.declaringClass.toSoot().getFieldByName(field.name)
+                    val fieldSymbolicValue = engine.createFieldOrMock(
+                        type,
+                        value.addr,
+                        sootField,
+                        mockInfoGenerator = null
+                    )
+                    engine.recordInstanceFieldRead(value.addr, sootField)
+                    constraints += withSymbolicValue(fieldSymbolicValue) {
+                        fieldModel.visit(this)
+                    }
+                }
+                constraints
+            }
+            else -> mismatchTypes()
+        }
+
+    override fun visitNull(model: UtNullModel): List<UtBoolExpression> =
+        when (val value = symbolicValue) {
+            is ReferenceValue -> listOf(mkEq(value.addr, nullObjectAddr))
+            else -> mismatchTypes()
+        }
+
+    override fun visitPrimitive(model: UtPrimitiveModel): List<UtBoolExpression> =
+        when(val value = symbolicValue) {
+            is PrimitiveValue -> listOf(mkEq(value, model.value.primitiveToSymbolic()))
+            else -> mismatchTypes()
+        }
+
+    override fun visitVoid(model: UtVoidModel): List<UtBoolExpression> =
+        when (val value = symbolicValue) {
+            is PrimitiveValue -> listOf(mkEq(voidValue, value))
+            else -> mismatchTypes()
+        }
+
+    override fun visitEnumConstant(model: UtEnumConstantModel): List<UtBoolExpression> =
+        when (val value = symbolicValue) {
+            is ObjectValue -> {
+                val ordinal = engine.memory.findOrdinal(model.classId.toSoot().type, value.addr)
+                listOf(mkEq(ordinal.expr, model.value.ordinal.primitiveToLiteral()))
+            }
+            else -> mismatchTypes()
+        }
+
+    override fun visitClassRef(model: UtClassRefModel): List<UtBoolExpression> =
+        when (val value = symbolicValue) {
+            is ObjectValue -> {
+                val classRef = engine.createClassRef(model.classId.toSoot().type)
+                listOf(mkEq(classRef.addr, value.addr))
+            }
+            else -> mismatchTypes()
+        }
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/mvisitors/ModelVisitor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/mvisitors/ModelVisitor.kt
@@ -1,0 +1,29 @@
+package org.utbot.engine.mvisitors
+
+import org.utbot.framework.plugin.api.*
+
+/**
+ * Class for traversing UtModel.
+ */
+interface UtModelVisitor<T> {
+    fun visitArray(model: UtArrayModel): T
+    fun visitAssemble(model: UtAssembleModel): T
+    fun visitComposite(model: UtCompositeModel): T
+    fun visitNull(model: UtNullModel): T
+    fun visitPrimitive(model: UtPrimitiveModel): T
+    fun visitVoid(model: UtVoidModel): T
+    fun visitEnumConstant(model: UtEnumConstantModel): T
+    fun visitClassRef(model: UtClassRefModel): T
+}
+
+fun <T> UtModel.visit(visitor: UtModelVisitor<T>): T =
+    when (this) {
+        is UtClassRefModel -> visitor.visitClassRef(this)
+        is UtEnumConstantModel -> visitor.visitEnumConstant(this)
+        is UtNullModel -> visitor.visitNull(this)
+        is UtPrimitiveModel -> visitor.visitPrimitive(this)
+        is UtArrayModel -> visitor.visitArray(this)
+        is UtAssembleModel -> visitor.visitAssemble(this)
+        is UtCompositeModel -> visitor.visitComposite(this)
+        UtVoidModel -> visitor.visitVoid(UtVoidModel)
+    }


### PR DESCRIPTION
# Description

Closes #217 

Idea was described in issue. So I create UtModelVisitor to traverse UtModels, collect constraints needed to initialize SMT Solver and also provide method of UtSolver doing it. 

## Type of Change
New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Manual Scenario 

I tested it using IDEA plugin on guava project. Generate tests several times with turning on this feature and without it then compare results (coverage).

# Checklist (remove irrelevant options):

- [ ] The change followed the style guidelines of the UTBot project
- [ ] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [ ] No new warnings
- [ ] Tests that prove my change is effective
- [ ] All tests pass locally with my changes
