### PR TITLE
Add unit tests for builders #543

### DIFF
--- a/utbot-summary/build.gradle
+++ b/utbot-summary/build.gradle
@@ -9,5 +9,7 @@ dependencies {
 
     implementation group: 'com.github.javaparser', name: 'javaparser-core', version: '3.22.1'
 
+    testImplementation 'org.mockito:mockito-core:4.7.0'
+
     testImplementation("org.junit.jupiter:junit-jupiter:$junit5_version")
 }

--- a/utbot-summary/build.gradle
+++ b/utbot-summary/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 
     implementation group: 'com.github.javaparser', name: 'javaparser-core', version: '3.22.1'
 
-    testImplementation 'org.mockito:mockito-core:4.7.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: mockito_version
 
     testImplementation("org.junit.jupiter:junit-jupiter:$junit5_version")
 }

--- a/utbot-summary/src/main/kotlin/org/utbot/summary/comment/SimpleCommentBuilder.kt
+++ b/utbot-summary/src/main/kotlin/org/utbot/summary/comment/SimpleCommentBuilder.kt
@@ -349,7 +349,7 @@ open class SimpleCommentBuilder(
      * In case when an enclosing class in nested, we need to replace '$' with '.'
      * to render the reference.
      */
-    protected fun invokeDescription(className: String, methodName: String, methodParameterTypes: List<Type>): String {
+    fun invokeDescription(className: String, methodName: String, methodParameterTypes: List<Type>): String {
         val prettyClassName: String = className.replace("$", ".")
 
         return if (methodParameterTypes.isEmpty()) {

--- a/utbot-summary/src/test/kotlin/org/utbot/summary/comment/SimpleClusterCommentBuilderTest.kt
+++ b/utbot-summary/src/test/kotlin/org/utbot/summary/comment/SimpleClusterCommentBuilderTest.kt
@@ -1,6 +1,6 @@
 package org.utbot.summary.comment
 
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -45,13 +45,18 @@ class SimpleClusterCommentBuilderTest {
     }
 
     @Test
-    fun `throws throwable if execution result is null`() {
+    fun `builds empty comment if execution result is null`() {
         val commentBuilder = SimpleClusterCommentBuilder(traceTag, sootToAst)
         val comment = commentBuilder.buildString(sootMethod)
-        val expectedComment = "<pre>\n" +
-                "Test throws Throwable \n" +
-                "</pre>"
-        Assertions.assertEquals(expectedComment, comment)
+        assertEquals(" ", comment)
+    }
+
+    @Test
+    fun `builds empty doc statement if execution result is null`() {
+        val commentBuilder = SimpleClusterCommentBuilder(traceTag, sootToAst)
+        val statements = commentBuilder.buildDocStmts(sootMethod)
+        assertEquals(statements.size, 1)
+        assertEquals(statements[0].toString(), " ")
     }
 
 }

--- a/utbot-summary/src/test/kotlin/org/utbot/summary/comment/SimpleClusterCommentBuilderTest.kt
+++ b/utbot-summary/src/test/kotlin/org/utbot/summary/comment/SimpleClusterCommentBuilderTest.kt
@@ -1,0 +1,57 @@
+package org.utbot.summary.comment
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.utbot.framework.plugin.api.Step
+import org.utbot.framework.plugin.api.UtOverflowFailure
+import org.utbot.summary.ast.JimpleToASTMap
+import org.utbot.summary.tag.StatementTag
+import org.utbot.summary.tag.TraceTag
+import soot.SootMethod
+import soot.jimple.Stmt
+import soot.jimple.internal.JReturnStmt
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SimpleClusterCommentBuilderTest {
+    private lateinit var traceTag: TraceTag
+    private lateinit var jimpleToASTMap: JimpleToASTMap
+    private lateinit var sootToAst: MutableMap<SootMethod, JimpleToASTMap>
+    private lateinit var sootMethod: SootMethod
+    private lateinit var statementTag: StatementTag
+    private lateinit var step: Step
+    private lateinit var statement: Stmt
+
+    @BeforeAll
+    fun setUp() {
+        traceTag = mock(TraceTag::class.java)
+        sootMethod = mock(SootMethod::class.java)
+        jimpleToASTMap = mock(JimpleToASTMap::class.java)
+        statementTag = mock(StatementTag::class.java)
+        step = mock(Step::class.java)
+        statement = mock(JReturnStmt::class.java)
+        sootToAst = mutableMapOf()
+
+        `when`(statementTag.step).thenReturn(step)
+        `when`(step.stmt).thenReturn(statement)
+        `when`(traceTag.path).thenReturn(listOf(step))
+        `when`(traceTag.rootStatementTag).thenReturn(statementTag)
+        `when`(traceTag.result).thenReturn(UtOverflowFailure(Throwable()))
+
+        sootToAst[sootMethod] = jimpleToASTMap
+    }
+
+    @Test
+    fun `throws throwable if execution result is null`() {
+        val commentBuilder = SimpleClusterCommentBuilder(traceTag, sootToAst)
+        val comment = commentBuilder.buildString(sootMethod)
+        val expectedComment = "<pre>\n" +
+                "Test throws Throwable \n" +
+                "</pre>"
+        Assertions.assertEquals(expectedComment, comment)
+    }
+
+}

--- a/utbot-summary/src/test/kotlin/org/utbot/summary/comment/SimpleCommentBuilderTest.kt
+++ b/utbot-summary/src/test/kotlin/org/utbot/summary/comment/SimpleCommentBuilderTest.kt
@@ -1,0 +1,57 @@
+package org.utbot.summary.comment
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.utbot.framework.plugin.api.Step
+import org.utbot.framework.plugin.api.UtOverflowFailure
+import org.utbot.summary.ast.JimpleToASTMap
+import org.utbot.summary.tag.StatementTag
+import org.utbot.summary.tag.TraceTag
+import soot.SootMethod
+import soot.jimple.Stmt
+import soot.jimple.internal.JReturnStmt
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SimpleCommentBuilderTest {
+    private lateinit var traceTag: TraceTag
+    private lateinit var jimpleToASTMap: JimpleToASTMap
+    private lateinit var sootToAst: MutableMap<SootMethod, JimpleToASTMap>
+    private lateinit var sootMethod: SootMethod
+    private lateinit var statementTag: StatementTag
+    private lateinit var step: Step
+    private lateinit var statement: Stmt
+
+    @BeforeAll
+    fun setUp() {
+        traceTag = mock(TraceTag::class.java)
+        sootMethod = mock(SootMethod::class.java)
+        jimpleToASTMap = mock(JimpleToASTMap::class.java)
+        statementTag = mock(StatementTag::class.java)
+        step = mock(Step::class.java)
+        statement = mock(JReturnStmt::class.java)
+        sootToAst = mutableMapOf()
+
+        `when`(statementTag.step).thenReturn(step)
+        `when`(step.stmt).thenReturn(statement)
+        `when`(traceTag.path).thenReturn(listOf(step))
+        `when`(traceTag.rootStatementTag).thenReturn(statementTag)
+        `when`(traceTag.result).thenReturn(UtOverflowFailure(Throwable()))
+
+        sootToAst[sootMethod] = jimpleToASTMap
+    }
+
+    @Test
+    fun `throws throwable if execution result is null`() {
+        val commentBuilder = SimpleCommentBuilder(traceTag, sootToAst)
+        val comment = commentBuilder.buildString(sootMethod)
+        val expectedComment = "<pre>\n" +
+                "Test throws Throwable \n" +
+                "</pre>"
+        assertEquals(expectedComment, comment)
+    }
+
+}

--- a/utbot-summary/src/test/kotlin/org/utbot/summary/comment/SimpleCommentBuilderTest.kt
+++ b/utbot-summary/src/test/kotlin/org/utbot/summary/comment/SimpleCommentBuilderTest.kt
@@ -64,4 +64,21 @@ class SimpleCommentBuilderTest {
         assertEquals(statements[0].toString(), expectedDocStatement)
     }
 
+    @Test
+    fun `builds inline link for method`() {
+        val commentBuilder = SimpleCommentBuilder(traceTag, sootToAst)
+        val methodReference = commentBuilder.invokeDescription("org.utbot.ClassName", "methodName", listOf())
+        val expectedMethodReference = "{@link org.utbot.ClassName#methodName()}"
+        assertEquals(methodReference, expectedMethodReference)
+    }
+
+    @Test
+    fun `builds inline link for method in nested class`() {
+        val commentBuilder = SimpleCommentBuilder(traceTag, sootToAst)
+        val methodReference =
+            commentBuilder.invokeDescription("org.utbot.ClassName\$NestedClassName", "methodName", listOf())
+        val expectedMethodReference = "{@link org.utbot.ClassName.NestedClassName#methodName()}"
+        assertEquals(methodReference, expectedMethodReference)
+    }
+
 }

--- a/utbot-summary/src/test/kotlin/org/utbot/summary/comment/SimpleCommentBuilderTest.kt
+++ b/utbot-summary/src/test/kotlin/org/utbot/summary/comment/SimpleCommentBuilderTest.kt
@@ -54,4 +54,14 @@ class SimpleCommentBuilderTest {
         assertEquals(expectedComment, comment)
     }
 
+    @Test
+    fun `builds one doc statement`() {
+        val commentBuilder = SimpleCommentBuilder(traceTag, sootToAst)
+        val statements = commentBuilder.buildDocStmts(sootMethod)
+        val expectedDocStatement = "Test \n" +
+                "throws Throwable \n"
+        assertEquals(statements.size, 1)
+        assertEquals(statements[0].toString(), expectedDocStatement)
+    }
+
 }

--- a/utbot-summary/src/test/kotlin/org/utbot/summary/name/SimpleNameBuilderTest.kt
+++ b/utbot-summary/src/test/kotlin/org/utbot/summary/name/SimpleNameBuilderTest.kt
@@ -1,0 +1,38 @@
+package org.utbot.summary.name
+
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.mockito.Mockito
+import org.utbot.framework.plugin.api.UtOverflowFailure
+import org.utbot.summary.ast.JimpleToASTMap
+import org.utbot.summary.tag.TraceTag
+import soot.SootMethod
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SimpleNameBuilderTest {
+    private lateinit var traceTag: TraceTag
+    private lateinit var jimpleToASTMap: JimpleToASTMap
+    private lateinit var sootToAst: MutableMap<SootMethod, JimpleToASTMap>
+    private lateinit var sootMethod: SootMethod
+
+    @BeforeAll
+    fun setUp() {
+        traceTag = Mockito.mock(TraceTag::class.java)
+        Mockito.`when`(traceTag.result).thenReturn(UtOverflowFailure(Throwable()))
+
+        jimpleToASTMap = Mockito.mock(JimpleToASTMap::class.java)
+
+        sootToAst = mutableMapOf()
+        sootMethod = Mockito.mock(SootMethod::class.java)
+        Mockito.`when`(sootMethod.name).thenReturn("methodName")
+        sootToAst[sootMethod] = jimpleToASTMap
+    }
+
+    @Test
+    fun `method name starts with test`() {
+        val simpleNameBuilder = SimpleNameBuilder(traceTag, sootToAst, sootMethod)
+        val methodName = simpleNameBuilder.name
+        assert(methodName.startsWith("test"))
+    }
+}

--- a/utbot-summary/src/test/kotlin/org/utbot/summary/name/SimpleNameBuilderTest.kt
+++ b/utbot-summary/src/test/kotlin/org/utbot/summary/name/SimpleNameBuilderTest.kt
@@ -4,7 +4,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.mockito.Mockito
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 import org.utbot.framework.plugin.api.UtOverflowFailure
 import org.utbot.summary.ast.JimpleToASTMap
 import org.utbot.summary.tag.TraceTag
@@ -20,19 +21,19 @@ class SimpleNameBuilderTest {
 
     @BeforeAll
     fun setUp() {
-        traceTag = Mockito.mock(TraceTag::class.java)
-        sootMethod = Mockito.mock(SootMethod::class.java)
-        jimpleToASTMap = Mockito.mock(JimpleToASTMap::class.java)
+        traceTag = mock(TraceTag::class.java)
+        sootMethod = mock(SootMethod::class.java)
+        jimpleToASTMap = mock(JimpleToASTMap::class.java)
         sootToAst = mutableMapOf()
 
-        Mockito.`when`(traceTag.result).thenReturn(UtOverflowFailure(Throwable()))
+        `when`(traceTag.result).thenReturn(UtOverflowFailure(Throwable()))
 
         sootToAst[sootMethod] = jimpleToASTMap
     }
 
     @Test
     fun `method name should start with test`() {
-        Mockito.`when`(sootMethod.name).thenReturn("methodName")
+        `when`(sootMethod.name).thenReturn("methodName")
 
         val simpleNameBuilder = SimpleNameBuilder(traceTag, sootToAst, sootMethod)
         val methodName = simpleNameBuilder.name
@@ -41,7 +42,7 @@ class SimpleNameBuilderTest {
 
     @Test
     fun `creates a name pair with a candidate with a bigger index`() {
-        Mockito.`when`(sootMethod.name).thenReturn("")
+        `when`(sootMethod.name).thenReturn("")
 
         val simpleNameBuilder = SimpleNameBuilder(traceTag, sootToAst, sootMethod)
         val fromCandidateName = DisplayNameCandidate("fromCandidate", UniquenessTag.Unique, 3)
@@ -57,7 +58,7 @@ class SimpleNameBuilderTest {
 
     @Test
     fun `returns null if candidates are equal`() {
-        Mockito.`when`(sootMethod.name).thenReturn("")
+        `when`(sootMethod.name).thenReturn("")
 
         val simpleNameBuilder = SimpleNameBuilder(traceTag, sootToAst, sootMethod)
         val fromCandidateName = DisplayNameCandidate("candidate", UniquenessTag.Unique, 0)

--- a/utbot-summary/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/utbot-summary/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
# Description

Added unit tests for SimpleNameBuilder, SimpleCommentBuilder, SimpleClusterCommentBuilder.
Unfortunately, most of the methods are private and kotlin properties not always could be mocked, so the number of tests is small.

Fixes #543 

## Type of Change

Please delete options that are not relevant.

- New tests

# How Has This Been Tested?

## Automated Testing

Run tests in PR.

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [ ] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] New tests have been added
- [x] All tests pass locally with my changes
