### PR TITLE
Support anonymous classes

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -31,6 +31,7 @@ import org.utbot.framework.plugin.api.util.method
 import org.utbot.framework.plugin.api.util.primitiveTypeJvmNameOrNull
 import org.utbot.framework.plugin.api.util.safeJField
 import org.utbot.framework.plugin.api.util.shortClassId
+import org.utbot.framework.plugin.api.util.supertypeOfAnonymousClass
 import org.utbot.framework.plugin.api.util.toReferenceTypeBytecodeSignature
 import org.utbot.framework.plugin.api.util.voidClassId
 import soot.ArrayType
@@ -679,8 +680,14 @@ open class ClassId @JvmOverloads constructor(
      */
     val prettifiedName: String
         get() {
-            val className = jClass.canonicalName ?: name // Explicit jClass reference to get null instead of exception
-            return className
+            val baseName = when {
+                // anonymous classes have empty simpleName and their canonicalName is null,
+                // so we create a specific name for them
+                isAnonymous -> "Anonymous${supertypeOfAnonymousClass.prettifiedName}"
+                // in other cases where canonical name is still null, we use ClassId.name instead
+                else -> jClass.canonicalName ?: name // Explicit jClass reference to get null instead of exception
+            }
+            return baseName
                 .substringAfterLast(".")
                 .replace(Regex("[^a-zA-Z0-9]"), "")
                 .let { if (this.isArray) it + "Array" else it }

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/objects/AnonymousClassesExampleTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/objects/AnonymousClassesExampleTest.kt
@@ -1,7 +1,7 @@
 package org.utbot.examples.objects
 
+import org.utbot.examples.Full
 import org.utbot.tests.infrastructure.UtValueTestCaseChecker
-import org.utbot.tests.infrastructure.DoNotCalculate
 import org.utbot.tests.infrastructure.isException
 import org.junit.jupiter.api.Test
 import org.utbot.testcheckers.eq
@@ -11,19 +11,23 @@ class AnonymousClassesExampleTest : UtValueTestCaseChecker(testClass = Anonymous
     fun testAnonymousClassAsParam() {
         checkWithException(
             AnonymousClassesExample::anonymousClassAsParam,
-            eq(2),
+            eq(3),
             { abstractAnonymousClass, r -> abstractAnonymousClass == null && r.isException<NullPointerException>() },
             { abstractAnonymousClass, r -> abstractAnonymousClass != null && r.getOrNull() == 0 },
-            coverage = DoNotCalculate
+            { abstractAnonymousClass, r -> abstractAnonymousClass != null && abstractAnonymousClass::class.java.isAnonymousClass && r.getOrNull() == 42 },
+            coverage = Full
         )
     }
 
     @Test
     fun testNonFinalAnonymousStatic() {
-        check(
+        checkStaticsAndException(
             AnonymousClassesExample::nonFinalAnonymousStatic,
-            eq(0), // we remove all anonymous classes in statics
-            coverage = DoNotCalculate
+            eq(3),
+            { statics, r -> statics.values.single().value == null && r.isException<NullPointerException>() },
+            { _, r -> r.getOrNull() == 0 },
+            { _, r -> r.getOrNull() == 42 },
+            coverage = Full
         )
     }
 
@@ -31,8 +35,9 @@ class AnonymousClassesExampleTest : UtValueTestCaseChecker(testClass = Anonymous
     fun testAnonymousClassAsStatic() {
         check(
             AnonymousClassesExample::anonymousClassAsStatic,
-            eq(0), // we remove all anonymous classes in statics
-            coverage = DoNotCalculate
+            eq(1),
+            { r -> r == 42 },
+            coverage = Full
         )
     }
 
@@ -40,8 +45,9 @@ class AnonymousClassesExampleTest : UtValueTestCaseChecker(testClass = Anonymous
     fun testAnonymousClassAsResult() {
         check(
             AnonymousClassesExample::anonymousClassAsResult,
-            eq(0), // we remove anonymous classes from the params and the result
-            coverage = DoNotCalculate
+            eq(1),
+            { abstractAnonymousClass -> abstractAnonymousClass != null && abstractAnonymousClass::class.java.isAnonymousClass },
+            coverage = Full
         )
     }
 }

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/objects/AnonymousClassesExampleTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/objects/AnonymousClassesExampleTest.kt
@@ -1,6 +1,6 @@
 package org.utbot.examples.objects
 
-import org.utbot.examples.Full
+import org.utbot.tests.infrastructure.Full
 import org.utbot.tests.infrastructure.UtValueTestCaseChecker
 import org.utbot.tests.infrastructure.isException
 import org.junit.jupiter.api.Test

--- a/utbot-framework-test/src/test/kotlin/org/utbot/framework/assemble/AssembleModelGeneratorTests.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/framework/assemble/AssembleModelGeneratorTests.kt
@@ -58,6 +58,8 @@ import org.utbot.framework.util.SootUtils
 import org.utbot.framework.util.instanceCounter
 import org.utbot.framework.util.modelIdCounter
 import kotlin.reflect.full.functions
+import org.utbot.examples.assemble.*
+import org.utbot.framework.codegen.model.constructor.util.arrayTypeOf
 
 /**
  * Test classes must be located in the same folder as [AssembleTestUtils] class.
@@ -1117,7 +1119,7 @@ class AssembleModelGeneratorTests {
             testClassId,
             "array" to UtArrayModel(
                 modelIdCounter.incrementAndGet(),
-                ClassId("[L${innerClassId.canonicalName}", innerClassId),
+                arrayTypeOf(innerClassId),
                 length = 3,
                 UtNullModel(innerClassId),
                 mutableMapOf(
@@ -1187,11 +1189,11 @@ class AssembleModelGeneratorTests {
         val testClassId = ArrayOfComplexArrays::class.id
         val innerClassId = PrimitiveFields::class.id
 
-        val innerArrayClassId = ClassId("[L${innerClassId.canonicalName}", innerClassId)
+        val innerArrayClassId = arrayTypeOf(innerClassId)
 
         val arrayOfArraysModel = UtArrayModel(
             modelIdCounter.incrementAndGet(),
-            ClassId("[Lorg.utbot.examples.assemble.ComplexArray", testClassId),
+            arrayTypeOf(testClassId),
             length = 2,
             UtNullModel(innerArrayClassId),
             mutableMapOf(

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -3405,9 +3405,18 @@ class Traverser(
         if (returnValue != null) {
             queuedSymbolicStateUpdates += constructConstraintForType(returnValue, returnValue.possibleConcreteTypes).asSoftConstraint()
 
+            // We only remove anonymous classes if there are regular classes available.
+            // If there are no other options, then we do use anonymous classes.
             workaround(REMOVE_ANONYMOUS_CLASSES) {
                 val sootClass = returnValue.type.sootClass
-                if (!environment.state.isInNestedMethod() && (sootClass.isAnonymous || sootClass.isArtificialEntity)) {
+                val isInNestedMethod = environment.state.isInNestedMethod()
+
+                if (!isInNestedMethod && sootClass.isArtificialEntity) {
+                    return
+                }
+
+                val onlyAnonymousTypesAvailable = returnValue.typeStorage.possibleConcreteTypes.all { (it as? RefType)?.sootClass?.isAnonymous == true }
+                if (!isInNestedMethod && sootClass.isAnonymous && !onlyAnonymousTypesAvailable) {
                     return
                 }
             }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
@@ -4,10 +4,8 @@ import mu.KotlinLogging
 import org.utbot.analytics.EngineAnalyticsContext
 import org.utbot.analytics.FeatureProcessor
 import org.utbot.analytics.Predictors
-import org.utbot.common.WorkaroundReason.REMOVE_ANONYMOUS_CLASSES
 import org.utbot.common.bracket
 import org.utbot.common.debug
-import org.utbot.common.workaround
 import org.utbot.engine.MockStrategy.NO_MOCKS
 import org.utbot.engine.pc.UtArraySelectExpression
 import org.utbot.engine.pc.UtBoolExpression
@@ -60,6 +58,8 @@ import org.utbot.framework.plugin.api.UtNullModel
 import org.utbot.framework.plugin.api.UtOverflowFailure
 import org.utbot.framework.plugin.api.UtResult
 import org.utbot.framework.plugin.api.UtSymbolicExecution
+import org.utbot.framework.util.graph
+import org.utbot.framework.plugin.api.util.executableId
 import org.utbot.framework.plugin.api.util.isStatic
 import org.utbot.framework.plugin.api.onSuccess
 import org.utbot.framework.plugin.api.util.description
@@ -469,15 +469,6 @@ class UtBotSymbolicEngine(
             // in case an exception occurred from the concrete execution
             concreteExecutionResult ?: return@forEach
 
-            workaround(REMOVE_ANONYMOUS_CLASSES) {
-                concreteExecutionResult.result.onSuccess {
-                    if (it.classId.isAnonymous) {
-                        logger.debug("Anonymous class found as a concrete result, symbolic one will be returned")
-                        return@flow
-                    }
-                }
-            }
-
             val coveredInstructions = concreteExecutionResult.coverage.coveredInstructions
             if (coveredInstructions.isNotEmpty()) {
                 val coverageKey = coveredInstructionTracker.add(coveredInstructions)
@@ -585,16 +576,6 @@ class UtBotSymbolicEngine(
                     stateBefore,
                     instrumentation
                 )
-
-                workaround(REMOVE_ANONYMOUS_CLASSES) {
-                    concreteExecutionResult.result.onSuccess {
-                        if (it.classId.isAnonymous) {
-                            logger.debug("Anonymous class found as a concrete result, symbolic one will be returned")
-                            emit(symbolicUtExecution)
-                            return
-                        }
-                    }
-                }
 
                 val concolicUtExecution = symbolicUtExecution.copy(
                     stateAfter = concreteExecutionResult.stateAfter,

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssembleModelGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssembleModelGenerator.kt
@@ -171,6 +171,11 @@ class AssembleModelGenerator(private val methodPackageName: String) {
     private fun assembleModel(utModel: UtModel): UtModel {
         val collectedCallChain = callChain.toMutableList()
 
+        // we cannot create an assemble model for an anonymous class instance
+        if (utModel.classId.isAnonymous) {
+            return utModel
+        }
+
         val assembledModel = withCleanState {
             try {
                 when (utModel) {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgVariableConstructor.kt
@@ -55,6 +55,7 @@ import org.utbot.framework.plugin.api.util.intClassId
 import org.utbot.framework.plugin.api.util.isArray
 import org.utbot.framework.plugin.api.util.isPrimitiveWrapperOrString
 import org.utbot.framework.plugin.api.util.stringClassId
+import org.utbot.framework.plugin.api.util.supertypeOfAnonymousClass
 import org.utbot.framework.plugin.api.util.wrapperByPrimitive
 import java.lang.reflect.Field
 import java.lang.reflect.Modifier
@@ -119,7 +120,9 @@ internal class CgVariableConstructor(val context: CgContext) :
         val obj = if (model.isMock) {
             mockFrameworkManager.createMockFor(model, baseName)
         } else {
-            newVar(model.classId, baseName) { utilsClassId[createInstance](model.classId.name) }
+            val modelType = model.classId
+            val variableType = if (modelType.isAnonymous) modelType.supertypeOfAnonymousClass else modelType
+            newVar(variableType, baseName) { utilsClassId[createInstance](model.classId.name) }
         }
 
         valueByModelId[model.id] = obj

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/util/ConstructorUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/util/ConstructorUtils.kt
@@ -50,6 +50,7 @@ import org.utbot.framework.plugin.api.WildcardTypeParameter
 import org.utbot.framework.plugin.api.util.isStatic
 import org.utbot.framework.plugin.api.util.arrayLikeName
 import org.utbot.framework.plugin.api.util.builtinStaticMethodId
+import org.utbot.framework.plugin.api.util.denotableType
 import org.utbot.framework.plugin.api.util.methodId
 import org.utbot.framework.plugin.api.util.objectArrayClassId
 import org.utbot.framework.plugin.api.util.objectClassId
@@ -256,18 +257,24 @@ internal fun CgContextOwner.importIfNeeded(method: MethodId) {
 /**
  * Casts [expression] to [targetType].
  *
+ * This method uses [denotableType] of the given [targetType] to ensure
+ * that we are using a denotable type in the type cast.
+ *
+ * Specifically, if we attempt to do a type cast to an anonymous class,
+ * then we will actually perform a type cast to its supertype.
+ *
+ * @see denotableType
+ *
  * @param isSafetyCast shows if we should render "as?" instead of "as" in Kotlin
  */
 internal fun CgContextOwner.typeCast(
     targetType: ClassId,
     expression: CgExpression,
     isSafetyCast: Boolean = false
-): CgTypeCast {
-    if (targetType.simpleName.isEmpty()) {
-        error("Cannot cast an expression to the anonymous type $targetType")
-    }
-    importIfNeeded(targetType)
-    return CgTypeCast(targetType, expression, isSafetyCast)
+): CgExpression {
+    val denotableTargetType = targetType.denotableType
+    importIfNeeded(denotableTargetType)
+    return CgTypeCast(denotableTargetType, expression, isSafetyCast)
 }
 
 /**

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/util/ConstructorUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/util/ConstructorUtils.kt
@@ -312,7 +312,7 @@ internal fun arrayInitializer(arrayType: ClassId, elementType: ClassId, values: 
  * @param elementType the element type of the returned array class id
  * @param isNullable a flag whether returned array is nullable or not
  */
-internal fun arrayTypeOf(elementType: ClassId, isNullable: Boolean = false): ClassId {
+fun arrayTypeOf(elementType: ClassId, isNullable: Boolean = false): ClassId {
     val arrayIdName = "[${elementType.arrayLikeName}"
     return when (elementType) {
         is BuiltinClassId -> BuiltinClassId(

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/util/ClassIdUtil.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/util/ClassIdUtil.kt
@@ -14,8 +14,7 @@ import org.utbot.framework.plugin.api.util.isArray
  * @param packageName name of the package we check accessibility from
  */
 infix fun ClassId.isAccessibleFrom(packageName: String): Boolean {
-
-    if (this.isLocal || this.isSynthetic) {
+    if (this.isLocal || this.isAnonymous || this.isSynthetic) {
         return false
     }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/tests/infrastructure/UtValueTestCaseChecker.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/tests/infrastructure/UtValueTestCaseChecker.kt
@@ -1141,7 +1141,7 @@ abstract class UtValueTestCaseChecker(
         vararg matchers: (StaticsType, Result<R>) -> Boolean,
         coverage: CoverageMatcher = Full,
         mockStrategy: MockStrategyApi = NO_MOCKS,
-        additionalDependencies: Array<KClass<*>> = emptyArray(),
+        additionalDependencies: Array<Class<*>> = emptyArray(),
         summaryTextChecks: List<(List<DocStatement>?) -> Boolean> = listOf(),
         summaryNameChecks: List<(String?) -> Boolean> = listOf(),
         summaryDisplayNameChecks: List<(String?) -> Boolean> = listOf()
@@ -1160,7 +1160,7 @@ abstract class UtValueTestCaseChecker(
         vararg matchers: (T, StaticsType, Result<R>) -> Boolean,
         coverage: CoverageMatcher = Full,
         mockStrategy: MockStrategyApi = NO_MOCKS,
-        additionalDependencies: Array<KClass<*>> = emptyArray(),
+        additionalDependencies: Array<Class<*>> = emptyArray(),
         summaryTextChecks: List<(List<DocStatement>?) -> Boolean> = listOf(),
         summaryNameChecks: List<(String?) -> Boolean> = listOf(),
         summaryDisplayNameChecks: List<(String?) -> Boolean> = listOf()
@@ -1179,7 +1179,7 @@ abstract class UtValueTestCaseChecker(
         vararg matchers: (T1, T2, StaticsType, Result<R>) -> Boolean,
         coverage: CoverageMatcher = Full,
         mockStrategy: MockStrategyApi = NO_MOCKS,
-        additionalDependencies: Array<KClass<*>> = emptyArray(),
+        additionalDependencies: Array<Class<*>> = emptyArray(),
         summaryTextChecks: List<(List<DocStatement>?) -> Boolean> = listOf(),
         summaryNameChecks: List<(String?) -> Boolean> = listOf(),
         summaryDisplayNameChecks: List<(String?) -> Boolean> = listOf()
@@ -1198,7 +1198,7 @@ abstract class UtValueTestCaseChecker(
         vararg matchers: (T1, T2, T3, StaticsType, Result<R>) -> Boolean,
         coverage: CoverageMatcher = Full,
         mockStrategy: MockStrategyApi = NO_MOCKS,
-        additionalDependencies: Array<KClass<*>> = emptyArray(),
+        additionalDependencies: Array<Class<*>> = emptyArray(),
         summaryTextChecks: List<(List<DocStatement>?) -> Boolean> = listOf(),
         summaryNameChecks: List<(String?) -> Boolean> = listOf(),
         summaryDisplayNameChecks: List<(String?) -> Boolean> = listOf()
@@ -1217,7 +1217,7 @@ abstract class UtValueTestCaseChecker(
         vararg matchers: (T1, T2, T3, T4, StaticsType, Result<R>) -> Boolean,
         coverage: CoverageMatcher = Full,
         mockStrategy: MockStrategyApi = NO_MOCKS,
-        additionalDependencies: Array<KClass<*>> = emptyArray(),
+        additionalDependencies: Array<Class<*>> = emptyArray(),
         summaryTextChecks: List<(List<DocStatement>?) -> Boolean> = listOf(),
         summaryNameChecks: List<(String?) -> Boolean> = listOf(),
         summaryDisplayNameChecks: List<(String?) -> Boolean> = listOf()

--- a/utbot-framework/src/main/kotlin/org/utbot/tests/infrastructure/UtValueTestCaseChecker.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/tests/infrastructure/UtValueTestCaseChecker.kt
@@ -1134,6 +1134,102 @@ abstract class UtValueTestCaseChecker(
         summaryDisplayNameChecks = summaryDisplayNameChecks
     )
 
+    // check arguments, statics and Result<R> for exceptions check
+    protected inline fun <reified R> checkStaticsAndException(
+        method: KFunction1<*, R>,
+        branches: ExecutionsNumberMatcher,
+        vararg matchers: (StaticsType, Result<R>) -> Boolean,
+        coverage: CoverageMatcher = Full,
+        mockStrategy: MockStrategyApi = NO_MOCKS,
+        additionalDependencies: Array<KClass<*>> = emptyArray(),
+        summaryTextChecks: List<(List<DocStatement>?) -> Boolean> = listOf(),
+        summaryNameChecks: List<(String?) -> Boolean> = listOf(),
+        summaryDisplayNameChecks: List<(String?) -> Boolean> = listOf()
+    ) = internalCheck(
+        method, mockStrategy, branches, matchers, coverage,
+        arguments = ::withStaticsBeforeAndExceptions,
+        additionalDependencies = additionalDependencies,
+        summaryTextChecks = summaryTextChecks,
+        summaryNameChecks = summaryNameChecks,
+        summaryDisplayNameChecks = summaryDisplayNameChecks
+    )
+
+    protected inline fun <reified T, reified R> checkStaticsAndException(
+        method: KFunction2<*, T, R>,
+        branches: ExecutionsNumberMatcher,
+        vararg matchers: (T, StaticsType, Result<R>) -> Boolean,
+        coverage: CoverageMatcher = Full,
+        mockStrategy: MockStrategyApi = NO_MOCKS,
+        additionalDependencies: Array<KClass<*>> = emptyArray(),
+        summaryTextChecks: List<(List<DocStatement>?) -> Boolean> = listOf(),
+        summaryNameChecks: List<(String?) -> Boolean> = listOf(),
+        summaryDisplayNameChecks: List<(String?) -> Boolean> = listOf()
+    ) = internalCheck(
+        method, mockStrategy, branches, matchers, coverage, T::class,
+        arguments = ::withStaticsBeforeAndExceptions,
+        additionalDependencies = additionalDependencies,
+        summaryTextChecks = summaryTextChecks,
+        summaryNameChecks = summaryNameChecks,
+        summaryDisplayNameChecks = summaryDisplayNameChecks
+    )
+
+    protected inline fun <reified T1, reified T2, reified R> checkStaticsAndException(
+        method: KFunction3<*, T1, T2, R>,
+        branches: ExecutionsNumberMatcher,
+        vararg matchers: (T1, T2, StaticsType, Result<R>) -> Boolean,
+        coverage: CoverageMatcher = Full,
+        mockStrategy: MockStrategyApi = NO_MOCKS,
+        additionalDependencies: Array<KClass<*>> = emptyArray(),
+        summaryTextChecks: List<(List<DocStatement>?) -> Boolean> = listOf(),
+        summaryNameChecks: List<(String?) -> Boolean> = listOf(),
+        summaryDisplayNameChecks: List<(String?) -> Boolean> = listOf()
+    ) = internalCheck(
+        method, mockStrategy, branches, matchers, coverage, T1::class, T2::class,
+        arguments = ::withStaticsBeforeAndExceptions,
+        additionalDependencies = additionalDependencies,
+        summaryTextChecks = summaryTextChecks,
+        summaryNameChecks = summaryNameChecks,
+        summaryDisplayNameChecks = summaryDisplayNameChecks
+    )
+
+    protected inline fun <reified T1, reified T2, reified T3, reified R> checkStaticsAndException(
+        method: KFunction4<*, T1, T2, T3, R>,
+        branches: ExecutionsNumberMatcher,
+        vararg matchers: (T1, T2, T3, StaticsType, Result<R>) -> Boolean,
+        coverage: CoverageMatcher = Full,
+        mockStrategy: MockStrategyApi = NO_MOCKS,
+        additionalDependencies: Array<KClass<*>> = emptyArray(),
+        summaryTextChecks: List<(List<DocStatement>?) -> Boolean> = listOf(),
+        summaryNameChecks: List<(String?) -> Boolean> = listOf(),
+        summaryDisplayNameChecks: List<(String?) -> Boolean> = listOf()
+    ) = internalCheck(
+        method, mockStrategy, branches, matchers, coverage, T1::class, T2::class, T3::class,
+        arguments = ::withStaticsBeforeAndExceptions,
+        additionalDependencies = additionalDependencies,
+        summaryTextChecks = summaryTextChecks,
+        summaryNameChecks = summaryNameChecks,
+        summaryDisplayNameChecks = summaryDisplayNameChecks
+    )
+
+    protected inline fun <reified T1, reified T2, reified T3, reified T4, reified R> checkStaticsAndException(
+        method: KFunction5<*, T1, T2, T3, T4, R>,
+        branches: ExecutionsNumberMatcher,
+        vararg matchers: (T1, T2, T3, T4, StaticsType, Result<R>) -> Boolean,
+        coverage: CoverageMatcher = Full,
+        mockStrategy: MockStrategyApi = NO_MOCKS,
+        additionalDependencies: Array<KClass<*>> = emptyArray(),
+        summaryTextChecks: List<(List<DocStatement>?) -> Boolean> = listOf(),
+        summaryNameChecks: List<(String?) -> Boolean> = listOf(),
+        summaryDisplayNameChecks: List<(String?) -> Boolean> = listOf()
+    ) = internalCheck(
+        method, mockStrategy, branches, matchers, coverage, T1::class, T2::class, T3::class, T4::class,
+        arguments = ::withStaticsBeforeAndExceptions,
+        additionalDependencies = additionalDependencies,
+        summaryTextChecks = summaryTextChecks,
+        summaryNameChecks = summaryNameChecks,
+        summaryDisplayNameChecks = summaryDisplayNameChecks
+    )
+
     protected inline fun <reified R> checkStaticsAfter(
         method: KFunction1<*, R>,
         branches: ExecutionsNumberMatcher,
@@ -2667,6 +2763,7 @@ class FullWithAssumptions(assumeCallsNumber: Int) : CoverageMatcher(
 fun withResult(ex: UtValueExecution<*>) = ex.paramsBefore + ex.evaluatedResult
 fun withException(ex: UtValueExecution<*>) = ex.paramsBefore + ex.returnValue
 fun withStaticsBefore(ex: UtValueExecution<*>) = ex.paramsBefore + ex.staticsBefore + ex.evaluatedResult
+fun withStaticsBeforeAndExceptions(ex: UtValueExecution<*>) = ex.paramsBefore + ex.staticsBefore + ex.returnValue
 fun withStaticsAfter(ex: UtValueExecution<*>) = ex.paramsBefore + ex.staticsAfter + ex.evaluatedResult
 fun withThisAndStaticsAfter(ex: UtValueExecution<*>) = listOf(ex.callerBefore) + ex.paramsBefore + ex.staticsAfter + ex.evaluatedResult
 fun withThisAndResult(ex: UtValueExecution<*>) = listOf(ex.callerBefore) + ex.paramsBefore + ex.evaluatedResult

--- a/utbot-sample/src/main/java/org/utbot/examples/objects/AnonymousClassesExample.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/objects/AnonymousClassesExample.java
@@ -1,9 +1,9 @@
 package org.utbot.examples.objects;
 
 public class AnonymousClassesExample {
-    private static final AbstractAnonymousClass staticAnonymousClass = AbstractAnonymousClass.getInstance(1);
+    static final AbstractAnonymousClass staticAnonymousClass = AbstractAnonymousClass.getInstance(1);
     @SuppressWarnings("FieldMayBeFinal")
-    private static AbstractAnonymousClass nonFinalAnonymousStatic = AbstractAnonymousClass.getInstance(1);
+    static AbstractAnonymousClass nonFinalAnonymousStatic = AbstractAnonymousClass.getInstance(1);
 
     public int anonymousClassAsParam(AbstractAnonymousClass abstractAnonymousClass) {
         return abstractAnonymousClass.constValue();


### PR DESCRIPTION
# Description

This PR removes filters that prevented anonymous classes from being used. It also allows code generation to work with anonymous class instances. Not via reflection, but rather by storing these instances in variables of the anonymous class supertype. For example, instance of anonymous class implementing interface `Predicate` will be stored in a variable of type `Predicate`. If we have to access any fields of methods declared in anonymous class, it will be done through reflection, but all members of the supertype will be accessed directly.

This PR partly fixes issue #617. Now tests are generated, but there seems to be some problem with accessing enum constants that have corresponding anonymous classes, to be discussed.

## Type of Change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Automated Testing

`org.utbot.examples.objects.AnonymousClassesExampleTest`

## Manual Scenario 

Change was tested manually on example of code from issue #617. Tests are generated, but as said in the description, they are yet not fully correct. The exact problem is unclear. To be discussed.

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
