### PR TITLE
Add warning on conflicting test frameworks

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -506,6 +506,8 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
         if (frameworkNotInstalled && createTestFrameworkNotificationDialog() == Messages.YES) {
             configureTestFramework()
         }
+
+        model.hasTestFrameworkConflict = TestFramework.allItems.count { it.isInstalled  } > 1
     }
 
     private fun configureMockFrameworkIfRequired() {

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsModel.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsModel.kt
@@ -27,7 +27,8 @@ data class GenerateTestsModel(
     var selectedMethods: Set<MemberInfo>?,
     var timeout:Long,
     var generateWarningsForStaticMocking: Boolean = false,
-    var forceMockHappened: Boolean = false
+    var forceMockHappened: Boolean = false,
+    var hasTestFrameworkConflict: Boolean = false,
 ) {
     var testSourceRoot: VirtualFile? = null
     var testPackageName: String? = null


### PR DESCRIPTION
# Description

Notify the user about test frameworks conflict in his project.
For more details see @alisevych comments in the issue being fixed.

Fixes # ([245](https://github.com/UnitTestBot/UTBotJava/issues/245))

## Type of Change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Manual Scenario 

Create tests via UtBot plugin having more than one test framework installed.
