### PR TITLE
Enable Java assertions in framework integration tests

### DIFF
--- a/utbot-framework/build.gradle
+++ b/utbot-framework/build.gradle
@@ -65,3 +65,9 @@ test {
         jvmArgs '-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=9009'
     }
 }
+
+compileKotlin {
+    kotlinOptions {
+        freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+    }
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/Domain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/Domain.kt
@@ -223,7 +223,8 @@ sealed class TestFramework(
         executionInvoke: String,
         classPath: String,
         classesNames: List<String>,
-        buildDirectory: String
+        buildDirectory: String,
+        additionalArguments: List<String>
     ): List<String>
 
     override fun toString() = displayName
@@ -298,16 +299,23 @@ object TestNg : TestFramework(displayName = "TestNG") {
         simpleName = "DataProvider"
     )
 
+    @OptIn(ExperimentalStdlibApi::class)
     override fun getRunTestsCommand(
         executionInvoke: String,
         classPath: String,
         classesNames: List<String>,
-        buildDirectory: String
+        buildDirectory: String,
+        additionalArguments: List<String>
     ): List<String> {
         // TestNg requires a specific xml to run with
         writeXmlFileForTestSuite(buildDirectory, classesNames)
 
-        return listOf(executionInvoke, "$mainPackage.TestNG", "$buildDirectory${File.separator}$testXmlName")
+        return buildList {
+            add(executionInvoke)
+            addAll(additionalArguments)
+            add("$mainPackage.TestNG")
+            add("$buildDirectory${File.separator}$testXmlName")
+        }
     }
 
     private fun writeXmlFileForTestSuite(buildDirectory: String, testsNames: List<String>) {
@@ -375,12 +383,19 @@ object Junit4 : TestFramework("JUnit4") {
         )
     }
 
+    @OptIn(ExperimentalStdlibApi::class)
     override fun getRunTestsCommand(
         executionInvoke: String,
         classPath: String,
         classesNames: List<String>,
-        buildDirectory: String
-    ): List<String> = listOf(executionInvoke, "$mainPackage.runner.JUnitCore") + classesNames
+        buildDirectory: String,
+        additionalArguments: List<String>
+    ): List<String> = buildList {
+        add(executionInvoke)
+        addAll(additionalArguments)
+        add("$mainPackage.runner.JUnitCore")
+        addAll(classesNames)
+    }
 }
 
 object Junit5 : TestFramework("JUnit5") {
@@ -464,16 +479,20 @@ object Junit5 : TestFramework("JUnit5") {
     private const val junitVersion = "1.7.1" // TODO read it from gradle.properties
     private const val platformJarName: String = "junit-platform-console-standalone-$junitVersion.jar"
 
+    @OptIn(ExperimentalStdlibApi::class)
     override fun getRunTestsCommand(
         executionInvoke: String,
         classPath: String,
         classesNames: List<String>,
-        buildDirectory: String
-    ): List<String> =
-        listOf(
-            executionInvoke,
-            "-jar", classPath.split(File.pathSeparator).single { platformJarName in it },
-        ) + isolateCommandLineArgumentsToArgumentFile(listOf("-cp", classPath).plus(classesNames.map { "-c=$it" }))
+        buildDirectory: String,
+        additionalArguments: List<String>
+    ): List<String> = buildList {
+        add(executionInvoke)
+        addAll(additionalArguments)
+        add("-jar")
+        add(classPath.split(File.pathSeparator).single { platformJarName in it })
+        add(isolateCommandLineArgumentsToArgumentFile(listOf("-cp", classPath).plus(classesNames.map { "-c=$it" })))
+    }
 }
 
 enum class RuntimeExceptionTestsBehaviour(

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/codegen/JavaAssertTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/codegen/JavaAssertTest.kt
@@ -1,0 +1,18 @@
+package org.utbot.examples.codegen
+
+import org.junit.jupiter.api.Test
+import org.utbot.examples.UtValueTestCaseChecker
+import org.utbot.examples.eq
+import org.utbot.examples.isException
+
+class JavaAssertTest : UtValueTestCaseChecker(testClass = JavaAssert::class){
+    @Test
+    fun testAssertPositive() {
+        checkWithException(
+            JavaAssert::assertPositive,
+            eq(2),
+            { value, result -> value > 0 && result.isSuccess && result.getOrNull() == value },
+            { value, result -> value <= 0 && result.isException<java.lang.AssertionError>() }
+        )
+    }
+}

--- a/utbot-framework/src/test/kotlin/org/utbot/framework/codegen/CompilationAndRunUtils.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/framework/codegen/CompilationAndRunUtils.kt
@@ -56,8 +56,17 @@ fun runTests(
 ) {
     val classpath = System.getProperty("java.class.path") + File.pathSeparator + buildDirectory
     val executionInvoke = generatedLanguage.executorInvokeCommand
+    val additionalArguments = listOf(
+        "-ea", // Enable assertions
+    )
 
-    val command = testFramework.getRunTestsCommand(executionInvoke, classpath, testsNames, buildDirectory)
+    val command = testFramework.getRunTestsCommand(
+        executionInvoke,
+        classpath,
+        testsNames,
+        buildDirectory,
+        additionalArguments
+    )
 
     logger.trace { "Command to run test: [${command.joinToString(" ")}]" }
 

--- a/utbot-sample/src/main/java/org/utbot/examples/codegen/JavaAssert.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/codegen/JavaAssert.java
@@ -1,0 +1,8 @@
+package org.utbot.examples.codegen;
+
+public class JavaAssert {
+    public int assertPositive(int value) {
+        assert value > 0;
+        return value;
+    }
+}


### PR DESCRIPTION
# Description

This PR adds the `-ea` command line for `java` invocation when an integration test is run. The test runner code is refactored: a list of additional arguments is added, and list builders are used instead of list concatenation during the command line construction.

As list builders are experimental in Kotlin 1.4.20, necessary `@OptIn` annotations and the corresponding compiler argument have been added. They will become obsolete upon transition to Kotlin 1.7.

Fixes #538 

## Type of Change

- Bug fix (non-breaking change which fixes an issue)
- Refactoring

# How Has This Been Tested?

## Automated Testing

A new test with `assert` statement was added to the `utbot-framework` test suite: `org.utbot.examples.codegen.JavaAssertTest`.

## Manual Scenario 

It is an infrastructural change, so no explicit manual checking is expected. To verify that the change works, it is necessary to add a test involving Java `assert` statement to the `utbot-framework` test suite.

# Checklist (remove irrelevant options):

- [X] The change followed the style guidelines of the UTBot project
- [X] Self-review of the code is passed
- [X] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [X] No new warnings
- [X] Tests that prove my change is effective
- [X] All tests pass locally with my changes
