### PR TITLE
UI. Gradle project. Test sources root can be located anywhere #549

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -569,7 +569,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
         try {
             val contentEntry = modifiableModel.contentEntries
                 .filterNot { it.file == null }
-                .firstOrNull { VfsUtil.isAncestor(it.file!!, testSourceRoot, true) }
+                .firstOrNull { VfsUtil.isAncestor(it.file!!, testSourceRoot, false) }
                 ?: return false
 
             contentEntry.addSourceRootIfAbsent(

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/components/TestFolderComboWithBrowseButton.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/components/TestFolderComboWithBrowseButton.kt
@@ -16,6 +16,7 @@ import javax.swing.JList
 import org.utbot.common.PathUtil
 import org.utbot.intellij.plugin.models.GenerateTestsModel
 import org.utbot.intellij.plugin.ui.utils.addDedicatedTestRoot
+import org.utbot.intellij.plugin.ui.utils.isGradle
 import org.utbot.intellij.plugin.ui.utils.suitableTestSourceRoots
 
 class TestFolderComboWithBrowseButton(private val model: GenerateTestsModel) : ComboboxWithBrowseButton() {
@@ -23,6 +24,10 @@ class TestFolderComboWithBrowseButton(private val model: GenerateTestsModel) : C
     private val SET_TEST_FOLDER = "set test folder"
 
     init {
+        if (model.project.isGradle()) {
+            setButtonEnabled(false)
+            button.toolTipText = "Please define custom test source root via Gradle"
+        }
         childComponent.isEditable = false
         childComponent.renderer = object : ColoredListCellRenderer<Any?>() {
             override fun customizeCellRenderer(

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/ModuleUtils.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/ModuleUtils.kt
@@ -1,5 +1,6 @@
 package org.utbot.intellij.plugin.ui.utils
 
+import com.android.tools.idea.gradle.project.GradleProjectInfo
 import org.utbot.common.PathUtil.toPath
 import org.utbot.common.WorkaroundReason
 import org.utbot.common.workaround
@@ -144,14 +145,14 @@ private fun Module.suitableTestSourceFolders(codegenLanguage: CodegenLanguage): 
         // Heuristics: User is more likely to choose the shorter path
         .sortedBy { it.url.length }
 }
+fun Project.isGradle() = GradleProjectInfo.getInstance(this).isBuildWithGradle
 
 private const val dedicatedTestSourceRootName = "utbot_tests"
 fun Module.addDedicatedTestRoot(testSourceRoots: MutableList<VirtualFile>): VirtualFile? {
+    // Don't suggest new test source roots for Gradle project where 'unexpected' test roots won't work
+    if (project.isGradle()) return null
     // Dedicated test root already exists
-    // OR it looks like standard structure of Gradle project where 'unexpected' test roots won't work
-    if (testSourceRoots.any { file ->
-            file.name == dedicatedTestSourceRootName || file.path.endsWith("src/test/java")
-        }) return null
+    if (testSourceRoots.any { file -> file.name == dedicatedTestSourceRootName }) return null
 
     val moduleInstance = ModuleRootManager.getInstance(this)
     val testFolder = moduleInstance.contentEntries.flatMap { it.sourceFolders.toList() }


### PR DESCRIPTION
# Description

1. Disable custom test source roots for Gradle projects
2. Don't show warnings if any existing test source root is chosen

Fixes #549 

## Type of Change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

"Browse" button in test root chooser should be disabled for Gradle projects (with a tooltip "Please define custom test source root via Gradle"), validation should pass for any existing test source root.

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings