### PR TITLE
Fix direct assigning of fields with private type #731

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssembleModelGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssembleModelGenerator.kt
@@ -6,6 +6,7 @@ import org.utbot.engine.ResolvedModels
 import org.utbot.engine.isPrivate
 import org.utbot.engine.isPublic
 import org.utbot.framework.UtSettings
+import org.utbot.framework.codegen.model.util.isAccessibleFrom
 import org.utbot.framework.modifications.AnalysisMode.SettersAndDirectAccessors
 import org.utbot.framework.modifications.ConstructorAnalyzer
 import org.utbot.framework.modifications.ConstructorAssembleInfo
@@ -254,6 +255,11 @@ class AssembleModelGenerator(private val methodUnderTest: UtMethod<*>) {
                     }
                     if (fieldId.isFinal) {
                         throw AssembleException("Final field $fieldId can't be set in an object of the class $classId")
+                    }
+                    if (!fieldId.type.isAccessibleFrom(methodPackageName)) {
+                        throw AssembleException(
+                            "Field $fieldId can't be set in an object of the class $classId because its type is inaccessible"
+                        )
                     }
                     //fill field value if it hasn't been filled by constructor, and it is not default
                     if (fieldId in constructorInfo.affectedFields ||

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/codegen/ClassWithStaticAndInnerClassesTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/codegen/ClassWithStaticAndInnerClassesTest.kt
@@ -98,6 +98,15 @@ internal class ClassWithStaticAndInnerClassesTest : UtValueTestCaseChecker(testC
     }
 
     @Test
+    fun testGetValueFromPublicFieldWithPrivateType() {
+        check(
+            ClassWithStaticAndInnerClasses::getValueFromPublicFieldWithPrivateType,
+            eq(2),
+            coverage = DoNotCalculate
+        )
+    }
+
+    @Test
     fun testPublicStaticClassWithPrivateField_DeepNestedStatic_g() {
         checkAllCombinations(
             ClassWithStaticAndInnerClasses.PublicStaticClassWithPrivateField.DeepNestedStatic::g,

--- a/utbot-sample/src/main/java/org/utbot/examples/codegen/ClassWithStaticAndInnerClasses.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/codegen/ClassWithStaticAndInnerClasses.java
@@ -3,6 +3,9 @@ package org.utbot.examples.codegen;
 public class ClassWithStaticAndInnerClasses {
     public int z = 0;
 
+    // public field that exposes private type PrivateInnerClassWithPublicField
+    public PrivateInnerClassWithPublicField publicFieldWithPrivateType = new PrivateInnerClassWithPublicField(0);
+
     private static class PrivateStaticClassWithPublicField {
         public int x;
 
@@ -238,5 +241,9 @@ public class ClassWithStaticAndInnerClasses {
         PackagePrivateFinalInnerClassWithPackagePrivateField innerClass = classWithStaticAndInnerClasses.new PackagePrivateFinalInnerClassWithPackagePrivateField(x);
 
         return innerClass.createFromIncrement(x);
+    }
+
+    int getValueFromPublicFieldWithPrivateType() {
+        return publicFieldWithPrivateType.x;
     }
 }


### PR DESCRIPTION
# Description

If we have a public field with type that is not accessible in testclass, then we should use reflection but not direct assignments to set it (because rhs will likely be declared as `Object`).

Fixes #731 

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Automated Testing

Added `org.utbot.examples.codegen.ClassWithStaticAndInnerClassesTest#testGetValueFromPublicFieldWithPrivateType`

## Manual Scenario 

Launch plugin on example from #731 -- works as expected. 

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [ ] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] New tests have been added
- [ ] All tests pass locally with my changes
