### PR TITLE
corrected ClassId.isAccessibleFrom behavior on arrays #743

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/util/ClassIdUtil.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/util/ClassIdUtil.kt
@@ -14,16 +14,19 @@ import org.utbot.framework.plugin.api.util.isArray
  * @param packageName name of the package we check accessibility from
  */
 infix fun ClassId.isAccessibleFrom(packageName: String): Boolean {
-    val isContainedElementsClassAccessible = elementClassId?.isAccessibleFrom(packageName) ?: true
 
-    // TODO: isNested checks that jClass.enclosingClass != null, outerClass returns jClass.enclosingClass, maybe simplify this?
-    val isOuterClassAccessible = if (isNested) {
-        outerClass!!.id.isAccessibleFrom(packageName)
-    } else {
-        true
+    if (this.isLocal || this.isSynthetic) {
+        return false
     }
 
-    val isAccessibleFromPackageByModifiers = isArray || isPublic || (this.packageName == packageName && (isPackagePrivate || isProtected))
+    val outerClassId = outerClass?.id
+    if (outerClassId != null && !outerClassId.isAccessibleFrom(packageName)) {
+        return false
+    }
 
-    return isContainedElementsClassAccessible && isOuterClassAccessible && isAccessibleFromPackageByModifiers && !isLocal && !isSynthetic
+    return if (this.isArray) {
+        elementClassId!!.isAccessibleFrom(packageName)
+    } else {
+        isPublic || (this.packageName == packageName && (isPackagePrivate || isProtected))
+    }
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/util/ClassIdUtil.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/util/ClassIdUtil.kt
@@ -2,6 +2,7 @@ package org.utbot.framework.codegen.model.util
 
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.util.id
+import org.utbot.framework.plugin.api.util.isArray
 
 /**
  * For now we will count class accessible if it is:
@@ -13,13 +14,16 @@ import org.utbot.framework.plugin.api.util.id
  * @param packageName name of the package we check accessibility from
  */
 infix fun ClassId.isAccessibleFrom(packageName: String): Boolean {
+    val isContainedElementsClassAccessible = elementClassId?.isAccessibleFrom(packageName) ?: true
+
+    // TODO: isNested checks that jClass.enclosingClass != null, outerClass returns jClass.enclosingClass, maybe simplify this?
     val isOuterClassAccessible = if (isNested) {
         outerClass!!.id.isAccessibleFrom(packageName)
     } else {
         true
     }
 
-    val isAccessibleFromPackageByModifiers = isPublic || (this.packageName == packageName && (isPackagePrivate || isProtected))
+    val isAccessibleFromPackageByModifiers = isArray || isPublic || (this.packageName == packageName && (isPackagePrivate || isProtected))
 
-    return isOuterClassAccessible && isAccessibleFromPackageByModifiers && !isLocal && !isSynthetic
+    return isContainedElementsClassAccessible && isOuterClassAccessible && isAccessibleFromPackageByModifiers && !isLocal && !isSynthetic
 }


### PR DESCRIPTION
# Description

`ClassId.isAccessibleFrom` didn't work correctly on arrays (sometimes returned false when it should have returned true), which lead to unnecessary usage of refelction and bugs in generated tests.

Now this method returns true on array iff contained elements' class is accessible.

Fixes #743

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

Launch plugin on example from #743 -- tests are generated without reflections.

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
