### PR TITLE
Replace currentExecutableId with currentTestSet

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/context/CgContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/context/CgContext.kt
@@ -66,7 +66,7 @@ import org.utbot.framework.plugin.api.util.jClass
  * Although, some of the properties are declared as 'var' so that
  * they can be reassigned as well as modified
  *
- * For example, [currentTestClass] and [currentExecutable] can be reassigned
+ * For example, [currentTestClass] and [currentTestSet] can be reassigned
  * when we start generating another method or test class
  *
  * [existingVariableNames] is a 'var' property
@@ -81,8 +81,8 @@ internal interface CgContextOwner {
     // test class currently being generated
     val currentTestClass: ClassId
 
-    // current executable under test
-    var currentExecutable: ExecutableId?
+    //current executable under test info
+    var currentTestSet: CgMethodTestSet?
 
     // test class superclass (if needed)
     var testClassSuperclass: ClassId?
@@ -230,10 +230,6 @@ internal interface CgContextOwner {
         CgStatementExecutableCall(this).also {
             currentBlock = currentBlock.add(it)
         }
-
-    fun updateCurrentExecutable(executableId: ExecutableId) {
-        currentExecutable = executableId
-    }
 
     fun addExceptionIfNeeded(exception: ClassId) {
         if (exception !is BuiltinClassId) {
@@ -385,7 +381,7 @@ internal interface CgContextOwner {
  */
 internal data class CgContext(
     override val classUnderTest: ClassId,
-    override var currentExecutable: ExecutableId? = null,
+    override var currentTestSet: CgMethodTestSet? = null,
     override val collectedTestClassInterfaces: MutableSet<ClassId> = mutableSetOf(),
     override val collectedTestClassAnnotations: MutableSet<CgAnnotation> = mutableSetOf(),
     override val collectedExceptions: MutableSet<ClassId> = mutableSetOf(),

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/name/CgNameGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/name/CgNameGenerator.kt
@@ -44,7 +44,7 @@ internal interface CgNameGenerator {
     /**
      * Generate a new test method name.
      */
-    fun testMethodNameFor(executableId: ExecutableId, customName: String? = null): String
+    fun testMethodNameFor(customName: String? = null): String
 
     /**
      * Generates a new parameterized test method name by data provider method name.
@@ -54,7 +54,7 @@ internal interface CgNameGenerator {
     /**
      * Generates a new data for parameterized test provider method name
      */
-    fun dataProviderMethodNameFor(executableId: ExecutableId): String
+    fun dataProviderMethodNameFor(): String
 
     /**
      * Generate a new error method name
@@ -85,8 +85,10 @@ internal class CgNameGeneratorImpl(private val context: CgContext)
         return variableName(baseName.decapitalize(), isMock)
     }
 
-    override fun testMethodNameFor(executableId: ExecutableId, customName: String?): String {
-        val executableName = createExecutableName(executableId)
+    override fun testMethodNameFor(customName: String?): String {
+        val executable = currentTestSet?.executableId
+            ?: error("CurrentTestSet must be initialized to create test method name")
+        val executableName = createExecutableName(executable)
 
         // no index suffix allowed only when there's a vacant custom name
         val name = if (customName != null && customName !in existingMethodNames) {
@@ -104,8 +106,10 @@ internal class CgNameGeneratorImpl(private val context: CgContext)
     override fun parameterizedTestMethodName(dataProviderMethodName: String) =
         dataProviderMethodName.replace(dataProviderMethodPrefix, "parameterizedTestsFor")
 
-    override fun dataProviderMethodNameFor(executableId: ExecutableId): String {
-        val executableName = createExecutableName(executableId)
+    override fun dataProviderMethodNameFor(): String {
+        val executable = currentTestSet?.executableId
+            ?: error("CurrentTestSet must be initialized to create name for data provider method")
+        val executableName = createExecutableName(executable)
         val indexedName = nextIndexedMethodName(executableName.capitalize(), skipOne = true)
 
         existingMethodNames += indexedName

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgCallableAccessManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgCallableAccessManager.kt
@@ -135,7 +135,7 @@ internal class CgCallableAccessManagerImpl(val context: CgContext) : CgCallableA
             addExceptionIfNeeded(Throwable::class.id)
         }
 
-        val methodIsUnderTestAndThrowsExplicitly = methodId == currentExecutable
+        val methodIsUnderTestAndThrowsExplicitly = methodId == currentTestSet?.executableId
                 && currentExecution?.result is UtExplicitlyThrownException
         val frameworkSupportsAssertThrows = testFramework == Junit5 || testFramework == TestNg
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/util/ConstructorUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/util/ConstructorUtils.kt
@@ -197,7 +197,7 @@ internal fun CgContextOwner.importIfNeeded(method: MethodId) {
     method.takeIf { it.isStatic && packageName != testClassPackageName && packageName != "java.lang" }
         .takeIf { importedStaticMethods.none { it.name == name } }
         // do not import method under test in order to specify the declaring class directly for its calls
-        .takeIf { currentExecutable != method }
+        .takeIf { method != currentTestSet?.executableId }
         ?.let {
             importedStaticMethods += method
             collectedImports += StaticImport(method.classId.canonicalName, method.name)

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -203,7 +203,7 @@ object UtTestsDialogProcessor {
                                                 generate = testFlow {
                                                     generationTimeout = model.timeout
                                                     isSymbolicEngineEnabled = true
-                                                    isFuzzingEnabled = UtSettings.useFuzzing
+                                                    isFuzzingEnabled = false
                                                     fuzzingValue = project.service<Settings>().fuzzingValue
                                                 }
                                             )


### PR DESCRIPTION
# Description

An entity `currentExecutable` is removed from `CgContext` and is replaced with `currentTestSet`.
We use this test set everywhere and avoid passing it as a parameter. All null-safety checks are provided explicitly.


## Type of Change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Full automatic and manual codegen regression

