### PR TITLE
Add new test for deepequals on object with nullable reference fields #696

### DIFF
--- a/utbot-framework/src/test/kotlin/org/utbot/examples/codegen/deepequals/DeepEqualsTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/codegen/deepequals/DeepEqualsTest.kt
@@ -164,4 +164,13 @@ class DeepEqualsTest : UtValueTestCaseChecker(
             coverage = DoNotCalculate
         )
     }
+
+    @Test
+    fun testClassWithNullableField() {
+        check(
+            ClassWithNullableField::returnCompoundWithNullableField,
+            eq(2),
+            coverage = DoNotCalculate
+        )
+    }
 }

--- a/utbot-sample/src/main/java/org/utbot/examples/codegen/deepequals/ClassWithNullableField.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/codegen/deepequals/ClassWithNullableField.java
@@ -1,0 +1,20 @@
+package org.utbot.examples.codegen.deepequals;
+
+class Component {
+    int a = 1;
+}
+
+class Compound {
+    Component component;
+
+    Compound(Component component) {
+        this.component = component;
+    }
+}
+
+public class ClassWithNullableField {
+    public Compound returnCompoundWithNullableField(int value) {
+        if (value > 0) return new Compound(null);
+        else return new Compound(new Component());
+    }
+}


### PR DESCRIPTION
# Description

This PR adds extra deepequals test that will be used as a foundation for deepequals improvements in the near future.

Fixes # ([696](https://github.com/UnitTestBot/UTBotJava/issues/696))

## Type of Change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Automated Testing

Extra test passes non-parametrized test generation utbot samples pipeline.

## Manual Scenario 
Run `testClassWithNullableField` with enabled parametrized test generation. Verify that the test fails.

