### PR TITLE
Test generation is enabled for interfaces via shortcut and menu actio…

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/actions/GenerateTestsAction.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/actions/GenerateTestsAction.kt
@@ -45,6 +45,7 @@ class GenerateTestsAction : AnAction() {
 
             if (psiElementHandler.isCreateTestActionAvailable(element)) {
                 val srcClass = psiElementHandler.containingClass(element) ?: return null
+                if (srcClass.isInterface) return null
                 val srcSourceRoot = srcClass.getSourceRoot() ?: return null
                 val srcMethods = TestIntegrationUtils.extractClassMethods(srcClass, false)
                 val focusedMethod = focusedMethodOrNull(element, srcMethods, psiElementHandler)


### PR DESCRIPTION
…ns #473

# Description

Filter out interface in editor-related branch

Fixes # (issue)

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

Create an interface with some (not default) methods, put cursor in its editor and call the action. Actually the action should be disabled.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
