### PR TITLE
Refactor code related to block construction

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -753,6 +753,7 @@ open class ClassId @JvmOverloads constructor(
  */
 class BuiltinClassId(
     name: String,
+    elementClassId: ClassId? = null,
     override val canonicalName: String,
     override val simpleName: String,
     // by default we assume that the class is not a member class
@@ -769,6 +770,7 @@ class BuiltinClassId(
     override val isInner: Boolean = false,
     override val isNested: Boolean = false,
     override val isSynthetic: Boolean = false,
+    override val typeParameters: TypeParameters = TypeParameters(),
     override val allMethods: Sequence<MethodId> = emptySequence(),
     override val allConstructors: Sequence<ConstructorId> = emptySequence(),
     override val outerClass: Class<*>? = null,
@@ -777,7 +779,7 @@ class BuiltinClassId(
             -1, 0 -> ""
             else -> canonicalName.substring(0, index)
         },
-) : ClassId(name = name, isNullable = isNullable) {
+) : ClassId(name = name, isNullable = isNullable, elementClassId = elementClassId) {
     init {
         BUILTIN_CLASSES_BY_NAMES[name] = this
     }

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SignatureUtil.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SignatureUtil.kt
@@ -1,5 +1,6 @@
 package org.utbot.framework.plugin.api.util
 
+import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.ExecutableId
 import java.lang.reflect.Constructor
 import java.lang.reflect.Executable
@@ -38,6 +39,23 @@ fun Constructor<*>.bytecodeSignature() = buildString {
 
 
 fun Class<*>.bytecodeSignature(): String = id.jvmName
+
+/**
+ * Method [Class.getName] works differently for arrays than for other types.
+ * - When an element of an array is a reference type (e.g. `java.lang.Object`),
+ * the array of `java.lang.Object` will have name `[Ljava.lang.Object;`.
+ * - When an element of an array is a primitive type (e.g. `int`),
+ * the array of `int` will have name `[I`.
+ *
+ * So, this property returns the name of the given class in the format of an array element type name.
+ * Basically, it performs conversions for primitives and reference types (e.g. `int` -> `I`, `java.lang.Object` -> `Ljava.lang.Object;`.
+ */
+val ClassId.arrayLikeName: String
+    get() = when {
+        isPrimitive -> primitiveTypeJvmNameOrNull()!!
+        isRefType -> "L$name;"
+        else -> name
+    }
 
 fun String.toReferenceTypeBytecodeSignature(): String {
     val packageName = this

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/context/CgContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/context/CgContext.kt
@@ -99,7 +99,7 @@ internal interface CgContextOwner {
     val collectedExceptions: MutableSet<ClassId>
 
     // annotations required by the current method being built
-    val collectedTestMethodAnnotations: MutableSet<CgAnnotation>
+    val collectedMethodAnnotations: MutableSet<CgAnnotation>
 
     // imports required by the test class being built
     val collectedImports: MutableSet<Import>
@@ -259,7 +259,7 @@ internal interface CgContextOwner {
     }
 
     fun addAnnotation(annotation: CgAnnotation) {
-        if (collectedTestMethodAnnotations.add(annotation)) {
+        if (collectedMethodAnnotations.add(annotation)) {
             importIfNeeded(annotation.classId) // TODO: check how JUnit annotations are loaded
         }
     }
@@ -391,7 +391,7 @@ internal data class CgContext(
     override val collectedTestClassInterfaces: MutableSet<ClassId> = mutableSetOf(),
     override val collectedTestClassAnnotations: MutableSet<CgAnnotation> = mutableSetOf(),
     override val collectedExceptions: MutableSet<ClassId> = mutableSetOf(),
-    override val collectedTestMethodAnnotations: MutableSet<CgAnnotation> = mutableSetOf(),
+    override val collectedMethodAnnotations: MutableSet<CgAnnotation> = mutableSetOf(),
     override val collectedImports: MutableSet<Import> = mutableSetOf(),
     override val importedStaticMethods: MutableSet<MethodId> = mutableSetOf(),
     override val importedClasses: MutableSet<ClassId> = mutableSetOf(),

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgVariableConstructor.kt
@@ -6,6 +6,7 @@ import org.utbot.framework.codegen.model.constructor.context.CgContext
 import org.utbot.framework.codegen.model.constructor.context.CgContextOwner
 import org.utbot.framework.codegen.model.constructor.util.CgComponents
 import org.utbot.framework.codegen.model.constructor.util.CgStatementConstructor
+import org.utbot.framework.codegen.model.constructor.util.MAX_ARRAY_INITIALIZER_SIZE
 import org.utbot.framework.codegen.model.constructor.util.arrayInitializer
 import org.utbot.framework.codegen.model.constructor.util.get
 import org.utbot.framework.codegen.model.constructor.util.isDefaultValueOf
@@ -221,7 +222,11 @@ internal class CgVariableConstructor(val context: CgContext) :
             arrayModel.stores.getOrDefault(it, arrayModel.constModel)
         }
 
-        val canInitWithValues = elementModels.all { it is UtPrimitiveModel } || elementModels.all { it is UtNullModel }
+        val allPrimitives = elementModels.all { it is UtPrimitiveModel }
+        val allNulls = elementModels.all { it is UtNullModel }
+        // we can use array initializer if all elements are primitives or all of them are null,
+        // and the size of an array is not greater than the fixed maximum size
+        val canInitWithValues = (allPrimitives || allNulls) && elementModels.size <= MAX_ARRAY_INITIALIZER_SIZE
 
         val initializer = if (canInitWithValues) {
             val elements = elementModels.map { model ->

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/TestFrameworkManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/TestFrameworkManager.kt
@@ -162,12 +162,12 @@ internal abstract class TestFrameworkManager(val context: CgContext)
             name = timeoutArgumentName,
             value = timeoutMs.resolve()
         )
-        val testAnnotation = collectedTestMethodAnnotations.singleOrNull { it.classId == testFramework.testAnnotationId }
+        val testAnnotation = collectedMethodAnnotations.singleOrNull { it.classId == testFramework.testAnnotationId }
 
         if (testAnnotation is CgMultipleArgsAnnotation) {
             testAnnotation.arguments += timeout
         } else {
-            collectedTestMethodAnnotations += CgMultipleArgsAnnotation(
+            collectedMethodAnnotations += CgMultipleArgsAnnotation(
                 testFramework.testAnnotationId,
                 mutableListOf(timeout)
             )
@@ -180,7 +180,7 @@ internal abstract class TestFrameworkManager(val context: CgContext)
     // because other test frameworks do not support such feature.
     open fun addDisplayName(name: String) {
         val displayName = CgSingleArgAnnotation(Junit5.displayNameClassId, stringLiteral(name))
-        collectedTestMethodAnnotations += CgCommentedAnnotation(displayName)
+        collectedMethodAnnotations += CgCommentedAnnotation(displayName)
     }
 
     protected fun ClassId.toExceptionClass(): CgExpression =
@@ -241,7 +241,7 @@ internal class TestNgManager(context: CgContext) : TestFrameworkManager(context)
             value = reason.resolve()
         )
 
-        val testAnnotation = collectedTestMethodAnnotations.singleOrNull { it.classId == testFramework.testAnnotationId }
+        val testAnnotation = collectedMethodAnnotations.singleOrNull { it.classId == testFramework.testAnnotationId }
         if (testAnnotation is CgMultipleArgsAnnotation) {
             testAnnotation.arguments += disabledAnnotationArgument
 
@@ -271,7 +271,7 @@ internal class TestNgManager(context: CgContext) : TestFrameworkManager(context)
                 testAnnotation.arguments += descriptionTestAnnotationArgument
             }
         } else {
-            collectedTestMethodAnnotations += CgMultipleArgsAnnotation(
+            collectedMethodAnnotations += CgMultipleArgsAnnotation(
                 testFramework.testAnnotationId,
                 mutableListOf(disabledAnnotationArgument, descriptionTestAnnotationArgument)
             )
@@ -291,11 +291,11 @@ internal class Junit4Manager(context: CgContext) : TestFrameworkManager(context)
             name = "expected",
             value = classLiteralAnnotationArgument(exception, codegenLanguage)
         )
-        val testAnnotation = collectedTestMethodAnnotations.singleOrNull { it.classId == testFramework.testAnnotationId }
+        val testAnnotation = collectedMethodAnnotations.singleOrNull { it.classId == testFramework.testAnnotationId }
         if (testAnnotation is CgMultipleArgsAnnotation) {
             testAnnotation.arguments += expected
         } else {
-            collectedTestMethodAnnotations += CgMultipleArgsAnnotation(testFramework.testAnnotationId, mutableListOf(expected))
+            collectedMethodAnnotations += CgMultipleArgsAnnotation(testFramework.testAnnotationId, mutableListOf(expected))
         }
         block()
     }
@@ -303,7 +303,7 @@ internal class Junit4Manager(context: CgContext) : TestFrameworkManager(context)
     override fun disableTestMethod(reason: String) {
         require(testFramework is Junit4) { "According to settings, JUnit4 was expected, but got: $testFramework" }
 
-        collectedTestMethodAnnotations += CgMultipleArgsAnnotation(
+        collectedMethodAnnotations += CgMultipleArgsAnnotation(
             testFramework.ignoreAnnotationClassId,
             mutableListOf(
                 CgNamedAnnotationArgument(
@@ -339,7 +339,7 @@ internal class Junit5Manager(context: CgContext) : TestFrameworkManager(context)
 
     override fun addDisplayName(name: String) {
         require(testFramework is Junit5) { "According to settings, JUnit5 was expected, but got: $testFramework" }
-        collectedTestMethodAnnotations += statementConstructor.annotation(testFramework.displayNameClassId, name)
+        collectedMethodAnnotations += statementConstructor.annotation(testFramework.displayNameClassId, name)
     }
 
     override fun setTestExecutionTimeout(timeoutMs: Long) {
@@ -358,7 +358,7 @@ internal class Junit5Manager(context: CgContext) : TestFrameworkManager(context)
         )
         importIfNeeded(testFramework.timeunitClassId)
 
-        collectedTestMethodAnnotations += CgMultipleArgsAnnotation(
+        collectedMethodAnnotations += CgMultipleArgsAnnotation(
             Junit5.timeoutClassId,
             timeoutAnnotationArguments
         )
@@ -367,7 +367,7 @@ internal class Junit5Manager(context: CgContext) : TestFrameworkManager(context)
     override fun disableTestMethod(reason: String) {
         require(testFramework is Junit5) { "According to settings, JUnit5 was expected, but got: $testFramework" }
 
-        collectedTestMethodAnnotations += CgMultipleArgsAnnotation(
+        collectedMethodAnnotations += CgMultipleArgsAnnotation(
             testFramework.disabledAnnotationClassId,
             mutableListOf(
                 CgNamedAnnotationArgument(

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/util/CgStatementConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/util/CgStatementConstructor.kt
@@ -106,7 +106,7 @@ interface CgStatementConstructor {
     infix fun CgExpression.`=`(value: Any?)
     infix fun CgExpression.and(other: CgExpression): CgLogicalAnd
     infix fun CgExpression.or(other: CgExpression): CgLogicalOr
-    fun ifStatement(condition: CgExpression, trueBranch: () -> Unit): CgIfStatement
+    fun ifStatement(condition: CgExpression, trueBranch: () -> Unit, falseBranch: (() -> Unit)? = null): CgIfStatement
     fun forLoop(init: CgForLoopBuilder.() -> Unit)
     fun whileLoop(condition: CgExpression, statements: () -> Unit)
     fun doWhileLoop(condition: CgExpression, statements: () -> Unit)
@@ -250,8 +250,10 @@ internal class CgStatementConstructorImpl(context: CgContext) :
     override fun CgExpression.or(other: CgExpression): CgLogicalOr =
         CgLogicalOr(this, other)
 
-    override fun ifStatement(condition: CgExpression, trueBranch: () -> Unit): CgIfStatement {
-        return CgIfStatement(condition, block(trueBranch)).also {
+    override fun ifStatement(condition: CgExpression, trueBranch: () -> Unit, falseBranch: (() -> Unit)?): CgIfStatement {
+        val trueBranchBlock = block(trueBranch)
+        val falseBranchBlock = falseBranch?.let { block(it) }
+        return CgIfStatement(condition, trueBranchBlock, falseBranchBlock).also {
             currentBlock += it
         }
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/util/CgStatementConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/util/CgStatementConstructor.kt
@@ -31,7 +31,6 @@ import org.utbot.framework.codegen.model.tree.CgParameterDeclaration
 import org.utbot.framework.codegen.model.tree.CgReturnStatement
 import org.utbot.framework.codegen.model.tree.CgSingleArgAnnotation
 import org.utbot.framework.codegen.model.tree.CgSingleLineComment
-import org.utbot.framework.codegen.model.tree.CgStatement
 import org.utbot.framework.codegen.model.tree.CgThrowStatement
 import org.utbot.framework.codegen.model.tree.CgTryCatch
 import org.utbot.framework.codegen.model.tree.CgVariable
@@ -40,7 +39,6 @@ import org.utbot.framework.codegen.model.tree.buildCgForEachLoop
 import org.utbot.framework.codegen.model.tree.buildDeclaration
 import org.utbot.framework.codegen.model.tree.buildDoWhileLoop
 import org.utbot.framework.codegen.model.tree.buildForLoop
-import org.utbot.framework.codegen.model.tree.buildSimpleBlock
 import org.utbot.framework.codegen.model.tree.buildTryCatch
 import org.utbot.framework.codegen.model.tree.buildWhileLoop
 import org.utbot.framework.codegen.model.util.buildExceptionHandler
@@ -117,7 +115,7 @@ interface CgStatementConstructor {
     fun CgTryCatch.catch(exception: ClassId, init: (CgVariable) -> Unit): CgTryCatch
     fun CgTryCatch.finally(init: () -> Unit): CgTryCatch
 
-    fun innerBlock(init: () -> Unit, additionalStatements: List<CgStatement>): CgInnerBlock
+    fun innerBlock(init: () -> Unit): CgInnerBlock
 
 //    fun CgTryCatchBuilder.statements(init: () -> Unit)
 //    fun CgTryCatchBuilder.handler(exception: ClassId, init: (CgVariable) -> Unit)
@@ -302,12 +300,10 @@ internal class CgStatementConstructorImpl(context: CgContext) :
         return this.copy(finally = finallyBlock)
     }
 
-    override fun innerBlock(
-        init: () -> Unit,
-        additionalStatements: List<CgStatement>,
-    ): CgInnerBlock = buildSimpleBlock {
-        statements = mutableListOf<CgStatement>() + block(init) + additionalStatements
-    }
+    override fun innerBlock(init: () -> Unit): CgInnerBlock =
+        CgInnerBlock(block(init)).also {
+            currentBlock += it
+        }
 
     override fun comment(text: String): CgComment =
         CgSingleLineComment(text).also {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/util/ConstructorUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/util/ConstructorUtils.kt
@@ -42,6 +42,9 @@ import org.utbot.framework.plugin.api.util.shortClassId
 import org.utbot.framework.plugin.api.util.underlyingType
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.PersistentSet
+import org.utbot.framework.codegen.model.tree.CgAllocateInitializedArray
+import org.utbot.framework.codegen.model.tree.CgArrayInitializer
+import org.utbot.framework.plugin.api.util.arrayLikeName
 
 internal data class EnvironmentFieldStateCache(
     val thisInstance: FieldStateCache,
@@ -214,6 +217,39 @@ internal fun CgContextOwner.typeCast(
     }
     importIfNeeded(targetType)
     return CgTypeCast(targetType, expression, isSafetyCast)
+}
+
+@Suppress("unused")
+internal fun newArrayOf(elementType: ClassId, values: List<CgExpression>): CgAllocateInitializedArray {
+    val arrayType = arrayTypeOf(elementType)
+    return CgAllocateInitializedArray(arrayInitializer(arrayType, elementType, values))
+}
+
+internal fun arrayInitializer(arrayType: ClassId, elementType: ClassId, values: List<CgExpression>): CgArrayInitializer =
+    CgArrayInitializer(arrayType, elementType, values)
+
+/**
+ * For a given [elementType] returns a [ClassId] of an array with elements of this type.
+ * For example, for an id of `int` the result will be an id of `int[]`.
+ *
+ * @param elementType the element type of the returned array class id
+ * @param isNullable a flag whether returned array is nullable or not
+ */
+internal fun arrayTypeOf(elementType: ClassId, isNullable: Boolean = false): ClassId {
+    val arrayIdName = "[${elementType.arrayLikeName}"
+    return when (elementType) {
+        is BuiltinClassId -> BuiltinClassId(
+            name = arrayIdName,
+            canonicalName = "${elementType.canonicalName}[]",
+            simpleName = "${elementType.simpleName}[]",
+            isNullable = isNullable
+        )
+        else -> ClassId(
+            name = arrayIdName,
+            elementClassId = elementType,
+            isNullable = isNullable
+        )
+    }
 }
 
 @Suppress("unused")

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/util/ConstructorUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/util/ConstructorUtils.kt
@@ -156,6 +156,8 @@ private fun FieldPath.toStringList(): List<String> =
 internal fun infiniteInts(): Sequence<Int> =
     generateSequence(1) { it + 1 }
 
+internal const val MAX_ARRAY_INITIALIZER_SIZE = 10
+
 /**
  * Checks if we have already imported a class with such simple name.
  * If so, we cannot import [type] (because it will be used with simple name and will be clashed with already imported)

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/tree/Builders.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/tree/Builders.kt
@@ -100,8 +100,8 @@ class CgParameterizedTestDataProviderBuilder : CgMethodBuilder<CgParameterizedTe
     override lateinit var returnType: ClassId
     override val parameters: List<CgParameterDeclaration> = mutableListOf()
     override lateinit var statements: List<CgStatement>
-    override lateinit var annotations: MutableList<CgAnnotation>
-    override lateinit var exceptions: MutableSet<ClassId>
+    override val annotations: MutableList<CgAnnotation> = mutableListOf()
+    override val exceptions: MutableSet<ClassId> = mutableSetOf()
     override var documentation: CgDocumentationComment = CgDocumentationComment(emptyList())
 
     override fun build() = CgParameterizedTestDataProviderMethod(name, statements, returnType, annotations, exceptions)

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/tree/Builders.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/tree/Builders.kt
@@ -145,14 +145,6 @@ class CgTryCatchBuilder : CgBuilder<CgTryCatch> {
 
 fun buildTryCatch(init: CgTryCatchBuilder.() -> Unit): CgTryCatch = CgTryCatchBuilder().apply(init).build()
 
-class CgBlockBuilder : CgBuilder<CgInnerBlock> {
-    lateinit var statements: List<CgStatement>
-
-    override fun build() = CgInnerBlock(statements)
-}
-
-fun buildSimpleBlock(init: CgBlockBuilder.() -> Unit) = CgBlockBuilder().apply(init).build()
-
 // Loops
 interface CgLoopBuilder<T : CgLoop> : CgBuilder<T> {
     val condition: CgExpression

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/tree/CgElement.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/tree/CgElement.kt
@@ -19,7 +19,6 @@ import org.utbot.framework.plugin.api.ExecutableId
 import org.utbot.framework.plugin.api.FieldId
 import org.utbot.framework.plugin.api.MethodId
 import org.utbot.framework.plugin.api.TypeParameters
-import org.utbot.framework.plugin.api.UtArrayModel
 import org.utbot.framework.plugin.api.util.booleanClassId
 import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.intClassId
@@ -83,6 +82,7 @@ interface CgElement {
             is CgNonStaticRunnable -> visit(element)
             is CgStaticRunnable -> visit(element)
             is CgAllocateInitializedArray -> visit(element)
+            is CgArrayInitializer -> visit(element)
             is CgAllocateArray -> visit(element)
             is CgEnumConstantAccess -> visit(element)
             is CgFieldAccess -> visit(element)
@@ -699,8 +699,19 @@ open class CgAllocateArray(type: ClassId, elementType: ClassId, val size: Int) :
         }
 }
 
-class CgAllocateInitializedArray(val model: UtArrayModel) :
-    CgAllocateArray(model.classId, model.classId.elementClassId!!, model.length)
+/**
+ * Allocation of an array with initialization. For example: `new String[] {"a", "b", null}`.
+ */
+class CgAllocateInitializedArray(val initializer: CgArrayInitializer) :
+    CgAllocateArray(initializer.arrayType, initializer.elementType, initializer.size)
+
+class CgArrayInitializer(val arrayType: ClassId, val elementType: ClassId, val values: List<CgExpression>) : CgExpression {
+    val size: Int
+        get() = values.size
+
+    override val type: ClassId
+        get() = arrayType
+}
 
 
 // Spread operator (for Kotlin, empty for Java)

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgAbstractRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgAbstractRenderer.kt
@@ -77,21 +77,18 @@ import org.utbot.framework.codegen.model.tree.CgVariable
 import org.utbot.framework.codegen.model.tree.CgWhileLoop
 import org.utbot.framework.codegen.model.util.CgPrinter
 import org.utbot.framework.codegen.model.util.CgPrinterImpl
-import org.utbot.framework.codegen.model.util.resolve
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.CodegenLanguage
 import org.utbot.framework.plugin.api.MethodId
 import org.utbot.framework.plugin.api.TypeParameters
-import org.utbot.framework.plugin.api.UtArrayModel
-import org.utbot.framework.plugin.api.UtModel
-import org.utbot.framework.plugin.api.UtNullModel
-import org.utbot.framework.plugin.api.UtPrimitiveModel
 import org.utbot.framework.plugin.api.util.booleanClassId
 import org.utbot.framework.plugin.api.util.byteClassId
 import org.utbot.framework.plugin.api.util.charClassId
 import org.utbot.framework.plugin.api.util.doubleClassId
 import org.utbot.framework.plugin.api.util.floatClassId
 import org.utbot.framework.plugin.api.util.intClassId
+import org.utbot.framework.plugin.api.util.isArray
+import org.utbot.framework.plugin.api.util.isRefType
 import org.utbot.framework.plugin.api.util.longClassId
 import org.utbot.framework.plugin.api.util.shortClassId
 
@@ -110,14 +107,15 @@ internal abstract class CgAbstractRenderer(val context: CgContext, val printer: 
 
     protected abstract val langPackage: String
 
-    //We may render array elements in initializer in one line or in separate lines:
-    //items count in one line depends on the value type.
-    protected fun arrayElementsInLine(constModel: UtModel): Int {
-        if (constModel is UtNullModel) return 10
-        return when (constModel.classId) {
+    // We may render array elements in initializer in one line or in separate lines:
+    // items count in one line depends on the element type.
+    protected fun arrayElementsInLine(elementType: ClassId): Int {
+        if (elementType.isRefType) return 10
+        if (elementType.isArray) return 1
+        return when (elementType) {
             intClassId, byteClassId, longClassId, charClassId -> 8
             booleanClassId, shortClassId, doubleClassId, floatClassId -> 6
-            else -> error("Non primitive value of type ${constModel.classId} is unexpected in array initializer")
+            else -> error("Non primitive value of type $elementType is unexpected in array initializer")
         }
     }
 
@@ -710,17 +708,6 @@ internal abstract class CgAbstractRenderer(val context: CgContext, val printer: 
 
     protected abstract fun renderExceptionCatchVariable(exception: CgVariable)
 
-    protected fun UtArrayModel.getElementExpr(index: Int): CgExpression {
-        val itemModel = stores.getOrDefault(index, constModel)
-        val cgValue: CgExpression = when (itemModel) {
-            is UtPrimitiveModel -> itemModel.value.resolve()
-            is UtNullModel -> null.resolve()
-            else -> error("Non primitive or null model $itemModel is unexpected in array initializer")
-        }
-
-        return cgValue
-    }
-
     protected fun getEscapedImportRendering(import: Import): String =
         import.qualifiedName
             .split(".")
@@ -752,10 +739,11 @@ internal abstract class CgAbstractRenderer(val context: CgContext, val printer: 
         }
     }
 
-    protected fun UtArrayModel.renderElements(length: Int, elementsInLine: Int) {
+    protected fun List<CgExpression>.renderElements(elementsInLine: Int) {
+        val length = this.size
         if (length <= elementsInLine) { // one-line array
             for (i in 0 until length) {
-                val expr = this.getElementExpr(i)
+                val expr = this[i]
                 expr.accept(this@CgAbstractRenderer)
                 if (i != length - 1) {
                     print(", ")
@@ -765,7 +753,7 @@ internal abstract class CgAbstractRenderer(val context: CgContext, val printer: 
             println() // line break after `int[] x = {`
             withIndent {
                 for (i in 0 until length) {
-                    val expr = this.getElementExpr(i)
+                    val expr = this[i]
                     expr.accept(this@CgAbstractRenderer)
 
                     if (i == length - 1) {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgJavaRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgJavaRenderer.kt
@@ -8,6 +8,7 @@ import org.utbot.framework.codegen.model.tree.CgAllocateArray
 import org.utbot.framework.codegen.model.tree.CgAllocateInitializedArray
 import org.utbot.framework.codegen.model.tree.CgAnonymousFunction
 import org.utbot.framework.codegen.model.tree.CgArrayAnnotationArgument
+import org.utbot.framework.codegen.model.tree.CgArrayInitializer
 import org.utbot.framework.codegen.model.tree.CgBreakStatement
 import org.utbot.framework.codegen.model.tree.CgConstructorCall
 import org.utbot.framework.codegen.model.tree.CgDeclaration
@@ -164,11 +165,21 @@ internal class CgJavaRenderer(context: CgContext, printer: CgPrinter = CgPrinter
     }
 
     override fun visit(element: CgAllocateInitializedArray) {
-        val arrayModel = element.model
-        val elementsInLine = arrayElementsInLine(arrayModel.constModel)
+        // TODO: same as in visit(CgAllocateArray): we should rewrite the typeName and otherDimensions variables declaration
+        // to avoid using substringBefore() and substringAfter() directly
+        val typeName = element.type.canonicalName.substringBefore("[")
+        val otherDimensions = element.type.canonicalName.substringAfter("]")
+        // we can't specify the size of the first dimension when using initializer,
+        // as opposed to CgAllocateArray where there is no initializer
+        print("new $typeName[]$otherDimensions")
+        element.initializer.accept(this)
+    }
+
+    override fun visit(element: CgArrayInitializer) {
+        val elementsInLine = arrayElementsInLine(element.elementType)
 
         print("{")
-        arrayModel.renderElements(element.size, elementsInLine)
+        element.values.renderElements(elementsInLine)
         print("}")
     }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgKotlinRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgKotlinRenderer.kt
@@ -12,6 +12,7 @@ import org.utbot.framework.codegen.model.tree.CgAllocateInitializedArray
 import org.utbot.framework.codegen.model.tree.CgAnonymousFunction
 import org.utbot.framework.codegen.model.tree.CgArrayAnnotationArgument
 import org.utbot.framework.codegen.model.tree.CgArrayElementAccess
+import org.utbot.framework.codegen.model.tree.CgArrayInitializer
 import org.utbot.framework.codegen.model.tree.CgComparison
 import org.utbot.framework.codegen.model.tree.CgConstructorCall
 import org.utbot.framework.codegen.model.tree.CgDeclaration
@@ -45,7 +46,6 @@ import org.utbot.framework.plugin.api.BuiltinClassId
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.CodegenLanguage
 import org.utbot.framework.plugin.api.TypeParameters
-import org.utbot.framework.plugin.api.UtPrimitiveModel
 import org.utbot.framework.plugin.api.WildcardTypeParameter
 import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.isArray
@@ -246,18 +246,26 @@ internal class CgKotlinRenderer(context: CgContext, printer: CgPrinter = CgPrint
     }
 
     override fun visit(element: CgAllocateInitializedArray) {
-        val arrayModel = element.model
-        val elementsInLine = arrayElementsInLine(arrayModel.constModel)
+        print(getKotlinClassString(element.type))
+        print("(${element.size})")
+        print(" {")
+        element.initializer.accept(this)
+        print(" }")
+    }
 
-        if (arrayModel.constModel is UtPrimitiveModel) {
-            val prefix = arrayModel.constModel.classId.name.toLowerCase()
+    override fun visit(element: CgArrayInitializer) {
+        val elementType = element.elementType
+        val elementsInLine = arrayElementsInLine(elementType)
+
+        if (elementType.isPrimitive) {
+            val prefix = elementType.name.toLowerCase()
             print("${prefix}ArrayOf(")
-            arrayModel.renderElements(element.size, elementsInLine)
+            element.values.renderElements(elementsInLine)
             print(")")
         } else {
-            print(getKotlinClassString(element.type))
+            print(getKotlinClassString(element.arrayType))
             print("(${element.size})")
-            if (!element.elementType.isPrimitive) print(" { null }")
+            print(" { null }")
         }
     }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgKotlinRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgKotlinRenderer.kt
@@ -310,8 +310,7 @@ internal class CgKotlinRenderer(context: CgContext, printer: CgPrinter = CgPrint
     }
 
     override fun renderMethodSignature(element: CgParameterizedTestDataProviderMethod) {
-        val returnType =
-            if (element.returnType.simpleName == "Array<Array<Any?>?>") "Array<Array<Any?>?>" else "${element.returnType}"
+        val returnType = getKotlinClassString(element.returnType)
         println("fun ${element.name}(): $returnType")
     }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgVisitor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgVisitor.kt
@@ -7,6 +7,7 @@ import org.utbot.framework.codegen.model.tree.CgAllocateInitializedArray
 import org.utbot.framework.codegen.model.tree.CgAnonymousFunction
 import org.utbot.framework.codegen.model.tree.CgArrayAnnotationArgument
 import org.utbot.framework.codegen.model.tree.CgArrayElementAccess
+import org.utbot.framework.codegen.model.tree.CgArrayInitializer
 import org.utbot.framework.codegen.model.tree.CgAssignment
 import org.utbot.framework.codegen.model.tree.CgBreakStatement
 import org.utbot.framework.codegen.model.tree.CgComment
@@ -203,6 +204,7 @@ interface CgVisitor<R> {
     // Array allocation
     fun visit(element: CgAllocateArray): R
     fun visit(element: CgAllocateInitializedArray): R
+    fun visit(element: CgArrayInitializer): R
 
     // Spread operator
     fun visit(element: CgSpread): R


### PR DESCRIPTION
# Description

Code generation relies on CgContext for storing information about the currently available variables, imports, statements, etc. The context also stores info about code block currently being generated (currentBlock).

It is possible to collect statements into some list and then update the currentBlock with them, but it is discouraged, because this way it is very easy to occacionally lose some of the statements. That's because some statements will go to the currentBlock, but then will be overriden on update from the new list of statements.

Hence, it is recommended to always work with the statements using currentBlock and DSL methods that also use it. Such methods can be found in CgStatementConstructor.kt, see method `ifStatement` for example.

This PR makes more use of currentBlock instead of using separate lists. That is done in order to prevent possible future bugs.

## Type of Change

- Minor bug fix (non-breaking small changes)
- Refactoring (typos and non-functional changes) 

# How Has This Been Tested?

## Automated Testing

The whole code generation pipeline is used to check the changes.
Given that most of the changes are related to the deep equals code generation,
the most useful test would be `org.utbot.examples.codegen.deepequals.DeepEqualsTest`.

## Manual Scenario 

I wrote a method that worked with multidimensional floating point arrays in the IntelliJ with UtBot plugin and the result of code generation was the same as before changes, i.e. refactoring did not break such an example.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
