### PR TITLE
Make CLI throw Exception for empty classes

### DIFF
--- a/utbot-cli/src/main/kotlin/org/utbot/cli/GenerateTestsCommand.kt
+++ b/utbot-cli/src/main/kotlin/org/utbot/cli/GenerateTestsCommand.kt
@@ -94,6 +94,9 @@ class GenerateTestsCommand :
             val targetMethods = classUnderTest.targetMethods()
             initializeEngine(workingDirectory)
 
+            if (targetMethods.isEmpty()) {
+                throw Exception("Nothing to process. No methods were provided")
+            }
             // utContext is used in `generateTestCases`, `generateTest`, `generateReport`
             withUtContext(UtContext(targetMethods.first().clazz.java.classLoader)) {
 


### PR DESCRIPTION
# Description

Java CLI's generation command now throws informative Exception when generating tests for empty classes.

Fixes #284 

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Automated Testing

Not attached.

## Manual Scenario 

Current functionality was tested on local machine.

# Checklist (remove irrelevant options):

- [x] Self-review of the code is passed
- [x] No new warnings
