### PR TITLE
java.net.URISyntaxException: Illegal character in path #587

### DIFF
--- a/utbot-core/src/main/kotlin/org/utbot/common/FileUtil.kt
+++ b/utbot-core/src/main/kotlin/org/utbot/common/FileUtil.kt
@@ -105,7 +105,7 @@ object FileUtil {
         return tempDir
     }
 
-    private fun URI.extractJarName(): URI = URI(this.schemeSpecificPart.substringBefore("!"))
+    private fun URI.extractJarName(): URI = URI(this.schemeSpecificPart.substringBefore("!").replace(" ", "%20"))
 
     private fun extractClassFromArchive(archiveFile: Path, clazz: KClass<*>, destPath: Path) {
         val classFilePath = clazz.toClassFilePath()


### PR DESCRIPTION
# Description

We got exception when path to JAR contains space, so we nee dto encode this symbol to `%20`

Fixes #587

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

Under macOS standard path fragment "Application Support" causes the issue
Probably standard path fragment "Prohram Files" can cause it either under Windows.
As for debugging one can put project to the directory with spaces like "My projects" to reproduce the issue.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
