### PR TITLE
Fix possible NPE for package name in rarely cases

### DIFF
--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/ObjectModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/ObjectModelProvider.kt
@@ -153,7 +153,7 @@ class ObjectModelProvider : ModelProvider {
 
         private fun isAccessible(member: Member, packageName: String?): Boolean {
             return isPublic(member.modifiers) ||
-                    (isPackagePrivate(member.modifiers) && member.declaringClass.`package`.name == packageName)
+                    (packageName != null && isPackagePrivate(member.modifiers) && member.declaringClass.`package`?.name == packageName)
         }
 
         private fun isPackagePrivate(modifiers: Int): Boolean {


### PR DESCRIPTION
# Description

In some cases `Class#getPackage` can return null. This should fix these cases.

## Type of Change

- Minor bug fix (non-breaking small changes)

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] Tests that prove my change is effective
- [ ] All tests pass locally with my changes
