### PR TITLE
Fix the child process debug commands order #736

### DIFF
--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/process/ChildProcessRunner.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/process/ChildProcessRunner.kt
@@ -21,16 +21,11 @@ private var processSeqN = 0
 
 class ChildProcessRunner {
     private val cmds: List<String> by lazy {
-        val debugCmd = if (Settings.runChildProcessWithDebug) {
-            listOf(DEBUG_RUN_CMD)
-        } else {
-            emptyList()
-        }
-
-        listOf(
-            JdkInfoService.provide().path.resolve("bin${File.separatorChar}java").toString(),
-            "-javaagent:$jarFile", "-ea", "-jar", "$jarFile"
-        ) + debugCmd
+        val pathToJava = JdkInfoService.provide().path
+        val debugCmd = listOfNotNull(DEBUG_RUN_CMD.takeIf { Settings.runChildProcessWithDebug })
+        listOf(pathToJava.resolve("bin${File.separatorChar}java").toString()) +
+            debugCmd +
+            listOf("-javaagent:$jarFile", "-ea", "-jar", "$jarFile")
     }
 
     var errorLogFile: File = NULL_FILE


### PR DESCRIPTION
# Description

Changed the order of commands for debugging.

Fixes #736

## Type of Change

- Minor bug fix (non-breaking small changes)

# Checklist

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] No new warnings
- [x] All tests pass locally with my changes
