### PR TITLE
Stricter check for enum classes in EnumModelProvider #558

### DIFF
--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/EnumModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/EnumModelProvider.kt
@@ -13,7 +13,7 @@ object EnumModelProvider : ModelProvider {
     override fun generate(description: FuzzedMethodDescription): Sequence<FuzzedParameter> = sequence {
         description.parametersMap
             .asSequence()
-            .filter { (classId, _) -> classId.isSubtypeOf(Enum::class.java.id) }
+            .filter { (classId, _) -> classId.jClass.isEnum }
             .forEach { (classId, indices) ->
                 yieldAllValues(indices, classId.jClass.enumConstants.filterIsInstance<Enum<*>>().map {
                     UtEnumConstantModel(classId, it).fuzzed { summary = "%var% = ${it.name}" }


### PR DESCRIPTION
Co-author: @volivan239

# Description

Java enums allow users to declare anonymous classes corresponding to constants. These classes are commonly used to overload `toString` or methods declared in the enum class. These classes are not enums themselves. According to the comment in the `java.lang.Class#isEnum` method:
```
        // An enum must both directly extend java.lang.Enum and have
        // the ENUM bit set; classes for specialized enum constants
        // don't do the former.
```

Suppose we have an enum:
```
public enum Foo {
    A {
        @Override
        public String toString() { return "It's A"; }
    },
    B {
        @Override
        public String toString() { return "It's B"; }
    }
}
```
Anonymous inner classes `Foo$1` and `Foo$2` are (non-direct) subtypes of `java.lang.Enum`, but are not declared as enums, and are not considered enums from the point of view of the Java specification: their direct superclass is `Foo`.

These specialized anonymous classes do not have enum constants themselves, and `getEnumConstants` method will return `null` for them.

Fixes #558 

## Type of Change

- Bug fix (non-breaking change which fixes an issue)
- Refactoring (typos and non-functional changes) 

# How Has This Been Tested?

## Automated Testing

No new unit tests are added. All existing tests should pass.

## Manual Scenario 

Run the contest estimator on `com.google.common.base.CaseFormat` class of the Guava library by editing `main` function body in `ContestEstimator.kt`:

```
methodFilter = "com.google.common.base.CaseFormat.*"
projectFilter = null
```

Tests (probably with errors due to other issues) should be generated. Without the fix, a `NullPointerException` would be thrown, and no tests would be generated.

# Checklist:

- [X] The change followed the style guidelines of the UTBot project
- [X] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [X] No new warnings
- [ ] New tests have been added
- [X] All fuzzer tests pass locally with my changes
