### PR TITLE
Enlarge the set of cases when we try to create parametrized tests

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -212,8 +212,6 @@ object UtSettings {
     /**
      * Activate or deactivate substituting static fields values set in static initializer
      * with symbolic variable to try to set them another value than in initializer.
-     *
-     * We should not try to substitute in parametrized tests, for example
      */
     var substituteStaticsWithSymbolicVariable by getBooleanProperty(true)
 

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/UtSettingsUtil.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/UtSettingsUtil.kt
@@ -6,7 +6,7 @@ import org.utbot.framework.UtSettings
  * Runs [block] with [UtSettings.substituteStaticsWithSymbolicVariable] value
  * modified in accordance with given [condition].
  */
-inline fun <T> withSubstitutionCondition(condition: Boolean, block: () -> T) {
+inline fun <T> withStaticsSubstitutionRequired(condition: Boolean, block: () -> T) {
     val standardSubstitutionSetting = UtSettings.substituteStaticsWithSymbolicVariable
     UtSettings.substituteStaticsWithSymbolicVariable = standardSubstitutionSetting && condition
     try {

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Mocks.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Mocks.kt
@@ -168,7 +168,13 @@ class Mocker(
     fun shouldMock(
         type: RefType,
         mockInfo: UtMockInfo,
-    ): Boolean = checkIfShouldMock(type, mockInfo).also { if (it) mockListenerController?.onShouldMock(strategy, mockInfo) }
+    ): Boolean = checkIfShouldMock(type, mockInfo).also {
+        //[utbotSuperClasses] are not involved in code generation, so
+        //we shouldn't listen events that such mocks happened
+        if (it && type.id !in utbotSuperClasses.map { it.id }) {
+            mockListenerController?.onShouldMock(strategy, mockInfo)
+        }
+    }
 
     private fun checkIfShouldMock(
         type: RefType,

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -19,7 +19,6 @@ import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.util.Computable
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.psi.PsiClass
-import com.intellij.psi.PsiModifier
 import com.intellij.psi.SyntheticElement
 import com.intellij.refactoring.util.classMembers.MemberInfo
 import com.intellij.testIntegration.TestIntegrationUtils
@@ -34,7 +33,7 @@ import org.utbot.framework.plugin.api.TestCaseGenerator
 import org.utbot.framework.plugin.api.UtMethod
 import org.utbot.framework.plugin.api.UtMethodTestSet
 import org.utbot.framework.plugin.api.util.UtContext
-import org.utbot.framework.plugin.api.util.withSubstitutionCondition
+import org.utbot.framework.plugin.api.util.withStaticsSubstitutionRequired
 import org.utbot.framework.plugin.api.util.withUtContext
 import org.utbot.intellij.plugin.generator.CodeGenerationController.generateTests
 import org.utbot.intellij.plugin.models.GenerateTestsModel
@@ -171,9 +170,6 @@ object UtTestsDialogProcessor {
                                     indicator.fraction = indicator.fraction.coerceAtLeast(0.9 * processedClasses / totalClasses)
                                 }
 
-                                //we should not substitute statics for parametrized tests
-                                val shouldSubstituteStatics =
-                                    model.parametrizedTestSource != ParametrizedTestSource.PARAMETRIZE
                                 // set timeout for concrete execution and for generated tests
                                 UtSettings.concreteExecutionTimeoutInChildProcess = model.hangingTestsTimeout.timeoutMs
 
@@ -181,7 +177,7 @@ object UtTestsDialogProcessor {
                                     .nonBlocking<Path> { project.basePath?.let { Paths.get(it) } ?: Paths.get(srcClass.containingFile.virtualFile.parent.path) }
                                     .executeSynchronously()
 
-                                withSubstitutionCondition(shouldSubstituteStatics) {
+                                withStaticsSubstitutionRequired(true) {
                                     val mockFrameworkInstalled = model.mockFramework?.isInstalled ?: true
 
                                     if (!mockFrameworkInstalled) {


### PR DESCRIPTION
# Description

`ForceMockListener` should not trigger on the force mocking related to `UtMock` or another `utbotSuperClasses` classes.
They are not mocks really, considering them as mocks is just a specific hack for symbolic engine with no impact on the code generation process.

Setting to avoid statics substitution in parametrized tests removed because they are now modified to deal with statics.

## Type of Change

Please delete options that are not relevant.

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Automated Testing

Running the pipeline on `utbot-samples`

## Manual Scenario 
