### PR TITLE
Removed unformatted symbols from code descriptions to avoid fail with code formatter from OpenAPI

### DIFF
--- a/utbot-summary-tests/src/test/kotlin/examples/SummaryTestCaseGeneratorTest.kt
+++ b/utbot-summary-tests/src/test/kotlin/examples/SummaryTestCaseGeneratorTest.kt
@@ -101,6 +101,7 @@ open class SummaryTestCaseGeneratorTest(
         val utMethod = UtMethod.from(method)
         val testCase = executionsModel(utMethod, mockStrategy)
         testCase.summarize(searchDirectory)
+
         testCase.executions.checkMatchersWithTextSummary(summaryKeys)
         testCase.executions.checkMatchersWithMethodNames(methodNames)
         testCase.executions.checkMatchersWithDisplayNames(displayNames)

--- a/utbot-summary-tests/src/test/kotlin/math/SummaryOfMath.kt
+++ b/utbot-summary-tests/src/test/kotlin/math/SummaryOfMath.kt
@@ -76,4 +76,140 @@ class SummaryOfMath : SummaryTestCaseGeneratorTest(
 
         check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
+
+    @Test
+    fun testOfDoubles() {
+        val summary1 = "Test calls StatsAccumulator::addAll,\n" +
+                "    there it triggers recursion of addAll once, \n" +
+                "Test throws NullPointerException in: acummulator.addAll(values);\n"
+        val summary2 = "Test calls StatsAccumulator::addAll,\n" +
+                "    there it does not iterate for(double value: values), \n" +
+                "Test next calls StatsAccumulator::snapshot,\n" +
+                "    there it returns from: return new Stats(count, mean, sumOfSquaresOfDeltas, min, max);\n" +
+                "    \n" +
+                "Test later returns from: return acummulator.snapshot();\n"
+        val summary3 = "Test calls StatsAccumulator::addAll,\n" +
+                "    there it iterates the loop for(double value: values) twice,\n" +
+                "        inside this loop, the test calls StatsAccumulator::add,\n" +
+                "        there it executes conditions:\n" +
+                "            (count == 0): True\n" +
+                "            (!isFinite(value)): True\n" +
+                "        calls StatsAccumulator::add,\n" +
+                "        there it executes conditions:\n" +
+                "            (count == 0): False\n" +
+                "            (isFinite(value) && isFinite(mean)): True\n" +
+                "            (if (isFinite(value) && isFinite(mean)) {\n" +
+                "    double delta = value - mean;\n" +
+                "    mean += delta / count;\n" +
+                "    sumOfSquaresOfDeltas += delta * (value - mean);\n" +
+                "} else {\n" +
+                "    mean = calculateNewMeanNonFinite(mean, value);\n" +
+                "    sumOfSquaresOfDeltas = NaN;\n" +
+                "}): False\n" +
+                "Test afterwards calls StatsAccumulator::snapshot,\n" +
+                "    there it returns from: return new Stats(count, mean, sumOfSquaresOfDeltas, min, max);\n" +
+                "    \n" +
+                "Test afterwards returns from: return acummulator.snapshot();\n"
+        val summary4 = "Test calls StatsAccumulator::addAll,\n" +
+                "    there it iterates the loop for(double value: values) twice,\n" +
+                "        inside this loop, the test calls StatsAccumulator::add,\n" +
+                "        there it executes conditions:\n" +
+                "            (!isFinite(value)): False\n" +
+                "Test next calls StatsAccumulator::snapshot,\n" +
+                "    there it returns from: return new Stats(count, mean, sumOfSquaresOfDeltas, min, max);\n" +
+                "    \n" +
+                "Test then returns from: return acummulator.snapshot();\n"
+        val summary5 = "Test calls StatsAccumulator::addAll,\n" +
+                "    there it iterates the loop for(double value: values) twice,\n" +
+                "        inside this loop, the test calls StatsAccumulator::add,\n" +
+                "        there it executes conditions:\n" +
+                "            (count == 0): True\n" +
+                "            (!isFinite(value)): False\n" +
+                "        calls StatsAccumulator::add,\n" +
+                "        there it executes conditions:\n" +
+                "            (count == 0): False\n" +
+                "            (isFinite(value) && isFinite(mean)): True\n" +
+                "            (if (isFinite(value) && isFinite(mean)) {\n" +
+                "    double delta = value - mean;\n" +
+                "    mean += delta / count;\n" +
+                "    sumOfSquaresOfDeltas += delta * (value - mean);\n" +
+                "} else {\n" +
+                "    mean = calculateNewMeanNonFinite(mean, value);\n" +
+                "    sumOfSquaresOfDeltas = NaN;\n" +
+                "}): True\n" +
+                "Test later calls StatsAccumulator::snapshot,\n" +
+                "    there it returns from: return new Stats(count, mean, sumOfSquaresOfDeltas, min, max);\n" +
+                "    \n" +
+                "Test then returns from: return acummulator.snapshot();\n"
+        val summary6 = "Test calls StatsAccumulator::addAll,\n" +
+                "    there it iterates the loop for(double value: values) twice,\n" +
+                "        inside this loop, the test calls StatsAccumulator::add,\n" +
+                "        there it executes conditions:\n" +
+                "            (!isFinite(value)): True\n" +
+                "Test afterwards calls StatsAccumulator::snapshot,\n" +
+                "    there it returns from: return new Stats(count, mean, sumOfSquaresOfDeltas, min, max);\n" +
+                "    \n" +
+                "Test then returns from: return acummulator.snapshot();\n"
+        val summary7 = "Test calls StatsAccumulator::addAll,\n" +
+                "    there it iterates the loop for(double value: values) twice,\n" +
+                "        inside this loop, the test calls StatsAccumulator::add,\n" +
+                "        there it executes conditions:\n" +
+                "            (!isFinite(value)): True\n" +
+                "Test later calls StatsAccumulator::snapshot,\n" +
+                "    there it returns from: return new Stats(count, mean, sumOfSquaresOfDeltas, min, max);\n" +
+                "    \n" +
+                "Test further returns from: return acummulator.snapshot();\n"
+
+        val methodName1 = "testOfDoubles_StatsAccumulatorAddAll"
+        val methodName2 = "testOfDoubles_snapshot"
+        val methodName3 = "testOfDoubles_IsFiniteAndIsFinite"
+        val methodName4 = "testOfDoubles_IsFinite"
+        val methodName5 = "testOfDoubles_IsFiniteAndIsFinite_1"
+        val methodName6 = "testOfDoubles_NotIsFinite"
+        val methodName7 = "testOfDoubles_NotIsFinite_1"
+
+        val displayName1 = "acummulator.addAll(values) : True -> ThrowNullPointerException"
+        val displayName2 = "snapshot -> return new Stats(count, mean, sumOfSquaresOfDeltas, min, max)"
+        val displayName3 = "!isFinite(value) : True -> StatsAccumulatorCalculateNewMeanNonFinite"
+        val displayName4 = "add -> !isFinite(value) : False"
+        val displayName5 = "!isFinite(value) : False -> isFinite(value) && isFinite(mean)"
+        val displayName6 = "add -> !isFinite(value) : True"
+        val displayName7 = "add -> !isFinite(value) : True"
+
+        val method = Stats::ofDoubles
+        val mockStrategy = MockStrategyApi.NO_MOCKS
+        val coverage = DoNotCalculate
+
+        val summaryKeys = listOf(
+            summary1,
+            summary2,
+            summary3,
+            summary4,
+            summary5,
+            summary6,
+            summary7
+        )
+
+        val displayNames = listOf(
+            displayName1,
+            displayName2,
+            displayName3,
+            displayName4,
+            displayName5,
+            displayName6,
+            displayName7
+        )
+
+        val methodNames = listOf(
+            methodName1,
+            methodName2,
+            methodName3,
+            methodName4,
+            methodName5,
+            methodName6,
+            methodName7
+        )
+
+        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+    }
 }

--- a/utbot-summary/src/main/kotlin/org/utbot/summary/comment/SimpleSentenceBlock.kt
+++ b/utbot-summary/src/main/kotlin/org/utbot/summary/comment/SimpleSentenceBlock.kt
@@ -433,7 +433,7 @@ data class SquashedStmtTexts(
             for (i in 0 until stmtTexts.size) {
                 val stmtText = stmtTexts[i]
                 if ((tab + stmtText.prefix).isNotEmpty()) stmts += DocRegularStmt(tab + stmtText.prefix)
-                stmts += DocCodeStmt(stmtText.description)
+                stmts += DocCodeStmt(stmtText.description.replace(CARRIAGE_RETURN, ""))
 
                 if (i != stmtTexts.lastIndex) {
                     if (separation.isNotEmpty()) stmts += DocRegularStmt(separation)


### PR DESCRIPTION
# Description

Fixes #271 

Fixes # (issue)

## Type of Change

Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

Run test generation for the `public static Stats of(double... values)` method in guava-26, before bug fix it fails with the error described in the issue, after bug fix it produces tests well

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
- [x] Tests that prove my change is effective
- [x] All tests pass locally with my changes
