### PR TITLE
Added the wrapper for static methods of java.util.List

### DIFF
--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/List.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/List.java
@@ -1,0 +1,72 @@
+package org.utbot.engine.overrides.collections;
+
+import org.utbot.api.annotation.UtClassMock;
+
+import java.util.Collection;
+
+@UtClassMock(target = java.util.List.class, internalUsage = true)
+public interface List<E> extends java.util.List<E> {
+    static <E> java.util.List<E> of() {
+        return new UtArrayList<>();
+    }
+
+    @SuppressWarnings("unchecked")
+    static <E> java.util.List<E> of(E e1) {
+        return new UtArrayList<>((E[]) new Object[]{e1});
+    }
+
+    @SuppressWarnings("unchecked")
+    static <E> java.util.List<E> of(E e1, E e2) {
+        return new UtArrayList<>((E[]) new Object[]{e1, e2});
+    }
+
+    @SuppressWarnings("unchecked")
+    static <E> java.util.List<E> of(E e1, E e2, E e3) {
+        return new UtArrayList<>((E[]) new Object[]{e1, e2, e3});
+    }
+
+    @SuppressWarnings("unchecked")
+    static <E> java.util.List<E> of(E e1, E e2, E e3, E e4) {
+        return new UtArrayList<>((E[]) new Object[]{e1, e2, e3, e4});
+    }
+
+    @SuppressWarnings("unchecked")
+    static <E> java.util.List<E> of(E e1, E e2, E e3, E e4, E e5) {
+        return new UtArrayList<>((E[]) new Object[]{e1, e2, e3, e4, e5});
+    }
+
+    @SuppressWarnings("unchecked")
+    static <E> java.util.List<E> of(E e1, E e2, E e3, E e4, E e5, E e6) {
+        return new UtArrayList<>((E[]) new Object[]{e1, e2, e3, e4, e5, e6});
+    }
+
+    @SuppressWarnings("unchecked")
+    static <E> java.util.List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7) {
+        return new UtArrayList<>((E[]) new Object[]{e1, e2, e3, e4, e5, e6, e7});
+    }
+
+    @SuppressWarnings("unchecked")
+    static <E> java.util.List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8) {
+        return new UtArrayList<>((E[]) new Object[]{e1, e2, e3, e4, e5, e6, e7, e8});
+    }
+
+    @SuppressWarnings("unchecked")
+    static <E> java.util.List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9) {
+        return new UtArrayList<>((E[]) new Object[]{e1, e2, e3, e4, e5, e6, e7, e8, e9});
+    }
+
+    @SuppressWarnings("unchecked")
+    static <E> java.util.List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9, E e10) {
+        return new UtArrayList<>((E[]) new Object[]{e1, e2, e3, e4, e5, e6, e7, e8, e9, e10});
+    }
+
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    static <E> java.util.List<E> of(E... elements) {
+        return new UtArrayList<>(elements);
+    }
+
+    static <E> java.util.List<E> copyOf(Collection<? extends E> collection) {
+        return new UtArrayList<>(collection);
+    }
+}

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtArrayList.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtArrayList.java
@@ -63,6 +63,14 @@ public class UtArrayList<E> extends AbstractList<E>
         addAll(c);
     }
 
+    public UtArrayList(E[] data) {
+        visit(this);
+        int length = data.length;
+        elementData = new RangeModifiableUnlimitedArray<>();
+        elementData.setRange(0, data, 0, length);
+        elementData.end = length;
+    }
+
     /**
      * Precondition check is called only once by object,
      * if it was passed as parameter to method under test.

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/SootUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/SootUtils.kt
@@ -26,6 +26,7 @@ import org.utbot.engine.overrides.collections.UtHashSet
 import org.utbot.engine.overrides.collections.UtLinkedList
 import org.utbot.engine.overrides.UtOverrideMock
 import org.utbot.engine.overrides.collections.Collection
+import org.utbot.engine.overrides.collections.List
 import org.utbot.engine.overrides.collections.UtGenericStorage
 import org.utbot.engine.overrides.collections.UtOptional
 import org.utbot.engine.overrides.collections.UtOptionalDouble
@@ -133,6 +134,7 @@ private val classesToLoad = arrayOf(
     UtStringBuffer::class,
     Stream::class,
     Collection::class,
+    List::class,
     UtStream::class,
     UtStream.UtStreamIterator::class
 )


### PR DESCRIPTION
# Description

Implemented the wrapper for `java.util.List` static methods `of` and `copyOf` (from Java 9+).

Fixes #387 

## Type of Change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Automated testing

No additional tests are provided because this API was introduced in Java 9, but we have Java 8 in the project.

## Manual Scenario 

Tests for such a method have been generated:
```java
public void method() {
    List<String> list = List.of("uno", "trez", "quatro");

    Object[] strings1 = list.toArray();

    String[] strings2a = list.toArray(new String[list.size()]);
    String[] strings2b = list.toArray(new String[0]);

    for (Object  str : strings2a) {
        System.out.println(str);
    }
}
```

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] Tests that prove my change is effective
- [x] All tests pass locally with my changes
