### PR TITLE
"State is null" error fix for parametrized test generation

### DIFF
--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/ConcreteExecutor.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/ConcreteExecutor.kt
@@ -314,6 +314,7 @@ class ConcreteExecutor<TIResult, TInstrumentation : Instrumentation<TIResult>> p
      * @see [org.utbot.instrumentation.instrumentation.coverage.CoverageInstrumentation].
      */
     fun <T : Protocol.Command, R> request(requestCmd: T, action: ((Protocol.Command) -> R)): R = runBlocking {
+        restartIfNeeded()
         awaitCommand(sendCommand(requestCmd), action)
     }
 


### PR DESCRIPTION
# Description

Running samples with enabled parametrized test generation mode causes some tests to throw `IllegalStateException`, "State is null" error. This PR fixes it by starting concrete executor child process in order to process a coverage.

Fixes # ([613](https://github.com/UnitTestBot/UTBotJava/issues/613))

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

Utbot samples.

## Manual Scenario 

Run `BaseStreamExampleTest`. Verify that the test is generated and there is no `IllegalStateException` exception.