### PR TITLE
Fix CNFE: kotlin.collections.ArrayDeque in ContestEstimator

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/fuzzer/FallbackModelProvider.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/fuzzer/FallbackModelProvider.kt
@@ -21,7 +21,6 @@ import org.utbot.framework.plugin.api.util.kClass
 import org.utbot.fuzzer.providers.AbstractModelProvider
 import java.util.*
 import java.util.function.IntSupplier
-import kotlin.collections.ArrayDeque
 import kotlin.collections.ArrayList
 import kotlin.collections.HashMap
 import kotlin.reflect.KClass
@@ -58,12 +57,13 @@ open class FallbackModelProvider(
                     mutableMapOf()
                 )
             classId.isIterable -> {
+                @Suppress("RemoveRedundantQualifierName") // ArrayDeque must be taken from java, not from kotlin
                 val defaultInstance = when {
                     defaultConstructor != null -> defaultConstructor.newInstance()
                     classId.jClass.isAssignableFrom(java.util.ArrayList::class.java) -> ArrayList<Any>()
                     classId.jClass.isAssignableFrom(java.util.TreeSet::class.java) -> TreeSet<Any>()
                     classId.jClass.isAssignableFrom(java.util.HashMap::class.java) -> HashMap<Any, Any>()
-                    classId.jClass.isAssignableFrom(java.util.ArrayDeque::class.java) -> ArrayDeque<Any>()
+                    classId.jClass.isAssignableFrom(java.util.ArrayDeque::class.java) -> java.util.ArrayDeque<Any>()
                     classId.jClass.isAssignableFrom(java.util.BitSet::class.java) -> BitSet()
                     else -> null
                 }


### PR DESCRIPTION
# Description

Fuzzing creates `kotlin.collections.ArrayDeque` instead of `java.util.ArrayDeque` from FallbackModelProvider. Thus created by`UtModelConstructor#construct`  model was broken and ClassNotFoundException is raised.

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

Try to generate test for this method:
```java
public int a(Queue<Integer> queue) {
    if (queue.size() > 0) {
        return 0;
    }
    return -1;
}
```

There's should be a result like this:

```java
public void testA() {
    QueueIsNotFound queueIsNotFound = new QueueIsNotFound();
    ArrayDeque arrayDeque = new ArrayDeque();

    int actual = queueIsNotFound.a(arrayDeque);

    assertEquals(-1, actual);
}
```

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] Tests that prove my change is effective
- [ ] All tests pass locally with my changes
