### PR TITLE
Initiate concrete execution if a wrapper method is missing

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/engine/CollectionWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/CollectionWrappers.kt
@@ -10,6 +10,7 @@ import org.utbot.engine.overrides.collections.UtHashSet
 import org.utbot.engine.overrides.collections.UtLinkedList
 import org.utbot.engine.pc.UtAddrExpression
 import org.utbot.engine.pc.UtExpression
+import org.utbot.engine.pc.UtFalse
 import org.utbot.engine.pc.select
 import org.utbot.engine.symbolic.asHardConstraint
 import org.utbot.engine.z3.intValue
@@ -84,10 +85,15 @@ abstract class BaseOverriddenWrapper(protected val overriddenClassName: String) 
 
         val overriddenMethod = overriddenClass.findMethodOrNull(method.subSignature)
 
-        val jimpleBody = overriddenMethod?.jimpleBody() ?: method.jimpleBody()
-        val graphResult = GraphResult(jimpleBody.graph())
-
-        return listOf(graphResult)
+        if (overriddenMethod == null) {
+            // No overridden method has been found, switch to concrete execution
+            pathLogger.warn("Method ${overriddenClass.name}::${method.subSignature} not found, executing concretely")
+            return emptyList()
+        } else {
+            val jimpleBody = overriddenMethod.jimpleBody()
+            val graphResult = GraphResult(jimpleBody.graph())
+            return listOf(graphResult)
+        }
     }
 }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
@@ -3079,6 +3079,11 @@ class UtBotSymbolicEngine(
 
         instanceAsWrapperOrNull?.run {
             val results = invoke(instance as ObjectValue, invocation.method, invocation.parameters)
+            if (results.isEmpty()) {
+                // Drop the branch and switch to concrete execution
+                statesForConcreteExecution += environment.state
+                queuedSymbolicStateUpdates += UtFalse.asHardConstraint()
+            }
             return OverrideResult(success = true, results)
         }
 


### PR DESCRIPTION
# Description

If a JVM class is overridden but a method is missing from the wrapper,
the engine will discard the path and fall back to concrete execution
instead of analysing the real JVM code graph.

This approach fixes the problem with methods that have been introduced
in newer JDKs. Now wrappers are mostly limited to Java 1.8 interfaces
and fail to analyze methods like `String::isBlank` or `String::lines`
when the code runs under JDK 11. Building graphs from the real JDK code
fails because the wrapper does not have private fields that the original
code uses.

TODO: to allow symbolic analysis of the code, missing methods should be
actually implemented in corresponding wrappers.

Fixes #375

## Type of Change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Existing unit tests did not break on JDK 1.8.

Tests involving JDK 11 `String` methods missing from `UtString` wrapper are correctly generated by the plugin (debug IDE).

## Automated Testing

No new automated tests have been added: we use JDK 1.8 to run unit tests.

## Manual Scenario 

Sample code:
```
import org.jetbrains.annotations.NotNull;

public class NewMethods {
    public long countLines(@NotNull String text) {
        return text.lines().count();
    }

    public String firstLine(@NotNull String text) {
        return text.lines().findFirst().orElse(null);
    }

    public boolean checkBlank(@NotNull String text) {
        return text.strip().isBlank();
    }
}
```

Tests for all these methods should be generated.

# Checklist:

- [X] The change followed the style guidelines of the UTBot project
- [X] Self-review of the code is passed
- [X] The change contains enough commentaries, particularly in hard-to-understand areas
- [X] No new warnings
- [X] Tests that prove my change is effective (manual tests only).
- [X] All tests pass locally with my changes
