### PR TITLE
assertArrayEquals overload is not found, tests doesn't compile #135

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/util/DependencyPatterns.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/util/DependencyPatterns.kt
@@ -37,13 +37,10 @@ fun MockFramework.patterns(): Patterns {
     return Patterns(moduleLibraryPatterns, libraryPatterns)
 }
 
-val JUNIT_4_JAR_PATTERN = Regex("junit-4(\\.[0-9]+){1,2}")
-val JUNIT_4_MVN_PATTERN = Regex("junit:junit:4(\\.[0-9]+){1,2}")
-val JUNIT_4_BASIC_PATTERN = Regex("JUnit4")
-val junit4Patterns = listOf(JUNIT_4_JAR_PATTERN, JUNIT_4_MVN_PATTERN, JUNIT_4_BASIC_PATTERN)
-
-val JUNIT4_BASIC_MODULE_PATTERN = Regex("junit$")
-val junit4ModulePatterns = listOf(JUNIT4_BASIC_MODULE_PATTERN)
+val JUNIT_4_JAR_PATTERN = Regex("junit-4(\\.1[2-9])(\\.[0-9]+)?")
+val JUNIT_4_MVN_PATTERN = Regex("junit:junit:4(\\.1[2-9])(\\.[0-9]+)?")
+val junit4Patterns = listOf(JUNIT_4_JAR_PATTERN, JUNIT_4_MVN_PATTERN)
+val junit4ModulePatterns = listOf(JUNIT_4_JAR_PATTERN, JUNIT_4_MVN_PATTERN)
 
 val JUNIT_5_JAR_PATTERN = Regex("junit-jupiter-5(\\.[0-9]+){1,2}")
 val JUNIT_5_MVN_PATTERN = Regex("org\\.junit\\.jupiter:junit-jupiter-api:5(\\.[0-9]+){1,2}")

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/ExternalLibraryDescriptors.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/ExternalLibraryDescriptors.kt
@@ -4,7 +4,7 @@ import com.intellij.openapi.roots.ExternalLibraryDescriptor
 
 //TODO: think about using JUnitExternalLibraryDescriptor from intellij-community sources (difficult to install)
 fun jUnit4LibraryDescriptor(versionInProject: String?) =
-    ExternalLibraryDescriptor("junit", "junit", "4.0", null, versionInProject ?: "4.13.2")
+    ExternalLibraryDescriptor("junit", "junit", "4.12", null, versionInProject ?: "4.13.2")
 
 fun jUnit5LibraryDescriptor(versionInProject: String?) =
     ExternalLibraryDescriptor("org.junit.jupiter", "junit-jupiter", "5.8.1", null, versionInProject ?: "5.8.1")


### PR DESCRIPTION
# Description

JUnit 4.12 is minimal required version for API compatibility reasons.
We detect precise version via library name and its JAR names as fallback.
In case user have JUnit 4.11 or older in project configuration "our" JUnit from Maven should be put in library list _upper_ than old one to provide proper imports in tests

Fixes #135

## Type of Change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 
Add JUnit 4.11 or older in project dependency
Generate tests for examples.PrimitiveArrays, resulting code uses assertArrayEquals(boolean[], boolean[]) that is absent in JUnit 4.11 or older, code won't compile. At first stage of generation JUnit 4.13.2 should be installed and put _higher_ than existing 4.11. As result test code can be compiled successfully.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
