### PR TITLE
Fix searching of modifiers field for JDK 8-17

### DIFF
--- a/utbot-core/src/main/kotlin/org/utbot/common/ReflectionUtil.kt
+++ b/utbot-core/src/main/kotlin/org/utbot/common/ReflectionUtil.kt
@@ -15,7 +15,15 @@ object Reflection {
         unsafe = f.get(null) as Unsafe
     }
 
-    private val modifiersField: Field = Field::class.java.getDeclaredField("modifiers")
+
+    // TODO: works on JDK 8-17. Doesn't work on JDK 18
+    private val modifiersField: Field = run {
+        val getDeclaredFields0 = Class::class.java.getDeclaredMethod("getDeclaredFields0", Boolean::class.java)
+        getDeclaredFields0.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        val fields = getDeclaredFields0.invoke(Field::class.java, false) as Array<Field>
+        fields.first { it.name == "modifiers" }
+    }
 
     init {
         modifiersField.isAccessible = true


### PR DESCRIPTION
# Description

Changed the way of searching `modifiers` field in `ReflectionUtil.kt`. The suggested change works for JDK 8-17, but doesn't work for JDK 18.

Fixes #374

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

<details>
<summary>
Repeated <b>To Reproduce</b> section from the #374:
</summary>

Steps to reproduce the behavior:

1. Define JDK-13 as primary (Path, JAVA_HOME)
2. Download one of the latest [CLI from master](https://github.com/UnitTestBot/UTBotJava/actions/runs/2596727243)
3. For simplicity in the folder where utbot-cli*.jar is located :
Create ExampleString.java using var (feature introduced in Java 9)

```
public class ExampleString {

    public void stringNewMethod() {
        var text = "Hello!\n This is String defined with var";

        text = text.toLowerCase();
        System.out.println(text);

        text = text.toUpperCase();
        System.out.println(text);
    }
}
```

4. Compile your files with JDK-13

`javac -version`

`javac ExampleString.class`

5. Run utbot-cli to generate tests for it, like that:

`java -jar utbot-cli-2022.7.jar generate --source ExampleString.java --classpath "D:\Current\Java" -o ExampleStringTest.java ExampleString
`
</details>


Tests are generated.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] Tests that prove my change is effective
- [x] All tests pass locally with my changes
