### PR TITLE
Add SecurityManager support to block suspicious code #622

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/UtExecutionResult.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/UtExecutionResult.kt
@@ -17,6 +17,10 @@ data class UtOverflowFailure(
     override val exception: Throwable,
 ) : UtExecutionFailure()
 
+data class UtSandboxFailure(
+    override val exception: Throwable
+) : UtExecutionFailure()
+
 /**
  * unexpectedFail (when exceptions such as NPE, IOBE, etc. appear, but not thrown by a user, applies both for function under test and nested calls )
  * expectedCheckedThrow (when function under test or nested call explicitly says that checked exception could be thrown and throws it)

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Resolver.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Resolver.kt
@@ -72,6 +72,7 @@ import kotlin.math.min
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentSetOf
 import org.utbot.framework.plugin.api.SYMBOLIC_NULL_ADDR
+import org.utbot.framework.plugin.api.UtSandboxFailure
 import soot.ArrayType
 import soot.BooleanType
 import soot.ByteType
@@ -88,6 +89,7 @@ import soot.SootClass
 import soot.SootField
 import soot.Type
 import soot.VoidType
+import java.security.AccessControlException
 
 // hack
 const val MAX_LIST_SIZE = 10
@@ -371,12 +373,11 @@ class Resolver(
         return if (explicit) {
             UtExplicitlyThrownException(exception, inNestedMethod)
         } else {
-            // TODO SAT-1561
-            val isOverflow = exception is ArithmeticException && exception.message?.contains("overflow") == true
-            if (isOverflow) {
-                UtOverflowFailure(exception)
-            } else {
-                UtImplicitlyThrownException(exception, inNestedMethod)
+            when {
+                // TODO SAT-1561
+                exception is ArithmeticException && exception.message?.contains("overflow") == true -> UtOverflowFailure(exception)
+                exception is AccessControlException -> UtSandboxFailure(exception)
+                else -> UtImplicitlyThrownException(exception, inNestedMethod)
             }
         }
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
@@ -106,6 +106,7 @@ import org.utbot.framework.plugin.api.UtNewInstanceInstrumentation
 import org.utbot.framework.plugin.api.UtNullModel
 import org.utbot.framework.plugin.api.UtPrimitiveModel
 import org.utbot.framework.plugin.api.UtReferenceModel
+import org.utbot.framework.plugin.api.UtSandboxFailure
 import org.utbot.framework.plugin.api.UtStaticMethodInstrumentation
 import org.utbot.framework.plugin.api.UtSymbolicExecution
 import org.utbot.framework.plugin.api.UtTimeoutException
@@ -141,6 +142,7 @@ import org.utbot.framework.plugin.api.util.wrapIfPrimitive
 import org.utbot.framework.util.isUnit
 import org.utbot.summary.SummarySentenceConstants.TAB
 import java.lang.reflect.InvocationTargetException
+import java.security.AccessControlException
 import java.lang.reflect.ParameterizedType
 import kotlin.reflect.jvm.javaType
 
@@ -351,6 +353,11 @@ internal class CgMethodConstructor(val context: CgContext) : CgContextOwner by c
                 methodType = CRASH
                 writeWarningAboutCrash()
             }
+            is AccessControlException -> {
+                methodType = CRASH
+                writeWarningAboutFailureTest(exception)
+                return
+            }
             else -> {
                 methodType = FAILING
                 writeWarningAboutFailureTest(exception)
@@ -361,6 +368,7 @@ internal class CgMethodConstructor(val context: CgContext) : CgContextOwner by c
     }
 
     private fun shouldTestPassWithException(execution: UtExecution, exception: Throwable): Boolean {
+        if (exception is AccessControlException) return false
         // tests with timeout or crash should be processed differently
         if (exception is TimeoutException || exception is ConcreteExecutionFailureException) return false
 
@@ -1530,6 +1538,12 @@ internal class CgMethodConstructor(val context: CgContext) : CgContextOwner by c
         if (result is UtConcreteExecutionFailure) {
             testFrameworkManager.disableTestMethod(
                 "Disabled due to possible JVM crash"
+            )
+        }
+
+        if (result is UtSandboxFailure) {
+            testFrameworkManager.disableTestMethod(
+                "Disabled due to sandbox"
             )
         }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/UtExecutionInstrumentation.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/UtExecutionInstrumentation.kt
@@ -20,6 +20,7 @@ import org.utbot.framework.plugin.api.UtInstrumentation
 import org.utbot.framework.plugin.api.UtMethod
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtNewInstanceInstrumentation
+import org.utbot.framework.plugin.api.UtSandboxFailure
 import org.utbot.framework.plugin.api.UtStaticMethodInstrumentation
 import org.utbot.framework.plugin.api.UtTimeoutException
 import org.utbot.framework.plugin.api.util.UtContext
@@ -37,6 +38,7 @@ import org.utbot.instrumentation.instrumentation.et.ExplicitThrowInstruction
 import org.utbot.instrumentation.instrumentation.et.TraceHandler
 import org.utbot.instrumentation.instrumentation.instrumenter.Instrumenter
 import org.utbot.instrumentation.instrumentation.mock.MockClassVisitor
+import java.security.AccessControlException
 import java.security.ProtectionDomain
 import java.util.IdentityHashMap
 import kotlin.reflect.jvm.javaMethod
@@ -220,6 +222,9 @@ object UtExecutionInstrumentation : Instrumentation<UtConcreteExecutionResult> {
     private fun sortOutException(exception: Throwable): UtExecutionFailure {
         if (exception is TimeoutException) {
             return UtTimeoutException(exception)
+        }
+        if (exception is AccessControlException) {
+            return UtSandboxFailure(exception)
         }
         val instrs = traceHandler.computeInstructionList()
         val isNested = if (instrs.isEmpty()) {

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/InvokeInstrumentation.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/InvokeInstrumentation.kt
@@ -2,6 +2,7 @@ package org.utbot.instrumentation.instrumentation
 
 import org.utbot.common.withAccessibility
 import org.utbot.framework.plugin.api.util.signature
+import org.utbot.instrumentation.process.sandbox
 import java.lang.reflect.Constructor
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
@@ -54,7 +55,7 @@ class InvokeInstrumentation : Instrumentation<Result<*>> {
                 is Method ->
                     withAccessibility {
                         runCatching {
-                            invoke(thisObject, *realArgs.toTypedArray()).let {
+                            sandbox { invoke(thisObject, *realArgs.toTypedArray()) }.let {
                                 if (returnType != Void.TYPE) it else Unit
                             } // invocation on method returning void will return null, so we replace it with Unit
                         }
@@ -63,7 +64,7 @@ class InvokeInstrumentation : Instrumentation<Result<*>> {
                 is Constructor<*> ->
                     withAccessibility {
                         runCatching {
-                            newInstance(*realArgs.toTypedArray())
+                            sandbox { newInstance(*realArgs.toTypedArray()) }
                         }
                     }
 

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/process/ChildProcess.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/process/ChildProcess.kt
@@ -11,6 +11,7 @@ import java.io.File
 import java.io.OutputStream
 import java.io.PrintStream
 import java.net.URLClassLoader
+import java.security.AllPermission
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import kotlin.system.exitProcess
@@ -51,6 +52,12 @@ private val kryoHelper: KryoHelper = KryoHelper(System.`in`, System.`out`)
  * It should be compiled into separate jar file (child_process.jar) and be run with an agent (agent.jar) option.
  */
 fun main() {
+    permissions {
+        // Enable all permissions for instrumentation.
+        // SecurityKt.sandbox() is used to restrict these permissions.
+        + AllPermission()
+    }
+
     // We don't want user code to litter the standard output, so we redirect it.
     val tmpStream = PrintStream(object : OutputStream() {
         override fun write(b: Int) {}

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/process/Security.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/process/Security.kt
@@ -1,0 +1,144 @@
+@file:Suppress("JAVA_MODULE_DOES_NOT_EXPORT_PACKAGE")
+
+package org.utbot.instrumentation.process
+
+import sun.security.provider.PolicyFile
+import java.net.URI
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.security.AccessControlContext
+import java.security.AccessController
+import java.security.CodeSource
+import java.security.Permission
+import java.security.PermissionCollection
+import java.security.Permissions
+import java.security.Policy
+import java.security.PrivilegedAction
+import java.security.PrivilegedActionException
+import java.security.ProtectionDomain
+import java.security.cert.Certificate
+
+internal fun permissions(block: SimplePolicy.() -> Unit) {
+    val policy = Policy.getPolicy()
+    if (policy !is SimplePolicy) {
+        Policy.setPolicy(SimplePolicy(block))
+        System.setSecurityManager(SecurityManager())
+    } else {
+        policy.block()
+    }
+}
+
+/**
+ * Run [block] in sandbox mode.
+ *
+ * When running in sandbox by default only necessary to instrumentation permissions are enabled.
+ * Other options are not enabled by default and rises [java.security.AccessControlException].
+ *
+ * To add new permissions create and/or edit file "{user.home}/.utbot/sandbox.policy".
+ *
+ * For example to enable property reading (`System.getProperty("user.home")`):
+ *
+ * ```
+ * grant {
+ *      permission java.util.PropertyPermission "user.home", "read";
+ * };
+ * ```
+ * Read more [about policy file and syntax](https://docs.oracle.com/javase/7/docs/technotes/guides/security/PolicyFiles.html#Examples)
+ */
+internal fun <T> sandbox(block: () -> T): T {
+    val policyPath = Paths.get(System.getProperty("user.home"), ".utbot", "sandbox.policy")
+    return sandbox(policyPath.toUri()) { block() }
+}
+
+internal fun <T> sandbox(file: URI, block: () -> T): T {
+    val path = Paths.get(file)
+    val perms = mutableListOf<Permission>()
+    val allCodeSource = CodeSource(null, emptyArray<Certificate>())
+    if (Files.exists(path)) {
+        val policyFile = PolicyFile(file.toURL())
+        val collection = policyFile.getPermissions(allCodeSource)
+        perms += collection.elements().toList()
+    }
+    return sandbox(perms, allCodeSource) { block() }
+}
+
+internal fun <T> sandbox(permission: List<Permission>, cs: CodeSource, block: () -> T): T {
+    val perms = permission.fold(Permissions()) { acc, p -> acc.add(p); acc }
+    return sandbox(perms, cs) { block() }
+}
+
+internal fun <T> sandbox(perms: PermissionCollection, cs: CodeSource, block: () -> T): T {
+    val acc = AccessControlContext(arrayOf(ProtectionDomain(cs, perms)))
+    return try {
+        AccessController.doPrivileged(PrivilegedAction { block() }, acc)
+    } catch (e: PrivilegedActionException) {
+        throw e.exception
+    }
+}
+
+/**
+ * This policy can add grant or denial rules for permissions.
+ *
+ * To add a grant permission use like this in any place:
+ *
+ * ```
+ * permissions {
+ *   + java.security.PropertyPolicy("user.home", "read,write")
+ * }
+ * ```
+ *
+ * After first call [SecurityManager] is set with this policy
+ *
+ * To deny a permission:
+ *
+ * ```
+ * permissions {
+ *   - java.security.PropertyPolicy("user.home", "read,write")
+ * }
+ * ```
+ *
+ * To delete all concrete permissions (if it was added before):
+ *
+ * ```
+ * permissions {
+ *   ! java.security.PropertyPolicy("user.home", "read,write")
+ * }
+ * ```
+ *
+ * The last permission has priority. Enable all property read for "user.*", but forbid to read only "user.home":
+ *
+ * ```
+ * permissions {
+ *   + java.security.PropertyPolicy("user.*", "read,write")
+ *   - java.security.PropertyPolicy("user.home", "read,write")
+ * }
+ * ```
+ */
+internal class SimplePolicy(init: SimplePolicy.() -> Unit = {}) : Policy() {
+    sealed class Access(val permission: Permission) {
+        class Allow(permission: Permission) : Access(permission)
+        class Deny(permission: Permission) : Access(permission)
+    }
+    private var permissions = mutableListOf<Access>()
+
+    init { apply(init) }
+
+    operator fun Permission.unaryPlus() = permissions.add(Access.Allow(this))
+
+    operator fun Permission.unaryMinus() = permissions.add(Access.Deny(this))
+
+    operator fun Permission.not() = permissions.removeAll { it.permission == this }
+
+    override fun getPermissions(codesource: CodeSource) = UNSUPPORTED_EMPTY_COLLECTION!!
+    override fun getPermissions(domain: ProtectionDomain) = UNSUPPORTED_EMPTY_COLLECTION!!
+    override fun implies(domain: ProtectionDomain, permission: Permission): Boolean {
+        // 0 means no info, < 0 is denied and > 0 is allowed
+        val result = permissions.lastOrNull { it.permission.implies(permission) }?.let {
+            when (it) {
+                is Access.Allow -> 1
+                is Access.Deny -> -1
+            }
+        } ?: 0
+        return result > 0
+    }
+}

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/process/Security.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/process/Security.kt
@@ -52,7 +52,9 @@ internal fun <T> sandbox(block: () -> T): T {
 
 internal fun <T> sandbox(file: URI, block: () -> T): T {
     val path = Paths.get(file)
-    val perms = mutableListOf<Permission>()
+    val perms = mutableListOf<Permission>(
+        RuntimePermission("accessDeclaredMembers")
+    )
     val allCodeSource = CodeSource(null, emptyArray<Certificate>())
     if (Files.exists(path)) {
         val policyFile = PolicyFile(file.toURL())

--- a/utbot-instrumentation/src/test/kotlin/org/utbot/instrumentation/security/SecurityTest.kt
+++ b/utbot-instrumentation/src/test/kotlin/org/utbot/instrumentation/security/SecurityTest.kt
@@ -1,0 +1,59 @@
+package org.utbot.instrumentation.security
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.utbot.instrumentation.process.permissions
+import org.utbot.instrumentation.process.sandbox
+import java.lang.NullPointerException
+import java.security.AccessControlException
+import java.security.AllPermission
+import java.security.BasicPermission
+import java.security.CodeSource
+import java.security.Permission
+import java.security.cert.Certificate
+import java.util.PropertyPermission
+
+class SecurityTest {
+
+    @BeforeEach
+    fun init() {
+        permissions {
+            +AllPermission()
+        }
+    }
+
+    @Test
+    fun `basic security works`() {
+        sandbox {
+            assertThrows<AccessControlException> {
+                System.getProperty("any")
+            }
+        }
+    }
+
+    @Test
+    fun `basic permission works`() {
+        sandbox(listOf(PropertyPermission("java.version", "read")), CodeSource(null, emptyArray<Certificate>())) {
+            val result = System.getProperty("java.version")
+            assertNotNull(result)
+            assertThrows<AccessControlException> {
+                System.setProperty("any_random_value_key", "random")
+            }
+        }
+    }
+
+    @Test
+    fun `null is ok`() {
+        val empty = object : BasicPermission("*") {}
+        val field = Permission::class.java.getDeclaredField("name")
+        field.isAccessible = true
+        field.set(empty, null)
+        val collection = empty.newPermissionCollection()
+        assertThrows<NullPointerException> {
+            collection.implies(empty)
+        }
+    }
+
+}

--- a/utbot-summary/src/main/kotlin/org/utbot/summary/TagGenerator.kt
+++ b/utbot-summary/src/main/kotlin/org/utbot/summary/TagGenerator.kt
@@ -9,6 +9,7 @@ import org.utbot.framework.plugin.api.UtExplicitlyThrownException
 import org.utbot.framework.plugin.api.UtImplicitlyThrownException
 import org.utbot.framework.plugin.api.UtOverflowFailure
 import org.utbot.framework.plugin.api.UtMethodTestSet
+import org.utbot.framework.plugin.api.UtSandboxFailure
 import org.utbot.framework.plugin.api.UtTimeoutException
 import org.utbot.framework.plugin.api.util.isCheckedException
 import org.utbot.summary.UtSummarySettings.MIN_NUMBER_OF_EXECUTIONS_FOR_CLUSTERING
@@ -140,7 +141,8 @@ enum class ClusterKind {
     EXPLICITLY_THROWN_UNCHECKED_EXCEPTIONS,
     OVERFLOWS,
     TIMEOUTS,
-    CRASH_SUITE;
+    CRASH_SUITE,
+    SECURITY;
 
     val displayName: String get() = toString().replace('_', ' ')
 }
@@ -152,6 +154,7 @@ private fun UtExecutionResult.clusterKind() = when (this) {
     is UtOverflowFailure -> ClusterKind.OVERFLOWS
     is UtTimeoutException -> ClusterKind.TIMEOUTS
     is UtConcreteExecutionFailure -> ClusterKind.CRASH_SUITE
+    is UtSandboxFailure -> ClusterKind.SECURITY
 }
 
 /**


### PR DESCRIPTION
# Description

This commit introduces support of SecurityManager in instrumentation.jar to restrict all suspicious code from running (File IO, Socket IO, Property reading and etc.). Security is enabled by default and limits all permissions to a small set that needed for execution. Settings can be extended by editing `.utbot/sandbox.policy` ([more about policy file and syntax](https://docs.oracle.com/javase/7/docs/technotes/guides/security/PolicyFiles.html#Examples)).

Fixes #622

## Type of Change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

## Automated Testing

All existing tests should pass

## Manual Scenario 

Disable symbolic execution test generation and leave only fuzzing (in the settings by choosing "Simpler" for "Code analysis"). Run test generations for these methods:

```java
public class SecurityCheck {

    public int normalTest(int value) {
        if (value < 0) {
            return -value;
        }
        return value;
    }

    public int read(File path) throws IOException {
        byte[] bytes = Files.readAllBytes(path.toPath());
        return bytes.length;
    }

    public int connect(Socket socket) throws IOException {
        socket.connect(new InetSocketAddress("0.0.0.0", 22));
        return 0;
    }

    public String property(String key) {
        return System.getProperty(key);
    }

    public String systemExit() {
        System.exit(0);
        return "bad";
    }

}
```

For every method except `normatTest()` there are should be several methods that look like:

```java
    public void testPropertyWithBlankString() {
        SecurityCheck securityCheck = new SecurityCheck();
        
        /* This test fails because method [com.company.security.SecurityCheck.property] produces [java.security.AccessControlException: access denied ("java.util.PropertyPermission" "   " "read")]
            java.security.AccessControlContext.checkPermission(AccessControlContext.java:472)
            java.security.AccessController.checkPermission(AccessController.java:886)
            java.lang.SecurityManager.checkPermission(SecurityManager.java:549)
            java.lang.SecurityManager.checkPropertyAccess(SecurityManager.java:1294)
            java.lang.System.getProperty(System.java:719)
            com.company.security.SecurityCheck.property(SecurityCheck.java:32) */
    }
```

Try to edit `{user.home}/.utbot/sandbox.policy`:

```
grant {
    permission java.util.PropertyPermission "*", "read";
};
```

and generate test for `String property(String key)`. Tests should be generated without access exception.

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
