### PR TITLE
Remove java/main from the path to the generated tests

### DIFF
--- a/utbot-gradle/src/main/kotlin/org/utbot/gradle/plugin/wrappers/SourceSetWrapper.kt
+++ b/utbot-gradle/src/main/kotlin/org/utbot/gradle/plugin/wrappers/SourceSetWrapper.kt
@@ -6,7 +6,6 @@ import org.utbot.common.FileUtil.findAllFilesOnly
 import org.utbot.common.PathUtil.classFqnToPath
 import org.utbot.common.PathUtil.replaceSeparator
 import org.utbot.common.tryLoadClass
-import org.utbot.framework.plugin.api.CodegenLanguage
 import org.utbot.framework.plugin.sarif.util.ClassUtil
 import org.utbot.framework.plugin.sarif.TargetClassWrapper
 import java.io.File
@@ -97,33 +96,22 @@ class SourceSetWrapper(
 
     /**
      * Creates and returns a file for a future SARIF report.
-     * For example, ".../main/com/qwerty/MainReport.sarif".
+     * For example, ".../com/qwerty/MainReport.sarif".
      */
     private fun createSarifReportFile(classFqn: String): File {
-        val relativePath = "${sourceSet.name}/${classFqnToPath(classFqn)}Report.sarif"
+        val relativePath = "${classFqnToPath(classFqn)}Report.sarif"
         val absolutePath = Paths.get(parentProject.generatedSarifDirectory.path, relativePath)
         return absolutePath.toFile().apply { createNewFileWithParentDirectories() }
     }
 
     /**
      * Creates and returns a file for future generated tests.
-     * For example, ".../java/main/com/qwerty/MainTest.java".
+     * For example, ".../com/qwerty/MainTest.java".
      */
     private fun createTestsCodeFile(classFqn: String): File {
         val fileExtension = parentProject.sarifProperties.codegenLanguage.extension
-        val sourceRoot = parentProject.sarifProperties.codegenLanguage.toSourceRootName()
-        val relativePath = "$sourceRoot/${sourceSet.name}/${classFqnToPath(classFqn)}Test$fileExtension"
+        val relativePath = "${classFqnToPath(classFqn)}Test$fileExtension"
         val absolutePath = Paths.get(parentProject.generatedTestsDirectory.path, relativePath)
         return absolutePath.toFile().apply { createNewFileWithParentDirectories() }
     }
-
-    /**
-     * Returns the source root name by [CodegenLanguage].
-     */
-    private fun CodegenLanguage.toSourceRootName(): String =
-        when (this) {
-            CodegenLanguage.JAVA -> "java"
-            CodegenLanguage.KOTLIN -> "kotlin"
-            else -> "unknown"
-        }
 }

--- a/utbot-maven/src/main/kotlin/org/utbot/maven/plugin/wrappers/MavenProjectWrapper.kt
+++ b/utbot-maven/src/main/kotlin/org/utbot/maven/plugin/wrappers/MavenProjectWrapper.kt
@@ -141,7 +141,7 @@ class MavenProjectWrapper(
 
     /**
      * Creates and returns a file for future generated tests.
-     * For example, ".../java/main/com/qwerty/MainTest.java".
+     * For example, ".../com/qwerty/MainTest.java".
      */
     private fun createTestsCodeFile(classFqn: String): File {
         val fileExtension = sarifProperties.codegenLanguage.extension


### PR DESCRIPTION
# Description

Remove java/main from the path to the generated (using `utbot-gradle` plugin) tests

Fixes #320

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Automated Testing

`org.utbot.gradle.plugin`

## Manual Scenario 

Run test generation using `utbot-gradle` and look at the path to generated tests.

# Checklist (remove irrelevant options):

- [x] Self-review of the code is passed
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] All tests pass locally with my changes
