### PR TITLE
Turn of fuzzing for AbstractModelBasedTest.kt

### DIFF
--- a/utbot-framework/src/test/kotlin/org/utbot/examples/AbstractModelBasedTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/AbstractModelBasedTest.kt
@@ -38,6 +38,7 @@ import kotlin.reflect.KFunction1
 import kotlin.reflect.KFunction2
 import kotlin.reflect.KFunction3
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.utbot.framework.UtSettings.useFuzzing
 
 internal abstract class AbstractModelBasedTest(
     testClass: KClass<*>,
@@ -88,6 +89,7 @@ internal abstract class AbstractModelBasedTest(
         workaround(HACK) {
             // @todo change to the constructor parameter
             checkSolverTimeoutMillis = 0
+            useFuzzing = false
         }
         val utMethod = UtMethod.from(method)
 


### PR DESCRIPTION
# Description

After implementing #439 there're 2 failed test: InnerMockWithFieldExampleTest and MockWithFieldExampleTest. The simple approach is to disable fuzzing for `AbstractModelBasedTest#internalCheck`

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

InnerMockWithFieldExampleTest and MockWithFieldExampleTest should pass

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] All tests pass locally with my changes
