### PR TITLE
Try another approach to mark hanging generated tests #371

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/Domain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/Domain.kt
@@ -27,6 +27,8 @@ import org.utbot.framework.plugin.api.util.objectClassId
 import org.utbot.framework.plugin.api.util.shortArrayClassId
 import org.utbot.framework.plugin.api.util.voidClassId
 import java.io.File
+import org.utbot.framework.plugin.api.util.longClassId
+import org.utbot.framework.plugin.api.util.voidWrapperClassId
 
 data class TestClassFile(val packageName: String, val imports: List<Import>, val testClass: String)
 
@@ -410,6 +412,19 @@ object Junit5 : TestFramework("JUnit5") {
         simpleName = "TimeUnit"
     )
 
+    val durationClassId = BuiltinClassId(
+        name = "Duration",
+        canonicalName = "java.time.Duration",
+        simpleName = "Duration"
+    )
+
+    val ofMillis = builtinStaticMethodId(
+        classId = durationClassId,
+        name = "ofMillis",
+        returnType = durationClassId,
+        arguments = arrayOf(longClassId)
+    )
+
     override val testAnnotationId = BuiltinClassId(
         name = "$JUNIT5_PACKAGE.Test",
         canonicalName = "$JUNIT5_PACKAGE.Test",
@@ -443,6 +458,16 @@ object Junit5 : TestFramework("JUnit5") {
         returnType = java.lang.Throwable::class.id,
         arguments = arrayOf(
             Class::class.id,
+            executableClassId
+        )
+    )
+
+    val assertTimeoutPreemptively = builtinStaticMethodId(
+        classId = assertionsClass,
+        name = "assertTimeoutPreemptively",
+        returnType = voidWrapperClassId,
+        arguments = arrayOf(
+            durationClassId,
             executableClassId
         )
     )


### PR DESCRIPTION
# Description

**Note, this issue affects JUnit 5 only!**

New methods and entities were added to codegen to provide required [assertion wrapper](https://stackoverflow.com/questions/57116801/how-to-fail-a-test-after-a-timeout-is-exceeded-in-junit-5/57116802#57116802). Now tests with timeout are being abrupt just after exceeding time limit.

Fixes #371 

## Type of Change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Manual Scenario 

Set handing test timeout to 100ms and generate tests for the example:
```
package issue371;

import java.io.File;

public class PomXmlFinder {
    public static void main(String[] args) {
        scan(new File("C:\\"));
    }

    private static int counter = 0;

    private static void scan(File file) {
        if (counter > 10) return;
        if (file.isFile() && file.getName().equals("pom.xml")) {
            counter++;
            if (counter > 10) return;
            System.out.println(file.getAbsolutePath());
        }
        File[] files = file.listFiles();
        if (files != null) {
            for (File child : files) {
                scan(child);
            }
        }
    }
}

```
Generated test methods should be not only annotated with `@Timeout` tag but also have wrappers like `assertTimeoutPreemptively(Duration.ofMillis(100L), () -> PomXmlFinder.main(stringArray));` inside
# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
