### PR TITLE
Support package-private classes and constructors in AssembleModelGenerator

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ValueConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ValueConstructor.kt
@@ -3,6 +3,7 @@ package org.utbot.engine
 import org.utbot.common.findField
 import org.utbot.common.findFieldOrNull
 import org.utbot.common.invokeCatching
+import org.utbot.common.withAccessibility
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.ConstructorId
 import org.utbot.framework.plugin.api.EnvironmentModels
@@ -390,12 +391,19 @@ class ValueConstructor {
      */
     private fun value(model: UtModel) = construct(model, null).value
 
-
     private fun MethodId.call(args: List<Any?>, instance: Any?): Any? =
-        method.invokeCatching(obj = instance, args = args).getOrThrow()
+        method.run {
+            withAccessibility {
+                invokeCatching(obj = instance, args = args).getOrThrow()
+            }
+        }
 
     private fun ConstructorId.call(args: List<Any?>): Any? =
-        constructor.newInstance(*args.toTypedArray())
+        constructor.run {
+            withAccessibility {
+                newInstance(*args.toTypedArray())
+            }
+        }
 
     /**
      * Fetches primitive value from NutsModel to create array of primitives.

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/MockValueConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/MockValueConstructor.kt
@@ -45,6 +45,7 @@ import kotlin.reflect.KClass
 import org.mockito.Mockito
 import org.mockito.stubbing.Answer
 import org.objectweb.asm.Type
+import org.utbot.common.withAccessibility
 
 /**
  * Constructs values (including mocks) from models.
@@ -433,10 +434,18 @@ class MockValueConstructor(
     }
 
     private fun MethodId.call(args: List<Any?>, instance: Any?): Any? =
-        method.invokeCatching(obj = instance, args = args).getOrThrow()
+        method.run {
+            withAccessibility {
+                invokeCatching(obj = instance, args = args).getOrThrow()
+            }
+        }
 
     private fun ConstructorId.call(args: List<Any?>): Any? =
-        constructor.newInstance(*args.toTypedArray())
+        constructor.run {
+            withAccessibility {
+                newInstance(*args.toTypedArray())
+            }
+        }
 
     /**
      * Fetches primitive value from NutsModel to create array of primitives.


### PR DESCRIPTION

# Description

Classes have package-private modifier by default, it is good enough to construct assemble models.
Java reflection does not allow to call newInstance method for a non-public class, but it may be fixed with `withAccessibility` modifier

Fixes # ([346](https://github.com/UnitTestBot/UTBotJava/issues/346))

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

Run `AssembleModelGeneratorTests` from standard pipeline

## Manual Scenario 

Could be tested on classes with default modifier of class or it constructors.

