### PR TITLE
Already created test source root is not found in Idea project #497

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -1081,7 +1081,7 @@ enum class CodegenLanguage(
     @Suppress("unused") override val description: String = "Generate unit tests in $displayName"
 ) : CodeGenerationSettingItem {
     JAVA(displayName = "Java"),
-    KOTLIN(displayName = "Kotlin");
+    KOTLIN(displayName = "Kotlin (experimental)");
 
     enum class OperatingSystem {
         WINDOWS,

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/components/TestFolderComboWithBrowseButton.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/components/TestFolderComboWithBrowseButton.kt
@@ -14,7 +14,6 @@ import java.io.File
 import javax.swing.DefaultComboBoxModel
 import javax.swing.JList
 import org.utbot.common.PathUtil
-import org.utbot.framework.plugin.api.CodegenLanguage
 import org.utbot.intellij.plugin.models.GenerateTestsModel
 import org.utbot.intellij.plugin.ui.utils.addDedicatedTestRoot
 import org.utbot.intellij.plugin.ui.utils.suitableTestSourceRoots
@@ -46,7 +45,7 @@ class TestFolderComboWithBrowseButton(private val model: GenerateTestsModel) : C
             }
         }
 
-        val testRoots = model.testModule.suitableTestSourceRoots(CodegenLanguage.JAVA).toMutableList()
+        val testRoots = model.testModule.suitableTestSourceRoots().toMutableList()
         model.testModule.addDedicatedTestRoot(testRoots)
         if (testRoots.isNotEmpty()) {
             configureRootsCombo(testRoots)


### PR DESCRIPTION
# Description
The problem is that we add utbot_tests as kotlin-test root (see .iml file for module, the line looks like 
`<sourceFolder url="file://$MODULE_DIR$/utbot_tests" type="kotlin-test" />` in case we add it initially for .kt source file. It's not a problem when it doesn't break a workflow. But it did.
1. Show all test roots (Java and Kotlin) in combobox, the choice is up to user.
2. Generation support for Kotlin is not stable, thus codegen language was renamed to _Kotlin (experimental)_ for a while.

Fixes #497 

## Type of Change

Please delete options that are not relevant.

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

See steps and attached project in the issue

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
