### PR TITLE
Change type of 'actual' variable

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
@@ -1076,7 +1076,7 @@ internal class CgMethodConstructor(val context: CgContext) : CgContextOwner by c
                     emptyLineIfNeeded()
 
                     actual = newVar(
-                        CgClassId(executable.returnType, isNullable = result is UtNullModel),
+                        CgClassId(result.classId, isNullable = result is UtNullModel),
                         "actual"
                     ) {
                         thisInstance[executable](*methodArguments.toTypedArray())


### PR DESCRIPTION
# Description

Before, the type of this variable was the same as the return type of executable under test. However, this could lead to undesired reflection usage: if a method returns `A`, but the real type of `actual` variable is `B` (subclass of `A`), then we will not be able to access fields that are declared in `B` without reflection, because the variable is declared with type `A`. For example, this can happen when we make equality assertions between fields of expected value and an actual result and some of these fields are from `B`, but are not accessible, because type `A` knows nothing about these new fields.

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

This change simply fixes unnecessary reflection usage. So, all tests worked before and should work after this change. The difference is that we will be able to avoid using reflection to access fields of variable `actual`.

## Automated Testing

The difference can be seen on `org.utbot.examples.objects.ObjectWithPrimitivesExample#max`. If you generate tests for this method before this change, then the field `anotherX` of the variable `actual` will be accessed via reflection, whereas after the change a regular field access is used.

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [x] All tests pass locally with my changes
