### PR TITLE
Fix the search of SootConstructor by ConstructorId

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/modifications/ConstructorAnalyzer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/modifications/ConstructorAnalyzer.kt
@@ -4,7 +4,9 @@ import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.ConstructorId
 import org.utbot.framework.plugin.api.FieldId
 import org.utbot.framework.plugin.api.id
+import org.utbot.framework.plugin.api.util.isArray
 import org.utbot.framework.plugin.api.util.isRefType
+import org.utbot.framework.plugin.api.util.jClass
 import soot.Scene
 import soot.SootMethod
 import soot.Type
@@ -248,7 +250,9 @@ class ConstructorAnalyzer {
      */
     private fun getParameterType(type: ClassId): Type? =
         try {
-            if (type.isRefType) scene.getRefType(type.name) else scene.getType(type.name)
+            if (type.isRefType) scene.getRefType(type.name)
+            else if (type.isArray) scene.getType(type.jClass.canonicalName)
+            else scene.getType(type.name)
         } catch (e: Exception) {
             null
         }


### PR DESCRIPTION
# Description

Fix the search of SootConstructor by ConstructorId: corrected Jimple processing

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?


## Manual Scenario 

```java
public class CashCoder {
    private int[] value;

    public CashCoder() {
    }

    public CashCoder(int[] value) {
        this.value = value;
    }

    public int cashCode() {
        int result = 0;
        for (int i : value) {
            result = 31 * result + i;
        }
        if (result == 42 && value.length > 1 && value[0] > 0) throw new RuntimeException("It's forty two!");
        return result;
    }
}
```

