### PR TITLE
Added missing local classes for method targets

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/engine/DataClasses.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/DataClasses.kt
@@ -89,7 +89,7 @@ data class Parameter(private val localVariable: LocalVariable, private val type:
  * that **usually** contains only concrete types (so-called appropriate). The only way to create [TypeStorage] with
  * inappropriate possibleType is to create it using constructor with the only type.
  *
- * @see isAppropriate
+ * @see isAppropriateForInstantiation
  */
 data class TypeStorage(val leastCommonType: Type, val possibleConcreteTypes: Set<Type>) {
     private val hashCode = Objects.hash(leastCommonType, possibleConcreteTypes)

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Extensions.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Extensions.kt
@@ -158,6 +158,10 @@ fun <K, V> PersistentMap<K, V>.putIfAbsent(key: K, value: V): PersistentMap<K, V
         this.put(key, value)
     }
 
+/**
+ * Filter out types that could not be used for method invocations - abstract classes, interfaces and UT mocks.
+ * @see isAppropriateForMethodInvocation
+ */
 fun Collection<Type>.appropriateForMethodInvocationClasses(): List<Type> = filterTypesByPredicate {
     it.isAppropriateForMethodInvocation
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Memory.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Memory.kt
@@ -512,7 +512,7 @@ class TypeRegistry {
 
         if (sootClass.name.contains("$")) finalCost += -4096
 
-        if (sootClass.type.sootClass.isInappropriate) finalCost += -8192
+        if (sootClass.type.sootClass.isInappropriateForInstantiation) finalCost += -8192
 
         finalCost
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
@@ -2646,7 +2646,7 @@ class UtBotSymbolicEngine(
         val implementationToClasses = concretePossibleTypes
             .filterIsInstance<RefType>()
             .groupBy { it.sootClass.findMethodOrNull(methodSubSignature)?.declaringClass }
-            .filterValues { it.appropriateClasses().isNotEmpty() }
+            .filterValues { it.appropriateForMethodInvocationClasses().isNotEmpty() }
 
         val targets = mutableListOf<MethodInvocationTarget>()
         for ((sootClass, types) in implementationToClasses) {


### PR DESCRIPTION
# Description

Changed filter for searching method targets - local classes are not filtered out now.

Fixes #316 

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

Running `ContestEstimator` for `spoon.reflect.factory.TypeFactory.createTypeAdapter` in `spoon-core-7.0.0`.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] Tests that prove my change is effective
- [x] All tests pass locally with my changes
