### PR TITLE
Removed always used coverage-based minimization strategy for plugin

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerator.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerator.kt
@@ -36,10 +36,6 @@ class CodeGenerator(
     engineActions: MutableList<(UtBotSymbolicEngine) -> Unit> = mutableListOf(),
     isCanceled: () -> Boolean,
 ) {
-    init {
-        UtSettings.testMinimizationStrategyType = TestSelectionStrategyType.COVERAGE_STRATEGY
-    }
-
     val generator = (project.service<Settings>().testCasesGenerator as UtBotTestCaseGenerator).apply {
         init(Paths.get(buildDir), classpath, pluginJarsPath, engineActions, isCanceled)
     }


### PR DESCRIPTION
# Description

In `CodeGenerator` for the IntelliJ Idea plugin, we have a constant value `COVERAGE_STRATEGY` for `UtSettings.testMinimizationStrategyType` (which is already the default value for this setting in `UtSettings`) that could not be changed even from `settings.properties`. But the `DO_NOT_MINIMIZE` minimization strategy is also useful sometimes for debugging, so we need to remove this constant value for the plugin.

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

Running tests in plugin and checking ``UtSettings.testMinimizationStrategyType` value in runtime.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
- [x] All tests pass locally with my changes
