### PR TITLE
Bring back test class generation

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/TestGenerator.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/TestGenerator.kt
@@ -151,7 +151,9 @@ object TestGenerator {
                 }
             }.get()
 
-            return if (FileModificationService.getInstance().preparePsiElementForWrite(testClass)) testClass else null
+            testClass?.let {
+                return if (FileModificationService.getInstance().preparePsiElementForWrite(it)) it else null
+            }
         }
 
         val fileTemplate = FileTemplateManager.getInstance(testDirectory.project).getInternalTemplate(


### PR DESCRIPTION
# Description

For some reason, in the previous version if test class was not found, it was not generated, which lead to the problems described in issue.
That behavior was introduced in one of the latest commits, now it is reverted to the previous state, which was correct.

Fixes # (403)

## Type of Change

Please delete options that are not relevant.

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

Scenario provided in the issue.

# Checklist (remove irrelevant options):

- [ ] The change followed the style guidelines of the UTBot project
- [ ] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [ ] No new warnings
- [ ] Tests that prove my change is effective
- [ ] All tests pass locally with my changes
