### PR TITLE
Added a few tests to check generated clustering comments

### DIFF
--- a/utbot-summary-tests/src/test/kotlin/examples/SummaryTestCaseGeneratorTest.kt
+++ b/utbot-summary-tests/src/test/kotlin/examples/SummaryTestCaseGeneratorTest.kt
@@ -10,10 +10,7 @@ import org.utbot.framework.UtSettings.checkNpeInNestedMethods
 import org.utbot.framework.UtSettings.checkNpeInNestedNotPrivateMethods
 import org.utbot.framework.UtSettings.checkSolverTimeoutMillis
 import org.utbot.framework.codegen.TestExecution
-import org.utbot.framework.plugin.api.CodegenLanguage
-import org.utbot.framework.plugin.api.MockStrategyApi
-import org.utbot.framework.plugin.api.UtExecution
-import org.utbot.framework.plugin.api.UtMethod
+import org.utbot.framework.plugin.api.*
 import org.utbot.framework.plugin.api.util.UtContext
 import org.utbot.summary.comment.nextSynonyms
 import org.utbot.summary.summarize
@@ -50,49 +47,14 @@ open class SummaryTestCaseGeneratorTest(
         cookie.close()
     }
 
-    protected inline fun <reified R> checkNoArguments(
-        method: KFunction1<*, R>,
-        coverage: CoverageMatcher = DoNotCalculate,
-        mockStrategy: MockStrategyApi = MockStrategyApi.NO_MOCKS,
-        summaryKeys: List<String>,
-        methodNames: List<String> = listOf(),
-        displayNames: List<String> = listOf()
-    ) = check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
-
-    protected inline fun <reified T, reified R> checkOneArgument(
-        method: KFunction2<*, T, R>,
-        coverage: CoverageMatcher = DoNotCalculate,
-        mockStrategy: MockStrategyApi = MockStrategyApi.NO_MOCKS,
-        summaryKeys: List<String>,
-        methodNames: List<String> = listOf(),
-        displayNames: List<String> = listOf()
-    ) = check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
-
-    protected inline fun <reified T1, reified T2, reified R> checkTwoArguments(
-        method: KFunction3<*, T1, T2, R>,
-        coverage: CoverageMatcher = DoNotCalculate,
-        mockStrategy: MockStrategyApi = MockStrategyApi.NO_MOCKS,
-        summaryKeys: List<String>,
-        methodNames: List<String> = listOf(),
-        displayNames: List<String> = listOf()
-    ) = check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
-
-    protected inline fun <reified T1, reified T2, reified T3, reified R> checkThreeArguments(
-        method: KFunction4<*, T1, T2, T3, R>,
-        coverage: CoverageMatcher = DoNotCalculate,
-        mockStrategy: MockStrategyApi = MockStrategyApi.NO_MOCKS,
-        summaryKeys: List<String>,
-        methodNames: List<String> = listOf(),
-        displayNames: List<String> = listOf()
-    ) = check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
-
-    inline fun <reified R> check(
+    inline fun <reified R> summaryCheck(
         method: KFunction<R>,
         mockStrategy: MockStrategyApi,
         coverageMatcher: CoverageMatcher,
         summaryKeys: List<String>,
-        methodNames: List<String>,
-        displayNames: List<String>
+        methodNames: List<String> = listOf(),
+        displayNames: List<String> = listOf(),
+        clusterInfo: List<Pair<UtClusterInfo, IntRange>> = listOf()
     ) {
         workaround(WorkaroundReason.HACK) {
             // @todo change to the constructor parameter
@@ -102,11 +64,12 @@ open class SummaryTestCaseGeneratorTest(
         }
         val utMethod = UtMethod.from(method)
         val testSet = executionsModel(utMethod, mockStrategy)
-        testSet.summarize(searchDirectory)
+        val testSetWithSummarization = testSet.summarize(searchDirectory)
 
-        testSet.executions.checkMatchersWithTextSummary(summaryKeys)
-        testSet.executions.checkMatchersWithMethodNames(methodNames)
-        testSet.executions.checkMatchersWithDisplayNames(displayNames)
+        testSetWithSummarization.executions.checkMatchersWithTextSummary(summaryKeys)
+        testSetWithSummarization.executions.checkMatchersWithMethodNames(methodNames)
+        testSetWithSummarization.executions.checkMatchersWithDisplayNames(displayNames)
+        testSetWithSummarization.checkClusterInfo(clusterInfo)
     }
 
     /**
@@ -123,6 +86,32 @@ open class SummaryTestCaseGeneratorTest(
         }
         return result
     }
+
+    // TODO: if next synonyms and normalize function will be removed, this method could be moved as overridden equals to the dataClass [UtClusterInfo]
+    private fun UtClusterInfo.normalizedAndEquals(other: UtClusterInfo): Boolean {
+        if (header != other.header) return false
+
+        return if (content == null) {
+            other.content == null
+        } else {
+            if (other.content == null) false
+            else {
+                content!!.normalize() == other.content!!.normalize()
+            }
+        }
+    }
+
+    fun UtMethodTestSet.checkClusterInfo(clusterInfo: List<Pair<UtClusterInfo, IntRange>>) {
+        if (clusterInfo.isEmpty()) {
+            return
+        }
+
+        this.clustersInfo.forEachIndexed { index, it ->
+            Assertions.assertTrue(it.first!!.normalizedAndEquals(clusterInfo[index].first))
+            Assertions.assertEquals(it.second.count(), clusterInfo[index].second.count())
+        }
+    }
+
 
     fun List<UtExecution>.checkMatchersWithTextSummary(
         comments: List<String>,
@@ -326,3 +315,6 @@ open class SummaryTestCaseGeneratorTest(
         }
     }
 }
+
+
+

--- a/utbot-summary-tests/src/test/kotlin/examples/algorithms/SummaryReturnExampleTest.kt
+++ b/utbot-summary-tests/src/test/kotlin/examples/algorithms/SummaryReturnExampleTest.kt
@@ -94,7 +94,7 @@ class SummaryReturnExampleTest : SummaryTestCaseGeneratorTest(
         val mockStrategy = MockStrategyApi.NO_MOCKS
         val coverage = DoNotCalculate
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
     @Test
@@ -160,7 +160,7 @@ class SummaryReturnExampleTest : SummaryTestCaseGeneratorTest(
         val mockStrategy = MockStrategyApi.NO_MOCKS
         val coverage = DoNotCalculate
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
     @Test
@@ -230,7 +230,7 @@ class SummaryReturnExampleTest : SummaryTestCaseGeneratorTest(
         val mockStrategy = MockStrategyApi.NO_MOCKS
         val coverage = DoNotCalculate
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
     @Test
@@ -304,7 +304,7 @@ class SummaryReturnExampleTest : SummaryTestCaseGeneratorTest(
         val mockStrategy = MockStrategyApi.NO_MOCKS
         val coverage = DoNotCalculate
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
     @Test
@@ -399,7 +399,7 @@ class SummaryReturnExampleTest : SummaryTestCaseGeneratorTest(
         val mockStrategy = MockStrategyApi.NO_MOCKS
         val coverage = DoNotCalculate
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
     @Test
@@ -501,6 +501,6 @@ class SummaryReturnExampleTest : SummaryTestCaseGeneratorTest(
         val mockStrategy = MockStrategyApi.NO_MOCKS
         val coverage = DoNotCalculate
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 }

--- a/utbot-summary-tests/src/test/kotlin/examples/collections/SummaryListWrapperReturnsVoidTest.kt
+++ b/utbot-summary-tests/src/test/kotlin/examples/collections/SummaryListWrapperReturnsVoidTest.kt
@@ -59,7 +59,7 @@ class SummaryListWrapperReturnsVoidTest : SummaryTestCaseGeneratorTest(
         val mockStrategy = MockStrategyApi.NO_MOCKS
         val coverage = DoNotCalculate
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
     @Test
@@ -125,6 +125,6 @@ class SummaryListWrapperReturnsVoidTest : SummaryTestCaseGeneratorTest(
         val mockStrategy = MockStrategyApi.NO_MOCKS
         val coverage = DoNotCalculate
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 }

--- a/utbot-summary-tests/src/test/kotlin/examples/controlflow/SummaryCycleTest.kt
+++ b/utbot-summary-tests/src/test/kotlin/examples/controlflow/SummaryCycleTest.kt
@@ -77,7 +77,7 @@ class SummaryCycleTest : SummaryTestCaseGeneratorTest(
         val mockStrategy = MockStrategyApi.NO_MOCKS
         val coverage = DoNotCalculate
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
     @Test
@@ -124,7 +124,6 @@ class SummaryCycleTest : SummaryTestCaseGeneratorTest(
         val mockStrategy = MockStrategyApi.NO_MOCKS
         val coverage = DoNotCalculate
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
-
 }

--- a/utbot-summary-tests/src/test/kotlin/examples/inner/SummaryInnerCallsTest.kt
+++ b/utbot-summary-tests/src/test/kotlin/examples/inner/SummaryInnerCallsTest.kt
@@ -88,7 +88,7 @@ class SummaryInnerCallsTest : SummaryTestCaseGeneratorTest(
         val mockStrategy = MockStrategyApi.NO_MOCKS
         val coverage = DoNotCalculate
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
     @Test
@@ -193,7 +193,7 @@ class SummaryInnerCallsTest : SummaryTestCaseGeneratorTest(
         val mockStrategy = MockStrategyApi.NO_MOCKS
         val coverage = DoNotCalculate
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
     // TODO: SAT-1211
@@ -240,7 +240,7 @@ class SummaryInnerCallsTest : SummaryTestCaseGeneratorTest(
         val mockStrategy = MockStrategyApi.NO_MOCKS
         val coverage = DoNotCalculate
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
     @Test
@@ -304,7 +304,7 @@ class SummaryInnerCallsTest : SummaryTestCaseGeneratorTest(
             methodName4
         )
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
     @Test
@@ -357,7 +357,7 @@ class SummaryInnerCallsTest : SummaryTestCaseGeneratorTest(
             methodName3
         )
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
     @Test
@@ -414,7 +414,7 @@ class SummaryInnerCallsTest : SummaryTestCaseGeneratorTest(
             methodName3
         )
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
     @Test
@@ -495,7 +495,7 @@ class SummaryInnerCallsTest : SummaryTestCaseGeneratorTest(
             methodName5
         )
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
     @Test
@@ -548,7 +548,7 @@ class SummaryInnerCallsTest : SummaryTestCaseGeneratorTest(
             methodName4
         )
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
     @Test
@@ -601,7 +601,7 @@ class SummaryInnerCallsTest : SummaryTestCaseGeneratorTest(
             methodName4
         )
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
     @Test
@@ -662,7 +662,7 @@ class SummaryInnerCallsTest : SummaryTestCaseGeneratorTest(
             methodName3
         )
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
     @Test
@@ -757,7 +757,7 @@ class SummaryInnerCallsTest : SummaryTestCaseGeneratorTest(
             methodName5
         )
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
     @Test
@@ -823,6 +823,6 @@ class SummaryInnerCallsTest : SummaryTestCaseGeneratorTest(
             methodName4
         )
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 }

--- a/utbot-summary-tests/src/test/kotlin/examples/inner/SummaryNestedCallsTest.kt
+++ b/utbot-summary-tests/src/test/kotlin/examples/inner/SummaryNestedCallsTest.kt
@@ -58,6 +58,6 @@ class SummaryNestedCallsTest : SummaryTestCaseGeneratorTest(
             methodName3
         )
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 }

--- a/utbot-summary-tests/src/test/kotlin/examples/ternary/SummaryTernaryTest.kt
+++ b/utbot-summary-tests/src/test/kotlin/examples/ternary/SummaryTernaryTest.kt
@@ -43,7 +43,7 @@ class SummaryTernaryTest : SummaryTestCaseGeneratorTest(
             methodName2
         )
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
     @Test
@@ -70,7 +70,7 @@ class SummaryTernaryTest : SummaryTestCaseGeneratorTest(
             methodName1
         )
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
     @Test
@@ -120,7 +120,7 @@ class SummaryTernaryTest : SummaryTestCaseGeneratorTest(
             methodName3
         )
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
     @Test
@@ -173,7 +173,7 @@ class SummaryTernaryTest : SummaryTestCaseGeneratorTest(
             methodName3
         )
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
     @Test
@@ -210,7 +210,7 @@ class SummaryTernaryTest : SummaryTestCaseGeneratorTest(
             methodName2
         )
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
     @Test
@@ -247,7 +247,7 @@ class SummaryTernaryTest : SummaryTestCaseGeneratorTest(
             methodName2
         )
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
     @Test
@@ -284,7 +284,7 @@ class SummaryTernaryTest : SummaryTestCaseGeneratorTest(
             methodName2
         )
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
     @Test
@@ -331,7 +331,7 @@ class SummaryTernaryTest : SummaryTestCaseGeneratorTest(
             methodName3
         )
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
     @Test
@@ -406,7 +406,7 @@ class SummaryTernaryTest : SummaryTestCaseGeneratorTest(
             methodName5
         )
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
     @Test
@@ -466,7 +466,7 @@ class SummaryTernaryTest : SummaryTestCaseGeneratorTest(
             methodName3
         )
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
 
@@ -508,7 +508,7 @@ class SummaryTernaryTest : SummaryTestCaseGeneratorTest(
             methodName2
         )
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
     @Test
@@ -545,7 +545,7 @@ class SummaryTernaryTest : SummaryTestCaseGeneratorTest(
             methodName2
         )
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 
     @Test
@@ -592,6 +592,6 @@ class SummaryTernaryTest : SummaryTestCaseGeneratorTest(
             methodName3
         )
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
 }

--- a/utbot-summary-tests/src/test/kotlin/math/SummaryIntMathTest.kt
+++ b/utbot-summary-tests/src/test/kotlin/math/SummaryIntMathTest.kt
@@ -5,6 +5,7 @@ import guava.examples.math.IntMath
 import org.junit.jupiter.api.Test
 import org.utbot.examples.DoNotCalculate
 import org.utbot.framework.plugin.api.MockStrategyApi
+import org.utbot.framework.plugin.api.UtClusterInfo
 
 class SummaryIntMathTest : SummaryTestCaseGeneratorTest(
     IntMath::class,
@@ -135,10 +136,14 @@ class SummaryIntMathTest : SummaryTestCaseGeneratorTest(
             methodName14
         )
 
+        val clusterInfo = listOf(
+            Pair(UtClusterInfo("SUCCESSFUL EXECUTIONS for method pow(int, int)", null), IntRange(0, 13))
+        )
+
         val method = IntMath::pow
         val mockStrategy = MockStrategyApi.NO_MOCKS
         val coverage = DoNotCalculate
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames, clusterInfo)
     }
 }

--- a/utbot-summary-tests/src/test/kotlin/math/SummaryOfMathTest.kt
+++ b/utbot-summary-tests/src/test/kotlin/math/SummaryOfMathTest.kt
@@ -5,6 +5,7 @@ import guava.examples.math.Stats
 import org.junit.jupiter.api.Test
 import org.utbot.examples.DoNotCalculate
 import org.utbot.framework.plugin.api.MockStrategyApi
+import org.utbot.framework.plugin.api.UtClusterInfo
 
 /**
  * It runs test generation for the poor analogue of the Stats.of method ported from the guava-26.0 framework
@@ -74,7 +75,12 @@ class SummaryOfMathTest : SummaryTestCaseGeneratorTest(
             methodName4
         )
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        val clusterInfo = listOf(
+            Pair(UtClusterInfo("SUCCESSFUL EXECUTIONS for method ofInts(int[])", null), IntRange(0, 2)),
+            Pair(UtClusterInfo("ERROR SUITE for method ofInts(int[])", null), IntRange(3, 3))
+        )
+
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames, clusterInfo)
     }
 
     @Test
@@ -210,6 +216,37 @@ class SummaryOfMathTest : SummaryTestCaseGeneratorTest(
             methodName7
         )
 
-        check(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+        val clusterInfo = listOf(
+            Pair(UtClusterInfo("SUCCESSFUL EXECUTIONS #0 for method ofDoubles(double[])", null), IntRange(0, 2)),
+            Pair(
+                UtClusterInfo(
+                    "SUCCESSFUL EXECUTIONS #1 for method ofDoubles(double[])", "\n" +
+                            "Common steps:\n" +
+                            "<pre>\n" +
+                            "Tests execute conditions:\n" +
+                            "    {@code (null): True}\n" +
+                            "call {@link guava.examples.math.StatsAccumulator#add(double)},\n" +
+                            "    there it execute conditions:\n" +
+                            "        {@code (count == 0): True}\n" +
+                            "    invoke:\n" +
+                            "        {@link guava.examples.math.StatsAccumulator#isFinite(double)} twice\n" +
+                            "Tests next execute conditions:\n" +
+                            "    {@code (null): False}\n" +
+                            "call {@link guava.examples.math.StatsAccumulator#isFinite(double)},\n" +
+                            "    there it invoke:\n" +
+                            "        {@link guava.examples.math.StatsAccumulator#isFinite(double)} once\n" +
+                            "    execute conditions:\n" +
+                            "        {@code (null): False}\n" +
+                            "    invoke:\n" +
+                            "        {@link guava.examples.math.StatsAccumulator#calculateNewMeanNonFinite(double,double)} twice,\n" +
+                            "        {@link java.lang.Math#min(double,double)} twice,\n" +
+                            "        {@link java.lang.Math#max(double,double)} twice\n" +
+                            "</pre>"
+                ), IntRange(3, 5)
+            ),
+            Pair(UtClusterInfo("ERROR SUITE for method ofDoubles(double[])", null), IntRange(6, 6))
+        )
+
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames, clusterInfo)
     }
 }

--- a/utbot-summary/src/main/kotlin/org/utbot/summary/Summarization.kt
+++ b/utbot-summary/src/main/kotlin/org/utbot/summary/Summarization.kt
@@ -44,7 +44,7 @@ fun UtMethodTestSet.summarize(sourceFile: File?, searchDirectory: Path = Paths.g
             pos += clusterSize
             it.clusterInfo to indices
         }
-        this.copy(executions = updatedExecutions, clustersInfo = clustersInfo)
+        this.copy(executions = updatedExecutions, clustersInfo = clustersInfo) // TODO: looks weird and don't create the real copy
     } catch (e: Throwable) {
         logger.info(e) { "Summary generation error" }
         this


### PR DESCRIPTION
# Description

This PR proposes a checker for generated clustering comments and adds a few tests to check them on a few non-trivial situations

Fixes #384 

## Type of Change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Automated Testing

Just run summary-tests

# Checklist (remove irrelevant options):

- [ ] The change followed the style guidelines of the UTBot project
- [ ] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [ ] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
