### PR TITLE
Add support for nested classes to UI #649

### DIFF
--- a/utbot-core/src/main/kotlin/org/utbot/common/KClassUtil.kt
+++ b/utbot-core/src/main/kotlin/org/utbot/common/KClassUtil.kt
@@ -2,7 +2,7 @@ package org.utbot.common
 
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
-
+import kotlin.reflect.KClass
 
 val Class<*>.packageName: String get() = `package`?.name?:""
 
@@ -11,3 +11,6 @@ fun Method.invokeCatching(obj: Any?, args: List<Any?>) = try {
 } catch (e: InvocationTargetException) {
     Result.failure<Nothing>(e.targetException)
 }
+
+val KClass<*>.allNestedClasses: List<KClass<*>>
+    get() = listOf(this) + nestedClasses.flatMap { it.allNestedClasses }

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -19,15 +19,14 @@ import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.util.Computable
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.psi.PsiClass
-import com.intellij.psi.SyntheticElement
+import com.intellij.psi.PsiMethod
 import com.intellij.refactoring.util.classMembers.MemberInfo
-import com.intellij.testIntegration.TestIntegrationUtils
 import com.intellij.util.concurrency.AppExecutorUtil
 import mu.KotlinLogging
 import org.jetbrains.kotlin.idea.util.module
 import org.utbot.analytics.EngineAnalyticsContext
 import org.utbot.analytics.Predictors
-import org.utbot.common.filterWhen
+import org.utbot.common.allNestedClasses
 import org.utbot.engine.util.mockListeners.ForceMockListener
 import org.utbot.framework.plugin.services.JdkInfoService
 import org.utbot.framework.UtSettings
@@ -56,11 +55,11 @@ import java.util.concurrent.TimeUnit
 import org.utbot.engine.util.mockListeners.ForceStaticMockListener
 import org.utbot.framework.PathSelectorType
 import org.utbot.framework.plugin.services.WorkingDirService
+import org.utbot.intellij.plugin.models.packageName
 import org.utbot.intellij.plugin.settings.Settings
+import org.utbot.intellij.plugin.util.extractClassMethodsIncludingNested
 import org.utbot.intellij.plugin.ui.utils.isBuildWithGradle
-import org.utbot.intellij.plugin.ui.utils.suitableTestSourceRoots
 import org.utbot.intellij.plugin.util.PluginWorkingDirProvider
-import org.utbot.intellij.plugin.util.isAbstract
 import kotlin.reflect.KClass
 import kotlin.reflect.full.functions
 
@@ -71,9 +70,10 @@ object UtTestsDialogProcessor {
     fun createDialogAndGenerateTests(
         project: Project,
         srcClasses: Set<PsiClass>,
+        extractMembersFromSrcClasses: Boolean,
         focusedMethod: MemberInfo?,
     ) {
-        createDialog(project, srcClasses, focusedMethod)?.let {
+        createDialog(project, srcClasses, extractMembersFromSrcClasses, focusedMethod)?.let {
             if (it.showAndGet()) createTests(project, it.model)
         }
     }
@@ -81,6 +81,7 @@ object UtTestsDialogProcessor {
     private fun createDialog(
         project: Project,
         srcClasses: Set<PsiClass>,
+        extractMembersFromSrcClasses: Boolean,
         focusedMethod: MemberInfo?,
     ): GenerateTestsDialogWindow? {
         val srcModule = findSrcModule(srcClasses)
@@ -105,6 +106,7 @@ object UtTestsDialogProcessor {
                 srcModule,
                 testModules,
                 srcClasses,
+                extractMembersFromSrcClasses,
                 if (focusedMethod != null) setOf(focusedMethod) else null,
                 UtSettings.utBotGenerationTimeoutInMillis,
             )
@@ -145,6 +147,7 @@ object UtTestsDialogProcessor {
                             val context = UtContext(classLoader)
 
                             val testSetsByClass = mutableMapOf<PsiClass, List<UtMethodTestSet>>()
+                            val psi2KClass = mutableMapOf<PsiClass, KClass<*>>()
                             var processedClasses = 0
                             val totalClasses = model.srcClasses.size
 
@@ -159,18 +162,23 @@ object UtTestsDialogProcessor {
 
                             for (srcClass in model.srcClasses) {
                                 val methods = ReadAction.nonBlocking<List<UtMethod<*>>> {
-                                    val clazz = classLoader.loadClass(srcClass.qualifiedName).kotlin
-                                    val srcMethods =
-                                        model.selectedMethods?.toList() ?: TestIntegrationUtils.extractClassMethods(
-                                            srcClass,
-                                            false
-                                        )
-                                            .filterWhen(UtSettings.skipTestGenerationForSyntheticMethods) {
-                                                it.member !is SyntheticElement
-                                            }
-                                            .filterNot { it.isAbstract }
+                                    val canonicalName = srcClass.canonicalName
+                                    val clazz = classLoader.loadClass(canonicalName).kotlin
+                                    psi2KClass[srcClass] = clazz
+
+                                    val srcMethods = if (model.extractMembersFromSrcClasses) {
+                                        val chosenMethods = model.selectedMembers?.filter { it.member is PsiMethod } ?: listOf()
+                                        val chosenNestedClasses = model.selectedMembers?.mapNotNull { it.member as? PsiClass } ?: listOf()
+                                        chosenMethods + chosenNestedClasses.flatMap {
+                                            it.extractClassMethodsIncludingNested(false)
+                                        }
+                                    } else {
+                                        srcClass.extractClassMethodsIncludingNested(false)
+                                    }
                                     DumbService.getInstance(project).runReadActionInSmartMode(Computable {
-                                        findMethodsInClassMatchingSelected(clazz, srcMethods)
+                                        clazz.allNestedClasses.flatMap {
+                                            findMethodsInClassMatchingSelected(it, srcMethods)
+                                        }
                                     })
                                 }.executeSynchronously()
 
@@ -264,7 +272,7 @@ object UtTestsDialogProcessor {
 
                             invokeLater {
                                 withUtContext(context) {
-                                    generateTests(model, testSetsByClass)
+                                    generateTests(model, testSetsByClass, psi2KClass)
                                 }
                             }
                         }
@@ -272,6 +280,19 @@ object UtTestsDialogProcessor {
                 }
             }
     }
+
+    private val PsiClass.canonicalName: String
+        get() {
+            return if (packageName.isEmpty()) {
+                qualifiedName?.replace(".", "$") ?: ""
+            } else {
+                val name = qualifiedName
+                    ?.substringAfter("$packageName.")
+                    ?.replace(".", "$")
+                    ?: ""
+                "$packageName.$name"
+            }
+        }
 
     /**
      * Configures utbot-analytics models for the better path selection.

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/GenerateTestsModel.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/GenerateTestsModel.kt
@@ -26,8 +26,9 @@ data class GenerateTestsModel(
     val srcModule: Module,
     val potentialTestModules: List<Module>,
     var srcClasses: Set<PsiClass>,
-    var selectedMethods: Set<MemberInfo>?,
-    var timeout:Long,
+    val extractMembersFromSrcClasses: Boolean,
+    var selectedMembers: Set<MemberInfo>?, // TODO: maybe we should make it not nullable?
+    var timeout: Long,
     var generateWarningsForStaticMocking: Boolean = false,
     var fuzzingValue: Double = 0.05
 ) {
@@ -36,6 +37,7 @@ data class GenerateTestsModel(
     var testModule: Module = potentialTestModules.firstOrNull() ?: error("Empty list of test modules in model")
 
     var testSourceRoot: VirtualFile? = null
+
     fun setSourceRootAndFindTestModule(newTestSourceRoot: VirtualFile?) {
         requireNotNull(newTestSourceRoot)
         testSourceRoot = newTestSourceRoot

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/JavaPsiElementHandler.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/JavaPsiElementHandler.kt
@@ -4,7 +4,6 @@ import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.util.PsiTreeUtil
-import com.intellij.testIntegration.TestIntegrationUtils
 import com.intellij.testIntegration.createTest.CreateTestAction
 
 class JavaPsiElementHandler(
@@ -25,7 +24,5 @@ class JavaPsiElementHandler(
         CreateTestAction.isAvailableForElement(element)
 
     override fun containingClass(element: PsiElement): PsiClass? =
-        if (PsiTreeUtil.getParentOfType(element, PsiClass::class.java, false) != null) {
-            TestIntegrationUtils.findOuterClass(element)
-        } else null
+        PsiTreeUtil.getParentOfType(element, classClass, false)
 }

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/KotlinPsiElementHandler.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/KotlinPsiElementHandler.kt
@@ -8,10 +8,11 @@ import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedDeclaration
 import org.jetbrains.kotlin.psi.KtNamedFunction
-import org.jetbrains.kotlin.psi.psiUtil.parents
+import org.jetbrains.kotlin.psi.psiUtil.parentsWithSelf
 import org.jetbrains.uast.toUElement
 
 class KotlinPsiElementHandler(
+    // TODO: KtClassOrObject?
     override val classClass: Class<KtClass> = KtClass::class.java,
     override val methodClass: Class<KtNamedFunction> = KtNamedFunction::class.java,
 ) : PsiElementHandler {
@@ -27,9 +28,9 @@ class KotlinPsiElementHandler(
         getTarget(element)?.let { KotlinCreateTestIntention().applicabilityRange(it) != null } ?: false
 
     private fun getTarget(element: PsiElement?): KtNamedDeclaration? =
-        element?.parents
+        element?.parentsWithSelf
             ?.firstOrNull { it is KtClassOrObject || it is KtNamedDeclaration && it.parent is KtFile } as? KtNamedDeclaration
 
     override fun containingClass(element: PsiElement): PsiClass? =
-         (element.parents.firstOrNull { it is KtClassOrObject })?.let { toPsi(it, PsiClass::class.java) }
+         element.parentsWithSelf.firstOrNull { it is KtClassOrObject }?.let { toPsi(it, PsiClass::class.java) }
 }

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/ExtractMembersHelper.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/ExtractMembersHelper.kt
@@ -1,0 +1,33 @@
+package org.utbot.intellij.plugin.util
+
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiModifier
+import com.intellij.psi.PsiModifierListOwner
+import com.intellij.psi.SyntheticElement
+import com.intellij.refactoring.classMembers.MemberInfoBase
+import com.intellij.refactoring.util.classMembers.MemberInfo
+import com.intellij.testIntegration.TestIntegrationUtils
+import org.utbot.common.filterWhen
+import org.utbot.framework.UtSettings
+
+private val MemberInfoBase<out PsiModifierListOwner>.isAbstract: Boolean
+    get() = this.member.modifierList?.hasModifierProperty(PsiModifier.ABSTRACT)?: false
+
+private fun Iterable<MemberInfo>.filterTestableMethods(): List<MemberInfo> = this
+    .filterWhen(UtSettings.skipTestGenerationForSyntheticMethods) { it.member !is SyntheticElement }
+    .filterNot { it.isAbstract }
+
+// TODO: maybe we need to delete [includeInherited] param here (always false when calling)?
+fun PsiClass.extractClassMethodsIncludingNested(includeInherited: Boolean): List<MemberInfo> =
+    TestIntegrationUtils.extractClassMethods(this, includeInherited)
+        .filterTestableMethods() + innerClasses.flatMap { it.extractClassMethodsIncludingNested(includeInherited) }
+
+fun PsiClass.extractFirstLevelMembers(includeInherited: Boolean): List<MemberInfo> {
+    val methods = TestIntegrationUtils.extractClassMethods(this, includeInherited)
+        .filterTestableMethods()
+    val classes = if (includeInherited)
+        allInnerClasses
+    else
+        innerClasses
+    return methods + classes.map { MemberInfo(it) }
+}

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/MemberInfoUtils.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/MemberInfoUtils.kt
@@ -1,8 +1,0 @@
-package org.utbot.intellij.plugin.util
-
-import com.intellij.psi.PsiModifier
-import com.intellij.psi.PsiModifierListOwner
-import com.intellij.refactoring.classMembers.MemberInfoBase
-
-val MemberInfoBase<out PsiModifierListOwner>.isAbstract: Boolean
-    get() = this.member.modifierList?.hasModifierProperty(PsiModifier.ABSTRACT)?: false


### PR DESCRIPTION
# Description

Changed the behavior of plugin on classes with nested classes. Now, when launching UTBot for a class, its nested classes will be shown in dialog (in addition to its methods). This behavior holds both when launching from editor and from 'Project' tool window.

Fixes #649

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

Launch UTBot from different scopes of the class below (both from editor and from 'Project' tool window) -- should work as expected.

```Java
public class SomeClass {
    public class InnerClass {
        private int y;
        InnerClass(int y) {
            this.y = y;
        }
        public class DeepInner {
            public int f() {
                if (y == 1) return 1;
                return 2;
            }
        }
        public int g() {
            return 2;
        }
    }
    public int h() {
        return 3;
    }
}
```

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [ ] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
