### PR TITLE
Test generation details are not accessible as Event Log tool window w…

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerationController.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerationController.kt
@@ -14,6 +14,7 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Computable
+import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.psi.JavaDirectoryService
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiClassOwner
@@ -370,6 +371,9 @@ object CodeGenerationController {
         }
     }
 
+    private fun isEventLogAvailable(project: Project) =
+        ToolWindowManager.getInstance(project).getToolWindow("Event Log") != null
+
     private fun eventLogMessage(): String =
         """
             <a href="${TestReportUrlOpeningListener.prefix}${TestReportUrlOpeningListener.eventLogSuffix}">See details in Event Log</a>.
@@ -405,8 +409,9 @@ object CodeGenerationController {
                             appendHtmlLine(it)
                             appendHtmlLine()
                         }
-
-                appendHtmlLine(eventLogMessage())
+                if (isEventLogAvailable(model.project)) {
+                    appendHtmlLine(eventLogMessage())
+                }
             }
             hasWarnings = report.hasWarnings
             Pair(message, report.detailedStatistics)
@@ -439,8 +444,9 @@ object CodeGenerationController {
                         }
                     }
                 }
-
-                appendHtmlLine(eventLogMessage())
+                if (isEventLogAvailable(model.project)) {
+                    appendHtmlLine(eventLogMessage())
+                }
             }
 
             Pair(message, null)

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -217,8 +217,11 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
         }
 
         TestReportUrlOpeningListener.callbacks[TestReportUrlOpeningListener.eventLogSuffix]?.plusAssign {
-            val twm = ToolWindowManager.getInstance(model.project)
-            twm.getToolWindow("Event Log")?.activate(null)
+            with(model.project) {
+                if (this.isDisposed) return@with
+                val twm = ToolWindowManager.getInstance(this)
+                twm.getToolWindow("Event Log")?.activate(null)
+            }
         }
 
         model.runGeneratedTestsWithCoverage = model.project.service<Settings>().runGeneratedTestsWithCoverage


### PR DESCRIPTION
…as deprecated #593

# Description

Don't add Event-Log related lines in case it's unavailable.
Check project for disposed state

Fixes #593 

## Type of Change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

Event log shouldn't be mentioned in resulting message( check in new IDEA versions), specified exception shouldn't appear

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
