### PR TITLE
UI. Gradle project. Suggest all Test sources roots for test generatio…

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -130,6 +130,7 @@ import org.utbot.intellij.plugin.ui.utils.addSourceRootIfAbsent
 import org.utbot.intellij.plugin.ui.utils.allLibraries
 import org.utbot.intellij.plugin.ui.utils.findFrameworkLibrary
 import org.utbot.intellij.plugin.ui.utils.getOrCreateTestResourcesPath
+import org.utbot.intellij.plugin.ui.utils.isGradle
 import org.utbot.intellij.plugin.ui.utils.kotlinTargetPlatform
 import org.utbot.intellij.plugin.ui.utils.parseVersion
 import org.utbot.intellij.plugin.ui.utils.testResourceRootTypes
@@ -435,7 +436,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
         val testRoot = getTestRoot()
             ?: return ValidationInfo("Test source root is not configured", testSourceFolderField.childComponent)
 
-        if (findReadOnlyContentEntry(testRoot) == null) {
+        if (!model.project.isGradle() && findReadOnlyContentEntry(testRoot) == null) {
             return ValidationInfo("Test source root is located out of content entry", testSourceFolderField.childComponent)
         }
 

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/components/TestFolderComboWithBrowseButton.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/components/TestFolderComboWithBrowseButton.kt
@@ -51,13 +51,9 @@ class TestFolderComboWithBrowseButton(private val model: GenerateTestsModel) : C
             }
         }
 
-        val testRoots = if (model.project.isGradle()) {
-            val allRoots = mutableSetOf<VirtualFile>()
-            model.project.allModules().map { it.suitableTestSourceRoots() }.forEach(allRoots::addAll)
-            allRoots.toMutableList()
-        } else {
-            model.potentialTestModules.flatMap { it.suitableTestSourceRoots().toMutableList() }.toMutableList()
-        }
+        val testRoots = model.potentialTestModules
+            .flatMap { it.suitableTestSourceRoots().toList() }
+            .toMutableList()
 
         // this method is blocked for Gradle, where multiple test modules can exist
         model.testModule.addDedicatedTestRoot(testRoots)

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/components/TestFolderComboWithBrowseButton.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/components/TestFolderComboWithBrowseButton.kt
@@ -13,6 +13,7 @@ import com.intellij.util.ArrayUtil
 import java.io.File
 import javax.swing.DefaultComboBoxModel
 import javax.swing.JList
+import org.jetbrains.kotlin.idea.util.projectStructure.allModules
 import org.utbot.common.PathUtil
 import org.utbot.intellij.plugin.models.GenerateTestsModel
 import org.utbot.intellij.plugin.ui.utils.addDedicatedTestRoot
@@ -50,7 +51,13 @@ class TestFolderComboWithBrowseButton(private val model: GenerateTestsModel) : C
             }
         }
 
-        val testRoots = model.potentialTestModules.flatMap { it.suitableTestSourceRoots().toMutableList() }.toMutableList()
+        val testRoots = if (model.project.isGradle()) {
+            val allRoots = mutableSetOf<VirtualFile>()
+            model.project.allModules().map { it.suitableTestSourceRoots() }.forEach(allRoots::addAll)
+            allRoots.toMutableList()
+        } else {
+            model.potentialTestModules.flatMap { it.suitableTestSourceRoots().toMutableList() }.toMutableList()
+        }
 
         // this method is blocked for Gradle, where multiple test modules can exist
         model.testModule.addDedicatedTestRoot(testRoots)

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/ModuleUtils.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/ModuleUtils.kt
@@ -31,6 +31,7 @@ import org.jetbrains.android.sdk.AndroidSdkType
 import org.jetbrains.jps.model.module.JpsModuleSourceRootType
 import org.jetbrains.kotlin.config.KotlinFacetSettingsProvider
 import org.jetbrains.kotlin.config.TestResourceKotlinRootType
+import org.jetbrains.kotlin.idea.util.projectStructure.allModules
 import org.jetbrains.kotlin.platform.TargetPlatformVersion
 
 private val logger = KotlinLogging.logger {}
@@ -86,6 +87,10 @@ fun Module.getOrCreateSarifReportsPath(testSourceRoot: VirtualFile?): Path {
  * Find test modules by current source module.
  */
 fun Module.testModules(project: Project): List<Module> {
+    if (project.isGradle()) {
+        return project.allModules()
+    }
+
     var testModules = findPotentialModulesForTests(project, this)
     val testRootUrls = testModules.flatMap { it.suitableTestSourceRoots() }
 


### PR DESCRIPTION
# Description

Let's suggest all available test roots for Gradle projects, the choice it up to user. 
"...located out of content entry" message is also irrelevant for Gradle projects

Fixes #549 

## Type of Change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Manual Scenario 

See the issue, for complex  Gradle project we should suggest all available test roots for the project.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
