### PR TITLE
UI. IDEA plugin dialog. Test framework is reset to JUnit5 on selectin…

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -901,7 +901,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
         }
 
         testFrameworks.model = DefaultComboBoxModel(enabledTestFrameworks.toTypedArray())
-        testFrameworks.item = if (currentFrameworkItem in enabledTestFrameworks && currentFrameworkItem.isInstalled) currentFrameworkItem else defaultItem
+        testFrameworks.item = if (currentFrameworkItem in enabledTestFrameworks) currentFrameworkItem else defaultItem
         testFrameworks.renderer = object : ColoredListCellRenderer<TestFramework>() {
             override fun customizeCellRenderer(
                 list: JList<out TestFramework>, value: TestFramework?,


### PR DESCRIPTION
…g Parametrized #472

# Description

Selected test framework shouldn't be reset to default one despite of what is install and what is not installed

Fixes #472 

## Type of Change

Please delete options that are not relevant.

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

See the issue

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
