### PR TITLE
ToString support for abstract collection using makeSymbolic #391

### DIFF
--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/AbstractCollection.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/AbstractCollection.java
@@ -1,0 +1,13 @@
+package org.utbot.engine.overrides.collections;
+
+import org.utbot.api.annotation.UtClassMock;
+
+import static org.utbot.api.mock.UtMock.makeSymbolic;
+
+@UtClassMock(target = java.util.AbstractCollection.class, internalUsage = true)
+public abstract class AbstractCollection<E> implements java.util.Collection<E> {
+    @Override
+    public String toString() {
+        return makeSymbolic();
+    }
+}

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtArrayList.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtArrayList.java
@@ -19,9 +19,9 @@ import org.jetbrains.annotations.NotNull;
 import org.utbot.engine.overrides.stream.UtStream;
 
 import static org.utbot.api.mock.UtMock.assume;
+import static org.utbot.api.mock.UtMock.assumeOrExecuteConcretely;
 import static org.utbot.engine.ResolverKt.MAX_LIST_SIZE;
 import static org.utbot.engine.overrides.UtOverrideMock.alreadyVisited;
-import static org.utbot.api.mock.UtMock.assumeOrExecuteConcretely;
 import static org.utbot.engine.overrides.UtOverrideMock.executeConcretely;
 import static org.utbot.engine.overrides.UtOverrideMock.parameter;
 import static org.utbot.engine.overrides.UtOverrideMock.visit;

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtHashMap.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtHashMap.java
@@ -15,9 +15,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static org.utbot.api.mock.UtMock.assume;
+import static org.utbot.api.mock.UtMock.makeSymbolic;
 import static org.utbot.engine.overrides.UtOverrideMock.alreadyVisited;
 import static org.utbot.engine.overrides.UtOverrideMock.doesntThrow;
-import static org.utbot.engine.overrides.UtOverrideMock.executeConcretely;
 import static org.utbot.engine.overrides.UtOverrideMock.parameter;
 import static org.utbot.engine.overrides.UtOverrideMock.visit;
 
@@ -556,8 +556,7 @@ public class UtHashMap<K, V> implements Map<K, V>, UtGenericStorage<K>, UtGeneri
     // TODO rewrite it JIRA:1604
     @Override
     public String toString() {
-        executeConcretely();
-        return super.toString();
+        return makeSymbolic();
     }
 
     public final class Entry implements Map.Entry<K, V> {

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/stream/Arrays.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/stream/Arrays.java
@@ -1,7 +1,9 @@
 package org.utbot.engine.overrides.stream;
 
 import org.utbot.api.annotation.UtClassMock;
+import org.utbot.engine.overrides.collections.UtArrayList;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 @UtClassMock(target = java.util.Arrays.class, internalUsage = true)
@@ -14,6 +16,13 @@ public class Arrays {
         }
 
         return new UtStream<>(array, startInclusive, endExclusive);
+    }
+
+    @SuppressWarnings({"unused", "varargs"})
+    @SafeVarargs
+    public static <T> List<T> asList(T... a) {
+        // TODO immutable collection https://github.com/UnitTestBot/UTBotJava/issues/398
+        return new UtArrayList<>(a);
     }
 
     // TODO primitive arrays https://github.com/UnitTestBot/UTBotJava/issues/146

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/CollectionWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/CollectionWrappers.kt
@@ -83,16 +83,23 @@ abstract class BaseOverriddenWrapper(protected val overriddenClassName: String) 
             return listOf(GraphResult(method.jimpleBody().graph()))
         }
 
-        val overriddenMethod = overriddenClass.findMethodOrNull(method.subSignature)
+        // We need to find either an override from the class (for example, implementation
+        // of the method from the wrapper) or a method from its ancestors.
+        // Note that the method from the ancestor might have substitutions as well.
+        // I.e., it is `toString` method for `UtArrayList` that is defined in
+        // `AbstractCollection` and has its own overridden implementation.
+        val overriddenMethod = overriddenClass
+            .findMethodOrNull(method.subSignature)
+            ?.let { typeRegistry.findSubstitutionOrNull(it) ?: it }
 
-        if (overriddenMethod == null) {
+        return if (overriddenMethod == null) {
             // No overridden method has been found, switch to concrete execution
             pathLogger.warn("Method ${overriddenClass.name}::${method.subSignature} not found, executing concretely")
-            return emptyList()
+            emptyList()
         } else {
             val jimpleBody = overriddenMethod.jimpleBody()
             val graphResult = GraphResult(jimpleBody.graph())
-            return listOf(graphResult)
+            listOf(graphResult)
         }
     }
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
@@ -2536,7 +2536,8 @@ class UtBotSymbolicEngine(
         if (methodSignature != makeSymbolicMethod.signature && methodSignature != nonNullableMakeSymbolic.signature) return null
 
         val method = environment.method
-        val isInternalMock = method.hasInternalMockAnnotation || method.declaringClass.allMethodsAreInternalMocks
+        val declaringClass = method.declaringClass
+        val isInternalMock = method.hasInternalMockAnnotation || declaringClass.allMethodsAreInternalMocks || declaringClass.isOverridden
         val parameters = resolveParameters(invokeExpr.args, invokeExpr.method.parameterTypes)
         val mockMethodResult = mockStaticMethod(invokeExpr.method, parameters)?.single()
             ?: error("Unsuccessful mock attempt of the `makeSymbolic` method call: $invokeExpr")

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/SootUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/SootUtils.kt
@@ -32,6 +32,8 @@ import org.utbot.engine.overrides.collections.UtOptional
 import org.utbot.engine.overrides.collections.UtOptionalDouble
 import org.utbot.engine.overrides.collections.UtOptionalInt
 import org.utbot.engine.overrides.collections.UtOptionalLong
+import org.utbot.engine.overrides.collections.AbstractCollection
+import org.utbot.engine.overrides.stream.Arrays
 import org.utbot.engine.overrides.stream.Stream
 import org.utbot.engine.overrides.stream.UtStream
 import java.io.File
@@ -91,6 +93,7 @@ private fun addBasicClasses(vararg classes: KClass<*>) {
 }
 
 private val classesToLoad = arrayOf(
+    AbstractCollection::class,
     UtMock::class,
     UtOverrideMock::class,
     UtLogicMock::class,
@@ -133,6 +136,7 @@ private val classesToLoad = arrayOf(
     UtStringBuilder::class,
     UtStringBuffer::class,
     Stream::class,
+    Arrays::class,
     Collection::class,
     List::class,
     UtStream::class,

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/strings/StringExamplesTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/strings/StringExamplesTest.kt
@@ -589,4 +589,14 @@ internal class StringExamplesTest : AbstractTestCaseGeneratorTest(
             )
         }
     }
+
+    @Test
+    fun testListToString() {
+        check(
+            StringExamples::listToString,
+            eq(1),
+            { r -> r == "[a, b, c]"},
+            coverage = DoNotCalculate
+        )
+    }
 }

--- a/utbot-sample/src/main/java/org/utbot/examples/strings/StringExamples.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/strings/StringExamples.java
@@ -1,5 +1,7 @@
 package org.utbot.examples.strings;
 
+import java.util.Arrays;
+
 import static java.lang.Boolean.valueOf;
 
 class IntPair {
@@ -410,5 +412,9 @@ public class StringExamples {
         } else {
             return "failure";
         }
+    }
+
+    public String listToString() {
+        return Arrays.asList("a", "b", "c").toString();
     }
 }


### PR DESCRIPTION
# Description

ToString for lists (as well as for other inheritors of `AbstractCollection` didn't work since it's too complicated for the engine because of StringBuilder usage somewhere inside of it. I've decided to make a temporary solution, implementing this method with `makeSymbolic` mechanism -- the method should return an unbounded symbolic variable, that will allow us to continue the analysis (in contrast to the `executeConcretely`). Later, the concrete execution will find the right result for such execution, if it's required. 

My suggestion is based on thoughts that people usually use `toString` on collections just for logging, showing or something like that, and the resulting line won't present in the path constraints. It's not 100% true, but in many cases, it will work.

Fixes #391

## Type of Change
- Breaking change. `toString` without concrete executor works differently now for the inheritors of the `AbstractCollection` and `HashSet`

# How Has This Been Tested?

## Automated Testing

Added test in the corresponding package.

## Manual Scenario 
Same test, since it is only about `toString` method on any collection.

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] No new warnings
- [x] Tests that prove my change is effective
- [x] All tests pass locally with my changes
