### PR TITLE
Fuzzing is not stopped on timeout when symbolic execution is excluded #570

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
@@ -435,7 +435,7 @@ class UtBotSymbolicEngine(
             })
         }
         fuzzedValues.forEach { values ->
-            if (System.currentTimeMillis() >= until) {
+            if (controller.job?.isActive == false || System.currentTimeMillis() >= until) {
                 logger.info { "Fuzzing overtime: $methodUnderTest" }
                 return@flow
             }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestFlow.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestFlow.kt
@@ -62,7 +62,7 @@ class TestFlow internal constructor(block: TestFlow.() -> Unit) {
             isFuzzingEnabled -> {
                 when (val value = if (isSymbolicEngineEnabled) (fuzzingValue * generationTimeout).toLong() else generationTimeout) {
                     0L -> engine.traverse()
-                    generationTimeout -> engine.fuzzing()
+                    generationTimeout -> engine.fuzzing(System.currentTimeMillis() + value)
                     else -> flowOf(
                         engine.fuzzing(System.currentTimeMillis() + value),
                         engine.traverse()


### PR DESCRIPTION
# Description

When symbolic execution is off fuzzing should be stopped after a total time for generation is over. This PR also fixes an issue when fuzzing can't be stopped by canceling task via progress bar button.

Fixes #570

## Type of Change

Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Automated Testing

All tests should pass

## Manual Scenario 

Generate test for:

```java
public int theSum(int a, int b, int c, int d, int e, int f) {
    int res = 100;
    if (a < 1) {
        res += 200;
    }
    if (b < 2) {
        res += 300;
    }
    if (c < 3) {
        res += 400;
    }
    if (d < 4) {
        res += 500;
    }
    if (e < 5) {
        res += 700;
    }
    if (f < 6) {
        res += 800;
    }
    return res;
}
```

This examples finds > 880 000 000 inputs values. After fix it should be stopped in both cases:
1. When timeout is over
2. If a user cancels task

# Checklist (remove irrelevant options):
- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
