### PR TITLE
The main branch is no more than 5 commits ahead

### DIFF
--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -7,10 +7,36 @@ on:
     branches: [main]
 
 jobs:
+  commits_behind_the_main:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-20.02
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        
+    - name: "Add commits number ahead of the main to env"
+      run: |
+        set -o xtrace
+        echo COMMITS_AHEAD_MAIN=$(git rev-list --left-only --count ${GITHUB_REF_NAME}...origin/main) >> $GITHUB_ENV
+        
+    - name: "Output information"
+      run: |
+        set -o xtrace
+        echo "The ${GITHUB_REF_NAME} is ahead of the [origin/main] by ${{ env.COMMITS_AHEAD_MAIN }} commits"
+        
+    - name: "Fails if the current branch is ahead of the [origin/main] by more than 5 commits"
+      if: ${{ env.COMMITS_AHEAD_MAIN > 5 }}
+      run: |
+        set -o xtrace
+        exit 1
+
   build_and_run_tests:
+    needs: commits_behind_the_main
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+          
     - uses: actions/setup-java@v2
       with:
         java-version: '8'


### PR DESCRIPTION
# Description

Now we check on PR if the current branch is no more than 5 commits behind the main branch. If it's not true, pipeline fails and the developer cannot merge into the main branch.

Fixes #491

## Type of Change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Automated Testing

Not applicable.

## Manual Scenario 

Provided changes were tested on fork.

# Checklist (remove irrelevant options):

- [ ] The change followed the style guidelines of the UTBot project
- [ ] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [ ] No new warnings
- [ ] Tests that prove my change is effective
- [ ] All tests pass locally with my changes
