### PR TITLE
Wrong wrapper for valueOf in parametrized tests #512

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
@@ -451,7 +451,7 @@ internal class CgMethodConstructor(val context: CgContext) : CgContextOwner by c
                             longClassId -> "${longWrapperClassId.simpleName.capitalize()}.valueOf(actual)"
                             byteClassId -> "${byteWrapperClassId.simpleName.capitalize()}.valueOf(actual)"
                             booleanClassId -> "${booleanWrapperClassId.simpleName.capitalize()}.valueOf(actual)"
-                            charClassId -> "${intWrapperClassId.simpleName.capitalize()}.valueOf(actual)"
+                            charClassId -> "${charWrapperClassId.simpleName.capitalize()}.valueOf(actual)"
                             floatClassId -> "${floatWrapperClassId.simpleName.capitalize()}.valueOf(actual)"
                             doubleWrapperClassId -> "${doubleWrapperClassId.simpleName.capitalize()}.valueOf(actual)"
                             else -> "actual"


### PR DESCRIPTION
# Description

Change Integer wrapper to Character wrapper when it's meant to be in parametrized test generation.

Fixes # ([512](https://github.com/UnitTestBot/UTBotJava/issues/512))

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

Run utbot-samples pipeline with parametrized tests generation.

## Manual Scenario 

Generate parametrized test for `CharacterWrapper.java` from `utbot-samples` for method `wrapperToPrimitive`. Verify that there is `Character.valueOf(...)` instead of `Integer.valueOf(...)`.
