### PR TITLE
Added pre-condition for non-empty paths in the ExecutionMetric to avoid unclear NPE #267

### DIFF
--- a/utbot-summary/src/main/kotlin/org/utbot/summary/clustering/ExecutionMetric.kt
+++ b/utbot-summary/src/main/kotlin/org/utbot/summary/clustering/ExecutionMetric.kt
@@ -9,6 +9,9 @@ class ExecutionMetric : Metric<Iterable<Step>> {
      * Minimum Edit Distance
      */
     private fun compareTwoPaths(path1: Iterable<Step>, path2: Iterable<Step>): Double {
+        require(path1.count() > 0) { "Two paths can not be compared: path1 is empty!"}
+        require(path2.count() > 0) { "Two paths can not be compared: path2 is empty!"}
+
         val distances = Array(path1.count()) { i -> Array(path2.count()) { j -> i + j } }
 
         for (i in 1 until path1.count()) {
@@ -22,7 +25,17 @@ class ExecutionMetric : Metric<Iterable<Step>> {
                 distances[i][j] = minOf(d1, d2, d3)
             }
         }
-        return distances.last().last().toDouble()
+
+        if (distances.isNotEmpty()) {
+            val last = distances.last()
+            if (last.isNotEmpty()) {
+                return last.last().toDouble()
+            } else {
+                throw IllegalStateException("Last row in the distance matrix has 0 columns. It should contain more or equal 1 column.")
+            }
+        } else {
+            throw IllegalStateException("Distance matrix has 0 rows. It should contain more or equal 1 row.")
+        }
     }
 
     private fun distance(stmt1: Step, stmt2: Step): Int {

--- a/utbot-summary/src/test/kotlin/org/utbot/summary/clustering/ExecutionMetricTest.kt
+++ b/utbot-summary/src/test/kotlin/org/utbot/summary/clustering/ExecutionMetricTest.kt
@@ -1,0 +1,26 @@
+package org.utbot.summary.clustering
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+import org.utbot.framework.plugin.api.Step
+import java.lang.IllegalArgumentException
+
+internal class ExecutionMetricTest {
+    @Test
+    fun computeWithTwoEmptySteps() {
+        val executionMetric = ExecutionMetric()
+        val object1 = listOf<Step>()
+        val object2 = listOf<Step>()
+
+
+        val exception = Assertions.assertThrows(IllegalArgumentException::class.java) {
+            executionMetric.compute(object1 = object1, object2 = object2)
+        }
+
+        Assertions.assertEquals(
+            "Two paths can not be compared: path1 is empty!",
+            exception.message
+        )
+    }
+}


### PR DESCRIPTION
# Description

The ExecutionMetric works with the non-empty paths, but could obtain it sometimes.
I've added pre-condition checks and throw a few exceptions to handle it later and with the correct message.

Fixes # 267

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Automated Testing

Added a new test to reproduce the condition with empty paths
```ExecutionMetricTest.computeWithTwoEmptySteps```

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] New tests have been added
- [x] All tests pass locally with my changes
