### PR TITLE
Timeout spinner should apply current value #675

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -82,6 +82,7 @@ import java.awt.event.ActionEvent
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.text.ParseException
 import java.util.Objects
 import java.util.concurrent.TimeUnit
 import javax.swing.AbstractAction
@@ -507,6 +508,10 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
         model.mockFramework = MOCKITO
         model.staticsMocking = staticsMocking.item
         model.codegenLanguage = codegenLanguages.item
+        try {
+            timeoutSpinner.commitEdit()
+        } catch (ignored: ParseException) {
+        }
         model.timeout = TimeUnit.SECONDS.toMillis(timeoutSpinner.number.toLong())
 
         val settings = model.project.service<Settings>()


### PR DESCRIPTION
# Description

During doOKAction() we call commitEdit() explicitly

Fixes #675 

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

See steps from the issue.
# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
