### PR TITLE
Improve processing CgNotNullAssertion in deepEquals

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
@@ -1004,18 +1004,17 @@ internal class CgMethodConstructor(val context: CgContext) : CgContextOwner by c
                         } else {
                             // array of objects, have to use deep equals
 
-                            if (expected is CgLiteral) {
-                                // Literal can only be Primitive or String, can use equals here
-                                testFrameworkManager.assertEquals(expected, actual)
-                                return
+                            when (expected) {
+                                is CgLiteral -> testFrameworkManager.assertEquals(expected, actual)
+                                is CgNotNullAssertion -> generateForNotNullAssertion(expected, actual)
+                                else -> {
+                                    require(resultModel is UtArrayModel) {
+                                        "Result model have to be UtArrayModel to generate arrays assertion " +
+                                                "but `${resultModel::class}` found"
+                                    }
+                                    generateDeepEqualsOrNullAssertion(expected, actual)
+                                }
                             }
-
-                            require(resultModel is UtArrayModel) {
-                                "Result model have to be UtArrayModel to generate arrays assertion " +
-                                        "but `${resultModel::class}` found"
-                            }
-
-                            generateDeepEqualsOrNullAssertion(expected, actual)
                         }
                     }
                 }
@@ -1046,21 +1045,20 @@ internal class CgMethodConstructor(val context: CgContext) : CgContextOwner by c
                 }
                 else -> {
                     when (expected) {
-                        is CgLiteral -> {
-                            // Literal can only be Primitive or String, can use equals here
-                            testFrameworkManager.assertEquals(expected, actual)
-                        }
-                        is CgNotNullAssertion -> {
-                            require(expected.expression is CgVariable) {
-                                "Only Variable wrapped in CgNotNullAssertion is supported in deep equals"
-                            }
-                            currentBlock = currentBlock.addAll(generateDeepEqualsAssertion(expected.expression, actual))
-                        }
+                        is CgLiteral -> testFrameworkManager.assertEquals(expected, actual)
+                        is CgNotNullAssertion -> generateForNotNullAssertion(expected, actual)
                         else -> generateDeepEqualsOrNullAssertion(expected, actual)
                     }
                 }
             }
         }
+    }
+
+    private fun generateForNotNullAssertion(expected: CgNotNullAssertion, actual: CgVariable) {
+        require(expected.expression is CgVariable) {
+            "Only CgVariable wrapped in CgNotNullAssertion is supported in deepEquals"
+        }
+        generateDeepEqualsOrNullAssertion(expected.expression, actual)
     }
 
     /**


### PR DESCRIPTION
# Description

This PR fixes 
- `Expected value have to be Literal or Variable but ...` in `deepEqualsTest` 
- and `NullPointerException` in `instanceOfExampleTest` parametrized test generation.

Fixes # ([579](https://github.com/UnitTestBot/UTBotJava/issues/579), [580](https://github.com/UnitTestBot/UTBotJava/issues/580))

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

Run `deepEqualsTest` and `instanceOfExampleTest`.

## Manual Scenario 

Run `deepEqualsTest` and `instanceOfExampleTest` with enabled parametrized test generation. Verify that tests are generated without fails and are green after execution.
