### PR TITLE
Enable smart fuzzer for UTBot by default for a plugin #66

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -246,12 +246,17 @@ object UtSettings {
     /**
      * Set to true to start fuzzing if symbolic execution haven't return anything
      */
-    var useFuzzing: Boolean by getBooleanProperty(false)
+    var useFuzzing: Boolean by getBooleanProperty(true)
 
     /**
      * Set the total attempts to improve coverage by fuzzer.
      */
-    var fuzzingMaxAttemps: Int by getIntProperty(Int.MAX_VALUE)
+    var fuzzingMaxAttempts: Int by getIntProperty(Int.MAX_VALUE)
+
+    /**
+     * Fuzzer tries to generate and run tests during this time.
+     */
+    var fuzzingTimeoutInMillis: Int by getIntProperty(3_000)
 
     /**
      * Generate tests that treat possible overflows in arithmetic operations as errors

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/UtBotTestCaseGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/UtBotTestCaseGenerator.kt
@@ -219,7 +219,10 @@ object UtBotTestCaseGenerator : TestCaseGenerator {
     private fun createDefaultFlow(engine: UtBotSymbolicEngine): Flow<UtResult> {
         var flow = engine.traverse()
         if (UtSettings.useFuzzing) {
-            flow = flowOf(flow, engine.fuzzing()).flattenConcat()
+            flow = flowOf(
+                engine.fuzzing(System.currentTimeMillis() + UtSettings.fuzzingTimeoutInMillis),
+                flow,
+            ).flattenConcat()
         }
         return flow
     }

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/AbstractTestCaseGeneratorTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/AbstractTestCaseGeneratorTest.kt
@@ -91,6 +91,7 @@ abstract class AbstractTestCaseGeneratorTest(
         UtSettings.substituteStaticsWithSymbolicVariable = true
         UtSettings.useAssembleModelGenerator = true
         UtSettings.saveRemainingStatesForConcreteExecution = false
+        UtSettings.useFuzzing = false
     }
 
     // checks paramsBefore and result

--- a/utbot-intellij/src/main/resources/log4j2.xml
+++ b/utbot-intellij/src/main/resources/log4j2.xml
@@ -9,6 +9,11 @@
         <Logger name="org.utbot.intellij" level="info">
             <AppenderRef ref="Console"/>
         </Logger>
-        <Root level="info"/>
+        <Logger name="org.utbot" level="error">
+            <AppenderRef ref="Console"/>
+        </Logger>
+        <Root level="error">
+            <AppenderRef ref="Console"/>
+        </Root>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
# Description

This change enables fuzzing by default.

Fixes #66

## Type of Change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

## Automated Testing

Fuzzing related tests can be found in module utbot-fuzzers (`org/utbot/framework/plugin/api`)

**NB:** Tests of different samples run without fuzzing

## Manual Scenario 

Change settings.properties with value:
```
checkSolverTimeoutMillis=1
```
and generate test. The result **should** contain fuzzing-generated tests and **can** contain test created by symbolic engine. Usually the time is too small, and output contains only fuzzing-generated tests.

Try this example. Among fuzzing-generated test there's no test that returns 2.

```
public int floatToInt(float x) {
    if (x < 0) {
        if ((int) x < 0) {
            return 1;
        }
        return 2; // smth small to int zero
    }
    return 3;
}
```
