### PR TITLE
Fuzzing consume much memory for a method with 10 and more parameters

### DIFF
--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/CartesianProduct.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/CartesianProduct.kt
@@ -15,10 +15,8 @@ class CartesianProduct<T>(
     override fun iterator(): Iterator<List<T>> {
         val combinations = Combinations(*lists.map { it.size }.toIntArray())
         val sequence = if (random != null) {
-            // todo create lazy random algo for this because this method can cause OOME even if we take only one value
-            val permutation = IntArray(combinations.size) { it }
-            permutation.shuffle(random)
-            permutation.asSequence().map(combinations::get)
+            val permutation = PseudoShuffledIntProgression(combinations.size, random)
+            (0 until combinations.size).asSequence().map { combinations[permutation[it]] }
         } else {
             combinations.asSequence()
         }

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/PseudoShuffledIntProgression.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/PseudoShuffledIntProgression.kt
@@ -1,0 +1,139 @@
+package org.utbot.fuzzer
+
+import kotlin.math.sqrt
+import kotlin.random.Random
+
+/**
+ * Generates pseudo random values from 0 to size exclusive.
+ *
+ * In general there are 2 ways to get random order for a given range:
+ * 1. Create an array of target size and shuffle values.
+ * 2. Create a set of generated values and generate new values until they're unique.
+ *
+ * Both cases cause high memory usage when target number of values is big.
+ *
+ * The memory usage can be reduced by using a pseudo-random sequence.
+ *
+ * Algorithm to create pseudo-random sequence:
+ * 1. Separate a sequence into 2 parts: matrix-part and tail
+ * 2. Transform linear representation of the matrix into 2-array view with cols × rows arrays
+ * 3. The tail array stores values that are greater than the biggest value of the matrix (cols × rows)
+ * 4. Shuffle all arrays
+ * 5. For a given index the target value is taken from the matrix or from the tail array.
+ *
+ * Example, input size = 23
+ * ```
+ * matrix             tail
+ * -----------------------
+ *  0  5 10 15        20
+ *  1  6 11 16        21
+ *  2  7 12 17        22
+ *  3  8 13 18
+ *  4  9 14 19
+ * ```
+ * Columns are shuffled:
+ *
+ * ```
+ * matrix             tail
+ * -----------------------
+ * 10  5 15  0        20
+ * 11  6 16  1        21
+ * 12  7 17  2        22
+ * 13  8 18  3
+ * 14  9 19  4
+ * ```
+ * Rows and tail are shuffled
+ * ```
+ * matrix             tail
+ * -----------------------
+ * 12  7 17  2        22
+ * 13  8 18  3        20
+ * 14  9 19  4        21
+ * 10  5 15  0
+ * 11  6 16  1
+ * ```
+ * Merge matrix and tail:
+ * ```
+ * 12  7 17  2 22
+ * 13  8 18  3 20
+ * 14  9 19  4 21
+ * 10  5 15  0 ×
+ * 11  6 16  1 ×
+ * ```
+ *
+ * Write down the sequence: `[12, 7, 17, 2, 22, 13, 8, 18, 3, 20, 14, 9, 19, 4, 21, 10, 5, 15, 0, 11, 6, 16, 1]`.
+ *
+ * This algorithm requires only `537 552 bytes (~ 550 KB)` instead of `Int.MAX_VALUE * 4 = 8 589 934 588 bytes (~ 8 GB)`
+ * in the simple array-shuffle algorithm.
+ *
+ */
+class PseudoShuffledIntProgression : Iterable<Int> {
+    private val top: IntArray
+    private val left: IntArray
+    private val tail: IntArray
+
+    val size: Int
+
+    constructor(size: Int, random: Random = Random) : this (size, random, { sqrt(it.toDouble()).toInt() })
+
+    /**
+     * Test only constructor
+     */
+    internal constructor(size: Int, random: Random, side: (Int) -> Int) {
+        check(size >= 0) { "Size must be positive or 0 but current value is $size" }
+        this.size = size
+        var topSize = side(size)
+        if (topSize > 0 && topSize > size / topSize) {
+            topSize = size / topSize
+        }
+        check(topSize > 0 || size == 0) { "Side of matrix must be greater than 0 but $topSize <= 0" }
+
+        top = IntArray(size = topSize) { it }.apply { shuffle(random) }
+        left = IntArray(size = if (topSize == 0) 0 else size / topSize) { it }.apply { shuffle(random) }
+        check(top.size <= left.size) { "Error in internal array state" }
+
+        val rectangle = top.size * left.size
+        tail = IntArray(size - rectangle) { it + rectangle }.apply { shuffle(random) }
+    }
+
+    /**
+     * Test only constructor
+     */
+    internal constructor(top: IntArray, left: IntArray, tail: IntArray) {
+        check(left.size >= tail.size) { "Tail cannot be placed into 1 column of the target matrix" }
+        this.top = top
+        this.left = left
+        this.tail = tail
+        this.size = top.size * left.size + tail.size
+    }
+
+    /**
+     * Returns a unique pseudo-random index for the current one.
+     */
+    operator fun get(index: Int): Int {
+        check(index in 0 until size) { "Index out of bounds: $index >= $size" }
+        val t = top.size
+        val l = left.size
+        val e = t + 1
+        var i = index % e
+        var j = index / e
+        return if (i == t && j < tail.size) {
+            tail[j]
+        } else {
+            val o = ((index - tail.size * e) / t).toLong()
+            if (o > 0) {
+                i = ((index + o) % e).toInt()
+                j = ((index + o) / e).toInt()
+            }
+            top[i] * l + left[j]
+        }
+    }
+
+    fun toArray(): IntArray = IntArray(size, this::get)
+
+    override fun iterator(): IntIterator = object : IntIterator() {
+        var current = 0
+        override fun hasNext() = current < size
+        override fun nextInt() = get(current++)
+    }
+}

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/PseudoShuffledIntProgression.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/PseudoShuffledIntProgression.kt
@@ -14,12 +14,16 @@ import kotlin.random.Random
  *
  * The memory usage can be reduced by using a pseudo-random sequence.
  *
- * Algorithm to create pseudo-random sequence:
- * 1. Separate a sequence into 2 parts: matrix-part and tail
- * 2. Transform linear representation of the matrix into 2-array view with cols × rows arrays
- * 3. The tail array stores values that are greater than the biggest value of the matrix (cols × rows)
- * 4. Shuffle all arrays
- * 5. For a given index the target value is taken from the matrix or from the tail array.
+ * Algorithm to create pseudo-random sequence of length L:
+ * 1. Take first K elements to create a matrix of size COLS × ROWS in such way that K = COLS * ROWS and ROWS >= L - K.
+ * 2. Move last L - K elements into a new array tail.
+ * 3. Any index N from [0, K) can be calculated by using 2 numbers: number of column (i) and number of row (j) as follows:
+ *      `N = i * ROWS + j` where `i = N % COLS` and `j = N / COLS`.
+ *      In such case the index N increases from top to bottom and left to right.
+ * 4. Tail contains all values from [K, L).
+ * 5. Shuffle matrix columns, matrix rows and the tail.
+ * 6. Add the tail as a column to the matrix. Since ROWS >= L - K there are missing values for i = COLS and j >= L - K.
+ * 7. Write down all values except missing from left to right and top to bottom.
  *
  * Example, input size = 23
  * ```
@@ -63,69 +67,163 @@ import kotlin.random.Random
  *
  * Write down the sequence: `[12, 7, 17, 2, 22, 13, 8, 18, 3, 20, 14, 9, 19, 4, 21, 10, 5, 15, 0, 11, 6, 16, 1]`.
  *
- * This algorithm requires only `537 552 bytes (~ 550 KB)` instead of `Int.MAX_VALUE * 4 = 8 589 934 588 bytes (~ 8 GB)`
- * in the simple array-shuffle algorithm.
+ * Instead of storing matrix itself only column and row numbers can be stored. Therefore, the 5th step of the algorithm
+ * can be changed into this:
  *
+ * 5. Shuffle column numbers, row numbers and tail.
+ *
+ * In this case any value from the matrix can be calculated as follows:
+ *      `N = column[i] * ROWS + rows[j]`, where column and rows are shuffled column and row numbers arrays.
+ *
+ * Using number arrays instead of the matrix this algorithm requires only
+ * `537 552 bytes (~ 550 KB)` compared to `Int.MAX_VALUE * 4 = 8 589 934 588 bytes (~ 8 GB)`
+ * when using simple array-shuffle algorithm.
  */
 class PseudoShuffledIntProgression : Iterable<Int> {
-    private val top: IntArray
-    private val left: IntArray
+    private val columnNumber: IntArray
+    private val rowNumber: IntArray
     private val tail: IntArray
 
     val size: Int
 
-    constructor(size: Int, random: Random = Random) : this (size, random, { sqrt(it.toDouble()).toInt() })
+    constructor(size: Int, random: Random = Random) : this(size, random, { sqrt(it.toDouble()).toInt() })
 
     /**
      * Test only constructor
      */
-    internal constructor(size: Int, random: Random, side: (Int) -> Int) {
+    internal constructor(size: Int, random: Random, columns: (Int) -> Int) {
         check(size >= 0) { "Size must be positive or 0 but current value is $size" }
         this.size = size
-        var topSize = side(size)
-        if (topSize > 0 && topSize > size / topSize) {
-            topSize = size / topSize
+        var cols = columns(size)
+        if (cols > 0 && cols > size / cols) {
+            cols = size / cols
         }
-        check(topSize > 0 || size == 0) { "Side of matrix must be greater than 0 but $topSize <= 0" }
+        check(cols > 0 || size == 0) { "Side of matrix must be greater than 0 but $cols <= 0" }
 
-        top = IntArray(size = topSize) { it }.apply { shuffle(random) }
-        left = IntArray(size = if (topSize == 0) 0 else size / topSize) { it }.apply { shuffle(random) }
-        check(top.size <= left.size) { "Error in internal array state" }
+        columnNumber = IntArray(size = cols) { it }.apply { shuffle(random) }
+        rowNumber = IntArray(size = if (cols == 0) 0 else size / cols) { it }.apply { shuffle(random) }
+        check(columnNumber.size <= rowNumber.size) { "Error in internal array state: number of rows shouldn't be less than number of columns" }
 
-        val rectangle = top.size * left.size
+        val rectangle = columnNumber.size * rowNumber.size
         tail = IntArray(size - rectangle) { it + rectangle }.apply { shuffle(random) }
     }
 
     /**
      * Test only constructor
      */
-    internal constructor(top: IntArray, left: IntArray, tail: IntArray) {
-        check(left.size >= tail.size) { "Tail cannot be placed into 1 column of the target matrix" }
-        this.top = top
-        this.left = left
+    internal constructor(columns: IntArray, rows: IntArray, tail: IntArray) {
+        check(rows.size >= tail.size) { "Tail cannot be placed into 1 column of the target matrix" }
+        this.columnNumber = columns
+        this.rowNumber = rows
         this.tail = tail
-        this.size = top.size * left.size + tail.size
+        this.size = columns.size * rows.size + tail.size
     }
 
     /**
      * Returns a unique pseudo-random index for the current one.
+     *
+     * To calculate correct value of the merged matrix as described before
+     * let's look at not shuffled merged matrix with size 2 × 6 and the tail with 2 elements.
+     *
+     * ```
+     * 0  6 13
+     * 1  7 14
+     * 2  9  ×
+     * 3 10  ×
+     * 4 11  ×
+     * 5 12  ×
+     * ```
+     *
+     * The index moves from left to right and top to bottom, so the result sequence should be
+     *      `[0, 6, 13, 1, 7, 14, 2, 9, 3, 10, 4, 11, 5, 12]`
+     * but the correct index in this matrix cannot be calculated just as `i * ROWS + j` because of missing values.
+     * To correct the index a property shift should be used. Let's transform the matrix into a matrix of shift
+     * that should be added to the index for jumping over missing values:
+     *
+     * ```
+     * 0  0  0
+     * 0  0  0
+     * 0  0  1
+     * 1  2  2
+     * 3  3  ×
+     * ×  ×  ×
+     * ```
+     *
+     * The matrix can be divided into 3 parts that calculates correct indices:
+     *
+     * ```
+     * 0  0 | 0
+     * 0  0 | 0
+     * _____|___
+     * 0  0   1
+     * 1  2   2
+     * 3  3   ×
+     * ×  ×   ×
+     * ```
+     *
+     * 1. Top left doesn't change the index and values are taken from the matrix.
+     * 2. Top right doesn't change the index and values are taken from the tail.
+     * 3. Bottom uses shifts to change index and values are taken from the matrix.
+     *
+     * To clarify general rule for calculating a shift let's look at merged matrix
+     * where every row has COLS values and TAILS missing values like this:
+     * ```
+     * 1:   N1 N2 N3 .. N_COLS | M1 M2 .. M_TAILS
+     * 2:   N1 N2 N3 .. N_COLS | M1 M2 .. M_TAILS
+     * ...
+     * ROW: N1 N2 N3 .. N_COLS | M1 M2 .. M_TAILS
+     * ```
+     * It can be shown that the shift changes every COLS values on TAILS, therefore the shift can be calculated as follows:
+     * ```
+     * shift = (index / COLS) * TAILS
+     * ```
+     *
+     * **Examples**
+     *
+     * COLS = 3, TAILS = 1:
+     * ```
+     *  0  0  0  1
+     *  1  1  2  2
+     *  2  3  3  3
+     * ...
+     * ```
+     *
+     * COLS = 1, TAILS = 3
+     * ```
+     *  0  3  6  9
+     * 12 15 18 21
+     * 24 27 30 33
+     * ...
+     * ```
+     *
+     * COLS = 2, TAILS = 2
+     * ```
+     *  0  0  2  2
+     *  4  4  6  6
+     *  8  8 10 10
+     *  ...
+     * ```
      */
     operator fun get(index: Int): Int {
         check(index in 0 until size) { "Index out of bounds: $index >= $size" }
-        val t = top.size
-        val l = left.size
-        val e = t + 1
+        val cols = columnNumber.size
+        val rows = rowNumber.size
+        val e = cols + 1
         var i = index % e
         var j = index / e
-        return if (i == t && j < tail.size) {
+        return if (i == cols && j < tail.size) {
+            // top right case
             tail[j]
         } else {
-            val o = ((index - tail.size * e) / t).toLong()
+            // first tail.size * e values can be calculated without index shift
+            // o < 0 is the top left case
+            // o >= 0 is the bottom case with COLS = cols and TAILS = 1
+            val o = ((index - tail.size * e) / cols).toLong()
             if (o > 0) {
                 i = ((index + o) % e).toInt()
                 j = ((index + o) / e).toInt()
             }
-            top[i] * l + left[j]
+            columnNumber[i] * rows + rowNumber[j]
         }
     }
 

--- a/utbot-fuzzers/src/test/kotlin/org/utbot/framework/plugin/api/PseudoShuffledIntProgressionTest.kt
+++ b/utbot-fuzzers/src/test/kotlin/org/utbot/framework/plugin/api/PseudoShuffledIntProgressionTest.kt
@@ -173,8 +173,8 @@ class PseudoShuffledIntProgressionTest {
     @Test
     fun testSpecification() {
         val shuffle = PseudoShuffledIntProgression(
-            top = intArrayOf(2, 1, 3, 0),
-            left = intArrayOf(2, 3, 4, 0, 1),
+            columns = intArrayOf(2, 1, 3, 0),
+            rows = intArrayOf(2, 3, 4, 0, 1),
             tail = intArrayOf(22, 20, 21)
         )
         assertArrayEquals(
@@ -186,14 +186,30 @@ class PseudoShuffledIntProgressionTest {
     @Test
     fun testIterator() {
         val shuffle = PseudoShuffledIntProgression(
-            top = intArrayOf(2, 1, 3, 0),
-            left = intArrayOf(2, 3, 4, 0, 1),
+            columns = intArrayOf(2, 1, 3, 0),
+            rows = intArrayOf(2, 3, 4, 0, 1),
             tail = intArrayOf(22, 20, 21)
         )
         val expected = intArrayOf(12, 7, 17, 2, 22, 13, 8, 18, 3, 20, 14, 9, 19, 4, 21, 10, 5, 15, 0, 11, 6, 16, 1)
         shuffle.forEachIndexed { index, value ->
             assertEquals(expected[index], value)
         }
+    }
+
+    @Test
+    fun testIteratorIteratesAllValuesExclusively() {
+        val progression = PseudoShuffledIntProgression(
+            columns = intArrayOf(0, 1, 2, 3),
+            rows = intArrayOf(0, 1, 2),
+            tail = intArrayOf(12)
+        )
+        val iterated = mutableListOf<Int>()
+        val iterator = progression.iterator()
+        while (iterator.hasNext()) {
+            iterated.add(iterator.nextInt())
+        }
+        assertEquals(4 * 3 + 1, iterated.size)
+        assertEquals((0 until 4 * 3 + 1).toList(), iterated.sorted())
     }
 
     @Test

--- a/utbot-fuzzers/src/test/kotlin/org/utbot/framework/plugin/api/PseudoShuffledIntProgressionTest.kt
+++ b/utbot-fuzzers/src/test/kotlin/org/utbot/framework/plugin/api/PseudoShuffledIntProgressionTest.kt
@@ -1,0 +1,213 @@
+package org.utbot.framework.plugin.api
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.utbot.fuzzer.PseudoShuffledIntProgression
+import kotlin.random.Random
+
+class PseudoShuffledIntProgressionTest {
+
+    @Test
+    fun testEmpty() {
+        val shuffle = PseudoShuffledIntProgression(0)
+        assertEquals(0, shuffle.size)
+        assertThrows(IllegalStateException::class.java) {
+            shuffle[1]
+        }
+        assertThrows(IllegalStateException::class.java) {
+            shuffle[-1]
+        }
+    }
+
+    @Test
+    fun testBadSize() {
+        assertThrows(IllegalStateException::class.java) {
+            PseudoShuffledIntProgression(-1)
+        }
+    }
+
+    @Test
+    fun testBadSideAndCorrectSize() {
+        assertThrows(IllegalStateException::class.java) {
+            PseudoShuffledIntProgression(100, Random) { -it }
+        }
+    }
+
+    @Test
+    fun testSingleValue() {
+        val shuffle = PseudoShuffledIntProgression(1)
+        assertEquals(0, shuffle[0])
+    }
+
+    @Test
+    fun testSequent() {
+        val shuffle = PseudoShuffledIntProgression(intArrayOf(0), intArrayOf(0, 1, 2, 3), intArrayOf())
+        assertEquals(4, shuffle.size)
+        val result = shuffle.toArray()
+        assertArrayEquals(intArrayOf(0, 1, 2, 3), result)
+    }
+
+    @Test
+    fun testSquare2() {
+        val shuffle = PseudoShuffledIntProgression(intArrayOf(0, 1), intArrayOf(0, 1), intArrayOf())
+        assertEquals(4, shuffle.size)
+        val result = shuffle.toArray()
+        assertArrayEquals(intArrayOf(0, 2, 1, 3), result)
+    }
+
+    @Test
+    fun testSquare3() {
+        val shuffle = PseudoShuffledIntProgression(intArrayOf(0, 1, 2), intArrayOf(0, 1, 2), intArrayOf())
+        assertEquals(9, shuffle.size)
+        val result = shuffle.toArray()
+        assertArrayEquals(intArrayOf(0, 3, 6, 1, 4, 7, 2, 5, 8), result)
+    }
+
+    @Test
+    fun testSquare2WithTail1() {
+        val shuffle = PseudoShuffledIntProgression(intArrayOf(0, 1), intArrayOf(0, 1), intArrayOf(5))
+        assertEquals(5, shuffle.size)
+        val result = shuffle.toArray()
+        assertArrayEquals(intArrayOf(0, 2, 5, 1, 3), result)
+    }
+
+    @Test
+    fun testSquare2WithTail1Reverse() {
+        val shuffle = PseudoShuffledIntProgression(intArrayOf(1, 0), intArrayOf(1, 0), intArrayOf(5))
+        assertEquals(5, shuffle.size)
+        val result = shuffle.toArray()
+        assertArrayEquals(intArrayOf(3, 1, 5, 2, 0), result)
+    }
+
+    @Test
+    fun testSquare3WithFullTailAndReverseOrder() {
+        val shuffle = PseudoShuffledIntProgression(intArrayOf(2, 1, 0), intArrayOf(2, 1, 0), intArrayOf(10, 11, 12))
+        assertEquals(12, shuffle.size)
+        val result = shuffle.toArray()
+        assertArrayEquals(intArrayOf(8, 5, 2, 10, 7, 4, 1, 11, 6, 3, 0, 12), result)
+    }
+
+    @Test
+    fun test2x6andNoTail() {
+        val shuffle = PseudoShuffledIntProgression(intArrayOf(0, 1), intArrayOf(0, 1, 2, 3, 4, 5), intArrayOf())
+        assertEquals(12, shuffle.size)
+        val result = shuffle.toArray()
+        assertArrayEquals(intArrayOf(0, 6, 1, 7, 2, 8, 3, 9, 4, 10, 5, 11), result)
+    }
+
+    @Test
+    fun test2x6and4Tail() {
+        val shuffle = PseudoShuffledIntProgression(intArrayOf(0, 1), intArrayOf(0, 1, 2, 3, 4, 5), intArrayOf(20, 21, 22, 23))
+        assertEquals(16, shuffle.size)
+        val result = shuffle.toArray()
+        assertArrayEquals(intArrayOf(0, 6, 20, 1, 7, 21, 2, 8, 22, 3, 9, 23, 4, 10, 5, 11), result)
+    }
+
+    @Test
+    fun test6x2andNoTail() {
+        val shuffle = PseudoShuffledIntProgression(intArrayOf(0, 1, 2, 3, 4, 5), intArrayOf(0, 1), intArrayOf())
+        assertEquals(12, shuffle.size)
+        val result = shuffle.toArray()
+        assertArrayEquals(intArrayOf(0, 2, 4, 6, 8, 10, 1, 3, 5, 7, 9, 11), result)
+    }
+
+    @Test
+    fun test6x2and4TailFailsBecauseItIsForbiddenSituation() {
+        assertThrows(IllegalStateException::class.java) {
+            PseudoShuffledIntProgression(intArrayOf(0, 1, 2, 3, 4, 5), intArrayOf(0, 1), intArrayOf(20, 21, 22, 23))
+        }
+    }
+
+    @Test
+    fun test6x2and1Tail() {
+        val shuffle = PseudoShuffledIntProgression(intArrayOf(0, 1, 2, 3, 4, 5), intArrayOf(0, 1), intArrayOf(20))
+        assertEquals(13, shuffle.size)
+        val result = shuffle.toArray()
+        assertArrayEquals(intArrayOf(0, 2, 4, 6, 8, 10, 20, 1, 3, 5, 7, 9, 11), result)
+    }
+
+    @Test
+    fun testIsShuffledAndNoDuplicatesForFirst1000() {
+        (2..1000).forEach {
+            val shuffle = PseudoShuffledIntProgression(it, Random(9))
+            val result = (0 until shuffle.size).map(shuffle::get)
+            assertNotEquals(result.sorted(), result)
+            assertEquals(result.size, result.toSet().size)
+        }
+    }
+
+    @Test
+    fun testIsRandom() {
+        val randomSeed = 10
+        val size = 1000
+        val expected = IntArray(size) { it }.apply { shuffle(Random(randomSeed)) }
+        val result = PseudoShuffledIntProgression(size, random = Random(randomSeed)) { it }.toArray()
+
+        assertArrayEquals(expected, result)
+    }
+
+    @Test
+    fun testForDifferentSides() {
+        val size = 10000
+        (1 until size).forEach { side ->
+            val shuffle = PseudoShuffledIntProgression(size, Random) { side }
+            assertEquals(size, shuffle.size)
+            val values = shuffle.toArray().toSet()
+            assertEquals(values.size, shuffle.size)
+        }
+    }
+
+    @ParameterizedTest(name = "testCorrectInternalArraysAreCreatedFor{arguments}DifferentSides")
+    @ValueSource(ints = [0, 1, 999, 1000])
+    fun testCorrectInternalArraysAreCreatedForDifferentSides(size: Int) {
+        (1 until size / 2).forEach { side ->
+            val one = PseudoShuffledIntProgression(size, Random(98)) { side }
+            val two = PseudoShuffledIntProgression(size, Random(98)) { it / side }
+            assertEquals(one.size, two.size)
+            assertArrayEquals(one.toArray(), two.toArray()) { "Fails for side = $side" }
+        }
+    }
+
+    @Test
+    fun testSpecification() {
+        val shuffle = PseudoShuffledIntProgression(
+            top = intArrayOf(2, 1, 3, 0),
+            left = intArrayOf(2, 3, 4, 0, 1),
+            tail = intArrayOf(22, 20, 21)
+        )
+        assertArrayEquals(
+            intArrayOf(12, 7, 17, 2, 22, 13, 8, 18, 3, 20, 14, 9, 19, 4, 21, 10, 5, 15, 0, 11, 6, 16, 1),
+            shuffle.toArray()
+        )
+    }
+
+    @Test
+    fun testIterator() {
+        val shuffle = PseudoShuffledIntProgression(
+            top = intArrayOf(2, 1, 3, 0),
+            left = intArrayOf(2, 3, 4, 0, 1),
+            tail = intArrayOf(22, 20, 21)
+        )
+        val expected = intArrayOf(12, 7, 17, 2, 22, 13, 8, 18, 3, 20, 14, 9, 19, 4, 21, 10, 5, 15, 0, 11, 6, 16, 1)
+        shuffle.forEachIndexed { index, value ->
+            assertEquals(expected[index], value)
+        }
+    }
+
+    @Test
+    fun testNoIntOverflowWhenCalculateValue() {
+        assertDoesNotThrow {
+            PseudoShuffledIntProgression(Int.MAX_VALUE)[2147479015]
+            PseudoShuffledIntProgression(Int.MAX_VALUE)[Int.MAX_VALUE - 1]
+        }
+    }
+
+    @Test
+    fun testNoDuplicates() {
+        val size = 2000
+        val set = PseudoShuffledIntProgression(size).toSet()
+        assertEquals(size, set.size)
+    }
+}


### PR DESCRIPTION
# Description

Provides another way to randomize fuzzer generated values. This approach helps to create a sequence of shuffled unique integers  without huge memory consumption for corner cases. Previously, it was creating an array for storing as much integers as fuzzer had possible values combinations thus it leads to OOME.

Fixes #293

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

Run PseudoShuffledIntProgressionTest to validate that an implementation is correct.

## Manual Scenario 

Create a test with 10 parameters:

```java
    public int test(int x, boolean y, String s, Integer z, float f, double g,
                    int x2, boolean y3, String s4, Integer z5, float f6, double g2) {
        return -1;
    }
```

Run test generation with fuzzer and capture memory snapshot. Find `org.utbot.fuzzer.PseudoShuffledIntProgression` object and check that retained size isn't big (in my case for 6 553 600 values it takes only 20 596 bytes).
