### PR TITLE
Make plugin dialog unresizable

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -138,6 +138,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
 
     init {
         title = "Generate tests with UtBot"
+        setResizable(false)
         init()
     }
 


### PR DESCRIPTION
# Description

Prohibit resizing because actually it seems that there is no need in it

Fixes # ([326](https://github.com/UnitTestBot/UTBotJava/issues/326))

## Type of Change

Please delete options that are not relevant.

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

Try to resize plugin UI dialog

