### PR TITLE
Use ClassId name in prettifiedName if canonical name is null

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -642,8 +642,12 @@ open class ClassId(
     open val simpleName: String get() = jClass.simpleName
 
     /**
-     * For regular classes this is just a simple name
-     * For anonymous classes this includes the containing class and numeric indices of the anonymous class
+     * For regular classes this is just a simple name.
+     * For anonymous classes this includes the containing class and numeric indices of the anonymous class.
+     *
+     * Note: according to [java.lang.Class.getCanonicalName] documentation, local and anonymous classes
+     * do not have canonical names, as well as arrays whose elements don't have canonical classes themselves.
+     * In these cases prettified names are constructed using [ClassId.name] instead of [ClassId.canonicalName].
      */
     val prettifiedName: String
         get() {

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -646,10 +646,13 @@ open class ClassId(
      * For anonymous classes this includes the containing class and numeric indices of the anonymous class
      */
     val prettifiedName: String
-        get() = canonicalName
-            .substringAfterLast(".")
-            .replace(Regex("[^a-zA-Z0-9]"), "")
-            .let { if (this.isArray) it + "Array" else it }
+        get() {
+            val className = jClass.canonicalName ?: name // Explicit jClass reference to get null instead of exception
+            return className
+                .substringAfterLast(".")
+                .replace(Regex("[^a-zA-Z0-9]"), "")
+                .let { if (this.isArray) it + "Array" else it }
+        }
 
     open val packageName: String get() = jClass.`package`?.name ?: "" // empty package for primitives
 


### PR DESCRIPTION
# Description

Anonymous classes do not have canonical names, It makes `ClassId::canonicalName` property fail with an exception. `ClassId::prettifiedName` fails for anonymous classes as well.

This fix changes the call to exception-throwing `ClassId::canonicalName` in `prettifiedName` with an explicit call to `jClass::canonicalName` which returns a nullable value. If the class has no canonical name, `ClassId::name` is used instead.

Fixes #459 

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

Existing tests should not fail.

## Manual Scenario 

Run contest estimator with `methodFilter = "com.google.common.base.CaseFormat.*"` and `projectFilter = null`.

Without this fix, errors like this will be presented:
```
 public void testValues_errors()
     {
        // Couldn't generate some tests. List of errors:
        // 
        // 1 occurrences of:
        // ClassId com.google.common.base.CaseFormat$1 does not have canonical name
        
    }
```

With the fix, no these errors will be produced (many other errors will probably be generated instead, as there are related bugs and limitations in enum processing, both in engine and codegen).

# Checklist (remove irrelevant options):

- [X] The change followed the style guidelines of the UTBot project
- [X] Self-review of the code is passed
- [X] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [X] No new warnings
- [ ] Tests that prove my change is effective
- [X] All tests pass locally with my changes
