### PR TITLE
Generate test by fuzzing for methods with no parameters #511

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
@@ -64,6 +64,7 @@ import org.utbot.framework.plugin.api.EnvironmentModels
 import org.utbot.framework.plugin.api.Instruction
 import org.utbot.framework.plugin.api.MissingState
 import org.utbot.framework.plugin.api.Step
+import org.utbot.framework.plugin.api.UtAssembleModel
 import org.utbot.framework.plugin.api.UtConcreteExecutionFailure
 import org.utbot.framework.plugin.api.UtError
 import org.utbot.framework.plugin.api.UtExecution
@@ -79,6 +80,7 @@ import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.utContext
 import org.utbot.framework.plugin.api.util.description
 import org.utbot.framework.util.jimpleBody
+import org.utbot.framework.plugin.api.util.voidClassId
 import org.utbot.fuzzer.FallbackModelProvider
 import org.utbot.fuzzer.FuzzedMethodDescription
 import org.utbot.fuzzer.FuzzedValue
@@ -89,10 +91,12 @@ import org.utbot.fuzzer.defaultModelProviders
 import org.utbot.fuzzer.fuzz
 import org.utbot.fuzzer.names.MethodBasedNameSuggester
 import org.utbot.fuzzer.names.ModelBasedNameSuggester
+import org.utbot.fuzzer.providers.ObjectModelProvider
 import org.utbot.instrumentation.ConcreteExecutor
 import soot.jimple.Stmt
 import soot.tagkit.ParamNamesTag
 import java.lang.reflect.Method
+import kotlin.random.Random
 import kotlin.system.measureTimeMillis
 
 val logger = KotlinLogging.logger {}
@@ -384,6 +388,7 @@ class UtBotSymbolicEngine(
         }
 
         val fallbackModelProvider = FallbackModelProvider { nextDefaultModelId++ }
+        val constantValues = collectConstantsForFuzzer(graph)
 
         val thisInstance = when {
             methodUnderTest.isStatic -> null
@@ -396,7 +401,9 @@ class UtBotSymbolicEngine(
                 null
             }
             else -> {
-                fallbackModelProvider.toModel(methodUnderTest.clazz).apply {
+                ObjectModelProvider { nextDefaultModelId++ }.withFallback(fallbackModelProvider).generate(
+                    FuzzedMethodDescription("thisInstance", voidClassId, listOf(methodUnderTest.clazz.id), constantValues)
+                ).take(10).shuffled(Random(0)).map { it.value.model }.first().apply {
                     if (this is UtNullModel) { // it will definitely fail because of NPE,
                         return@flow
                     }
@@ -411,17 +418,34 @@ class UtBotSymbolicEngine(
             val names = graph.body.method.tags.filterIsInstance<ParamNamesTag>().firstOrNull()?.names
             parameterNameMap = { index -> names?.getOrNull(index) }
         }
-        val modelProviderWithFallback = modelProvider(defaultModelProviders { nextDefaultModelId++ }).withFallback(fallbackModelProvider::toModel)
         val coveredInstructionTracker = Trie(Instruction::id)
         val coveredInstructionValues = mutableMapOf<Trie.Node<Instruction>, List<FuzzedValue>>()
         var attempts = UtSettings.fuzzingMaxAttempts
-        fuzz(methodUnderTestDescription, modelProviderWithFallback).forEach { values ->
+        val hasMethodUnderTestParametersToFuzz = executableId.parameters.isNotEmpty()
+        val fuzzedValues = if (hasMethodUnderTestParametersToFuzz) {
+            fuzz(methodUnderTestDescription, modelProvider(defaultModelProviders { nextDefaultModelId++ }))
+        } else {
+            // in case a method with no parameters is passed fuzzing tries to fuzz this instance with different constructors, setters and field mutators
+            val thisMethodDescription = FuzzedMethodDescription("thisInstance", voidClassId, listOf(methodUnderTest.clazz.id), constantValues).apply {
+                className = executableId.classId.simpleName
+                packageName = executableId.classId.packageName
+            }
+            fuzz(thisMethodDescription, ObjectModelProvider { nextDefaultModelId++ }.apply {
+                limitValuesCreatedByFieldAccessors = 500
+            })
+        }
+        fuzzedValues.forEach { values ->
             if (System.currentTimeMillis() >= until) {
                 logger.info { "Fuzzing overtime: $methodUnderTest" }
                 return@flow
             }
 
-            val initialEnvironmentModels = EnvironmentModels(thisInstance, values.map { it.model }, mapOf())
+            val initialEnvironmentModels = if (hasMethodUnderTestParametersToFuzz) {
+                EnvironmentModels(thisInstance, values.map { it.model }, mapOf())
+            } else {
+                check(values.size == 1 && values.first().model is UtAssembleModel)
+                EnvironmentModels(values.first().model, emptyList(), mapOf())
+            }
 
             try {
                 val concreteExecutionResult =
@@ -462,7 +486,7 @@ class UtBotSymbolicEngine(
                         fullPath = emptyList(),
                         coverage = concreteExecutionResult.coverage,
                         testMethodName = testMethodName?.testName,
-                        displayName = testMethodName?.displayName
+                        displayName = testMethodName?.takeIf { hasMethodUnderTestParametersToFuzz }?.displayName
                     )
                 )
             } catch (e: CancellationException) {

--- a/utbot-framework/src/main/kotlin/org/utbot/external/api/UtBotJavaApi.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/external/api/UtBotJavaApi.kt
@@ -32,6 +32,7 @@ import org.utbot.framework.plugin.api.util.withUtContext
 import org.utbot.framework.plugin.api.util.wrapperByPrimitive
 import org.utbot.fuzzer.FuzzedValue
 import org.utbot.fuzzer.ModelProvider
+import org.utbot.fuzzer.ModelProvider.Companion.yieldValue
 import org.utbot.instrumentation.ConcreteExecutor
 import org.utbot.instrumentation.execute
 import java.lang.reflect.Method
@@ -175,11 +176,13 @@ object UtBotJavaApi {
                 }
                 ?.map { UtPrimitiveModel(it) } ?: emptySequence()
 
-        val customModelProvider = ModelProvider { description, consumer ->
-            description.parametersMap.forEach { (classId, indices) ->
-                createPrimitiveModels(primitiveValuesSupplier, classId).forEach { model ->
-                    indices.forEach { index ->
-                        consumer.accept(index, FuzzedValue(model))
+        val customModelProvider = ModelProvider { description ->
+            sequence {
+                description.parametersMap.forEach { (classId, indices) ->
+                    createPrimitiveModels(primitiveValuesSupplier, classId).forEach { model ->
+                        indices.forEach { index ->
+                            yieldValue(index, FuzzedValue(model))
+                        }
                     }
                 }
             }

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/FuzzedParameter.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/FuzzedParameter.kt
@@ -1,0 +1,15 @@
+package org.utbot.fuzzer
+
+/**
+ * Fuzzed parameter of a method.
+ *
+ * @param index of the parameter in method signature
+ * @param value fuzzed values
+ */
+class FuzzedParameter(
+    val index: Int,
+    val value: FuzzedValue
+) {
+    operator fun component1() = index
+    operator fun component2() = value
+}

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/Fuzzer.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/Fuzzer.kt
@@ -20,7 +20,7 @@ private val logger = KotlinLogging.logger {}
 fun fuzz(description: FuzzedMethodDescription, vararg modelProviders: ModelProvider): Sequence<List<FuzzedValue>> {
     val values = List<MutableList<FuzzedValue>>(description.parameters.size) { mutableListOf() }
     modelProviders.forEach { fuzzingProvider ->
-        fuzzingProvider.generate(description) { index, model ->
+        fuzzingProvider.generate(description).forEach { (index, model) ->
             values[index].add(model)
         }
     }

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/AbstractModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/AbstractModelProvider.kt
@@ -2,20 +2,20 @@ package org.utbot.fuzzer.providers
 
 import org.utbot.framework.plugin.api.*
 import org.utbot.fuzzer.FuzzedMethodDescription
-import org.utbot.fuzzer.FuzzedValue
+import org.utbot.fuzzer.FuzzedParameter
 import org.utbot.fuzzer.ModelProvider
-import java.util.function.BiConsumer
+import org.utbot.fuzzer.ModelProvider.Companion.yieldValue
 
 /**
  * Simple model implementation.
  */
 @Suppress("unused")
 abstract class AbstractModelProvider: ModelProvider {
-    override fun generate(description: FuzzedMethodDescription, consumer: BiConsumer<Int, FuzzedValue>) {
+    override fun generate(description: FuzzedMethodDescription): Sequence<FuzzedParameter> = sequence{
         description.parametersMap.forEach { (classId, indices) ->
             toModel(classId)?.let { defaultModel ->
                 indices.forEach { index ->
-                    consumer.accept(index, defaultModel.fuzzed())
+                    yieldValue(index, defaultModel.fuzzed())
                 }
             }
         }

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/ArrayModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/ArrayModelProvider.kt
@@ -4,21 +4,20 @@ import org.utbot.framework.plugin.api.UtArrayModel
 import org.utbot.framework.plugin.api.util.defaultValueModel
 import org.utbot.framework.plugin.api.util.isArray
 import org.utbot.fuzzer.FuzzedMethodDescription
-import org.utbot.fuzzer.FuzzedValue
+import org.utbot.fuzzer.FuzzedParameter
 import org.utbot.fuzzer.ModelProvider
-import org.utbot.fuzzer.ModelProvider.Companion.consumeAll
-import java.util.function.BiConsumer
+import org.utbot.fuzzer.ModelProvider.Companion.yieldAllValues
 import java.util.function.IntSupplier
 
 class ArrayModelProvider(
     private val idGenerator: IntSupplier
 ) : ModelProvider {
-    override fun generate(description: FuzzedMethodDescription, consumer: BiConsumer<Int, FuzzedValue>) {
+    override fun generate(description: FuzzedMethodDescription): Sequence<FuzzedParameter> = sequence {
         description.parametersMap
             .asSequence()
             .filter { (classId, _) -> classId.isArray }
             .forEach { (arrayClassId, indices) ->
-                consumer.consumeAll(indices, listOf(0, 10).map { arraySize ->
+                yieldAllValues(indices, listOf(0, 10).map { arraySize ->
                     UtArrayModel(
                         id = idGenerator.asInt,
                         arrayClassId,

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/CharToStringModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/CharToStringModelProvider.kt
@@ -4,16 +4,16 @@ import org.utbot.framework.plugin.api.UtPrimitiveModel
 import org.utbot.framework.plugin.api.util.charClassId
 import org.utbot.framework.plugin.api.util.stringClassId
 import org.utbot.fuzzer.FuzzedMethodDescription
-import org.utbot.fuzzer.FuzzedValue
+import org.utbot.fuzzer.FuzzedParameter
 import org.utbot.fuzzer.ModelProvider
-import java.util.function.BiConsumer
+import org.utbot.fuzzer.ModelProvider.Companion.yieldValue
 
 /**
  * Collects all char constants and creates string with them.
  */
 object CharToStringModelProvider : ModelProvider {
-    override fun generate(description: FuzzedMethodDescription, consumer: BiConsumer<Int, FuzzedValue>) {
-        val indices = description.parametersMap[stringClassId] ?: return
+    override fun generate(description: FuzzedMethodDescription): Sequence<FuzzedParameter> = sequence {
+        val indices = description.parametersMap[stringClassId] ?: return@sequence
         if (indices.isNotEmpty()) {
             val string = description.concreteValues.asSequence()
                 .filter { it.classId == charClassId }
@@ -21,9 +21,11 @@ object CharToStringModelProvider : ModelProvider {
                 .filterIsInstance<Char>()
                 .joinToString(separator = "")
             if (string.isNotEmpty()) {
-                val model = UtPrimitiveModel(string).fuzzed()
-                indices.forEach {
-                    consumer.accept(it, model)
+                sequenceOf(string.reversed(), string).forEach { str ->
+                    val model = UtPrimitiveModel(str).fuzzed()
+                    indices.forEach {
+                        yieldValue(it, model)
+                    }
                 }
             }
         }

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/CollectionModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/CollectionModelProvider.kt
@@ -10,10 +10,9 @@ import org.utbot.framework.plugin.api.UtStatementModel
 import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.fuzzer.FuzzedMethodDescription
-import org.utbot.fuzzer.FuzzedValue
+import org.utbot.fuzzer.FuzzedParameter
 import org.utbot.fuzzer.ModelProvider
-import org.utbot.fuzzer.ModelProvider.Companion.consumeAll
-import java.util.function.BiConsumer
+import org.utbot.fuzzer.ModelProvider.Companion.yieldAllValues
 import java.util.function.IntSupplier
 
 /**
@@ -36,12 +35,12 @@ class CollectionModelProvider(
         java.util.Iterator::class.java to ::createIteratorModels,
     )
 
-    override fun generate(description: FuzzedMethodDescription, consumer: BiConsumer<Int, FuzzedValue>) {
+    override fun generate(description: FuzzedMethodDescription): Sequence<FuzzedParameter> = sequence {
         description.parametersMap
             .asSequence()
             .forEach { (classId, indices) ->
                  generators[classId.jClass]?.let { createModels ->
-                     consumer.consumeAll(indices, createModels().map { it.fuzzed() })
+                     yieldAllValues(indices, createModels().map { it.fuzzed() })
                  }
             }
     }

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/ConstantsModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/ConstantsModelProvider.kt
@@ -4,16 +4,17 @@ import org.utbot.framework.plugin.api.UtPrimitiveModel
 import org.utbot.framework.plugin.api.util.isPrimitive
 import org.utbot.fuzzer.FuzzedMethodDescription
 import org.utbot.fuzzer.FuzzedOp
+import org.utbot.fuzzer.FuzzedParameter
 import org.utbot.fuzzer.FuzzedValue
 import org.utbot.fuzzer.ModelProvider
-import java.util.function.BiConsumer
+import org.utbot.fuzzer.ModelProvider.Companion.yieldValue
 
 /**
  * Traverses through method constants and creates appropriate models for them.
  */
 object ConstantsModelProvider : ModelProvider {
 
-    override fun generate(description: FuzzedMethodDescription, consumer: BiConsumer<Int, FuzzedValue>) {
+    override fun generate(description: FuzzedMethodDescription): Sequence<FuzzedParameter> = sequence {
         description.concreteValues
             .asSequence()
             .filter { (classId, _) -> classId.isPrimitive }
@@ -25,7 +26,7 @@ object ConstantsModelProvider : ModelProvider {
                     .filterNotNull()
                     .forEach { m ->
                         description.parametersMap.getOrElse(m.model.classId) { emptyList() }.forEach { index ->
-                            consumer.accept(index, m)
+                            yieldValue(index, m)
                         }
                     }
         }

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/EnumModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/EnumModelProvider.kt
@@ -5,18 +5,17 @@ import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.isSubtypeOf
 import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.fuzzer.FuzzedMethodDescription
-import org.utbot.fuzzer.FuzzedValue
+import org.utbot.fuzzer.FuzzedParameter
 import org.utbot.fuzzer.ModelProvider
-import org.utbot.fuzzer.ModelProvider.Companion.consumeAll
-import java.util.function.BiConsumer
+import org.utbot.fuzzer.ModelProvider.Companion.yieldAllValues
 
 object EnumModelProvider : ModelProvider {
-    override fun generate(description: FuzzedMethodDescription, consumer: BiConsumer<Int, FuzzedValue>) {
+    override fun generate(description: FuzzedMethodDescription): Sequence<FuzzedParameter> = sequence {
         description.parametersMap
             .asSequence()
             .filter { (classId, _) -> classId.isSubtypeOf(Enum::class.java.id) }
             .forEach { (classId, indices) ->
-                consumer.consumeAll(indices, classId.jClass.enumConstants.filterIsInstance<Enum<*>>().map {
+                yieldAllValues(indices, classId.jClass.enumConstants.filterIsInstance<Enum<*>>().map {
                     UtEnumConstantModel(classId, it).fuzzed { summary = "%var% = ${it.name}" }
                 })
             }

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/NullModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/NullModelProvider.kt
@@ -3,22 +3,23 @@ package org.utbot.fuzzer.providers
 import org.utbot.framework.plugin.api.UtNullModel
 import org.utbot.framework.plugin.api.util.isRefType
 import org.utbot.fuzzer.FuzzedMethodDescription
-import org.utbot.fuzzer.FuzzedValue
+import org.utbot.fuzzer.FuzzedParameter
 import org.utbot.fuzzer.ModelProvider
-import java.util.function.BiConsumer
+import org.utbot.fuzzer.ModelProvider.Companion.yieldValue
 
 /**
  * Provides [UtNullModel] for every reference class.
  */
 @Suppress("unused") // disabled until fuzzer breaks test with null/nonnull annotations
 object NullModelProvider : ModelProvider {
-    override fun generate(description: FuzzedMethodDescription, consumer: BiConsumer<Int, FuzzedValue>) {
+    override fun generate(description: FuzzedMethodDescription): Sequence<FuzzedParameter> = sequence {
         description.parametersMap
             .asSequence()
             .filter { (classId, _) ->  classId.isRefType }
             .forEach { (classId, indices) ->
                 val model = UtNullModel(classId)
-                indices.forEach { consumer.accept(it, model.fuzzed { this.summary = "%var% = null" }) }
+                indices.forEach {
+                    yieldValue(it, model.fuzzed { this.summary = "%var% = null" }) }
             }
     }
 }

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/PrimitiveDefaultsModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/PrimitiveDefaultsModelProvider.kt
@@ -12,19 +12,20 @@ import org.utbot.framework.plugin.api.util.longClassId
 import org.utbot.framework.plugin.api.util.shortClassId
 import org.utbot.framework.plugin.api.util.stringClassId
 import org.utbot.fuzzer.FuzzedMethodDescription
+import org.utbot.fuzzer.FuzzedParameter
 import org.utbot.fuzzer.FuzzedValue
 import org.utbot.fuzzer.ModelProvider
-import java.util.function.BiConsumer
+import org.utbot.fuzzer.ModelProvider.Companion.yieldValue
 
 /**
  * Provides default values for primitive types.
  */
 object PrimitiveDefaultsModelProvider : ModelProvider {
-    override fun generate(description: FuzzedMethodDescription, consumer: BiConsumer<Int, FuzzedValue>) {
+    override fun generate(description: FuzzedMethodDescription): Sequence<FuzzedParameter> = sequence {
         description.parametersMap.forEach { (classId, parameterIndices) ->
             valueOf(classId)?.let { model ->
                 parameterIndices.forEach { index ->
-                    consumer.accept(index, model)
+                    yieldValue(index, model)
                 }
             }
         }

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/PrimitivesModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/PrimitivesModelProvider.kt
@@ -3,15 +3,16 @@ package org.utbot.fuzzer.providers
 import org.utbot.framework.plugin.api.UtPrimitiveModel
 import org.utbot.framework.plugin.api.util.*
 import org.utbot.fuzzer.FuzzedMethodDescription
+import org.utbot.fuzzer.FuzzedParameter
 import org.utbot.fuzzer.FuzzedValue
 import org.utbot.fuzzer.ModelProvider
-import java.util.function.BiConsumer
+import org.utbot.fuzzer.ModelProvider.Companion.yieldValue
 
 /**
  * Produces bound values for primitive types.
  */
 object PrimitivesModelProvider : ModelProvider {
-    override fun generate(description: FuzzedMethodDescription, consumer: BiConsumer<Int, FuzzedValue>) {
+    override fun generate(description: FuzzedMethodDescription): Sequence<FuzzedParameter> = sequence {
         description.parametersMap.forEach { (classId, parameterIndices) ->
             val primitives: List<FuzzedValue> = when (classId) {
                 booleanClassId -> listOf(
@@ -81,7 +82,7 @@ object PrimitivesModelProvider : ModelProvider {
 
             primitives.forEach { model ->
                 parameterIndices.forEach { index ->
-                    consumer.accept(index, model)
+                    yieldValue(index, model)
                 }
             }
         }

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/StringConstantModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/StringConstantModelProvider.kt
@@ -4,14 +4,14 @@ import org.utbot.framework.plugin.api.UtPrimitiveModel
 import org.utbot.framework.plugin.api.util.stringClassId
 import org.utbot.fuzzer.FuzzedMethodDescription
 import org.utbot.fuzzer.FuzzedOp
-import org.utbot.fuzzer.FuzzedValue
+import org.utbot.fuzzer.FuzzedParameter
 import org.utbot.fuzzer.ModelProvider
-import java.util.function.BiConsumer
+import org.utbot.fuzzer.ModelProvider.Companion.yieldValue
 import kotlin.random.Random
 
 object StringConstantModelProvider : ModelProvider {
 
-    override fun generate(description: FuzzedMethodDescription, consumer: BiConsumer<Int, FuzzedValue>) {
+    override fun generate(description: FuzzedMethodDescription): Sequence<FuzzedParameter> = sequence {
         val random = Random(72923L)
         description.concreteValues
             .asSequence()
@@ -22,7 +22,7 @@ object StringConstantModelProvider : ModelProvider {
                     .filterNotNull()
                     .map { UtPrimitiveModel(it) }.forEach { model ->
                         description.parametersMap.getOrElse(model.classId) { emptyList() }.forEach { index ->
-                            consumer.accept(index, model.fuzzed { summary = "%var% = string" })
+                            yieldValue(index, model.fuzzed { summary = "%var% = string" })
                         }
                     }
             }

--- a/utbot-fuzzers/src/test/kotlin/org/utbot/framework/plugin/api/FuzzedValueDescriptionTest.kt
+++ b/utbot-fuzzers/src/test/kotlin/org/utbot/framework/plugin/api/FuzzedValueDescriptionTest.kt
@@ -45,7 +45,7 @@ class FuzzedValueDescriptionTest {
                 parameters = listOf(intClassId),
                 concreteValues = concreteValues
             )
-        ) { _, value -> values.add(value) }
+        ).forEach { (_, value) -> values.add(value) }
         assertEquals(expected, values.size) {
             "Expected $expected values: a half is origin values and another is modified, but only ${values.size} are generated"
         }

--- a/utbot-fuzzers/src/test/kotlin/org/utbot/framework/plugin/api/ModelProviderTest.kt
+++ b/utbot-fuzzers/src/test/kotlin/org/utbot/framework/plugin/api/ModelProviderTest.kt
@@ -28,6 +28,7 @@ import org.utbot.framework.plugin.api.samples.PackagePrivateFieldAndClass
 import org.utbot.framework.plugin.api.util.primitiveByWrapper
 import org.utbot.framework.plugin.api.util.primitiveWrappers
 import org.utbot.framework.plugin.api.util.voidWrapperClassId
+import org.utbot.fuzzer.ModelProvider.Companion.yieldValue
 import org.utbot.fuzzer.defaultModelProviders
 import org.utbot.fuzzer.providers.EnumModelProvider
 import org.utbot.fuzzer.providers.EnumModelProvider.fuzzed
@@ -254,8 +255,10 @@ class ModelProviderTest {
 
     @Test
     fun `test fallback model can create custom values for any parameter`() {
-        val firstParameterIsUserGenerated = ModelProvider { _, consumer ->
-            consumer.accept(0, UtPrimitiveModel(-123).fuzzed())
+        val firstParameterIsUserGenerated = ModelProvider {
+            sequence {
+                yieldValue(0, UtPrimitiveModel(-123).fuzzed())
+            }
         }.withFallback(PrimitivesModelProvider)
 
         val result = collect(
@@ -513,7 +516,7 @@ class ModelProviderTest {
         block: FuzzedMethodDescription.() -> Unit = {}
     ): Map<Int, List<UtModel>> {
         return mutableMapOf<Int, MutableList<UtModel>>().apply {
-            modelProvider.generate(FuzzedMethodDescription(name, returnType, parameters, constants).apply(block)) { i, m ->
+            modelProvider.generate(FuzzedMethodDescription(name, returnType, parameters, constants).apply(block)).forEach { (i, m) ->
                 computeIfAbsent(i) { mutableListOf() }.add(m.model)
             }
         }


### PR DESCRIPTION
# Description

This PR resolves several issues:
* _This instance_ now created with any public constructor. Reflection is used only if there's no another ways to create _this instance_
* ModelProvider changed its signature to provide a sequence. This is needed to supply values lazily (for example, generate first 10 values and take random)
* For methods without parameters fuzzer will generate models to change _this instance_
* No more fallback for a regular value generating. Thus, fuzzer doesn't generate test using reflection anymore (except case with _this instance_)

Fixes #511

## Type of Change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

## Automated Testing

`org.utbot.framework.plugin.api.ModelProviderTest`

## Manual Scenario 

Test method `foo` from this example:

```java
package com.company.objects;

public class TestThisInstance {

    MyObject value;

    TestThisInstance() {}

    TestThisInstance(int value) {
        this.value = new MyObject();
        this.value.setField(value);
    }

    public boolean foo() {
        if (value.getField() < 100 || value.getField() == 102) {
            return true;
        }
        return value.getField() % 2 == 0;
    }

}

class MyObject {
    private int field;

    public int getField() {
        return field;
    }

    public void setField(int field) {
        this.field = field;
    }
}
```

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] All tests pass locally with my changes
