### PR TITLE
Empty tooltips are shown on Java plugin popup #420

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -156,12 +156,14 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
 
     @Suppress("UNCHECKED_CAST")
     private val itemsToHelpTooltip = hashMapOf(
-        (codegenLanguages as ComboBox<CodeGenerationSettingItem>) to ContextHelpLabel.create(""),
-        (testFrameworks as ComboBox<CodeGenerationSettingItem>) to ContextHelpLabel.create(""),
-        (mockStrategies as ComboBox<CodeGenerationSettingItem>) to ContextHelpLabel.create(""),
-        (staticsMocking as ComboBox<CodeGenerationSettingItem>) to ContextHelpLabel.create(""),
-        (parametrizedTestSources as ComboBox<CodeGenerationSettingItem>) to ContextHelpLabel.create("")
+        (codegenLanguages as ComboBox<CodeGenerationSettingItem>) to createHelpLabel(),
+        (testFrameworks as ComboBox<CodeGenerationSettingItem>) to createHelpLabel(),
+        (mockStrategies as ComboBox<CodeGenerationSettingItem>) to createHelpLabel(),
+        (staticsMocking as ComboBox<CodeGenerationSettingItem>) to createHelpLabel(),
+        (parametrizedTestSources as ComboBox<CodeGenerationSettingItem>) to createHelpLabel()
     )
+
+    private fun createHelpLabel() = JBLabel(AllIcons.General.ContextHelp)
 
     init {
         title = "Generate tests with UtBot"
@@ -253,11 +255,11 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
 
     private fun Row.makePanelWithHelpTooltip(
         mainComponent: JComponent,
-        contextHelpLabel: ContextHelpLabel?
+        label: JBLabel?
     ): CellBuilder<JPanel> =
         component(Panel().apply {
             add(mainComponent, BorderLayout.LINE_START)
-            contextHelpLabel?.let { add(it, BorderLayout.LINE_END) }
+            label?.let { add(it, BorderLayout.LINE_END) }
         })
 
     private fun findSdkVersion(): JavaVersion? {
@@ -957,7 +959,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
     }
 }
 
-private fun ComboBox<CodeGenerationSettingItem>.setHelpTooltipTextChanger(helpLabel: ContextHelpLabel) {
+private fun ComboBox<CodeGenerationSettingItem>.setHelpTooltipTextChanger(helpLabel: JBLabel) {
     addActionListener { event ->
         val comboBox = event.source as ComboBox<*>
         val item = comboBox.item as CodeGenerationSettingItem


### PR DESCRIPTION
# Description
Unfortunately `com.intellij.ide.HelpTooltip` machinery doesn't work for us, the issue is caused by empty HelpTooltip plus standard javax.swing.JTooltip

The solution is to use standard tooltip only.

Fixes #420 

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

See the issue, help labels in our dialog should have standard tooltips with no empty artefacts.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings