### PR TITLE
Revert missed changes for default values in UI

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -76,6 +76,7 @@ import com.intellij.util.ui.UIUtil
 import com.intellij.util.ui.components.BorderLayoutPanel
 import org.jetbrains.concurrency.Promise
 import org.jetbrains.concurrency.thenRun
+import org.jetbrains.kotlin.asJava.classes.KtUltraLightClass
 import org.utbot.common.filterWhen
 import org.utbot.common.PathUtil.toPath
 import org.utbot.framework.UtSettings
@@ -185,6 +186,16 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
     init {
         title = "Generate tests with UtBot"
         setResizable(false)
+
+        TestFramework.allItems.forEach {
+            it.isInstalled = findFrameworkLibrary(model.project, model.testModule, it) != null
+        }
+        MockFramework.allItems.forEach {
+            it.isInstalled = findFrameworkLibrary(model.project, model.testModule, it) != null
+        }
+        StaticsMocking.allItems.forEach {
+            it.isConfigured = staticsMockingConfigured()
+        }
 
         // Configure notification urls callbacks
         TestsReportNotifier.urlOpeningListener.callbacks[TestReportUrlOpeningListener.mockitoSuffix]?.plusAssign {
@@ -435,7 +446,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
             .toSet()
 
         val selectedMethods = selectedMembers.filter { it.member is PsiMethod }.toSet()
-        model.selectedMethods = if (selectedMethods.isEmpty()) null else selectedMethods
+        model.selectedMethods = if (selectedMethods.any()) selectedMethods else null
 
         model.testFramework = testFrameworks.item
         model.mockStrategy = mockStrategies.item
@@ -582,7 +593,6 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
         cbSpecifyTestPackage.isEnabled = model.srcClasses.all { cl -> cl.packageName.isNotEmpty() }
 
         val settings = model.project.service<Settings>()
-        codegenLanguages.item = settings.codegenLanguage
         mockStrategies.item = settings.mockStrategy
         staticsMocking.item = settings.staticsMocking
         parametrizedTestSources.item = settings.parametrizedTestSource
@@ -591,15 +601,18 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
         mockStrategies.isEnabled = areMocksSupported
         staticsMocking.isEnabled = areMocksSupported && mockStrategies.item != MockStrategyApi.NO_MOCKS
 
-        //We do not support parameterized tests for JUnit4
+        codegenLanguages.item =
+            if (model.srcClasses.all { it is KtUltraLightClass }) CodegenLanguage.KOTLIN else CodegenLanguage.JAVA
+
+        val installedTestFramework = TestFramework.allItems.singleOrNull { it.isInstalled }
         currentFrameworkItem = when (parametrizedTestSources.item) {
-            ParametrizedTestSource.DO_NOT_PARAMETRIZE -> settings.testFramework
-            ParametrizedTestSource.PARAMETRIZE ->
-                if (settings.testFramework == Junit4) TestFramework.parametrizedDefaultItem else settings.testFramework
+            ParametrizedTestSource.DO_NOT_PARAMETRIZE -> installedTestFramework ?: settings.testFramework
+            ParametrizedTestSource.PARAMETRIZE -> installedTestFramework
+                ?: if (settings.testFramework != Junit4) settings.testFramework else TestFramework.parametrizedDefaultItem
         }
 
         updateTestFrameworksList(settings.parametrizedTestSource)
-        updateParametrizationVisibility(settings.testFramework)
+        updateParametrizationEnabled(currentFrameworkItem)
 
         updateMockStrategyList()
         updateStaticMockingStrategyList()
@@ -814,7 +827,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
             val item = comboBox.item as TestFramework
 
             currentFrameworkItem = item
-            updateParametrizationVisibility(currentFrameworkItem)
+            updateParametrizationEnabled(currentFrameworkItem)
         }
 
         parametrizedTestSources.addActionListener { event ->
@@ -864,10 +877,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
             ParametrizedTestSource.DO_NOT_PARAMETRIZE -> TestFramework.defaultItem
             ParametrizedTestSource.PARAMETRIZE -> TestFramework.parametrizedDefaultItem
         }
-        enabledTestFrameworks.forEach {
-            it.isInstalled = findFrameworkLibrary(model.project, model.testModule, it) != null
-            if (it.isInstalled && !defaultItem.isInstalled) defaultItem = it
-        }
+        enabledTestFrameworks.forEach { if (it.isInstalled && !defaultItem.isInstalled) defaultItem = it }
 
         testFrameworks.model = DefaultComboBoxModel(enabledTestFrameworks.toTypedArray())
         testFrameworks.item = if (currentFrameworkItem in enabledTestFrameworks) currentFrameworkItem else defaultItem
@@ -887,7 +897,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
     }
 
     //We would like to disable parametrization options for JUnit4
-    private fun updateParametrizationVisibility(testFramework: TestFramework) {
+    private fun updateParametrizationEnabled(testFramework: TestFramework) {
         when (testFramework) {
             Junit4 -> parametrizedTestSources.isEnabled = false
             Junit5,
@@ -896,9 +906,6 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
     }
 
     private fun updateMockStrategyList() {
-        MOCKITO.isInstalled =
-            findFrameworkLibrary(model.project, model.testModule, MOCKITO) != null
-
         mockStrategies.renderer = object : ColoredListCellRenderer<MockStrategyApi>() {
             override fun customizeCellRenderer(
                 list: JList<out MockStrategyApi>, value: MockStrategyApi?,
@@ -913,8 +920,6 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
     }
 
     private fun updateStaticMockingStrategyList() {
-        val staticsMockingConfigured = staticsMockingConfigured()
-        StaticsMocking.allItems.forEach { it.isConfigured = staticsMockingConfigured }
         staticsMocking.renderer = object : ColoredListCellRenderer<StaticsMocking>() {
             override fun customizeCellRenderer(
                 list: JList<out StaticsMocking>, value: StaticsMocking?,


### PR DESCRIPTION
# Description

This commit https://github.com/UnitTestBot/UTBotJava/commit/0a4ac22650f7ed9820a2109e40267555a63053e6 removed some useful changes for issues 499 and 500. We revert them.


## Type of Change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Similarly as original issues 499 and 500.
