### PR TITLE
Added setting for suppressing child process errors

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -278,9 +278,9 @@ object UtSettings {
      * Determines whether should errors from a child process be written to a log file or suppressed.
      * Note: being enabled, this option can highly increase disk usage when using ContestEstimator.
      *
-     * True by default.
+     * False by default (for saving disk space).
      */
-    var logConcreteExecutionErrors by getBooleanProperty(true)
+    var logConcreteExecutionErrors by getBooleanProperty(false)
 
     /**
      * Number of branch instructions using for clustering executions in the test minimization phase.

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -275,6 +275,14 @@ object UtSettings {
     )
 
     /**
+     * Determines whether should errors from a child process be written to a log file or suppressed.
+     * Note: being enabled, this option can highly increase disk usage when using ContestEstimator.
+     *
+     * True by default.
+     */
+    var logConcreteExecutionErrors by getBooleanProperty(true)
+
+    /**
      * Number of branch instructions using for clustering executions in the test minimization phase.
      */
     var numberOfBranchInstructionsForClustering by getIntProperty(4)

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/process/ChildProcessRunner.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/process/ChildProcessRunner.kt
@@ -1,5 +1,6 @@
 package org.utbot.instrumentation.process
 
+import mu.KotlinLogging
 import org.utbot.common.bracket
 import org.utbot.common.debug
 import org.utbot.common.firstOrNullResourceIS
@@ -9,11 +10,11 @@ import org.utbot.common.pid
 import org.utbot.common.scanForResourcesContaining
 import org.utbot.common.utBotTempDirectory
 import org.utbot.framework.JdkPathService
+import org.utbot.framework.UtSettings
 import org.utbot.instrumentation.Settings
 import org.utbot.instrumentation.agent.DynamicClassTransformer
 import java.io.File
 import java.nio.file.Paths
-import mu.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
 private var processSeqN = 0
@@ -30,19 +31,24 @@ class ChildProcessRunner {
                 debugCmd + listOf("-javaagent:$jarFile", "-ea", "-jar", "$jarFile")
     }
 
-    lateinit var errorLogFile: File
+    var errorLogFile: File = NULL_FILE
 
     fun start(): Process {
         logger.debug { "Starting child process: ${cmds.joinToString(" ")}" }
         processSeqN++
 
-        val dir = File(utBotTempDirectory.toFile(), ERRORS_FILE_PREFIX)
-        dir.mkdirs()
-        errorLogFile = File(dir, "${hashCode()}-${processSeqN}.log")
+        if (UtSettings.logConcreteExecutionErrors) {
+            UT_BOT_TEMP_DIR.mkdirs()
+            errorLogFile = File(UT_BOT_TEMP_DIR, "${hashCode()}-${processSeqN}.log")
+        }
 
         val processBuilder = ProcessBuilder(cmds).redirectError(errorLogFile)
         return processBuilder.start().also {
-            logger.debug { "Process started with PID=${it.pid} , error log: ${errorLogFile.absolutePath}" }
+            logger.debug { "Process started with PID=${it.pid}" }
+
+            if (UtSettings.logConcreteExecutionErrors) {
+                logger.debug { "Child process error log: ${errorLogFile.absolutePath}" }
+            }
         }
     }
 
@@ -52,6 +58,16 @@ class ChildProcessRunner {
         private const val INSTRUMENTATION_LIB = "instrumentation-lib"
 
         private const val DEBUG_RUN_CMD = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,quiet=y,address=5005"
+
+        private val UT_BOT_TEMP_DIR: File = File(utBotTempDirectory.toFile(), ERRORS_FILE_PREFIX)
+
+        private val NULL_FILE_PATH: String = if (System.getProperty("os.name").startsWith("Windows")) {
+            "NUL"
+        } else {
+            "/dev/null"
+        }
+
+        private val NULL_FILE = File(NULL_FILE_PATH)
 
         /**
          * * Firstly, searches for utbot-instrumentation jar in the classpath.


### PR DESCRIPTION
# Description

Make logging of child process errors optional (disabled by default).

Fixes #336

## Type of Change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Automated Testing

Running `ContestEstimator`, no log files are written with the disabled option, and all are written with the enabled option.

# Checklist (remove irrelevant options):

- [ ] The change followed the style guidelines of the UTBot project
- [ ] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [ ] No new warnings
- [ ] Tests that prove my change is effective
- [ ] All tests pass locally with my changes
