### PR TITLE
Workaround: run concrete execution for invokedynamic

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
@@ -2471,7 +2471,7 @@ class UtBotSymbolicEngine(
             is JInterfaceInvokeExpr -> virtualAndInterfaceInvoke(invokeExpr.base, invokeExpr.methodRef, invokeExpr.args)
             is JVirtualInvokeExpr -> virtualAndInterfaceInvoke(invokeExpr.base, invokeExpr.methodRef, invokeExpr.args)
             is JSpecialInvokeExpr -> specialInvoke(invokeExpr)
-            is JDynamicInvokeExpr -> TODO("$invokeExpr")
+            is JDynamicInvokeExpr -> dynamicInvoke(invokeExpr)
             else -> error("Unknown class ${invokeExpr::class}")
         }
 
@@ -2729,6 +2729,15 @@ class UtBotSymbolicEngine(
         val parameters = resolveParameters(invokeExpr.args, method.parameterTypes)
         val invocation = Invocation(instance, method, parameters, InvocationTarget(instance, method))
         return commonInvokePart(invocation)
+    }
+
+    private fun dynamicInvoke(invokeExpr: JDynamicInvokeExpr): List<MethodResult> {
+        workaround(HACK) {
+            // The engine does not yet support JDynamicInvokeExpr, so switch to concrete execution if we encounter it
+            statesForConcreteExecution += environment.state
+            queuedSymbolicStateUpdates += UtFalse.asHardConstraint()
+            return emptyList()
+        }
     }
 
     /**


### PR DESCRIPTION
# Description

This PR adds a fake implementation of `invokedynamic` opcode: symbolic engine just initiates concrete execution for the branch.

This is a temporary solution to make operator `+` on Strings work on JDK 11.

Fixes #388 

## Type of Change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Automated Testing

Unit tests for `utbot-framework` should not fail (on JDK 1.8) because this commit implements the function that previously was just throwing an exception. Actually no existing tests should depend on the behavior of the new function.

## Manual Scenario 

Tests can now be generated for the following methods on JDK 11:

```
public class Concatenation {
    public String concatWithConstant(@NotNull String text) {
        return "prefix:" + text;
    }

    public String concatTwoStrings(@NotNull String a, @NotNull String b) {
        return a + b;
    }
}
```

Expected (with fuzzing turned off):
```
    @Test
    public void testConcatWithConstant() {
        Concatenation concatenation = new Concatenation();
        String string = "";

        String actual = concatenation.concatWithConstant(string);

        String expected = "prefix:";

        assertEquals(expected, actual);
    }

    @Test
    public void testConcatTwoStrings() {
        Concatenation concatenation = new Concatenation();
        String string = "";

        String actual = concatenation.concatTwoStrings(string, string);

        String expected = "";

        assertEquals(expected, actual);
    }
```

Before this PR no tests could be generated:

```
 public void testConcatWithConstant_errors() {
        // Couldn't generate some tests. List of errors:
        // 
        // 1 occurrences of:
        /* An operation is not implemented: dynamicinvoke "makeConcatWithConstants" <java.lang.String (java.lang.String)>(r0) <java.lang.invoke.StringConcatFactory:
        java.lang.invoke.CallSite makeConcatWithConstants(java.lang.invoke.MethodHandles$Lookup,java.lang.String,java.lang.invoke.MethodType,java.lang.String,java.lang.Object[])>("prefix:\u0001") */

    }
    
public void testConcatTwoStrings_errors() {
        // Couldn't generate some tests. List of errors:
        // 
        // 1 occurrences of:
        /* An operation is not implemented: dynamicinvoke "makeConcatWithConstants" <java.lang.String (java.lang.String,java.lang.String)>(r0, r1)
        <java.lang.invoke.StringConcatFactory: java.lang.invoke.CallSite makeConcatWithConstants(java.lang.invoke.MethodHandles$Lookup,java.lang.String,java.lang.invoke.MethodType,java.lang.String,java.lang.Object[])>("\u0001\u0001") */

    }
```

# Checklist (remove irrelevant options):

- [X] The change followed the style guidelines of the UTBot project
- [X] Self-review of the code is passed
- [X] The change contains enough commentaries, particularly in hard-to-understand areas
- [X] All tests pass locally with my changes
