### PR TITLE
Support startColumn field in the SARIF report

### DIFF
--- a/utbot-core/src/main/kotlin/org/utbot/common/PathUtil.kt
+++ b/utbot-core/src/main/kotlin/org/utbot/common/PathUtil.kt
@@ -7,14 +7,14 @@ import java.nio.file.Paths
 object PathUtil {
 
     /**
-     * Creates a Path from the String
+     * Creates a Path from the String.
      */
     fun String.toPath(): Path = Paths.get(this)
 
     /**
-     * Finds a path for the [other] relative to the [root] if it is possible
+     * Finds a path for the [other] relative to the [root] if it is possible.
      *
-     * Example: safeRelativize("C:/project/", "C:/project/src/Main.java") = "src/Main.java"
+     * Example: safeRelativize("C:/project/", "C:/project/src/Main.java") = "src/Main.java".
      */
     fun safeRelativize(root: String?, other: String?): String? {
         if (root == null || other == null)
@@ -28,9 +28,9 @@ object PathUtil {
     }
 
     /**
-     * Removes class fully qualified name from absolute path to the file if it is possible
+     * Removes class fully qualified name from absolute path to the file if it is possible.
      *
-     * Example: removeClassFqnFromPath("C:/project/src/com/Main.java", "com.Main") = "C:/project/src/"
+     * Example: removeClassFqnFromPath("C:/project/src/com/Main.java", "com.Main") = "C:/project/src/".
      */
     fun removeClassFqnFromPath(sourceAbsolutePath: String?, classFqn: String?): String? {
         if (sourceAbsolutePath == null || classFqn == null)
@@ -48,9 +48,9 @@ object PathUtil {
     }
 
     /**
-     * Resolves `pathToResolve` against `absolutePath` and checks if a resolved path exists
+     * Resolves [toResolve] against [absolute] and checks if a resolved path exists.
      *
-     * Example: resolveIfExists("C:/project/src/", "Main.java") = "C:/project/src/Main.java"
+     * Example: resolveIfExists("C:/project/src/", "Main.java") = "C:/project/src/Main.java".
      */
     fun resolveIfExists(absolute: String, toResolve: String): String? {
         val absolutePath = absolute.toPath()
@@ -64,19 +64,19 @@ object PathUtil {
     }
 
     /**
-     * Replaces '\\' in the [path] with '/'
+     * Replaces '\\' in the [path] with '/'.
      */
     fun replaceSeparator(path: String): String =
         path.replace('\\', '/')
 
     /**
-     * Replaces '.' in the [classFqn] with '/'
+     * Replaces '.' in the [classFqn] with '/'.
      */
     fun classFqnToPath(classFqn: String): String =
         classFqn.replace('.', '/')
 
     /**
-     * Returns a URL to represent this path
+     * Returns a URL to represent this path.
      */
     fun Path.toURL(): URL =
         this.toUri().toURL()
@@ -88,7 +88,7 @@ object PathUtil {
         """<a href="file:///$filePath">${fileName}</a>"""
 
     /**
-     * Returns the extension of this file (including the dot)
+     * Returns the extension of this file (including the dot).
      */
     val Path.fileExtension: String
         get() = "." + this.toFile().extension

--- a/utbot-framework/src/main/kotlin/org/utbot/sarif/DataClasses.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/sarif/DataClasses.kt
@@ -142,12 +142,26 @@ data class SarifArtifact(
     val uriBaseId: String = "%SRCROOT%"
 )
 
+// all fields should be one-based
 data class SarifRegion(
     val startLine: Int,
     val endLine: Int? = null,
     val startColumn: Int? = null,
     val endColumn: Int? = null
-)
+) {
+    companion object {
+        /**
+         * Makes [startColumn] the first non-whitespace character in [startLine] in the [text].
+         * If the [text] contains less than [startLine] lines, [startColumn] == null.
+         */
+        fun fromStartLine(startLine: Int, text: String): SarifRegion {
+            val neededLine = text.split('\n').getOrNull(startLine - 1) // to zero-based
+            val startColumnZeroBased = neededLine?.takeWhile { it.toString().isBlank() }?.length
+            val startColumn = startColumnZeroBased?.let { it + 1 }
+            return SarifRegion(startLine = startLine, startColumn = startColumn)
+        }
+    }
+}
 
 // related locations
 

--- a/utbot-framework/src/main/kotlin/org/utbot/sarif/DataClasses.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/sarif/DataClasses.kt
@@ -154,10 +154,11 @@ data class SarifRegion(
          * Makes [startColumn] the first non-whitespace character in [startLine] in the [text].
          * If the [text] contains less than [startLine] lines, [startColumn] == null.
          */
-        fun fromStartLine(startLine: Int, text: String): SarifRegion {
+        fun withStartLine(text: String, startLine: Int): SarifRegion {
             val neededLine = text.split('\n').getOrNull(startLine - 1) // to zero-based
-            val startColumnZeroBased = neededLine?.takeWhile { it.toString().isBlank() }?.length
-            val startColumn = startColumnZeroBased?.let { it + 1 }
+            val startColumn = neededLine?.let {
+                neededLine.takeWhile { it.toString().isBlank() }.length + 1 // to one-based
+            }
             return SarifRegion(startLine = startLine, startColumn = startColumn)
         }
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/sarif/SarifReport.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/sarif/SarifReport.kt
@@ -252,6 +252,14 @@ class SarifReport(
         }
         if (testMethodStartsAt == -1)
             return null
+        /**
+         * ...
+         * public void testMethodName() { // <- `testMethodStartsAt`
+         *     ...
+         *     className.methodName(...) // <- needed `startLine`
+         *     ...
+         * }
+         */
 
         // searching needed method call
         val publicMethodCallPattern = "$methodName("
@@ -270,6 +278,7 @@ class SarifReport(
         //     shift to the method call     (+ methodCallShiftInTestMethod)
         //     to one-based                 (+ 1)
         val startLine = testMethodStartsAt + 1 + methodCallShiftInTestMethod + 1
+
         return SarifPhysicalLocation(
             SarifArtifact(sourceFinding.testsRelativePath),
             SarifRegion.withStartLine(generatedTestsCode, startLine)

--- a/utbot-framework/src/main/kotlin/org/utbot/sarif/SarifReport.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/sarif/SarifReport.kt
@@ -305,6 +305,6 @@ class SarifReport(
         try {
             utExecution.path.lastOrNull()?.stmt?.javaSourceStartLineNumber
         } catch (t: Throwable) {
-            utExecution.coverage?.coveredInstructions?.lastOrNull()?.lineNumber
+            null
         }
 }

--- a/utbot-framework/src/test/kotlin/org/utbot/sarif/SarifReportTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/sarif/SarifReportTest.kt
@@ -86,6 +86,7 @@ class SarifReportTest {
         assert(location.region.startLine == 1337)
         assert(relatedLocation.artifactLocation.uri.contains("MainTest.java"))
         assert(relatedLocation.region.startLine == 1)
+        assert(relatedLocation.region.startColumn == 1)
     }
 
     @Test
@@ -158,6 +159,7 @@ class SarifReportTest {
         }
         assert(codeFlowPhysicalLocations[0].artifactLocation.uri.contains("MainTest.java"))
         assert(codeFlowPhysicalLocations[0].region.startLine == 3)
+        assert(codeFlowPhysicalLocations[0].region.startColumn == 7)
     }
 
     @Test
@@ -181,6 +183,7 @@ class SarifReportTest {
         }
         assert(codeFlowPhysicalLocations[0].artifactLocation.uri.contains("MainTest.java"))
         assert(codeFlowPhysicalLocations[0].region.startLine == 4)
+        assert(codeFlowPhysicalLocations[0].region.startColumn == 5)
     }
 
     // internal
@@ -217,7 +220,7 @@ class SarifReportTest {
     private val generatedTestsCodeMain = """
         public void testMain_ThrowArithmeticException() {
             Main main = new Main();
-            main.main(0);
+              main.main(0); // shift for `startColumn` == 7
         }
     """.trimIndent()
 

--- a/utbot-gradle/src/main/kotlin/org/utbot/gradle/plugin/wrappers/SourceFindingStrategyGradle.kt
+++ b/utbot-gradle/src/main/kotlin/org/utbot/gradle/plugin/wrappers/SourceFindingStrategyGradle.kt
@@ -3,6 +3,7 @@ package org.utbot.gradle.plugin.wrappers
 import org.utbot.common.PathUtil
 import org.utbot.common.PathUtil.toPath
 import org.utbot.sarif.SourceFindingStrategy
+import java.io.File
 
 /**
  * The search strategy based on the information available to the Gradle.
@@ -36,6 +37,13 @@ class SourceFindingStrategyGradle(
             PathUtil.safeRelativize(projectRootPath, sourceCodeFile.absolutePath)
         } ?: defaultPath
     }
+
+    /**
+     * Finds the source file containing the class [classFqn].
+     * Returns null if the file does not exist.
+     */
+    override fun getSourceFile(classFqn: String, extension: String?): File? =
+        sourceSet.findSourceCodeFile(classFqn)
 
     // internal
 

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/sarif/SourceFindingStrategyIdea.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/sarif/SourceFindingStrategyIdea.kt
@@ -7,6 +7,7 @@ import org.utbot.sarif.SourceFindingStrategy
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiClass
 import org.jetbrains.kotlin.idea.search.allScope
+import java.io.File
 
 /**
  * The search strategy based on the information available to the PsiClass
@@ -28,6 +29,16 @@ class SourceFindingStrategyIdea(testClass: PsiClass) : SourceFindingStrategy() {
             .findClass(classFqn, project.allScope())?.let { psiClass ->
                 safeRelativize(project.basePath, psiClass.containingFile.virtualFile.path)
             } ?: (classFqnToPath(classFqn) + (extension ?: defaultExtension))
+
+    /**
+     * Finds the source file containing the class [classFqn].
+     * Returns null if the file does not exist.
+     */
+    override fun getSourceFile(classFqn: String, extension: String?): File? {
+        val psiClass = JavaPsiFacade.getInstance(project).findClass(classFqn, project.allScope())
+        val sourceCodeFile = psiClass?.containingFile?.virtualFile?.path?.let(::File)
+        return if (sourceCodeFile?.exists() == true) sourceCodeFile else null
+    }
 
     // internal
 

--- a/utbot-maven/src/main/kotlin/org/utbot/maven/plugin/wrappers/SourceFindingStrategyMaven.kt
+++ b/utbot-maven/src/main/kotlin/org/utbot/maven/plugin/wrappers/SourceFindingStrategyMaven.kt
@@ -3,6 +3,7 @@ package org.utbot.maven.plugin.wrappers
 import org.utbot.common.PathUtil
 import org.utbot.common.PathUtil.toPath
 import org.utbot.sarif.SourceFindingStrategy
+import java.io.File
 
 /**
  * The search strategy based on the information available to the Maven.
@@ -36,6 +37,13 @@ class SourceFindingStrategyMaven(
             PathUtil.safeRelativize(projectRootPath, sourceCodeFile.absolutePath)
         } ?: defaultPath
     }
+
+    /**
+     * Finds the source file containing the class [classFqn].
+     * Returns null if the file does not exist.
+     */
+    override fun getSourceFile(classFqn: String, extension: String?): File? =
+        mavenProjectWrapper.findSourceCodeFile(classFqn)
 
     // internal
 


### PR DESCRIPTION
# Description

Add a new field `startColumn` to the SARIF report.

An empty space at the beginning of the line is not highlighted:

![image](https://user-images.githubusercontent.com/54814796/177996176-929e189d-1d47-45ae-964b-d24615062e3b.png)

Fixes #452

## Type of Change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Automated Testing

`org.utbot.sarif.SarifReportTest`

## Manual Scenario 

1. Run test generation in any way
2. Look at the created SARIF report
3. Make sure it contains `physicalLocation.region.startColumn` field
4. Check the highlighted region (examples in the issue #452)

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] Tests that prove my change is effective
- [x] All tests pass locally with my changes
