### PR TITLE
Add statics support in parametrized tests generation #612 #672

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/name/CgNameGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/name/CgNameGenerator.kt
@@ -18,8 +18,9 @@ internal interface CgNameGenerator {
     /**
      * Generate a variable name given a [base] name.
      * @param isMock denotes whether a variable represents a mock object or not
+     * @param isStatic denotes whether a variable represents a static variable or not
      */
-    fun variableName(base: String, isMock: Boolean = false): String
+    fun variableName(base: String, isMock: Boolean = false, isStatic: Boolean = false): String
 
     /**
      * Convert a given class id to a string that can serve
@@ -69,8 +70,12 @@ internal interface CgNameGenerator {
 internal class CgNameGeneratorImpl(private val context: CgContext)
     : CgNameGenerator, CgContextOwner by context {
 
-    override fun variableName(base: String, isMock: Boolean): String {
-        val baseName = if (isMock) base + "Mock" else base
+    override fun variableName(base: String, isMock: Boolean, isStatic: Boolean): String {
+        val baseName = when {
+            isMock -> base + "Mock"
+            isStatic -> base + "Static"
+            else -> base
+        }
         return when {
             baseName in existingVariableNames -> nextIndexedVarName(baseName)
             isLanguageKeyword(baseName, codegenLanguage) -> createNameFromKeyword(baseName)

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
@@ -212,8 +212,9 @@ internal class CgMethodConstructor(val context: CgContext) : CgContextOwner by c
      * Thus, this method only caches an actual initial static fields state in order to recover it
      * at the end of the test, and it has nothing to do with the 'before' and 'after' caches.
      */
-    private fun rememberInitialStaticFields() {
-        for ((field, _) in currentExecution!!.stateBefore.statics.accessibleFields()) {
+    private fun rememberInitialStaticFields(statics: Map<FieldId, UtModel>) {
+        val accessibleStaticFields = statics.accessibleFields()
+        for ((field, _) in accessibleStaticFields) {
             val declaringClass = field.declaringClass
             val fieldAccessible = field.isAccessibleFrom(testClassPackageName)
 
@@ -236,11 +237,18 @@ internal class CgMethodConstructor(val context: CgContext) : CgContextOwner by c
         }
     }
 
-    private fun mockStaticFields() {
-        for ((field, model) in currentExecution!!.stateBefore.statics.accessibleFields()) {
+    private fun substituteStaticFields(statics: Map<FieldId, UtModel>, isParametrized: Boolean = false) {
+        val accessibleStaticFields = statics.accessibleFields()
+        for ((field, model) in accessibleStaticFields) {
             val declaringClass = field.declaringClass
             val fieldAccessible = field.canBeSetIn(testClassPackageName)
-            val fieldValue = variableConstructor.getOrCreateVariable(model, field.name)
+
+            val fieldValue = if (isParametrized) {
+                currentMethodParameters[CgParameterKind.Statics(model)]
+            } else {
+                variableConstructor.getOrCreateVariable(model, field.name)
+            }
+
             if (fieldAccessible) {
                 declaringClass[field] `=` fieldValue
             } else {
@@ -1097,12 +1105,13 @@ internal class CgMethodConstructor(val context: CgContext) : CgContextOwner by c
             // TODO: remove this line when SAT-1273 is completed
             execution.displayName = execution.displayName?.let { "${executableId.name}: $it" }
             testMethod(testMethodName, execution.displayName) {
-                rememberInitialStaticFields()
+                val statics = currentExecution!!.stateBefore.statics
+                rememberInitialStaticFields(statics)
                 val stateAnalyzer = ExecutionStateAnalyzer(execution)
                 val modificationInfo = stateAnalyzer.findModifiedFields()
                 // TODO: move such methods to another class and leave only 2 public methods: remember initial and final states
                 val mainBody = {
-                    mockStaticFields()
+                    substituteStaticFields(statics)
                     setupInstrumentation()
                     // build this instance
                     thisInstance = execution.stateBefore.thisInstance?.let {
@@ -1120,7 +1129,6 @@ internal class CgMethodConstructor(val context: CgContext) : CgContextOwner by c
                     generateFieldStateAssertions()
                 }
 
-                val statics = currentExecution!!.stateBefore.statics
                 if (statics.isNotEmpty()) {
                     +tryBlock {
                         mainBody()
@@ -1177,11 +1185,14 @@ internal class CgMethodConstructor(val context: CgContext) : CgContextOwner by c
             .firstOrNull { it.result is UtExecutionSuccess && (it.result as UtExecutionSuccess).model !is UtNullModel }
             ?: testSet.executions.first()
 
+        val statics = genericExecution.stateBefore.statics
+
         return withTestMethodScope(genericExecution) {
             val testName = nameGenerator.parameterizedTestMethodName(dataProviderMethodName)
             withNameScope {
                 val testParameterDeclarations = createParameterDeclarations(testSet, genericExecution)
                 val mainBody = {
+                    substituteStaticFields(statics, isParametrized = true)
                     // build this instance
                     thisInstance = genericExecution.stateBefore.thisInstance?.let { currentMethodParameters[CgParameterKind.ThisInstance] }
 
@@ -1203,9 +1214,15 @@ internal class CgMethodConstructor(val context: CgContext) : CgContextOwner by c
                     parameterized = true,
                     dataProviderMethodName
                 ) {
-                    if (containsFailureExecution(testSet)) {
-                        +tryBlock(mainBody)
-                            .catch(Throwable::class.java.id) { e ->
+                    rememberInitialStaticFields(statics)
+
+                    if (containsFailureExecution(testSet) || statics.isNotEmpty()) {
+                        var currentTryBlock = tryBlock {
+                            mainBody()
+                        }
+
+                        if (containsFailureExecution(testSet)) {
+                            currentTryBlock = currentTryBlock.catch(Throwable::class.java.id) { e ->
                                 val pseudoExceptionVarName = when (codegenLanguage) {
                                     CodegenLanguage.JAVA -> "${expectedErrorVarName}.isInstance(${e.name.decapitalize()})"
                                     CodegenLanguage.KOTLIN -> "${expectedErrorVarName}!!.isInstance(${e.name.decapitalize()})"
@@ -1213,6 +1230,14 @@ internal class CgMethodConstructor(val context: CgContext) : CgContextOwner by c
 
                                 testFrameworkManager.assertBoolean(CgVariable(pseudoExceptionVarName, booleanClassId))
                             }
+                        }
+
+                        if (statics.isNotEmpty()) {
+                            currentTryBlock = currentTryBlock.finally {
+                                recoverStaticFields()
+                            }
+                        }
+                        +currentTryBlock
                     } else {
                         mainBody()
                     }
@@ -1263,6 +1288,22 @@ internal class CgMethodConstructor(val context: CgContext) : CgContextOwner by c
                 )
                 this += argument
                 currentMethodParameters[CgParameterKind.Argument(index)] = argument.parameter
+            }
+
+            val statics = genericExecution.stateBefore.statics
+            if (statics.isNotEmpty()) {
+                for ((fieldId, model) in statics) {
+                    val staticType = wrapTypeIfRequired(model.classId)
+                    val static = CgParameterDeclaration(
+                        parameter = declareParameter(
+                            type = staticType,
+                            name = nameGenerator.variableName(fieldId.name, isStatic = true)
+                        ),
+                        isReferenceType = staticType.isRefType
+                    )
+                    this += static
+                    currentMethodParameters[CgParameterKind.Statics(model)] = static.parameter
+                }
             }
 
             val expectedResultClassId = wrapTypeIfRequired(testSet.resultType())
@@ -1346,6 +1387,12 @@ internal class CgMethodConstructor(val context: CgContext) : CgContextOwner by c
             val argumentName = paramNames[testSet.executableId]?.get(paramIndex)
             arguments += variableConstructor.getOrCreateVariable(paramModel, argumentName)
         }
+
+        val statics = execution.stateBefore.statics
+        for ((field, model) in statics) {
+            arguments += variableConstructor.getOrCreateVariable(model, field.name)
+        }
+
 
         val method = currentExecutable!!
         val needsReturnValue = method.returnType != voidClassId

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgTestClassConstructor.kt
@@ -107,8 +107,15 @@ internal class CgTestClassConstructor(val context: CgContext) :
                 }
             }
             ParametrizedTestSource.PARAMETRIZE -> {
-                for (currentTestSet in testSet.splitExecutionsByResult()) {
-                    createParametrizedTestAndDataProvider(currentTestSet, requiredFields, regions, methodUnderTest)
+                for (splitByExecutionTestSet in testSet.splitExecutionsByResult()) {
+                    for (splitByChangedStaticsTestSet in splitByExecutionTestSet.splitExecutionsByChangedStatics()) {
+                        createParametrizedTestAndDataProvider(
+                            splitByChangedStaticsTestSet,
+                            requiredFields,
+                            regions,
+                            methodUnderTest
+                        )
+                    }
                 }
             }
         }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/tree/CgElement.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/tree/CgElement.kt
@@ -19,6 +19,7 @@ import org.utbot.framework.plugin.api.ExecutableId
 import org.utbot.framework.plugin.api.FieldId
 import org.utbot.framework.plugin.api.MethodId
 import org.utbot.framework.plugin.api.TypeParameters
+import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.util.booleanClassId
 import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.intClassId
@@ -630,6 +631,7 @@ data class CgParameterDeclaration(
 sealed class CgParameterKind {
     object ThisInstance : CgParameterKind()
     data class Argument(val index: Int) : CgParameterKind()
+    data class Statics(val model: UtModel) : CgParameterKind()
     object ExpectedResult : CgParameterKind()
     object ExpectedException : CgParameterKind()
 }


### PR DESCRIPTION
# Description

This PR adds support for statics in parametrized test generation.
Now, executions are split and grouped not only by their result type, but also by mutated static fields.
We create separated test methods and corresponding data providers when we have executions with different intentions of changing\not changing static field.

Fixes # ([612](https://github.com/UnitTestBot/UTBotJava/issues/612), [672](https://github.com/UnitTestBot/UTBotJava/issues/672))

## Type of Change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Automated Testing

Run utbot samples with enabled parametrized test generation.

## Manual Scenario 

Run `StaticsSubstitutionTest` with enabled parametrized test generation. Verify that generated file contains two separated test methods and their data providers.