### PR TITLE
Improve exception rendering in parametrized tests

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/context/CgContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/context/CgContext.kt
@@ -171,6 +171,10 @@ internal interface CgContextOwner {
     // a variable representing an actual result of the method under test call
     var actual: CgVariable
 
+    // a variable representing if test method contains reflective call or not
+    // and should we catch exceptions like InvocationTargetException or not so on
+    var containsReflectiveCall: Boolean
+
     // map from a set of tests for a method to another map
     // which connects code generation error message
     // with the number of times it occurred
@@ -420,7 +424,8 @@ internal data class CgContext(
     override val runtimeExceptionTestsBehaviour: RuntimeExceptionTestsBehaviour =
         RuntimeExceptionTestsBehaviour.defaultItem,
     override val hangingTestsTimeout: HangingTestsTimeout = HangingTestsTimeout(),
-    override val enableTestsTimeout: Boolean = true
+    override val enableTestsTimeout: Boolean = true,
+    override var containsReflectiveCall: Boolean = false,
 ) : CgContextOwner {
     override lateinit var statesCache: EnvironmentFieldStateCache
     override lateinit var actual: CgVariable

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgCallableAccessManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgCallableAccessManager.kt
@@ -359,6 +359,7 @@ internal class CgCallableAccessManagerImpl(val context: CgContext) : CgCallableA
         }
 
     private fun MethodId.callWithReflection(caller: CgExpression?, args: List<CgExpression>): CgMethodCall {
+        containsReflectiveCall = true
         val method = declaredExecutableRefs[this]
             ?: toExecutableVariable(args).also {
                 declaredExecutableRefs = declaredExecutableRefs.put(this, it)
@@ -372,6 +373,7 @@ internal class CgCallableAccessManagerImpl(val context: CgContext) : CgCallableA
     }
 
     private fun ConstructorId.callWithReflection(args: List<CgExpression>): CgExecutableCall {
+        containsReflectiveCall = true
         val constructor = declaredExecutableRefs[this]
             ?: this.toExecutableVariable(args).also {
                 declaredExecutableRefs = declaredExecutableRefs.put(this, it)

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/util/CgStatementConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/util/CgStatementConstructor.kt
@@ -58,6 +58,8 @@ import org.utbot.framework.plugin.api.util.objectArrayClassId
 import org.utbot.framework.plugin.api.util.objectClassId
 import fj.data.Either
 import org.utbot.framework.codegen.model.tree.CgArrayInitializer
+import org.utbot.framework.codegen.model.tree.CgIsInstance
+import org.utbot.framework.plugin.api.util.classClassId
 import java.lang.reflect.Constructor
 import java.lang.reflect.Method
 import kotlin.reflect.KFunction
@@ -115,6 +117,8 @@ interface CgStatementConstructor {
     fun tryBlock(init: () -> Unit, resources: List<CgDeclaration>?): CgTryCatch
     fun CgTryCatch.catch(exception: ClassId, init: (CgVariable) -> Unit): CgTryCatch
     fun CgTryCatch.finally(init: () -> Unit): CgTryCatch
+
+    fun CgExpression.isInstance(value: CgExpression): CgIsInstance
 
     fun innerBlock(init: () -> Unit): CgInnerBlock
 
@@ -300,6 +304,15 @@ internal class CgStatementConstructorImpl(context: CgContext) :
     override fun CgTryCatch.finally(init: () -> Unit): CgTryCatch {
         val finallyBlock = block(init)
         return this.copy(finally = finallyBlock)
+    }
+
+    override fun CgExpression.isInstance(value: CgExpression): CgIsInstance {
+        require(this.type == classClassId) {
+            "isInstance method can be called on object with type $classClassId only, but actual type is ${this.type}"
+        }
+
+        //TODO: we should better process it as this[isInstanceMethodId](value) as it is a call
+        return CgIsInstance(this, value)
     }
 
     override fun innerBlock(init: () -> Unit): CgInnerBlock =

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/tree/CgElement.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/tree/CgElement.kt
@@ -75,6 +75,7 @@ interface CgElement {
             is CgDeclaration -> visit(element)
             is CgAssignment -> visit(element)
             is CgTypeCast -> visit(element)
+            is CgIsInstance -> visit(element)
             is CgThisInstance -> visit(element)
             is CgNotNullAssertion -> visit(element)
             is CgVariable -> visit(element)
@@ -535,6 +536,16 @@ class CgTypeCast(
     val isSafetyCast: Boolean = false,
 ) : CgExpression {
     override val type: ClassId = targetType
+}
+
+/**
+ * Represents [java.lang.Class.isInstance] method.
+ */
+class CgIsInstance(
+    val classExpression: CgExpression,
+    val value: CgExpression,
+): CgExpression {
+    override val type: ClassId = booleanClassId
 }
 
 // Value

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgAbstractRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgAbstractRenderer.kt
@@ -39,6 +39,7 @@ import org.utbot.framework.codegen.model.tree.CgGreaterThan
 import org.utbot.framework.codegen.model.tree.CgIfStatement
 import org.utbot.framework.codegen.model.tree.CgIncrement
 import org.utbot.framework.codegen.model.tree.CgInnerBlock
+import org.utbot.framework.codegen.model.tree.CgIsInstance
 import org.utbot.framework.codegen.model.tree.CgLessThan
 import org.utbot.framework.codegen.model.tree.CgLiteral
 import org.utbot.framework.codegen.model.tree.CgLogicalAnd
@@ -420,6 +421,15 @@ internal abstract class CgAbstractRenderer(val context: CgContext, val printer: 
 
     override fun visit(element: CgDecrement) {
         print("${element.variable.name}--")
+    }
+
+    // isInstance check
+
+    override fun visit(element: CgIsInstance) {
+        element.classExpression.accept(this)
+        print(".isInstance(")
+        element.value.accept(this)
+        print(")")
     }
 
     // Try-catch

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgVisitor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgVisitor.kt
@@ -42,6 +42,7 @@ import org.utbot.framework.codegen.model.tree.CgGreaterThan
 import org.utbot.framework.codegen.model.tree.CgIfStatement
 import org.utbot.framework.codegen.model.tree.CgIncrement
 import org.utbot.framework.codegen.model.tree.CgInnerBlock
+import org.utbot.framework.codegen.model.tree.CgIsInstance
 import org.utbot.framework.codegen.model.tree.CgLessThan
 import org.utbot.framework.codegen.model.tree.CgLiteral
 import org.utbot.framework.codegen.model.tree.CgLogicalAnd
@@ -179,6 +180,9 @@ interface CgVisitor<R> {
 
     // Type cast
     fun visit(element: CgTypeCast): R
+
+    // isInstance check
+    fun visit(element: CgIsInstance): R
 
     // This instance
     fun visit(element: CgThisInstance): R


### PR DESCRIPTION
# Description

Parametrized tests may contain reflective call in it's body or not.
If we do not have them, we should just catch `Throwable` and verify that it's type has one type with the  expected one.
Otherwise we should catch `InvocationTargetException` and verify that it's `targetException` has one type with the  expected one.
We should also wrap with `try/catch` block only the method call with the related assert, not all statements before too.

Also fixes # ([641](https://github.com/UnitTestBot/UTBotJava/issues/641))

## Type of Change

- Bug fix (non-breaking change which fixes an issue)
- Refactoring (typos and non-functional changes) 

# How Has This Been Tested?

## Automated Testing

utbot-samples pipeline passing is enough

## Manual Scenario 

Several typical scenarios for parametrized tests including tests with expected exceptions.
