### PR TITLE
Skip test generation for abstract methods #550

### DIFF
--- a/utbot-cli/src/main/kotlin/org/utbot/cli/GenerateTestsCommand.kt
+++ b/utbot-cli/src/main/kotlin/org/utbot/cli/GenerateTestsCommand.kt
@@ -96,6 +96,7 @@ class GenerateTestsCommand :
             val classUnderTest: KClass<*> = loadClassBySpecifiedFqn(targetClassFqn)
             val targetMethods = classUnderTest.targetMethods()
                 .filterWhen(UtSettings.skipTestGenerationForSyntheticMethods) { !isKnownSyntheticMethod(it) }
+                .filterNot { it.callable.isAbstract }
             val testCaseGenerator = initializeGenerator(workingDirectory)
 
             if (targetMethods.isEmpty()) {

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -40,6 +40,7 @@ import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiManager
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.SyntheticElement
+import com.intellij.psi.PsiModifier
 import com.intellij.refactoring.PackageWrapper
 import com.intellij.refactoring.ui.MemberSelectionTable
 import com.intellij.refactoring.ui.PackageNameReferenceEditorCombo
@@ -129,6 +130,7 @@ import javax.swing.JComponent
 import javax.swing.JList
 import javax.swing.JPanel
 import kotlin.streams.toList
+import org.utbot.intellij.plugin.util.isAbstract
 
 private const val RECENTS_KEY = "org.utbot.recents"
 
@@ -372,6 +374,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
         if (srcClasses.size == 1) {
             items = TestIntegrationUtils.extractClassMethods(srcClasses.single(), false)
                 .filterWhen(UtSettings.skipTestGenerationForSyntheticMethods) { it.member !is SyntheticElement }
+                .filterNot { it.isAbstract }
             updateMethodsTable(items)
         } else {
             items = srcClasses.map { MemberInfo(it) }

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/MemberInfoUtils.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/MemberInfoUtils.kt
@@ -1,0 +1,8 @@
+package org.utbot.intellij.plugin.util
+
+import com.intellij.psi.PsiModifier
+import com.intellij.psi.PsiModifierListOwner
+import com.intellij.refactoring.classMembers.MemberInfoBase
+
+val MemberInfoBase<out PsiModifierListOwner>.isAbstract: Boolean
+    get() = this.member.modifierList?.hasModifierProperty(PsiModifier.ABSTRACT)?: false

--- a/utbot-junit-contest/src/main/kotlin/org/utbot/contest/Contest.kt
+++ b/utbot-junit-contest/src/main/kotlin/org/utbot/contest/Contest.kt
@@ -442,6 +442,7 @@ private fun prepareClass(kotlinClass: KClass<*>, methodNameFilter: String?): Lis
         .filter { methodNameFilter?.equals(it.callable.name) ?: true }
         .filterNot { it.isConstructor && (it.clazz.isAbstract || it.clazz.java.isEnum) }
         .filterWhen(UtSettings.skipTestGenerationForSyntheticMethods) { !isKnownSyntheticMethod(it) }
+        .filterNot { it.callable.isAbstract }
         .toList()
 
     return if (kotlinClass.nestedClasses.isEmpty()) {


### PR DESCRIPTION
# Description

* Added filters for abstract methods, so now they don't reach test generator
* Added catch for exception which is thrown when plugin tries to generate tests for an abstract class that has no implementations (in this case error message is shown in UI)

Fixes #550

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

No tests were added.

## Manual Scenario 

* Launch plugin on example from #550 -- works as expected.
* Launch plugin on a package with abstract class with default functions and no derived classes -- test generation for this class is skipped and an error message is shown.

# Checklist (remove irrelevant options):

- [ ] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
