### PR TITLE
Existing test file without test class obstruct generation #160

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/TestGenerator.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/TestGenerator.kt
@@ -207,6 +207,7 @@ object TestGenerator {
                 CodegenLanguage.KOTLIN -> "Kotlin Class"
             }
         )
+        runWriteAction { testDirectory.findFile(testClassName + model.codegenLanguage.extension)?.delete() }
         val createFromTemplate: PsiElement = FileTemplateUtil.createFromTemplate(
             fileTemplate,
             testClassName,


### PR DESCRIPTION
# Description

In case desired file exists we delete it under write action, before we create new one from template

Fixes #160 

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

See the issue, existing file should be overwritten silently

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
