### PR TITLE
Generate parametrized test for methods without force mocking in Uber and sample tests #591 #596

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
@@ -1277,7 +1277,7 @@ internal class CgMethodConstructor(val context: CgContext) : CgContextOwner by c
             // this instance
             val thisInstanceModel = genericExecution.stateBefore.thisInstance
             if (thisInstanceModel != null) {
-                val type = thisInstanceModel.classId
+                val type = wrapTypeIfRequired(thisInstanceModel.classId)
                 val thisInstance = CgParameterDeclaration(
                     parameter = declareParameter(
                         type = type,

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/util/TestUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/util/TestUtils.kt
@@ -149,8 +149,16 @@ enum class Conflict {
 }
 
 class ConflictTriggers(
-    private val triggers: MutableMap<Conflict, Boolean> = EnumMap<Conflict, Boolean>(Conflict::class.java).withDefault { false }
-): MutableMap<Conflict, Boolean> by triggers  {
+    private val triggers: MutableMap<Conflict, Boolean> = EnumMap<Conflict, Boolean>(Conflict::class.java).also { map ->
+        Conflict.values().forEach { conflict -> map[conflict] = false }
+    }
+) : MutableMap<Conflict, Boolean> by triggers {
     val triggered: Boolean
         get() = triggers.values.any { it }
+
+    fun reset(vararg conflicts: Conflict) {
+        for (conflict in conflicts) {
+            triggers[conflict] = false
+        }
+    }
 }

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/CodeGenerationIntegrationTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/CodeGenerationIntegrationTest.kt
@@ -4,7 +4,6 @@ import org.utbot.common.FileUtil
 import org.utbot.common.packageName
 import org.utbot.common.withAccessibility
 import org.utbot.framework.UtSettings
-import org.utbot.framework.codegen.TestCodeGeneratorPipeline.Companion.defaultCodegenPipeline
 import org.utbot.framework.codegen.ClassStages
 import org.utbot.framework.codegen.CodeGeneration
 import org.utbot.framework.codegen.ExecutionStatus
@@ -29,6 +28,7 @@ import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.api.fail
 import org.junit.jupiter.engine.descriptor.ClassTestDescriptor
 import org.junit.jupiter.engine.descriptor.JupiterEngineDescriptor
+import org.utbot.framework.codegen.TestCodeGeneratorPipeline
 import java.nio.file.Path
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -119,7 +119,8 @@ abstract class CodeGenerationIntegrationTest(
                         )
                     }
 
-                    language.defaultCodegenPipeline.runClassesCodeGenerationTests(classStages)
+                    val config = TestCodeGeneratorPipeline.defaultTestFrameworkConfiguration(language)
+                    TestCodeGeneratorPipeline(config).runClassesCodeGenerationTests(classStages)
                 } catch (e: RuntimeException) {
                     pipelineErrors.add(e.message)
                 }

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/TestSpecificTestCaseGenerator.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/TestSpecificTestCaseGenerator.kt
@@ -1,6 +1,7 @@
 package org.utbot.examples
 
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
 import mu.KotlinLogging
 import org.utbot.common.runBlockingWithCancellationPredicate
 import org.utbot.common.runIgnoringCancellationException
@@ -10,6 +11,8 @@ import org.utbot.engine.UtBotSymbolicEngine
 import org.utbot.engine.util.mockListeners.ForceMockListener
 import org.utbot.engine.util.mockListeners.ForceStaticMockListener
 import org.utbot.framework.UtSettings
+import org.utbot.framework.codegen.ParametrizedTestSource
+import org.utbot.framework.codegen.TestCodeGeneratorPipeline
 import org.utbot.framework.plugin.api.MockStrategyApi
 import org.utbot.framework.plugin.api.TestCaseGenerator
 import org.utbot.framework.plugin.api.UtError
@@ -47,24 +50,33 @@ class TestSpecificTestCaseGenerator(
         val mockAlwaysDefaults = Mocker.javaDefaultClasses.mapTo(mutableSetOf()) { it.id }
         val defaultTimeEstimator = ExecutionTimeEstimator(UtSettings.utBotGenerationTimeoutInMillis, 1)
 
-        val forceMockListener = ForceMockListener.create(this, conflictTriggers)
-        val forceStaticMockListener = ForceStaticMockListener.create(this, conflictTriggers)
+        val config = TestCodeGeneratorPipeline.currentTestFrameworkConfiguration
+        var forceMockListener: ForceMockListener? = null
+        var forceStaticMockListener: ForceStaticMockListener? = null
+
+        if (config.parametrizedTestSource == ParametrizedTestSource.PARAMETRIZE) {
+            forceMockListener = ForceMockListener.create(this, conflictTriggers)
+            forceStaticMockListener = ForceStaticMockListener.create(this, conflictTriggers)
+        }
 
         runIgnoringCancellationException {
             runBlockingWithCancellationPredicate(isCanceled) {
-                super
-                    .generateAsync(EngineController(), method, mockStrategy, mockAlwaysDefaults, defaultTimeEstimator)
-                    .collect {
-                        when (it) {
-                            is UtExecution -> executions += it
-                            is UtError -> errors.merge(it.description, 1, Int::plus)
+                val controller = EngineController()
+                controller.job = launch {
+                    super
+                        .generateAsync(controller, method, mockStrategy, mockAlwaysDefaults, defaultTimeEstimator)
+                        .collect {
+                            when (it) {
+                                is UtExecution -> executions += it
+                                is UtError -> errors.merge(it.description, 1, Int::plus)
+                            }
                         }
-                    }
+                }
             }
         }
 
-        forceMockListener.detach(this, forceMockListener)
-        forceStaticMockListener.detach(this, forceStaticMockListener)
+        forceMockListener?.detach(this, forceMockListener)
+        forceStaticMockListener?.detach(this, forceStaticMockListener)
 
         val minimizedExecutions = super.minimizeExecutions(executions)
         return UtMethodTestSet(method, minimizedExecutions, jimpleBody(method), errors)

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/UtModelTestCaseChecker.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/UtModelTestCaseChecker.kt
@@ -38,6 +38,8 @@ import kotlin.reflect.KFunction2
 import kotlin.reflect.KFunction3
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.utbot.framework.UtSettings.useFuzzing
+import org.utbot.framework.codegen.TestCodeGeneratorPipeline
+import org.utbot.framework.util.Conflict
 
 internal abstract class UtModelTestCaseChecker(
     testClass: KClass<*>,
@@ -97,6 +99,13 @@ internal abstract class UtModelTestCaseChecker(
 
             assertTrue(testSet.errors.isEmpty()) {
                 "We have errors: ${testSet.errors.entries.map { "${it.value}: ${it.key}" }.prettify()}"
+            }
+
+            // if force mocking took place in parametrized test generation,
+            // we do not need to process this [testSet]
+            if (TestCodeGeneratorPipeline.currentTestFrameworkConfiguration.isParametrizedAndMocked) {
+                conflictTriggers.reset(Conflict.ForceMockHappened, Conflict.ForceStaticMockHappened)
+                return
             }
 
             val executions = testSet.executions


### PR DESCRIPTION
# Description

Before this PR, we didn't generate any tests for a whole test class if there were force mocking and parametrized test generation mode in one of the methods.
Now, we just exclude methods with force mocking and parametrized mode, generating methods that were not affected by force mocking.

Additionally, there was a bug with parametrized test generation trying to use private inner class as a type for one of the parameters.

Fixes # ([591](https://github.com/UnitTestBot/UTBotJava/issues/591), [596](https://github.com/UnitTestBot/UTBotJava/issues/596))

## Type of Change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Automated Testing

Run `deepEqualsTest` with enabled parametrized test generation. Verify that the generated test class is not empty (there are methods where force mocking didn't take place), instead of being empty after [#573](https://github.com/UnitTestBot/UTBotJava/pull/573).