### PR TITLE
Fuzzer should change objects with its public setters

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
@@ -406,6 +406,8 @@ class UtBotSymbolicEngine(
 
         val methodUnderTestDescription = FuzzedMethodDescription(executableId, collectConstantsForFuzzer(graph)).apply {
             compilableName = if (methodUnderTest.isMethod) executableId.name else null
+            className = executableId.classId.simpleName
+            packageName = executableId.classId.packageName
             val names = graph.body.method.tags.filterIsInstance<ParamNamesTag>().firstOrNull()?.names
             parameterNameMap = { index -> names?.getOrNull(index) }
         }

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/FuzzedMethodDescription.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/FuzzedMethodDescription.kt
@@ -26,6 +26,16 @@ class FuzzedMethodDescription(
     var compilableName: String? = null
 
     /**
+     * Class Name
+     */
+    var className: String? = null
+
+    /**
+     * Package Name
+     */
+    var packageName: String? = null
+
+    /**
      * Returns parameter name by its index in the signature
      */
     var parameterNameMap: (Int) -> String? = { null }

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/ObjectModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/ObjectModelProvider.kt
@@ -2,7 +2,10 @@ package org.utbot.fuzzer.providers
 
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.ConstructorId
+import org.utbot.framework.plugin.api.FieldId
+import org.utbot.framework.plugin.api.MethodId
 import org.utbot.framework.plugin.api.UtAssembleModel
+import org.utbot.framework.plugin.api.UtDirectSetFieldModel
 import org.utbot.framework.plugin.api.UtExecutableCallModel
 import org.utbot.framework.plugin.api.UtStatementModel
 import org.utbot.framework.plugin.api.util.id
@@ -10,6 +13,8 @@ import org.utbot.framework.plugin.api.util.isPrimitive
 import org.utbot.framework.plugin.api.util.isPrimitiveWrapper
 import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.framework.plugin.api.util.stringClassId
+import org.utbot.framework.plugin.api.util.voidClassId
+import org.utbot.fuzzer.FuzzedConcreteValue
 import org.utbot.fuzzer.FuzzedMethodDescription
 import org.utbot.fuzzer.FuzzedValue
 import org.utbot.fuzzer.ModelProvider
@@ -18,6 +23,8 @@ import org.utbot.fuzzer.fuzz
 import org.utbot.fuzzer.objectModelProviders
 import org.utbot.fuzzer.providers.ConstantsModelProvider.fuzzed
 import java.lang.reflect.Constructor
+import java.lang.reflect.Field
+import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 import java.util.function.BiConsumer
 import java.util.function.IntSupplier
@@ -32,6 +39,16 @@ class ObjectModelProvider : ModelProvider {
     private val idGenerator: IntSupplier
     private val recursion: Int
     private val limit: Int
+
+    private val nonRecursiveModelProvider: ModelProvider
+        get() {
+            val modelProviderWithoutRecursion = modelProvider.exceptIsInstance<ObjectModelProvider>()
+            return if (recursion > 0) {
+                ObjectModelProvider(idGenerator, limit = 1, recursion - 1).with(modelProviderWithoutRecursion)
+            } else {
+                modelProviderWithoutRecursion.withFallback(NullModelProvider)
+            }
+        }
 
     constructor(idGenerator: IntSupplier) : this(idGenerator, Int.MAX_VALUE)
 
@@ -55,20 +72,16 @@ class ObjectModelProvider : ModelProvider {
                         primitiveParameterizedConstructorsFirstAndThenByParameterCount
                     ).take(limit)
                 }
-                    .associateWith { constructorId ->
-                    val modelProviderWithoutRecursion = modelProvider.exceptIsInstance<ObjectModelProvider>()
+                .associateWith { constructorId ->
                     fuzzParameters(
                         constructorId,
-                        if (recursion > 0) {
-                            ObjectModelProvider(idGenerator, limit = 1, recursion - 1).with(modelProviderWithoutRecursion)
-                        } else {
-                            modelProviderWithoutRecursion.withFallback(NullModelProvider)
-                        }
+                        nonRecursiveModelProvider
                     )
                 }
                 .flatMap { (constructorId, fuzzedParameters) ->
                     if (constructorId.parameters.isEmpty()) {
-                        sequenceOf(assembleModel(idGenerator.asInt, constructorId, emptyList()))
+                        sequenceOf(assembleModel(idGenerator.asInt, constructorId, emptyList())) +
+                                generateModelsWithFieldsInitialization(constructorId, concreteValues)
                     }
                     else {
                         fuzzedParameters.map { params ->
@@ -83,6 +96,40 @@ class ObjectModelProvider : ModelProvider {
                 consumer.accept(index, fuzzedValue)
             }
         }
+    }
+
+    private fun generateModelsWithFieldsInitialization(constructorId: ConstructorId, concreteValues: Collection<FuzzedConcreteValue>): Sequence<FuzzedValue> {
+        val fields = findSuitableFields(constructorId.classId)
+        val syntheticClassFieldsSetterMethodDescription = FuzzedMethodDescription(
+            "${constructorId.classId.simpleName}<syntheticClassFieldSetter>",
+            voidClassId,
+            fields.map { it.classId },
+            concreteValues
+        )
+
+        return fuzz(syntheticClassFieldsSetterMethodDescription, nonRecursiveModelProvider)
+            .map { fieldValues ->
+                val fuzzedModel = assembleModel(idGenerator.asInt, constructorId, emptyList())
+                val assembleModel = fuzzedModel.model as? UtAssembleModel ?: error("Expected UtAssembleModel but ${fuzzedModel.model::class.java} found")
+                val modificationChain = assembleModel.modificationsChain as? MutableList ?: error("Modification chain must be mutable")
+                fieldValues.asSequence().mapIndexedNotNull { index, value ->
+                    val field = fields[index]
+                    when {
+                        field.setter != null -> UtExecutableCallModel(
+                            fuzzedModel.model,
+                            MethodId(constructorId.classId, field.setter.name, field.setter.returnType.id, listOf(field.classId)),
+                            listOf(value.model)
+                        )
+                        field.canBeSetDirectly -> UtDirectSetFieldModel(
+                            fuzzedModel.model,
+                            FieldId(constructorId.classId, field.name),
+                            value.model
+                        )
+                        else -> null
+                    }
+                }.forEach(modificationChain::add)
+                fuzzedModel
+            }
     }
 
     companion object {
@@ -112,13 +159,55 @@ class ObjectModelProvider : ModelProvider {
                 id,
                 constructorId.classId,
                 "${constructorId.classId.name}${constructorId.parameters}#" + id.toString(16),
-                instantiationChain
+                instantiationChain = instantiationChain,
+                modificationsChain = mutableListOf()
             ).apply {
                 instantiationChain += UtExecutableCallModel(null, constructorId, params.map { it.model }, this)
             }.fuzzed {
                 summary = "%var% = ${constructorId.classId.simpleName}(${constructorId.parameters.joinToString { it.simpleName }})"
             }
         }
+
+        private fun findSuitableFields(classId: ClassId): List<FieldDescription>  {
+            val jClass = classId.jClass
+            return jClass.declaredFields.map { field ->
+                FieldDescription(
+                    field.name,
+                    field.type.id,
+                    field.isPublic && !field.isFinal && !field.isStatic,
+                    jClass.findPublicSetterIfHasPublicGetter(field)
+                )
+            }
+        }
+
+        private fun Class<*>.findPublicSetterIfHasPublicGetter(field: Field): Method? {
+            val postfixName = field.name.capitalize()
+            val setterName = "set$postfixName"
+            val getterName = "get$postfixName"
+            val getter = try { getDeclaredMethod(getterName) } catch (_: NoSuchMethodException) { return null }
+            return if (getter has Modifier.PUBLIC && getter.returnType == field.type) {
+                declaredMethods.find {
+                    it has Modifier.PUBLIC &&
+                            it.name == setterName &&
+                            it.parameterCount == 1 &&
+                            it.parameterTypes[0] == field.type
+                }
+            } else {
+                null
+            }
+        }
+        private val Field.isPublic
+            get() = has(Modifier.PUBLIC)
+
+        private val Field.isFinal
+            get() = has(Modifier.FINAL)
+
+        private val Field.isStatic
+            get() = has(Modifier.STATIC)
+
+        private infix fun Field.has(modifier: Int) = (modifiers and modifier) != 0
+
+        private infix fun Method.has(modifier: Int) = (modifiers and modifier) != 0
 
         private val primitiveParameterizedConstructorsFirstAndThenByParameterCount =
             compareByDescending<ConstructorId> { constructorId ->
@@ -128,5 +217,12 @@ class ObjectModelProvider : ModelProvider {
             }.thenComparingInt { constructorId ->
                 constructorId.parameters.size
             }
+
+        private class FieldDescription(
+            val name: String,
+            val classId: ClassId,
+            val canBeSetDirectly: Boolean,
+            val setter: Method?,
+        )
     }
 }

--- a/utbot-fuzzers/src/test/java/org/utbot/framework/plugin/api/samples/FieldSetterClass.java
+++ b/utbot-fuzzers/src/test/java/org/utbot/framework/plugin/api/samples/FieldSetterClass.java
@@ -1,0 +1,28 @@
+package org.utbot.framework.plugin.api.samples;
+
+@SuppressWarnings("All")
+public class FieldSetterClass {
+
+    public static int pubStaticField;
+    public final int pubFinalField = 0;
+    public int pubField;
+    public int pubFieldWithSetter;
+    private int prvField;
+    private int prvFieldWithSetter;
+
+    public int getPubFieldWithSetter() {
+        return pubFieldWithSetter;
+    }
+
+    public void setPubFieldWithSetter(int pubFieldWithSetter) {
+        this.pubFieldWithSetter = pubFieldWithSetter;
+    }
+
+    public int getPrvFieldWithSetter() {
+        return prvFieldWithSetter;
+    }
+
+    public void setPrvFieldWithSetter(int prvFieldWithSetter) {
+        this.prvFieldWithSetter = prvFieldWithSetter;
+    }
+}

--- a/utbot-fuzzers/src/test/java/org/utbot/framework/plugin/api/samples/PackagePrivateFieldAndClass.java
+++ b/utbot-fuzzers/src/test/java/org/utbot/framework/plugin/api/samples/PackagePrivateFieldAndClass.java
@@ -1,0 +1,16 @@
+package org.utbot.framework.plugin.api.samples;
+
+@SuppressWarnings("All")
+public class PackagePrivateFieldAndClass {
+
+    volatile int pkgField = 0;
+
+    PackagePrivateFieldAndClass() {
+
+    }
+
+    PackagePrivateFieldAndClass(int value) {
+        pkgField = value;
+    }
+
+}


### PR DESCRIPTION
# Description

Fuzzing now can create object with empty constructor and change that object with public field or field setter if exists.
Setter can have any return type but must have corresponding getter.

Fixes #289

## Type of Change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Automated Testing

`org.utbot.framework.plugin.api.ModelProviderTest#test complex object is created with setters`

## Manual Scenario 

Try to generate test for method `equalsTo` from this class:

```java
public class MyJavaObject {

    public static int pubStaticField;
    public final int pubFinalField = 0;
    public int pubField;
    public int pubFieldWithSetter;
    private int prvField;
    private int prvFieldWithSetter;

    public int getPubFieldWithSetter() {
        return pubFieldWithSetter;
    }

    public void setPubFieldWithSetter(int pubFieldWithSetter) {
        this.pubFieldWithSetter = pubFieldWithSetter;
    }

    public int getPrvFieldWithSetter() {
        return prvFieldWithSetter;
    }

    public void setPrvFieldWithSetter(int prvFieldWithSetter) {
        this.prvFieldWithSetter = prvFieldWithSetter;
    }

    public boolean equalsTo(MyJavaObject o) {
        if (o.prvField > 0) {}
        if (this == o) return true;
        if (pubStaticField != o.pubStaticField) return false;
        if (pubFinalField != o.pubFinalField) return false;
        if (pubField != o.pubField) return false;
        if (pubFieldWithSetter != o.pubFieldWithSetter) return false;
        if (prvField != o.prvField) return false;
        if (prvFieldWithSetter != o.prvFieldWithSetter) return false;
        return true;
    }
}
```

Example of result test:

```java
@Test
@DisplayName("equalsTo: o = MyJavaObject() -> return true")
public void testEqualsToReturnsTrue() {
    MyJavaObject myJavaObject = new MyJavaObject();
    MyJavaObject myJavaObject1 = new MyJavaObject();
    myJavaObject1.pubField = 0;
    myJavaObject1.setPubFieldWithSetter(0);
    myJavaObject1.setPrvFieldWithSetter(0);

    boolean actual = myJavaObject.equalsTo(myJavaObject1);

    assertTrue(actual);
}
```

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] All tests pass locally with my changes
