### PR TITLE
Rename mock strategy options in gradle and maven plugins

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/sarif/SarifExtensionProvider.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/sarif/SarifExtensionProvider.kt
@@ -93,10 +93,10 @@ interface SarifExtensionProvider {
 
     fun mockStrategyParse(mockStrategy: String): MockStrategyApi =
         when (mockStrategy.toLowerCase()) {
-            "do-not-mock" -> MockStrategyApi.NO_MOCKS
-            "package-based" -> MockStrategyApi.OTHER_PACKAGES
-            "all-except-cut" -> MockStrategyApi.OTHER_CLASSES
-            else -> error("Parameter mockStrategy == '$mockStrategy', but it can take only 'do-not-mock', 'package-based' or 'all-except-cut'")
+            "no-mocks" -> MockStrategyApi.NO_MOCKS
+            "other-packages" -> MockStrategyApi.OTHER_PACKAGES
+            "other-classes" -> MockStrategyApi.OTHER_CLASSES
+            else -> error("Parameter mockStrategy == '$mockStrategy', but it can take only 'no-mocks', 'other-packages' or 'other-classes'")
         }
 
     fun staticsMockingParse(staticsMocking: String): StaticsMocking =

--- a/utbot-gradle/docs/utbot-gradle.md
+++ b/utbot-gradle/docs/utbot-gradle.md
@@ -44,7 +44,7 @@ __Groovy:__
       mockFramework = 'mockito'
       generationTimeout = 60000L
       codegenLanguage = 'java'
-      mockStrategy = 'package-based'
+      mockStrategy = 'other-packages'
       staticsMocking = 'mock-statics'
       forceStaticMocking = 'force'
       classesToMockAlways = ['org.slf4j.Logger', 'java.util.Random']
@@ -62,7 +62,7 @@ __Kotlin DSL:__
       mockFramework.set("mockito")
       generationTimeout.set(60000L)
       codegenLanguage.set("java")
-      mockStrategy.set("package-based")
+      mockStrategy.set("other-packages")
       staticsMocking.set("mock-statics")
       forceStaticMocking.set("force")
       classesToMockAlways.set(listOf("org.slf4j.Logger", "java.util.Random"))
@@ -118,9 +118,9 @@ __Kotlin DSL:__
 - `mockStrategy` &ndash;
   - The mock strategy to be used.
   - Can be one of:
-    - `'do-not-mock'` &ndash; do not use mock frameworks at all
-    - `'package-based'` &ndash; mock all classes outside the current package except system ones _(by default)_
-    - `'all-except-cut'` &ndash; mock all classes outside the class under test except system ones
+    - `'no-mocks'` &ndash; do not use mock frameworks at all
+    - `'other-packages'` &ndash; mock all classes outside the current package except system ones _(by default)_
+    - `'other-classes'` &ndash; mock all classes outside the class under test except system ones
 
 - `staticsMocking` &ndash;
   - Use static methods mocking or not.

--- a/utbot-gradle/src/main/kotlin/org/utbot/gradle/plugin/extension/SarifGradleExtension.kt
+++ b/utbot-gradle/src/main/kotlin/org/utbot/gradle/plugin/extension/SarifGradleExtension.kt
@@ -68,7 +68,7 @@ abstract class SarifGradleExtension {
     abstract val codegenLanguage: Property<String>
 
     /**
-     * Can be one of: 'do-not-mock', 'package-based', 'all-except-cut'.
+     * Can be one of: 'no-mocks', 'other-packages', 'other-classes'.
      */
     @get:Input
     abstract val mockStrategy: Property<String>
@@ -105,7 +105,7 @@ sarifReport {
     mockFramework = 'mockito'
     generationTimeout = 60 * 1000L
     codegenLanguage = 'java'
-    mockStrategy = 'do-not-mock'
+    mockStrategy = 'no-mocks'
     staticsMocking = 'do-not-mock-statics'
     forceStaticMocking = 'force'
     classesToMockAlways = ['org.utbot.api.mock.UtMock']

--- a/utbot-gradle/src/test/kotlin/org/utbot/gradle/plugin/extension/SarifGradleExtensionProviderTest.kt
+++ b/utbot-gradle/src/test/kotlin/org/utbot/gradle/plugin/extension/SarifGradleExtensionProviderTest.kt
@@ -256,19 +256,19 @@ class SarifGradleExtensionProviderTest {
 
         @Test
         fun `should be equal to NO_MOCKS`() {
-            setMockStrategy("do-not-mock")
+            setMockStrategy("no-mocks")
             assertEquals(MockStrategyApi.NO_MOCKS, extensionProvider.mockStrategy)
         }
 
         @Test
         fun `should be equal to OTHER_PACKAGES`() {
-            setMockStrategy("package-based")
+            setMockStrategy("other-packages")
             assertEquals(MockStrategyApi.OTHER_PACKAGES, extensionProvider.mockStrategy)
         }
 
         @Test
         fun `should be equal to OTHER_CLASSES`() {
-            setMockStrategy("all-except-cut")
+            setMockStrategy("other-classes")
             assertEquals(MockStrategyApi.OTHER_CLASSES, extensionProvider.mockStrategy)
         }
 

--- a/utbot-maven/docs/utbot-maven.md
+++ b/utbot-maven/docs/utbot-maven.md
@@ -44,7 +44,7 @@ For example, the following configuration may be used:
     <mockFramework>mockito</mockFramework>
     <generationTimeout>60000L</generationTimeout>
     <codegenLanguage>java</codegenLanguage>
-    <mockStrategy>package-based</mockStrategy>
+    <mockStrategy>other-packages</mockStrategy>
     <staticsMocking>mock-statics</staticsMocking>
     <forceStaticMocking>force</forceStaticMocking>
     <classesToMockAlways>
@@ -104,9 +104,9 @@ For example, the following configuration may be used:
 - `mockStrategy` &ndash;
     - The mock strategy to be used.
     - Can be one of:
-        - `'do-not-mock'` &ndash; do not use mock frameworks at all
-        - `'package-based'` &ndash; mock all classes outside the current package except system ones _(by default)_
-        - `'all-except-cut'` &ndash; mock all classes outside the class under test except system ones
+        - `'no-mocks'` &ndash; do not use mock frameworks at all
+        - `'other-packages'` &ndash; mock all classes outside the current package except system ones _(by default)_
+        - `'other-classes'` &ndash; mock all classes outside the class under test except system ones
 
 - `staticsMocking` &ndash;
     - Use static methods mocking or not.

--- a/utbot-maven/src/main/kotlin/org/utbot/maven/plugin/GenerateTestsAndSarifReportMojo.kt
+++ b/utbot-maven/src/main/kotlin/org/utbot/maven/plugin/GenerateTestsAndSarifReportMojo.kt
@@ -96,9 +96,9 @@ class GenerateTestsAndSarifReportMojo : AbstractMojo() {
     internal lateinit var codegenLanguage: String
 
     /**
-     * Can be one of: 'do-not-mock', 'package-based', 'all-except-cut'.
+     * Can be one of: 'no-mocks', 'other-packages', 'other-classes'.
      */
-    @Parameter(defaultValue = "do-not-mock")
+    @Parameter(defaultValue = "no-mocks")
     internal lateinit var mockStrategy: String
 
     /**

--- a/utbot-maven/src/test/resources/project-to-test/pom.xml
+++ b/utbot-maven/src/test/resources/project-to-test/pom.xml
@@ -34,7 +34,7 @@
                     <mockFramework>mockito</mockFramework>
                     <generationTimeout>10000</generationTimeout>
                     <codegenLanguage>java</codegenLanguage>
-                    <mockStrategy>package-based</mockStrategy>
+                    <mockStrategy>other-packages</mockStrategy>
                     <staticsMocking>mock-statics</staticsMocking>
                     <forceStaticMocking>force</forceStaticMocking>
                     <classesToMockAlways>


### PR DESCRIPTION
# Description

Renamed unclear option names of the parameter `mockStrategy` in the Gradle/Maven plugins.
Fixes #366

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Automated Testing

`org.utbot.gradle.plugin`

## Manual Scenario 

Run tests generation using Gradle/Maven plugin and specify the parameter `mockStrategy`.

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] All tests pass locally with my changes
