### PR TITLE
Fix symbolic link in Dockerfile_java_cli

### DIFF
--- a/docker/Dockerfile_java_cli
+++ b/docker/Dockerfile_java_cli
@@ -22,5 +22,5 @@ RUN curl -H "Authorization: Bearer ${ACCESS_TOKEN}" \
     && unzip "${JAVA_CLI_ZIP_NAME}" \
     && rm "${JAVA_CLI_ZIP_NAME}"
 
-ENV JAVA_CLI_PATH="$(find $pwd -type f -name "utbot-cli*")"
+ENV JAVA_CLI_PATH="$(find /usr/src -type f -name utbot-cli*)"
 RUN ln -s "${JAVA_CLI_PATH}" $pwd/utbot-cli.jar


### PR DESCRIPTION
# Description

Now Dockerfile_java_cli creates correct symbolic link that refers on Java CLI.

Fixes #395 

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Automated Testing

Not applicable.

## Manual Scenario 

It was tested on local machine.

# Checklist (remove irrelevant options):

Not applicable.
