### PR TITLE
NoSuchMethodError is thrown for Generate & Run action #679

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -31,7 +31,6 @@ import com.intellij.openapi.ui.OptionAction
 import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.openapi.ui.popup.IconButton
 import com.intellij.openapi.util.Computable
-import com.intellij.openapi.util.text.TextWithMnemonic
 import com.intellij.openapi.vfs.StandardFileSystems
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VfsUtilCore.urlToPath
@@ -147,7 +146,7 @@ private const val WILL_BE_CONFIGURED_LABEL = " (will be configured)"
 private const val MINIMUM_TIMEOUT_VALUE_IN_SECONDS = 1
 
 private const val ACTION_GENERATE = "Generate Tests"
-private const val ACTION_GENERATE_AND_RUN = "Generate && Run" //Note that ampersand has to be escaped (doubled)
+private const val ACTION_GENERATE_AND_RUN = "Generate and Run"
 
 class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(model.project) {
     companion object {
@@ -469,7 +468,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
 
         private fun updateButtonText(e: ActionEvent?) {
             with(e?.source as JButton) {
-                text = TextWithMnemonic.parse(testsModel.getActionText()).dropMnemonic().text
+                text = testsModel.getActionText()
                 testsModel.project.service<Settings>().runGeneratedTestsWithCoverage =
                     testsModel.runGeneratedTestsWithCoverage
                 repaint()


### PR DESCRIPTION
# Description

Avoid mnemonic and thus avoid needless API usage

Fixes #679

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

Open the dialog, try to switch resulting action "Generate tests" / "Generate and Run", exception shouldn't appear anymore.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
