### PR TITLE
Remove duplicates in SARIF report

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/TestGenerator.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/TestGenerator.kt
@@ -133,7 +133,13 @@ object TestGenerator {
         }
     }
 
-    private fun mergeSarifReports(model: GenerateTestsModel, sarifReportsPath : Path) {
+    private fun mergeSarifReports(model: GenerateTestsModel, sarifReportsPath: Path) {
+        val mergedReportFile = sarifReportsPath
+            .resolve("${model.project.name}Report.sarif")
+            .toFile()
+        // deleting the old report so that `sarifReports` does not contain it
+        mergedReportFile.delete()
+
         val sarifReports = sarifReportsPath.toFile()
             .walkTopDown()
             .filter { it.extension == "sarif" }
@@ -141,13 +147,12 @@ object TestGenerator {
             .toList()
 
         val mergedReport = SarifReport.mergeReports(sarifReports)
-        val mergedReportPath = sarifReportsPath.resolve("${model.project.name}Report.sarif")
-        mergedReportPath.toFile().writeText(mergedReport)
+        mergedReportFile.writeText(mergedReport)
 
         // notifying the user
         SarifReportNotifier.notify(
             info = """
-                SARIF report was saved to ${toHtmlLinkTag(mergedReportPath.toString())}$HTML_LINE_SEPARATOR
+                SARIF report was saved to ${toHtmlLinkTag(mergedReportFile.path)}$HTML_LINE_SEPARATOR
                 You can open it using the VS Code extension "Sarif Viewer"
             """.trimIndent()
         )


### PR DESCRIPTION
# Description

Now after _N_ test generations (using IDEA plugin) we have no duplicates in the merged SARIF report.
Fixes #463

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

Check the issue #463

# Checklist:

- [ ] The change followed the style guidelines of the UTBot project
- [ ] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
