### PR TITLE
Use fully qualified name for java.lang.reflect.Modifier

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/UtilMethods.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/UtilMethods.kt
@@ -152,7 +152,7 @@ fun getFieldValue(language: CodegenLanguage): String =
                         field.setAccessible(true);
                         java.lang.reflect.Field modifiersField = java.lang.reflect.Field.class.getDeclaredField("modifiers");
                         modifiersField.setAccessible(true);
-                        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+                        modifiersField.setInt(field, field.getModifiers() & ~java.lang.reflect.Modifier.FINAL);
                         
                         return field.get(obj);
                     } catch (NoSuchFieldException e) {


### PR DESCRIPTION
# Description

Fix compilation error in util methods caused by missed fqn for `Modifier`.

Fixes # ([333](https://github.com/UnitTestBot/UTBotJava/issues/333))

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

Generate tests that require an util method `private static Object getFieldValue(Object obj, String fieldName)`

