### PR TITLE
Add support for classes with hidden fields #563

### DIFF
--- a/utbot-core/src/main/kotlin/org/utbot/common/KClassUtil.kt
+++ b/utbot-core/src/main/kotlin/org/utbot/common/KClassUtil.kt
@@ -7,22 +7,9 @@ import java.lang.reflect.Method
 
 val Class<*>.packageName: String get() = `package`?.name?:""
 
-fun Class<*>.findField(name: String): Field =
-    findFieldOrNull(name) ?: error("Can't find field $name in $this")
-
-fun Class<*>.findFieldOrNull(name: String): Field? = generateSequence(this) { it.superclass }
-    .mapNotNull {
-        try {
-            it.getField(name)
-        } catch (e: NoSuchFieldException) {
-            try {
-                it.getDeclaredField(name)
-            } catch (e: NoSuchFieldException) {
-                null
-            }
-        }
-    }
-    .firstOrNull()
+fun Class<*>.findDirectAccessedField(fieldName: String): Field? = generateSequence(this) { it.superclass }
+    .flatMap { it.declaredFields.asSequence() }
+    .firstOrNull { it.name == fieldName }
 
 fun Method.invokeCatching(obj: Any?, args: List<Any?>) = try {
     Result.success(invoke(obj, *args.toTypedArray()))

--- a/utbot-core/src/main/kotlin/org/utbot/common/KClassUtil.kt
+++ b/utbot-core/src/main/kotlin/org/utbot/common/KClassUtil.kt
@@ -7,7 +7,12 @@ import java.lang.reflect.Method
 
 val Class<*>.packageName: String get() = `package`?.name?:""
 
-fun Class<*>.findDirectAccessedField(fieldName: String): Field? = generateSequence(this) { it.superclass }
+/**
+ * Returns the Field that would be used by compiler when you try to direct access [fieldName] from code, i.e.
+ * when you write `${this.name}.$fieldName`.
+ * If there is no field named [fieldName] in the class, null is returned
+ */
+fun Class<*>.findDirectAccessedFieldOrNull(fieldName: String): Field? = generateSequence(this) { it.superclass }
     .flatMap { it.declaredFields.asSequence() }
     .firstOrNull { it.name == fieldName }
 

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -519,20 +519,13 @@ data class UtDirectSetFieldModel(
     val fieldId: FieldId,
     val fieldModel: UtModel,
 ) : UtStatementModel(instance) {
-    private val fieldName
-        get() =
-            if (instance.classId == fieldId.declaringClass)
-                "${instance.modelName}.${fieldId.name}"
-            else
-                "${instance.modelName}.(${fieldId.declaringClass.name})${fieldId.name}"
-
 
     override fun toString(): String = withToStringThreadLocalReentrancyGuard {
             val modelRepresentation = when (fieldModel) {
                 is UtAssembleModel -> fieldModel.modelName
                 else -> fieldModel.toString()
             }
-            "$fieldName = $modelRepresentation"
+            "${instance.modelName}.${fieldId.name} = $modelRepresentation"
         }
 
 }
@@ -813,6 +806,9 @@ enum class FieldIdStrategyValues {
  */
 open class FieldId(val declaringClass: ClassId, val name: String) {
 
+    init {
+        //assert(declaringClass.jClass.declaredFields.any { it.name == name })
+    }
     object Strategy {
         var value: FieldIdStrategyValues = FieldIdStrategyValues.Soot
     }

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -20,7 +20,7 @@ import org.utbot.framework.plugin.api.util.charClassId
 import org.utbot.framework.plugin.api.util.constructor
 import org.utbot.framework.plugin.api.util.doubleClassId
 import org.utbot.framework.plugin.api.util.executableId
-import org.utbot.framework.plugin.api.util.findFieldOrNull
+import org.utbot.framework.plugin.api.util.fieldOrNull
 import org.utbot.framework.plugin.api.util.floatClassId
 import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.intClassId
@@ -347,7 +347,7 @@ data class UtCompositeModel(
             if (fields.isNotEmpty()) {
                 append(" ")
                 append(fields.entries.joinToString(", ", "{", "}") { (field, value) ->
-                    if (value.classId != classId || value.isNull()) "${field.name}: $value" else "${field.name}: not evaluated"
+                    if (value.classId != classId || value.isNull()) "(${field.declaringClass}) ${field.name}: $value" else "${field.name}: not evaluated"
                 }) // TODO: here we can get an infinite recursion if we have cyclic dependencies.
             }
             if (mocks.isNotEmpty()) {
@@ -863,7 +863,7 @@ open class FieldId(val declaringClass: ClassId, val name: String) {
         return result
     }
 
-    override fun toString() = declaringClass.findFieldOrNull(name).toString()
+    override fun toString() = declaringClass.fieldOrNull(this).toString()
 }
 
 inline fun <T> withReflection(block: () -> T): T {

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -519,12 +519,20 @@ data class UtDirectSetFieldModel(
     val fieldId: FieldId,
     val fieldModel: UtModel,
 ) : UtStatementModel(instance) {
+    private val fieldName
+        get() =
+            if (instance.classId == fieldId.declaringClass)
+                "${instance.modelName}.${fieldId.name}"
+            else
+                "${instance.modelName}.(${fieldId.declaringClass.name})${fieldId.name}"
+
+
     override fun toString(): String = withToStringThreadLocalReentrancyGuard {
             val modelRepresentation = when (fieldModel) {
                 is UtAssembleModel -> fieldModel.modelName
                 else -> fieldModel.toString()
             }
-            "${instance.modelName}.${fieldId.name} = $modelRepresentation"
+            "$fieldName = $modelRepresentation"
         }
 
 }

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -20,7 +20,7 @@ import org.utbot.framework.plugin.api.util.charClassId
 import org.utbot.framework.plugin.api.util.constructor
 import org.utbot.framework.plugin.api.util.doubleClassId
 import org.utbot.framework.plugin.api.util.executableId
-import org.utbot.framework.plugin.api.util.fieldByIdOrNull
+import org.utbot.framework.plugin.api.util.findFieldByIdOrNull
 import org.utbot.framework.plugin.api.util.floatClassId
 import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.intClassId
@@ -856,7 +856,7 @@ open class FieldId(val declaringClass: ClassId, val name: String) {
         return result
     }
 
-    override fun toString() = declaringClass.fieldByIdOrNull(this).toString()
+    override fun toString() = declaringClass.findFieldByIdOrNull(this).toString()
 }
 
 inline fun <T> withReflection(block: () -> T): T {

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -20,7 +20,7 @@ import org.utbot.framework.plugin.api.util.charClassId
 import org.utbot.framework.plugin.api.util.constructor
 import org.utbot.framework.plugin.api.util.doubleClassId
 import org.utbot.framework.plugin.api.util.executableId
-import org.utbot.framework.plugin.api.util.findFieldByIdOrNull
+import org.utbot.framework.plugin.api.util.field
 import org.utbot.framework.plugin.api.util.floatClassId
 import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.intClassId
@@ -30,6 +30,7 @@ import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.framework.plugin.api.util.longClassId
 import org.utbot.framework.plugin.api.util.method
 import org.utbot.framework.plugin.api.util.primitiveTypeJvmNameOrNull
+import org.utbot.framework.plugin.api.util.safeField
 import org.utbot.framework.plugin.api.util.shortClassId
 import org.utbot.framework.plugin.api.util.toReferenceTypeBytecodeSignature
 import org.utbot.framework.plugin.api.util.voidClassId
@@ -856,7 +857,7 @@ open class FieldId(val declaringClass: ClassId, val name: String) {
         return result
     }
 
-    override fun toString() = declaringClass.findFieldByIdOrNull(this).toString()
+    override fun toString() = safeField.toString()
 }
 
 inline fun <T> withReflection(block: () -> T): T {

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -806,9 +806,6 @@ enum class FieldIdStrategyValues {
  */
 open class FieldId(val declaringClass: ClassId, val name: String) {
 
-    init {
-        //assert(declaringClass.jClass.declaredFields.any { it.name == name })
-    }
     object Strategy {
         var value: FieldIdStrategyValues = FieldIdStrategyValues.Soot
     }

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -20,7 +20,7 @@ import org.utbot.framework.plugin.api.util.charClassId
 import org.utbot.framework.plugin.api.util.constructor
 import org.utbot.framework.plugin.api.util.doubleClassId
 import org.utbot.framework.plugin.api.util.executableId
-import org.utbot.framework.plugin.api.util.fieldOrNull
+import org.utbot.framework.plugin.api.util.fieldByIdOrNull
 import org.utbot.framework.plugin.api.util.floatClassId
 import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.intClassId
@@ -856,7 +856,7 @@ open class FieldId(val declaringClass: ClassId, val name: String) {
         return result
     }
 
-    override fun toString() = declaringClass.fieldOrNull(this).toString()
+    override fun toString() = declaringClass.fieldByIdOrNull(this).toString()
 }
 
 inline fun <T> withReflection(block: () -> T): T {

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/IdUtil.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/IdUtil.kt
@@ -285,17 +285,17 @@ val ClassId.isMap: Boolean
 val ClassId.isIterableOrMap: Boolean
     get() = isIterable || isMap
 
-fun ClassId.fieldOrNull(fieldId: FieldId): Field? {
-    if (this.isNotSubtypeOf(fieldId.declaringClass))
-        return null
-    return try {
-        fieldId.field
-    } catch (e: IllegalStateException) {
-        null
-    }
-}
+fun ClassId.fieldById(fieldId: FieldId): Field =
+    fieldByIdOrNull(fieldId) ?: error("Can't find field ${fieldId.name} in $name")
 
-fun ClassId.hasField(fieldId: FieldId): Boolean = fieldOrNull(fieldId) != null
+fun ClassId.fieldByIdOrNull(fieldId: FieldId): Field? =
+    if (isNotSubtypeOf(fieldId.declaringClass)) {
+        null
+    } else {
+        fieldId.declaringClass.jClass.declaredFields.firstOrNull { it.name == fieldId.name }
+    }
+
+fun ClassId.hasField(fieldId: FieldId): Boolean = fieldByIdOrNull(fieldId) != null
 
 fun ClassId.defaultValueModel(): UtModel = when (this) {
     intClassId -> UtPrimitiveModel(0)

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/IdUtil.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/IdUtil.kt
@@ -285,22 +285,15 @@ val ClassId.isMap: Boolean
 val ClassId.isIterableOrMap: Boolean
     get() = isIterable || isMap
 
-// TODO: needs to be refactored (do we really need receiver? Can't we specify cases where we should return null?)
 fun ClassId.findFieldByIdOrNull(fieldId: FieldId): Field? {
     if (isNotSubtypeOf(fieldId.declaringClass)) {
-        error("findFieldByIdOrNull is called on class ${name}, which is not a subclass of ${fieldId.name}'s declaring class")
+        return null
     }
 
     return fieldId.declaringClass.jClass.declaredFields.firstOrNull { it.name == fieldId.name }
 }
 
-// TODO: maybe we could replace its usages with FieldId.field
-fun ClassId.findFieldById(fieldId: FieldId): Field =
-    findFieldByIdOrNull(fieldId) ?: error("Can't find field ${fieldId.name} in $name")
-
-// TODO: check if we need this function
 fun ClassId.hasField(fieldId: FieldId): Boolean {
-    assert(findFieldByIdOrNull(fieldId) != null)
     return findFieldByIdOrNull(fieldId) != null
 }
 

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/IdUtil.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/IdUtil.kt
@@ -288,7 +288,11 @@ val ClassId.isIterableOrMap: Boolean
 fun ClassId.fieldOrNull(fieldId: FieldId): Field? {
     if (this.isNotSubtypeOf(fieldId.declaringClass))
         return null
-    return fieldId.field
+    return try {
+        fieldId.field
+    } catch (e: Exception) {
+        null
+    }
 }
 
 fun ClassId.hasField(fieldId: FieldId): Boolean = fieldOrNull(fieldId) != null

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/IdUtil.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/IdUtil.kt
@@ -290,7 +290,7 @@ fun ClassId.fieldOrNull(fieldId: FieldId): Field? {
         return null
     return try {
         fieldId.field
-    } catch (e: Exception) {
+    } catch (e: IllegalStateException) {
         null
     }
 }

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/IdUtil.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/IdUtil.kt
@@ -1,6 +1,5 @@
 package org.utbot.framework.plugin.api.util
 
-import org.utbot.common.findFieldOrNull
 import org.utbot.framework.plugin.api.BuiltinClassId
 import org.utbot.framework.plugin.api.BuiltinMethodId
 import org.utbot.framework.plugin.api.ClassId
@@ -286,9 +285,13 @@ val ClassId.isMap: Boolean
 val ClassId.isIterableOrMap: Boolean
     get() = isIterable || isMap
 
-fun ClassId.findFieldOrNull(fieldName: String): Field? = jClass.findFieldOrNull(fieldName)
+fun ClassId.fieldOrNull(fieldId: FieldId): Field? {
+    if (this.isNotSubtypeOf(fieldId.declaringClass))
+        return null
+    return fieldId.field
+}
 
-fun ClassId.hasField(fieldName: String): Boolean = findFieldOrNull(fieldName) != null
+fun ClassId.hasField(fieldId: FieldId): Boolean = fieldOrNull(fieldId) != null
 
 fun ClassId.defaultValueModel(): UtModel = when (this) {
     intClassId -> UtPrimitiveModel(0)

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/IdUtil.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/IdUtil.kt
@@ -290,7 +290,7 @@ fun ClassId.findFieldByIdOrNull(fieldId: FieldId): Field? {
         return null
     }
 
-    return fieldId.declaringClass.jClass.declaredFields.firstOrNull { it.name == fieldId.name }
+    return fieldId.safeField
 }
 
 fun ClassId.hasField(fieldId: FieldId): Boolean {
@@ -310,11 +310,11 @@ fun ClassId.defaultValueModel(): UtModel = when (this) {
 }
 
 // FieldId utils
-
-// TODO: maybe cache it somehow in the future
-val FieldId.field: Field
+val FieldId.safeField: Field?
     get() = declaringClass.jClass.declaredFields.firstOrNull { it.name == name }
-        ?: error("Field $name is not found in class ${declaringClass.jClass.name}")
+
+val FieldId.field: Field
+    get() = safeField ?: error("Field $name is not found in class ${declaringClass.jClass.name}")
 
 // https://docstore.mik.ua/orelly/java-ent/jnut/ch03_13.htm
 val FieldId.isInnerClassEnclosingClassReference: Boolean

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/IdUtil.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/IdUtil.kt
@@ -285,17 +285,24 @@ val ClassId.isMap: Boolean
 val ClassId.isIterableOrMap: Boolean
     get() = isIterable || isMap
 
-fun ClassId.fieldById(fieldId: FieldId): Field =
-    fieldByIdOrNull(fieldId) ?: error("Can't find field ${fieldId.name} in $name")
-
-fun ClassId.fieldByIdOrNull(fieldId: FieldId): Field? =
+// TODO: needs to be refactored (do we really need receiver? Can't we specify cases where we should return null?)
+fun ClassId.findFieldByIdOrNull(fieldId: FieldId): Field? {
     if (isNotSubtypeOf(fieldId.declaringClass)) {
-        null
-    } else {
-        fieldId.declaringClass.jClass.declaredFields.firstOrNull { it.name == fieldId.name }
+        error("findFieldByIdOrNull is called on class ${name}, which is not a subclass of ${fieldId.name}'s declaring class")
     }
 
-fun ClassId.hasField(fieldId: FieldId): Boolean = fieldByIdOrNull(fieldId) != null
+    return fieldId.declaringClass.jClass.declaredFields.firstOrNull { it.name == fieldId.name }
+}
+
+// TODO: maybe we could replace its usages with FieldId.field
+fun ClassId.findFieldById(fieldId: FieldId): Field =
+    findFieldByIdOrNull(fieldId) ?: error("Can't find field ${fieldId.name} in $name")
+
+// TODO: check if we need this function
+fun ClassId.hasField(fieldId: FieldId): Boolean {
+    assert(findFieldByIdOrNull(fieldId) != null)
+    return findFieldByIdOrNull(fieldId) != null
+}
 
 fun ClassId.defaultValueModel(): UtModel = when (this) {
     intClassId -> UtPrimitiveModel(0)

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Hierarchy.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Hierarchy.kt
@@ -29,8 +29,10 @@ class Hierarchy(private val typeRegistry: TypeRegistry) {
 
         val realType = typeRegistry.findRealType(type) as RefType
 
-        val ancestorType = ancestors(realType.sootClass.id).lastOrNull { it.declaresField(field.subSignature) }?.type
-            ?: error("No such field ${field.subSignature} found in ${realType.sootClass.name}")
+
+        val ancestorType = field.declaringClass
+        //val ancestorType = ancestors(realType.sootClass.id).firstOrNull { it.declaresField(field.subSignature) }?.type
+            //?: error("No such field ${field.subSignature} found in ${realType.sootClass.name}")
         return ChunkId("$ancestorType", field.name)
     }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Hierarchy.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Hierarchy.kt
@@ -28,11 +28,12 @@ class Hierarchy(private val typeRegistry: TypeRegistry) {
         type as? RefType ?: error("$type is not a refType")
 
         val realType = typeRegistry.findRealType(type) as RefType
-        val realFieldDeclaringClass = typeRegistry.findRealType(field.declaringClass.type) as RefType
+        val realFieldDeclaringType = typeRegistry.findRealType(field.declaringClass.type) as RefType
 
-        if (realFieldDeclaringClass.sootClass !in ancestors(realType.sootClass.id))
+        if (realFieldDeclaringType.sootClass !in ancestors(realType.sootClass.id)) {
             error("No such field ${field.subSignature} found in ${realType.sootClass.name}")
-        return ChunkId("$realFieldDeclaringClass", field.name)
+        }
+        return ChunkId("$realFieldDeclaringType", field.name)
     }
 
     /**

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Hierarchy.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Hierarchy.kt
@@ -28,17 +28,11 @@ class Hierarchy(private val typeRegistry: TypeRegistry) {
         type as? RefType ?: error("$type is not a refType")
 
         val realType = typeRegistry.findRealType(type) as RefType
+        val realFieldDeclaringClass = typeRegistry.findRealType(field.declaringClass.type) as RefType
 
-
-        /*val ancestorType = field.declaringClass
-        val ancestorType2 = ancestors(realType.sootClass.id).firstOrNull { it.declaresField(field.subSignature) }?.type
-            ?: error("No such field ${field.subSignature} found in ${realType.sootClass.name}")*/
-        val ancestorType = if (field.declaringClass in ancestors(realType.sootClass.id))
-            field.declaringClass
-        else
-            ancestors(realType.sootClass.id).firstOrNull { it.declaresField(field.subSignature) }?.type
-                ?: error("No such field ${field.subSignature} found in ${realType.sootClass.name}")
-        return ChunkId("$ancestorType", field.name)
+        if (realFieldDeclaringClass.sootClass !in ancestors(realType.sootClass.id))
+            error("No such field ${field.subSignature} found in ${realType.sootClass.name}")
+        return ChunkId("$realFieldDeclaringClass", field.name)
     }
 
     /**

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Hierarchy.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Hierarchy.kt
@@ -30,9 +30,14 @@ class Hierarchy(private val typeRegistry: TypeRegistry) {
         val realType = typeRegistry.findRealType(type) as RefType
 
 
-        val ancestorType = field.declaringClass
-        //val ancestorType = ancestors(realType.sootClass.id).firstOrNull { it.declaresField(field.subSignature) }?.type
-            //?: error("No such field ${field.subSignature} found in ${realType.sootClass.name}")
+        /*val ancestorType = field.declaringClass
+        val ancestorType2 = ancestors(realType.sootClass.id).firstOrNull { it.declaresField(field.subSignature) }?.type
+            ?: error("No such field ${field.subSignature} found in ${realType.sootClass.name}")*/
+        val ancestorType = if (field.declaringClass in ancestors(realType.sootClass.id))
+            field.declaringClass
+        else
+            ancestors(realType.sootClass.id).firstOrNull { it.declaresField(field.subSignature) }?.type
+                ?: error("No such field ${field.subSignature} found in ${realType.sootClass.name}")
         return ChunkId("$ancestorType", field.name)
     }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Strings.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Strings.kt
@@ -313,7 +313,7 @@ sealed class UtAbstractStringBuilderWrapper(className: String) : BaseOverriddenW
 
         val arrayValuesChunkId = typeRegistry.arrayChunkId(charArrayType)
 
-        val valuesFieldChunkId = hierarchy.chunkIdForField(utStringClass.type, overriddenClass.valueField)
+        val valuesFieldChunkId = hierarchy.chunkIdForField(utStringClass.type, utStringClass.valueField)
         val valuesArrayAddrDescriptor = MemoryChunkDescriptor(valuesFieldChunkId, wrapper.type, charType)
         val valuesArrayAddr = findArray(valuesArrayAddrDescriptor, MemoryState.CURRENT).select(wrapper.addr)
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -89,7 +89,7 @@ import org.utbot.framework.plugin.api.MethodId
 import org.utbot.framework.plugin.api.UtMethod
 import org.utbot.framework.plugin.api.classId
 import org.utbot.framework.plugin.api.id
-import org.utbot.framework.plugin.api.util.fieldById
+import org.utbot.framework.plugin.api.util.findFieldById
 import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.signature
@@ -639,7 +639,7 @@ class Traverser(
             SECURITY_FIELD_SIGNATURE -> SecurityManager()
             FIELD_FILTER_MAP_FIELD_SIGNATURE -> mapOf(Reflection::class to arrayOf("fieldFilterMap", "methodFilterMap"))
             METHOD_FILTER_MAP_FIELD_SIGNATURE -> emptyMap<Class<*>, Array<String>>()
-            else -> declaringClass.id.fieldById(field.fieldId).let { it.withAccessibility { it.get(null) } }
+            else -> declaringClass.id.findFieldById(field.fieldId).let { it.withAccessibility { it.get(null) } }
         }
 
     private fun isStaticInstanceInMethodResult(id: ClassId, methodResult: MethodResult?) =

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -89,7 +89,7 @@ import org.utbot.framework.plugin.api.MethodId
 import org.utbot.framework.plugin.api.UtMethod
 import org.utbot.framework.plugin.api.classId
 import org.utbot.framework.plugin.api.id
-import org.utbot.framework.plugin.api.util.findFieldById
+import org.utbot.framework.plugin.api.util.field
 import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.signature
@@ -582,7 +582,7 @@ class Traverser(
         declaringClass: SootClass,
         stmt: Stmt
     ): SymbolicStateUpdate {
-        val concreteValue = extractConcreteValue(field, declaringClass)
+        val concreteValue = extractConcreteValue(field)
         val (symbolicResult, symbolicStateUpdate) = toMethodResult(concreteValue, field.type)
         val symbolicValue = (symbolicResult as SymbolicSuccess).value
 
@@ -634,12 +634,12 @@ class Traverser(
     // Some fields are inaccessible with reflection, so we have to instantiate it by ourselves.
     // Otherwise, extract it from the class.
     // TODO JIRA:1593
-    private fun extractConcreteValue(field: SootField, declaringClass: SootClass): Any? =
+    private fun extractConcreteValue(field: SootField): Any? =
         when (field.signature) {
             SECURITY_FIELD_SIGNATURE -> SecurityManager()
             FIELD_FILTER_MAP_FIELD_SIGNATURE -> mapOf(Reflection::class to arrayOf("fieldFilterMap", "methodFilterMap"))
             METHOD_FILTER_MAP_FIELD_SIGNATURE -> emptyMap<Class<*>, Array<String>>()
-            else -> declaringClass.id.findFieldById(field.fieldId).let { it.withAccessibility { it.get(null) } }
+            else -> field.fieldId.field.let { it.withAccessibility { it.get(null) } }
         }
 
     private fun isStaticInstanceInMethodResult(id: ClassId, methodResult: MethodResult?) =

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -89,7 +89,7 @@ import org.utbot.framework.plugin.api.MethodId
 import org.utbot.framework.plugin.api.UtMethod
 import org.utbot.framework.plugin.api.classId
 import org.utbot.framework.plugin.api.id
-import org.utbot.framework.plugin.api.util.field
+import org.utbot.framework.plugin.api.util.fieldById
 import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.signature
@@ -639,7 +639,7 @@ class Traverser(
             SECURITY_FIELD_SIGNATURE -> SecurityManager()
             FIELD_FILTER_MAP_FIELD_SIGNATURE -> mapOf(Reflection::class to arrayOf("fieldFilterMap", "methodFilterMap"))
             METHOD_FILTER_MAP_FIELD_SIGNATURE -> emptyMap<Class<*>, Array<String>>()
-            else -> field.fieldId.field.let { it.withAccessibility { it.get(null) } }
+            else -> declaringClass.id.fieldById(field.fieldId).let { it.withAccessibility { it.get(null) } }
         }
 
     private fun isStaticInstanceInMethodResult(id: ClassId, methodResult: MethodResult?) =

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -8,7 +8,6 @@ import kotlinx.collections.immutable.toPersistentMap
 import kotlinx.collections.immutable.toPersistentSet
 import org.utbot.common.WorkaroundReason.HACK
 import org.utbot.common.WorkaroundReason.REMOVE_ANONYMOUS_CLASSES
-import org.utbot.common.findField
 import org.utbot.common.unreachableBranch
 import org.utbot.common.withAccessibility
 import org.utbot.common.workaround
@@ -91,6 +90,7 @@ import org.utbot.framework.plugin.api.UtMethod
 import org.utbot.framework.plugin.api.classId
 import org.utbot.framework.plugin.api.id
 import org.utbot.framework.plugin.api.util.id
+import org.utbot.framework.plugin.api.util.field
 import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.framework.plugin.api.util.signature
 import org.utbot.framework.plugin.api.util.utContext
@@ -639,7 +639,7 @@ class Traverser(
             SECURITY_FIELD_SIGNATURE -> SecurityManager()
             FIELD_FILTER_MAP_FIELD_SIGNATURE -> mapOf(Reflection::class to arrayOf("fieldFilterMap", "methodFilterMap"))
             METHOD_FILTER_MAP_FIELD_SIGNATURE -> emptyMap<Class<*>, Array<String>>()
-            else -> declaringClass.id.jClass.findField(field.name).let { it.withAccessibility { it.get(null) } }
+            else -> field.fieldId.field.let { it.withAccessibility { it.get(null) } }
         }
 
     private fun isStaticInstanceInMethodResult(id: ClassId, methodResult: MethodResult?) =

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -89,9 +89,9 @@ import org.utbot.framework.plugin.api.MethodId
 import org.utbot.framework.plugin.api.UtMethod
 import org.utbot.framework.plugin.api.classId
 import org.utbot.framework.plugin.api.id
-import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.field
 import org.utbot.framework.plugin.api.util.jClass
+import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.signature
 import org.utbot.framework.plugin.api.util.utContext
 import org.utbot.framework.util.executableId

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/TypeResolver.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/TypeResolver.kt
@@ -70,8 +70,8 @@ class TypeResolver(private val typeRegistry: TypeRegistry, private val hierarchy
         hierarchy
             .ancestors(type.sootClass.id)
             .flatMap { it.fields }
-            .asReversed() // to take fields of the farthest parent in the distinctBy
-            .distinctBy { it.name } // TODO we lose hidden fields here JIRA:315
+            //.asReversed() // to take fields of the farthest parent in the distinctBy
+            //.distinctBy { it.name } // TODO we lose hidden fields here JIRA:315
     }
 
     /**

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/TypeResolver.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/TypeResolver.kt
@@ -70,8 +70,6 @@ class TypeResolver(private val typeRegistry: TypeRegistry, private val hierarchy
         hierarchy
             .ancestors(type.sootClass.id)
             .flatMap { it.fields }
-            //.asReversed() // to take fields of the farthest parent in the distinctBy
-            //.distinctBy { it.name } // TODO we lose hidden fields here JIRA:315
     }
 
     /**

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ValueConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ValueConstructor.kt
@@ -360,7 +360,8 @@ class ValueConstructor {
         val instanceClassId = instanceModel.classId
         val fieldModel = directSetterModel.fieldModel
 
-        val field = instance::class.java.findField(directSetterModel.fieldId.name)
+        val field = directSetterModel.fieldId.declaringClass.jClass.findField(directSetterModel.fieldId.name)
+        // val field = instance::class.java.findField(directSetterModel.fieldId.name)
         val isAccessible = field.isAccessible
 
         try {

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ValueConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ValueConstructor.kt
@@ -36,7 +36,6 @@ import org.utbot.framework.plugin.api.UtVoidModel
 import org.utbot.framework.plugin.api.isMockModel
 import org.utbot.framework.plugin.api.util.constructor
 import org.utbot.framework.plugin.api.util.field
-import org.utbot.framework.plugin.api.util.findFieldById
 import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.framework.plugin.api.util.method
 import org.utbot.framework.plugin.api.util.utContext
@@ -212,8 +211,8 @@ class ValueConstructor {
         val classInstance = javaClass.anyInstance
         constructedObjects[model] = classInstance
 
-        model.fields.forEach { (field, fieldModel) ->
-            val declaredField = model.classId.findFieldById(field)
+        model.fields.forEach { (fieldId, fieldModel) ->
+            val declaredField = fieldId.field
             val accessible = declaredField.isAccessible
 
             try {
@@ -227,7 +226,7 @@ class ValueConstructor {
                         fieldModel.classId.name,
                         model.classId.name,
                         UtConcreteValue(classInstance),
-                        field.name
+                        fieldId.name
                     )
                 }
                 val value = construct(fieldModel, target).value

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ValueConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ValueConstructor.kt
@@ -36,7 +36,7 @@ import org.utbot.framework.plugin.api.UtVoidModel
 import org.utbot.framework.plugin.api.isMockModel
 import org.utbot.framework.plugin.api.util.constructor
 import org.utbot.framework.plugin.api.util.field
-import org.utbot.framework.plugin.api.util.fieldById
+import org.utbot.framework.plugin.api.util.findFieldById
 import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.framework.plugin.api.util.method
 import org.utbot.framework.plugin.api.util.utContext
@@ -213,7 +213,7 @@ class ValueConstructor {
         constructedObjects[model] = classInstance
 
         model.fields.forEach { (field, fieldModel) ->
-            val declaredField = model.classId.fieldById(field)
+            val declaredField = model.classId.findFieldById(field)
             val accessible = declaredField.isAccessible
 
             try {

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ValueConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ValueConstructor.kt
@@ -36,7 +36,7 @@ import org.utbot.framework.plugin.api.UtVoidModel
 import org.utbot.framework.plugin.api.isMockModel
 import org.utbot.framework.plugin.api.util.constructor
 import org.utbot.framework.plugin.api.util.field
-import org.utbot.framework.plugin.api.util.fieldOrNull
+import org.utbot.framework.plugin.api.util.fieldById
 import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.framework.plugin.api.util.method
 import org.utbot.framework.plugin.api.util.utContext
@@ -213,8 +213,7 @@ class ValueConstructor {
         constructedObjects[model] = classInstance
 
         model.fields.forEach { (field, fieldModel) ->
-            val declaredField =
-                model.classId.fieldOrNull(field) ?: error("Can't find field: $field for $javaClass")
+            val declaredField = model.classId.fieldById(field)
             val accessible = declaredField.isAccessible
 
             try {
@@ -361,7 +360,6 @@ class ValueConstructor {
         val fieldModel = directSetterModel.fieldModel
 
         val field = directSetterModel.fieldId.field
-        // val field = instance::class.java.findField(directSetterModel.fieldId.name)
         val isAccessible = field.isAccessible
 
         try {

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ValueConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ValueConstructor.kt
@@ -1,7 +1,5 @@
 package org.utbot.engine
 
-import org.utbot.common.findField
-import org.utbot.common.findFieldOrNull
 import org.utbot.common.invokeCatching
 import org.utbot.common.withAccessibility
 import org.utbot.framework.plugin.api.ClassId
@@ -37,6 +35,8 @@ import org.utbot.framework.plugin.api.UtValueExecutionState
 import org.utbot.framework.plugin.api.UtVoidModel
 import org.utbot.framework.plugin.api.isMockModel
 import org.utbot.framework.plugin.api.util.constructor
+import org.utbot.framework.plugin.api.util.field
+import org.utbot.framework.plugin.api.util.fieldOrNull
 import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.framework.plugin.api.util.method
 import org.utbot.framework.plugin.api.util.utContext
@@ -214,7 +214,7 @@ class ValueConstructor {
 
         model.fields.forEach { (field, fieldModel) ->
             val declaredField =
-                javaClass.findFieldOrNull(field.name) ?: error("Can't find field: $field for $javaClass")
+                model.classId.fieldOrNull(field) ?: error("Can't find field: $field for $javaClass")
             val accessible = declaredField.isAccessible
 
             try {
@@ -360,7 +360,7 @@ class ValueConstructor {
         val instanceClassId = instanceModel.classId
         val fieldModel = directSetterModel.fieldModel
 
-        val field = directSetterModel.fieldId.declaringClass.jClass.findField(directSetterModel.fieldId.name)
+        val field = directSetterModel.fieldId.field
         // val field = instance::class.java.findField(directSetterModel.fieldId.name)
         val isAccessible = field.isAccessible
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgFieldStateManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgFieldStateManager.kt
@@ -177,7 +177,7 @@ internal class CgFieldStateManagerImpl(val context: CgContext)
                     }
 
                     // if previous field has type that does not have current field, this field is inaccessible
-                    if (index > 0 && !path[index - 1].type.hasField(fieldPathElement.field.name)) {
+                    if (index > 0 && !path[index - 1].type.hasField(fieldPathElement.field)) {
                         lastAccessibleIndex = index - 1
                         break
                     }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
@@ -928,8 +928,8 @@ internal class CgMethodConstructor(val context: CgContext) : CgContextOwner by c
     private fun FieldId.getAccessExpression(variable: CgVariable): CgExpression =
         // Can directly access field only if it is declared in variable class (or in its ancestors)
         // and is accessible from current package
-        if (variable.type.hasField(name) && isAccessibleFrom(testClassPackageName)) {
-            if (field.isStatic) CgStaticFieldAccess(this) else CgFieldAccess(variable, this)
+        if (variable.type.hasField(this) && isAccessibleFrom(testClassPackageName)) {
+            if (field.isStatic) CgStaticFieldAccess(this) else variable[this]
         } else {
             testClassThisInstance[getFieldValue](variable, stringLiteral(name))
         }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
@@ -43,7 +43,6 @@ import org.utbot.framework.codegen.model.tree.CgEqualTo
 import org.utbot.framework.codegen.model.tree.CgErrorTestMethod
 import org.utbot.framework.codegen.model.tree.CgExecutableCall
 import org.utbot.framework.codegen.model.tree.CgExpression
-import org.utbot.framework.codegen.model.tree.CgFieldAccess
 import org.utbot.framework.codegen.model.tree.CgGetJavaClass
 import org.utbot.framework.codegen.model.tree.CgIfStatement
 import org.utbot.framework.codegen.model.tree.CgLiteral

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgVariableConstructor.kt
@@ -45,7 +45,7 @@ import org.utbot.framework.plugin.api.UtPrimitiveModel
 import org.utbot.framework.plugin.api.UtReferenceModel
 import org.utbot.framework.plugin.api.UtVoidModel
 import org.utbot.framework.plugin.api.util.defaultValueModel
-import org.utbot.framework.plugin.api.util.fieldByIdOrNull
+import org.utbot.framework.plugin.api.util.findFieldByIdOrNull
 import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.intClassId
 import org.utbot.framework.plugin.api.util.isArray
@@ -126,7 +126,7 @@ internal class CgVariableConstructor(val context: CgContext) :
 
         for ((fieldId, fieldModel) in model.fields) {
             val variableForField = getOrCreateVariable(fieldModel)
-            val field = obj.type.fieldByIdOrNull(fieldId)
+            val field = obj.type.findFieldByIdOrNull(fieldId)
 
             // we cannot set field directly if variable declared type does not have such field
             // or we cannot directly create variable for field with the specified type (it is private, for example)

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgVariableConstructor.kt
@@ -15,10 +15,8 @@ import org.utbot.framework.codegen.model.tree.CgAllocateInitializedArray
 import org.utbot.framework.codegen.model.tree.CgDeclaration
 import org.utbot.framework.codegen.model.tree.CgEnumConstantAccess
 import org.utbot.framework.codegen.model.tree.CgExpression
-import org.utbot.framework.codegen.model.tree.CgFieldAccess
 import org.utbot.framework.codegen.model.tree.CgGetJavaClass
 import org.utbot.framework.codegen.model.tree.CgLiteral
-import org.utbot.framework.codegen.model.tree.CgNotNullAssertion
 import org.utbot.framework.codegen.model.tree.CgStaticFieldAccess
 import org.utbot.framework.codegen.model.tree.CgValue
 import org.utbot.framework.codegen.model.tree.CgVariable
@@ -47,7 +45,7 @@ import org.utbot.framework.plugin.api.UtPrimitiveModel
 import org.utbot.framework.plugin.api.UtReferenceModel
 import org.utbot.framework.plugin.api.UtVoidModel
 import org.utbot.framework.plugin.api.util.defaultValueModel
-import org.utbot.framework.plugin.api.util.fieldOrNull
+import org.utbot.framework.plugin.api.util.fieldByIdOrNull
 import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.intClassId
 import org.utbot.framework.plugin.api.util.isArray
@@ -128,7 +126,7 @@ internal class CgVariableConstructor(val context: CgContext) :
 
         for ((fieldId, fieldModel) in model.fields) {
             val variableForField = getOrCreateVariable(fieldModel)
-            val field = obj.type.fieldOrNull(fieldId)
+            val field = obj.type.fieldByIdOrNull(fieldId)
 
             // we cannot set field directly if variable declared type does not have such field
             // or we cannot directly create variable for field with the specified type (it is private, for example)

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/util/DslUtil.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/util/DslUtil.kt
@@ -23,7 +23,19 @@ import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.CodegenLanguage
 import org.utbot.framework.plugin.api.FieldId
 import org.utbot.framework.plugin.api.MethodId
-import org.utbot.framework.plugin.api.util.*
+import org.utbot.framework.plugin.api.util.booleanClassId
+import org.utbot.framework.plugin.api.util.byteClassId
+import org.utbot.framework.plugin.api.util.charClassId
+import org.utbot.framework.plugin.api.util.doubleClassId
+import org.utbot.framework.plugin.api.util.field
+import org.utbot.framework.plugin.api.util.floatClassId
+import org.utbot.framework.plugin.api.util.intClassId
+import org.utbot.framework.plugin.api.util.isArray
+import org.utbot.framework.plugin.api.util.jClass
+import org.utbot.framework.plugin.api.util.longClassId
+import org.utbot.framework.plugin.api.util.objectClassId
+import org.utbot.framework.plugin.api.util.shortClassId
+import org.utbot.framework.plugin.api.util.stringClassId
 
 fun CgExpression.at(index: Any?): CgArrayElementAccess =
     CgArrayElementAccess(this, index.resolve())

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/util/DslUtil.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/util/DslUtil.kt
@@ -1,6 +1,6 @@
 package org.utbot.framework.codegen.model.util
 
-import org.utbot.common.findDirectAccessedField
+import org.utbot.common.findDirectAccessedFieldOrNull
 import org.utbot.framework.codegen.model.constructor.tree.CgCallableAccessManager
 import org.utbot.framework.codegen.model.tree.CgArrayElementAccess
 import org.utbot.framework.codegen.model.tree.CgDecrement
@@ -76,10 +76,11 @@ fun stringLiteral(string: String) = CgLiteral(stringClassId, string)
 
 // non-static fields
 operator fun CgExpression.get(fieldId: FieldId): CgFieldAccess =
-    if (type.jClass.findDirectAccessedField(fieldId.name) != fieldId.field)
+    if (type.jClass.findDirectAccessedFieldOrNull(fieldId.name) != fieldId.field) {
         CgFieldAccess(CgTypeCast(fieldId.declaringClass, this), fieldId)
-    else
+    } else {
         CgFieldAccess(this, fieldId)
+    }
 
 // static fields
 // TODO: unused receiver

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/util/DslUtil.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/util/DslUtil.kt
@@ -1,5 +1,6 @@
 package org.utbot.framework.codegen.model.util
 
+import org.utbot.common.findDirectAccessedField
 import org.utbot.framework.codegen.model.constructor.tree.CgCallableAccessManager
 import org.utbot.framework.codegen.model.tree.CgArrayElementAccess
 import org.utbot.framework.codegen.model.tree.CgDecrement
@@ -16,22 +17,13 @@ import org.utbot.framework.codegen.model.tree.CgLessThan
 import org.utbot.framework.codegen.model.tree.CgLiteral
 import org.utbot.framework.codegen.model.tree.CgStaticFieldAccess
 import org.utbot.framework.codegen.model.tree.CgThisInstance
+import org.utbot.framework.codegen.model.tree.CgTypeCast
 import org.utbot.framework.codegen.model.tree.CgVariable
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.CodegenLanguage
 import org.utbot.framework.plugin.api.FieldId
 import org.utbot.framework.plugin.api.MethodId
-import org.utbot.framework.plugin.api.util.booleanClassId
-import org.utbot.framework.plugin.api.util.byteClassId
-import org.utbot.framework.plugin.api.util.charClassId
-import org.utbot.framework.plugin.api.util.doubleClassId
-import org.utbot.framework.plugin.api.util.floatClassId
-import org.utbot.framework.plugin.api.util.intClassId
-import org.utbot.framework.plugin.api.util.isArray
-import org.utbot.framework.plugin.api.util.longClassId
-import org.utbot.framework.plugin.api.util.objectClassId
-import org.utbot.framework.plugin.api.util.shortClassId
-import org.utbot.framework.plugin.api.util.stringClassId
+import org.utbot.framework.plugin.api.util.*
 
 fun CgExpression.at(index: Any?): CgArrayElementAccess =
     CgArrayElementAccess(this, index.resolve())
@@ -72,7 +64,10 @@ fun stringLiteral(string: String) = CgLiteral(stringClassId, string)
 
 // non-static fields
 operator fun CgExpression.get(fieldId: FieldId): CgFieldAccess =
-    CgFieldAccess(this, fieldId)
+    if (type.jClass.findDirectAccessedField(fieldId.name) != fieldId.field)
+        CgFieldAccess(CgTypeCast(fieldId.declaringClass, this), fieldId)
+    else
+        CgFieldAccess(this, fieldId)
 
 // static fields
 // TODO: unused receiver

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgAbstractRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgAbstractRenderer.kt
@@ -86,14 +86,7 @@ import org.utbot.framework.plugin.api.UtArrayModel
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtNullModel
 import org.utbot.framework.plugin.api.UtPrimitiveModel
-import org.utbot.framework.plugin.api.util.booleanClassId
-import org.utbot.framework.plugin.api.util.byteClassId
-import org.utbot.framework.plugin.api.util.charClassId
-import org.utbot.framework.plugin.api.util.doubleClassId
-import org.utbot.framework.plugin.api.util.floatClassId
-import org.utbot.framework.plugin.api.util.intClassId
-import org.utbot.framework.plugin.api.util.longClassId
-import org.utbot.framework.plugin.api.util.shortClassId
+import org.utbot.framework.plugin.api.util.*
 
 internal abstract class CgAbstractRenderer(val context: CgContext, val printer: CgPrinter = CgPrinterImpl()) : CgVisitor<Unit>,
     CgPrinter by printer {
@@ -594,7 +587,13 @@ internal abstract class CgAbstractRenderer(val context: CgContext, val printer: 
     }
 
     override fun visit(element: CgFieldAccess) {
-        element.caller.accept(this)
+        if (element.caller.type.findFieldOrNull(element.fieldId.name)!!.fieldId != element.fieldId) {
+            print("((${element.fieldId.declaringClass.asString()}) ")
+            element.caller.accept(this)
+            print(")")
+        } else {
+            element.caller.accept(this)
+        }
         print(".")
         print(element.fieldId.name)
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgAbstractRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgAbstractRenderer.kt
@@ -587,13 +587,7 @@ internal abstract class CgAbstractRenderer(val context: CgContext, val printer: 
     }
 
     override fun visit(element: CgFieldAccess) {
-        if (element.caller.type.findFieldOrNull(element.fieldId.name)!!.fieldId != element.fieldId) {
-            print("((${element.fieldId.declaringClass.asString()}) ")
-            element.caller.accept(this)
-            print(")")
-        } else {
-            element.caller.accept(this)
-        }
+        element.caller.accept(this)
         print(".")
         print(element.fieldId.name)
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgAbstractRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgAbstractRenderer.kt
@@ -86,7 +86,14 @@ import org.utbot.framework.plugin.api.UtArrayModel
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtNullModel
 import org.utbot.framework.plugin.api.UtPrimitiveModel
-import org.utbot.framework.plugin.api.util.*
+import org.utbot.framework.plugin.api.util.booleanClassId
+import org.utbot.framework.plugin.api.util.byteClassId
+import org.utbot.framework.plugin.api.util.charClassId
+import org.utbot.framework.plugin.api.util.doubleClassId
+import org.utbot.framework.plugin.api.util.floatClassId
+import org.utbot.framework.plugin.api.util.intClassId
+import org.utbot.framework.plugin.api.util.longClassId
+import org.utbot.framework.plugin.api.util.shortClassId
 
 internal abstract class CgAbstractRenderer(val context: CgContext, val printer: CgPrinter = CgPrinterImpl()) : CgVisitor<Unit>,
     CgPrinter by printer {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgKotlinRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgKotlinRenderer.kt
@@ -116,13 +116,9 @@ internal class CgKotlinRenderer(context: CgContext, printer: CgPrinter = CgPrint
     // Property access
 
     override fun visit(element: CgFieldAccess) {
-        if (element.caller.type.findFieldOrNull(element.fieldId.name)!!.fieldId != element.fieldId) {
-            print("(")
-            element.caller.accept(this)
-            print(" as ${element.fieldId.declaringClass.asString()})")
-        } else {
-            element.caller.accept(this)
-        }
+        if (element.caller is CgTypeCast) print("(")
+        element.caller.accept(this)
+        if (element.caller is CgTypeCast) print(")")
         renderAccess(element.caller)
         print(element.fieldId.name)
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgKotlinRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgKotlinRenderer.kt
@@ -47,7 +47,12 @@ import org.utbot.framework.plugin.api.CodegenLanguage
 import org.utbot.framework.plugin.api.TypeParameters
 import org.utbot.framework.plugin.api.UtPrimitiveModel
 import org.utbot.framework.plugin.api.WildcardTypeParameter
-import org.utbot.framework.plugin.api.util.*
+import org.utbot.framework.plugin.api.util.id
+import org.utbot.framework.plugin.api.util.isArray
+import org.utbot.framework.plugin.api.util.isPrimitive
+import org.utbot.framework.plugin.api.util.isPrimitiveWrapper
+import org.utbot.framework.plugin.api.util.kClass
+import org.utbot.framework.plugin.api.util.voidClassId
 
 //TODO rewrite using KtPsiFactory?
 internal class CgKotlinRenderer(context: CgContext, printer: CgPrinter = CgPrinterImpl()) : CgAbstractRenderer(context, printer) {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgKotlinRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgKotlinRenderer.kt
@@ -47,12 +47,7 @@ import org.utbot.framework.plugin.api.CodegenLanguage
 import org.utbot.framework.plugin.api.TypeParameters
 import org.utbot.framework.plugin.api.UtPrimitiveModel
 import org.utbot.framework.plugin.api.WildcardTypeParameter
-import org.utbot.framework.plugin.api.util.id
-import org.utbot.framework.plugin.api.util.isArray
-import org.utbot.framework.plugin.api.util.isPrimitive
-import org.utbot.framework.plugin.api.util.isPrimitiveWrapper
-import org.utbot.framework.plugin.api.util.kClass
-import org.utbot.framework.plugin.api.util.voidClassId
+import org.utbot.framework.plugin.api.util.*
 
 //TODO rewrite using KtPsiFactory?
 internal class CgKotlinRenderer(context: CgContext, printer: CgPrinter = CgPrinterImpl()) : CgAbstractRenderer(context, printer) {
@@ -121,7 +116,13 @@ internal class CgKotlinRenderer(context: CgContext, printer: CgPrinter = CgPrint
     // Property access
 
     override fun visit(element: CgFieldAccess) {
-        element.caller.accept(this)
+        if (element.caller.type.findFieldOrNull(element.fieldId.name)!!.fieldId != element.fieldId) {
+            print("(")
+            element.caller.accept(this)
+            print(" as ${element.fieldId.declaringClass.asString()})")
+        } else {
+            element.caller.accept(this)
+        }
         renderAccess(element.caller)
         print(element.fieldId.name)
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/MockValueConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/MockValueConstructor.kt
@@ -45,7 +45,6 @@ import org.mockito.Mockito
 import org.mockito.stubbing.Answer
 import org.objectweb.asm.Type
 import org.utbot.common.withAccessibility
-import org.utbot.framework.plugin.api.util.findFieldById
 
 /**
  * Constructs values (including mocks) from models.
@@ -169,8 +168,8 @@ class MockValueConstructor(
             mockInstance
         }
 
-        model.fields.forEach { (field, fieldModel) ->
-            val declaredField = model.classId.findFieldById(field)
+        model.fields.forEach { (fieldId, fieldModel) ->
+            val declaredField = fieldId.field
             val accessible = declaredField.isAccessible
             declaredField.isAccessible = true
 
@@ -178,7 +177,7 @@ class MockValueConstructor(
             modifiersField.isAccessible = true
 
             val target = mockTarget(fieldModel) {
-                FieldMockTarget(fieldModel.classId.name, model.classId.name, UtConcreteValue(classInstance), field.name)
+                FieldMockTarget(fieldModel.classId.name, model.classId.name, UtConcreteValue(classInstance), fieldId.name)
             }
             val value = construct(fieldModel, target).value
             val instance = if (Modifier.isStatic(declaredField.modifiers)) null else classInstance

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/MockValueConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/MockValueConstructor.kt
@@ -45,7 +45,7 @@ import org.mockito.Mockito
 import org.mockito.stubbing.Answer
 import org.objectweb.asm.Type
 import org.utbot.common.withAccessibility
-import org.utbot.framework.plugin.api.util.fieldById
+import org.utbot.framework.plugin.api.util.findFieldById
 
 /**
  * Constructs values (including mocks) from models.
@@ -170,7 +170,7 @@ class MockValueConstructor(
         }
 
         model.fields.forEach { (field, fieldModel) ->
-            val declaredField = model.classId.fieldById(field)
+            val declaredField = model.classId.findFieldById(field)
             val accessible = declaredField.isAccessible
             declaredField.isAccessible = true
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/MockValueConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/MockValueConstructor.kt
@@ -394,7 +394,7 @@ class MockValueConstructor(
         val instanceClassId = instanceModel.classId
         val fieldModel = directSetterModel.fieldModel
 
-        val field = instance::class.java.findField(directSetterModel.fieldId.name)
+        val field = directSetterModel.fieldId.declaringClass.jClass.findField(directSetterModel.fieldId.name)
         val isAccessible = field.isAccessible
 
         try {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/MockValueConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/MockValueConstructor.kt
@@ -1,7 +1,5 @@
 package org.utbot.framework.concrete
 
-import org.utbot.common.findField
-import org.utbot.common.findFieldOrNull
 import org.utbot.common.invokeCatching
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.ConstructorId
@@ -33,6 +31,8 @@ import org.utbot.framework.plugin.api.UtVoidModel
 import org.utbot.framework.plugin.api.isMockModel
 import org.utbot.framework.plugin.api.util.constructor
 import org.utbot.framework.plugin.api.util.executableId
+import org.utbot.framework.plugin.api.util.field
+import org.utbot.framework.plugin.api.util.fieldOrNull
 import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.framework.plugin.api.util.method
 import org.utbot.framework.plugin.api.util.utContext
@@ -171,7 +171,7 @@ class MockValueConstructor(
 
         model.fields.forEach { (field, fieldModel) ->
             val declaredField =
-                javaClass.findFieldOrNull(field.name) ?: error("Can't find field: $field for $javaClass")
+                model.classId.fieldOrNull(field) ?: error("Can't find field: $field for $javaClass")
             val accessible = declaredField.isAccessible
             declaredField.isAccessible = true
 
@@ -394,7 +394,7 @@ class MockValueConstructor(
         val instanceClassId = instanceModel.classId
         val fieldModel = directSetterModel.fieldModel
 
-        val field = directSetterModel.fieldId.declaringClass.jClass.findField(directSetterModel.fieldId.name)
+        val field = directSetterModel.fieldId.field
         val isAccessible = field.isAccessible
 
         try {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/MockValueConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/MockValueConstructor.kt
@@ -32,7 +32,6 @@ import org.utbot.framework.plugin.api.isMockModel
 import org.utbot.framework.plugin.api.util.constructor
 import org.utbot.framework.plugin.api.util.executableId
 import org.utbot.framework.plugin.api.util.field
-import org.utbot.framework.plugin.api.util.fieldOrNull
 import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.framework.plugin.api.util.method
 import org.utbot.framework.plugin.api.util.utContext
@@ -46,6 +45,7 @@ import org.mockito.Mockito
 import org.mockito.stubbing.Answer
 import org.objectweb.asm.Type
 import org.utbot.common.withAccessibility
+import org.utbot.framework.plugin.api.util.fieldById
 
 /**
  * Constructs values (including mocks) from models.
@@ -170,8 +170,7 @@ class MockValueConstructor(
         }
 
         model.fields.forEach { (field, fieldModel) ->
-            val declaredField =
-                model.classId.fieldOrNull(field) ?: error("Can't find field: $field for $javaClass")
+            val declaredField = model.classId.fieldById(field)
             val accessible = declaredField.isAccessible
             declaredField.isAccessible = true
 

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/UtModelTestCaseChecker.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/UtModelTestCaseChecker.kt
@@ -165,8 +165,8 @@ internal abstract class UtModelTestCaseChecker(
     /**
      * Finds field model in [UtCompositeModel] and [UtAssembleModel]. For assemble model supports direct field access only.
      */
-    protected fun UtModel.findField(fieldName: String, declarationClass: ClassId = this.classId): UtModel =
-        findField(FieldId(declarationClass, fieldName))
+    protected fun UtModel.findField(fieldName: String, declaringClass: ClassId = this.classId): UtModel =
+        findField(FieldId(declaringClass, fieldName))
 
     /**
      * Finds field model in [UtCompositeModel] and [UtAssembleModel]. For assemble model supports direct field access only.

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/UtModelTestCaseChecker.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/UtModelTestCaseChecker.kt
@@ -6,10 +6,10 @@ import org.utbot.common.ClassLocation
 import org.utbot.common.FileUtil.findPathToClassFiles
 import org.utbot.common.FileUtil.locateClass
 import org.utbot.common.WorkaroundReason.HACK
-import org.utbot.common.findField
 import org.utbot.common.workaround
 import org.utbot.engine.prettify
 import org.utbot.framework.UtSettings.checkSolverTimeoutMillis
+import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.CodegenLanguage
 import org.utbot.framework.plugin.api.FieldId
 import org.utbot.framework.plugin.api.MockStrategyApi
@@ -27,8 +27,6 @@ import org.utbot.framework.plugin.api.getOrThrow
 import org.utbot.framework.plugin.api.util.UtContext
 import org.utbot.framework.plugin.api.util.defaultValueModel
 import org.utbot.framework.plugin.api.util.executableId
-import org.utbot.framework.plugin.api.util.fieldId
-import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.framework.plugin.api.util.withUtContext
 import java.nio.file.Path
 import kotlin.reflect.KClass
@@ -167,8 +165,8 @@ internal abstract class UtModelTestCaseChecker(
     /**
      * Finds field model in [UtCompositeModel] and [UtAssembleModel]. For assemble model supports direct field access only.
      */
-    protected fun UtModel.findField(fieldName: String): UtModel =
-        findField(this.classId.jClass.findField(fieldName).fieldId)
+    protected fun UtModel.findField(fieldName: String, declarationClass: ClassId = this.classId): UtModel =
+        findField(FieldId(declarationClass, fieldName))
 
     /**
      * Finds field model in [UtCompositeModel] and [UtAssembleModel]. For assemble model supports direct field access only.

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/enums/ClassWithEnumTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/enums/ClassWithEnumTest.kt
@@ -12,7 +12,6 @@ import org.utbot.framework.plugin.api.FieldId
 import org.utbot.framework.plugin.api.util.id
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
-import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.util.field
 
 class ClassWithEnumTest : UtValueTestCaseChecker(testClass = ClassWithEnum::class) {

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/enums/ClassWithEnumTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/enums/ClassWithEnumTest.kt
@@ -1,6 +1,5 @@
 package org.utbot.examples.enums
 
-import org.utbot.common.findField
 import org.utbot.examples.UtValueTestCaseChecker
 import org.utbot.examples.DoNotCalculate
 import org.utbot.examples.enums.ClassWithEnum.StatusEnum.ERROR
@@ -13,6 +12,8 @@ import org.utbot.framework.plugin.api.FieldId
 import org.utbot.framework.plugin.api.util.id
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.utbot.framework.plugin.api.ClassId
+import org.utbot.framework.plugin.api.util.field
 
 class ClassWithEnumTest : UtValueTestCaseChecker(testClass = ClassWithEnum::class) {
     @Test
@@ -111,7 +112,7 @@ class ClassWithEnumTest : UtValueTestCaseChecker(testClass = ClassWithEnum::clas
             eq(1),
             { t, staticsAfter, r ->
                 // for some reasons x is inaccessible
-                val x = t.javaClass.findField("x").get(t) as Int
+                val x = FieldId(t.javaClass.id, "x").field.get(t) as Int
 
                 val y = staticsAfter[FieldId(ClassWithEnum.ClassWithStaticField::class.id, "y")]!!.value as Int
 

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/objects/HiddenFieldAccessModifiersTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/objects/HiddenFieldAccessModifiersTest.kt
@@ -1,0 +1,20 @@
+package org.utbot.examples.objects
+
+import org.utbot.examples.UtValueTestCaseChecker
+import org.utbot.examples.DoNotCalculate
+import org.utbot.examples.eq
+import org.junit.jupiter.api.Test
+
+internal class HiddenFieldAccessModifiersTest : UtValueTestCaseChecker(testClass = HiddenFieldExample::class) {
+    @Test
+    fun testCheckSuperFieldEqualsOne() {
+        check(
+            HiddenFieldAccessModifiersExample::checkSuperFieldEqualsOne,
+            eq(3),
+            { o, _ -> o == null },
+            { _, r -> r == true },
+            { _, r -> r == false},
+            coverage = DoNotCalculate
+        )
+    }
+}

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/objects/HiddenFieldAccessModifiersTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/objects/HiddenFieldAccessModifiersTest.kt
@@ -5,7 +5,7 @@ import org.utbot.examples.DoNotCalculate
 import org.utbot.examples.eq
 import org.junit.jupiter.api.Test
 
-internal class HiddenFieldAccessModifiersTest : UtValueTestCaseChecker(testClass = HiddenFieldExample::class) {
+internal class HiddenFieldAccessModifiersTest : UtValueTestCaseChecker(testClass = HiddenFieldAccessModifiersExample::class) {
     @Test
     fun testCheckSuperFieldEqualsOne() {
         check(

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/objects/HiddenFieldAccessModifiersTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/objects/HiddenFieldAccessModifiersTest.kt
@@ -14,7 +14,6 @@ internal class HiddenFieldAccessModifiersTest : UtValueTestCaseChecker(testClass
             { o, _ -> o == null },
             { _, r -> r == true },
             { _, r -> r == false},
-            coverage = DoNotCalculate
         )
     }
 }

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/objects/HiddenFieldExampleTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/objects/HiddenFieldExampleTest.kt
@@ -3,8 +3,9 @@ package org.utbot.examples.objects
 import org.utbot.examples.UtValueTestCaseChecker
 import org.utbot.examples.DoNotCalculate
 import org.utbot.examples.eq
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+
+
 
 internal class HiddenFieldExampleTest : UtValueTestCaseChecker(testClass = HiddenFieldExample::class) {
     @Test
@@ -22,7 +23,7 @@ internal class HiddenFieldExampleTest : UtValueTestCaseChecker(testClass = Hidde
     }
 
     @Test
-    @Disabled("SAT-315 Engine cannot work with hidden fields")
+    //@Disabled("SAT-315 Engine cannot work with hidden fields")
     // Engine translates calls to super.b as calls to succ.b
     fun testCheckSuccField() {
         check(

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/objects/HiddenFieldExampleTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/objects/HiddenFieldExampleTest.kt
@@ -29,7 +29,6 @@ internal class HiddenFieldExampleTest : UtValueTestCaseChecker(testClass = Hidde
             { o, r -> o.a != 1 && o.b == 2.0 && r == 2 },
             { o, r -> o.a != 1 && o.b != 2.0 && (o as HiddenFieldSuperClass).b == 3 && r == 3 },
             { o, r -> o.a != 1 && o.b != 2.0 && (o as HiddenFieldSuperClass).b != 3 && r == 4 },
-            coverage = DoNotCalculate
         )
     }
 }

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/objects/HiddenFieldExampleTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/objects/HiddenFieldExampleTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test
 
 internal class HiddenFieldExampleTest : UtValueTestCaseChecker(testClass = HiddenFieldExample::class) {
     @Test
-    // Engine creates HiddenFieldSuccClass instead of HiddenFieldSuperClass, feels wrong field and matchers fail
     fun testCheckHiddenField() {
         check(
             HiddenFieldExample::checkHiddenField,
@@ -21,8 +20,6 @@ internal class HiddenFieldExampleTest : UtValueTestCaseChecker(testClass = Hidde
     }
 
     @Test
-    //@Disabled("SAT-315 Engine cannot work with hidden fields")
-    // Engine translates calls to super.b as calls to succ.b
     fun testCheckSuccField() {
         check(
             HiddenFieldExample::checkSuccField,

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/objects/HiddenFieldExampleTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/objects/HiddenFieldExampleTest.kt
@@ -5,8 +5,6 @@ import org.utbot.examples.DoNotCalculate
 import org.utbot.examples.eq
 import org.junit.jupiter.api.Test
 
-
-
 internal class HiddenFieldExampleTest : UtValueTestCaseChecker(testClass = HiddenFieldExample::class) {
     @Test
     // Engine creates HiddenFieldSuccClass instead of HiddenFieldSuperClass, feels wrong field and matchers fail

--- a/utbot-sample/src/main/java/org/utbot/examples/objects/HiddenFieldAccessModifiersExample.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/objects/HiddenFieldAccessModifiersExample.java
@@ -1,0 +1,7 @@
+package org.utbot.examples.objects;
+
+public class HiddenFieldAccessModifiersExample {
+    public boolean checkSuperFieldEqualsOne(HiddenFieldAccessModifiersSucc b) {
+        return b.getF() == 1;
+    }
+}

--- a/utbot-sample/src/main/java/org/utbot/examples/objects/HiddenFieldAccessModifiersSucc.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/objects/HiddenFieldAccessModifiersSucc.java
@@ -1,0 +1,5 @@
+package org.utbot.examples.objects;
+
+public class HiddenFieldAccessModifiersSucc extends HiddenFieldAccessModifiersSuper {
+    private int f;
+}

--- a/utbot-sample/src/main/java/org/utbot/examples/objects/HiddenFieldAccessModifiersSuper.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/objects/HiddenFieldAccessModifiersSuper.java
@@ -1,0 +1,11 @@
+package org.utbot.examples.objects;
+
+public class HiddenFieldAccessModifiersSuper {
+    public int f;
+    public int getF() {
+        return this.f;
+    }
+    public void setF(int val) {
+        this.f = val;
+    }
+}

--- a/utbot-sample/src/main/java/org/utbot/examples/objects/HiddenFieldSuccClass.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/objects/HiddenFieldSuccClass.java
@@ -2,4 +2,9 @@ package org.utbot.examples.objects;
 
 public class HiddenFieldSuccClass extends HiddenFieldSuperClass {
     public double b;
+
+    @Override
+    public String toString() {
+        return b + ". Super b: " + super.b;
+    }
 }

--- a/utbot-sample/src/main/java/org/utbot/examples/objects/HiddenFieldSuccClass.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/objects/HiddenFieldSuccClass.java
@@ -2,9 +2,4 @@ package org.utbot.examples.objects;
 
 public class HiddenFieldSuccClass extends HiddenFieldSuperClass {
     public double b;
-
-    @Override
-    public String toString() {
-        return b + ". Super b: " + super.b;
-    }
 }


### PR DESCRIPTION
# Description

Now if class has hidden fields, they can be recognized by engine and correct code for instantiation of such classes will be generated.

Fixes #563

## Type of Change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

Switched `org.utbot.examples.objects.HiddenFieldExampleTest#testCheckSuccField` to enabled, added `org.utbot.examples.objects.HiddenFieldAccessModifiersTest`

## Manual Scenario 

Tested plugin on examples from #563 -- generates tests the way as expected.

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [ ] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [ ] No new warnings
- [x] New tests have been added
- [ ] All tests pass locally with my changes
