### PR TITLE
Put utbot-instrumentation.jar into the gradle plugin jar

### DIFF
--- a/utbot-gradle/build.gradle
+++ b/utbot-gradle/build.gradle
@@ -6,11 +6,16 @@ plugins {
 
 apply from: "${parent.projectDir}/gradle/include/jvm-project.gradle"
 
+configurations {
+    fetchInstrumentationJar
+}
+
 dependencies {
     shadow gradleApi()
     shadow localGroovy()
 
     implementation project(":utbot-framework")
+    fetchInstrumentationJar project(path: ':utbot-instrumentation', configuration: 'instrumentationArchive')
 
     implementation group: 'io.github.microutils', name: 'kotlin-logging', version: kotlin_logging_version
 }
@@ -30,9 +35,22 @@ jar {
     }
 }
 
+/**
+ * Shadow plugin unpacks the nested `utbot-instrumentation-<version>.jar`.
+ * But we need it to be packed. Workaround: double-nest the jar.
+ */
+task shadowBugWorkaround(type: Jar) {
+    destinationDir file('build/shadow-bug-workaround')
+    from(configurations.fetchInstrumentationJar) {
+        into "lib"
+    }
+}
+
+// Documentation: https://imperceptiblethoughts.com/shadow/
 shadowJar {
     archiveClassifier.set('')
     minimize()
+    from shadowBugWorkaround
 }
 
 // no module metadata => no dependency on the `utbot-framework`


### PR DESCRIPTION
# Description

Put `utbot-instrumentation.jar` into the utbot gradle plugin.

Fixes #365

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

Please, repeat steps from the issue.

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
