### PR TITLE
Support hidden fields in code generation

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/IdUtil.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/IdUtil.kt
@@ -144,6 +144,9 @@ val floatWrapperClassId = java.lang.Float::class.id
 val doubleWrapperClassId = java.lang.Double::class.id
 
 val classClassId = java.lang.Class::class.id
+val fieldClassId = java.lang.reflect.Field::class.id
+val methodClassId = java.lang.reflect.Method::class.id
+val constructorClassId = java.lang.reflect.Constructor::class.id
 
 // We consider void wrapper as primitive wrapper
 // because voidClassId is considered primitive here

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/objects/HiddenFieldAccessModifiersTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/objects/HiddenFieldAccessModifiersTest.kt
@@ -7,8 +7,7 @@ import org.utbot.testcheckers.eq
 internal class HiddenFieldAccessModifiersTest : UtValueTestCaseChecker(testClass = HiddenFieldAccessModifiersExample::class) {
     @Test
     fun testCheckSuperFieldEqualsOne() {
-        // TODO: currently, codegen can't handle tests with field hiding (see #646)
-        withEnabledTestingCodeGeneration(testCodeGeneration = false) {
+        withEnabledTestingCodeGeneration(testCodeGeneration = true) {
             check(
                 HiddenFieldAccessModifiersExample::checkSuperFieldEqualsOne,
                 eq(3),

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/objects/HiddenFieldExampleTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/objects/HiddenFieldExampleTest.kt
@@ -21,8 +21,7 @@ internal class HiddenFieldExampleTest : UtValueTestCaseChecker(testClass = Hidde
 
     @Test
     fun testCheckSuccField() {
-        // TODO: currently, codegen can't handle tests with field hiding (see #646)
-        withEnabledTestingCodeGeneration(testCodeGeneration = false) {
+        withEnabledTestingCodeGeneration(testCodeGeneration = true) {
             check(
                 HiddenFieldExample::checkSuccField,
                 eq(5),

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/builtin/ReflectionBuiltins.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/builtin/ReflectionBuiltins.kt
@@ -21,10 +21,10 @@ import java.lang.reflect.InvocationTargetException
 
 internal val reflectionBuiltins: Set<MethodId>
          get() = setOf(
-                setAccessible, invoke, newInstance, get, forName,
+                setAccessible, invoke, newInstance, getMethodId, forName,
                 getDeclaredMethod, getDeclaredConstructor, allocateInstance,
                 getClass, getDeclaredField, isEnumConstant, getFieldName,
-                equals, getSuperclass, set, newArrayInstance,
+                equals, getSuperclass, setMethodId, newArrayInstance,
                 setArrayElement, getArrayElement, getTargetException,
         )
 
@@ -49,7 +49,7 @@ internal val newInstance = methodId(
         arguments = arrayOf(Array<Any>::class.id)
 )
 
-internal val get = methodId(
+internal val getMethodId = methodId(
         classId = Field::class.id,
         name = "get",
         returnType = objectClassId,
@@ -132,7 +132,7 @@ internal val getSuperclass = methodId(
         returnType = Class::class.id
 )
 
-internal val set = methodId(
+internal val setMethodId = methodId(
         classId = Field::class.id,
         name = "set",
         returnType = voidClassId,

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/builtin/UtilMethodBuiltins.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/builtin/UtilMethodBuiltins.kt
@@ -69,7 +69,7 @@ internal abstract class UtilMethodProvider(val utilClassId: ClassId) {
         get() = utilClassId.utilMethodId(
             name = "setField",
             returnType = voidClassId,
-            arguments = arrayOf(objectClassId, stringClassId, objectClassId)
+            arguments = arrayOf(objectClassId, stringClassId, stringClassId, objectClassId)
         )
 
     val setStaticFieldMethodId: MethodId
@@ -83,7 +83,7 @@ internal abstract class UtilMethodProvider(val utilClassId: ClassId) {
         get() = utilClassId.utilMethodId(
             name = "getFieldValue",
             returnType = objectClassId,
-            arguments = arrayOf(objectClassId, stringClassId)
+            arguments = arrayOf(objectClassId, stringClassId, stringClassId)
         )
 
     val getStaticFieldValueMethodId: MethodId

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/context/CgContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/context/CgContext.kt
@@ -162,6 +162,9 @@ internal interface CgContextOwner {
     // java.lang.reflect.Executable is a superclass of both of these types.
     var declaredExecutableRefs: PersistentMap<ExecutableId, CgVariable>
 
+    // Variables of java.lang.reflect.Field type declared in the current name scope
+    var declaredFieldRefs: PersistentMap<FieldId, CgVariable>
+
     // generated this instance for method under test
     var thisInstance: CgValue?
 
@@ -308,6 +311,7 @@ internal interface CgContextOwner {
         val prevVariableNames = existingVariableNames
         val prevDeclaredClassRefs = declaredClassRefs
         val prevDeclaredExecutableRefs = declaredExecutableRefs
+        val prevDeclaredFieldRefs = declaredFieldRefs
         val prevValueByModel = IdentityHashMap(valueByModel)
         val prevValueByModelId = valueByModelId.toMutableMap()
         return try {
@@ -316,6 +320,7 @@ internal interface CgContextOwner {
             existingVariableNames = prevVariableNames
             declaredClassRefs = prevDeclaredClassRefs
             declaredExecutableRefs = prevDeclaredExecutableRefs
+            declaredFieldRefs = prevDeclaredFieldRefs
             valueByModel = prevValueByModel
             valueByModelId = prevValueByModelId
         }
@@ -416,6 +421,7 @@ internal data class CgContext(
     override var existingVariableNames: PersistentSet<String> = persistentSetOf(),
     override var declaredClassRefs: PersistentMap<ClassId, CgVariable> = persistentMapOf(),
     override var declaredExecutableRefs: PersistentMap<ExecutableId, CgVariable> = persistentMapOf(),
+    override var declaredFieldRefs: PersistentMap<FieldId, CgVariable> = persistentMapOf(),
     override var thisInstance: CgValue? = null,
     override val methodArguments: MutableList<CgValue> = mutableListOf(),
     override val codeGenerationErrors: MutableMap<CgMethodTestSet, MutableMap<String, Int>> = mutableMapOf(),

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgFieldStateManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgFieldStateManager.kt
@@ -17,7 +17,6 @@ import org.utbot.framework.codegen.model.tree.CgGetJavaClass
 import org.utbot.framework.codegen.model.tree.CgValue
 import org.utbot.framework.codegen.model.tree.CgVariable
 import org.utbot.framework.codegen.model.util.at
-import org.utbot.framework.codegen.model.util.get
 import org.utbot.framework.codegen.model.util.isAccessibleFrom
 import org.utbot.framework.codegen.model.util.stringLiteral
 import org.utbot.framework.fields.ArrayElementAccess
@@ -230,8 +229,8 @@ internal class CgFieldStateManagerImpl(val context: CgContext)
             val name = if (index == path.lastIndex) customName else getFieldVariableName(prev, passedPath)
             val expression = when (val newElement = path[index++]) {
                 is FieldAccess -> {
-                    val field = newElement.field
-                    utilsClassId[getFieldValue](prev, stringLiteral(field.name))
+                    val fieldId = newElement.field
+                    utilsClassId[getFieldValue](prev, fieldId.declaringClass.name, fieldId.name)
                 }
                 is ArrayElementAccess -> {
                     Array::class.id[getArrayElement](prev, newElement.index)

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
@@ -67,14 +67,12 @@ import org.utbot.framework.codegen.model.tree.convertDocToCg
 import org.utbot.framework.codegen.model.tree.toStatement
 import org.utbot.framework.codegen.model.util.canBeSetIn
 import org.utbot.framework.codegen.model.util.equalTo
-import org.utbot.framework.codegen.model.util.get
 import org.utbot.framework.codegen.model.util.inc
 import org.utbot.framework.codegen.model.util.isAccessibleFrom
 import org.utbot.framework.codegen.model.util.length
 import org.utbot.framework.codegen.model.util.lessThan
 import org.utbot.framework.codegen.model.util.nullLiteral
 import org.utbot.framework.codegen.model.util.resolve
-import org.utbot.framework.codegen.model.util.stringLiteral
 import org.utbot.framework.fields.ExecutionStateAnalyzer
 import org.utbot.framework.fields.FieldPath
 import org.utbot.framework.plugin.api.BuiltinClassId
@@ -1048,7 +1046,7 @@ internal class CgMethodConstructor(val context: CgContext) : CgContextOwner by c
         if (variable.type.hasField(this) && isAccessibleFrom(testClassPackageName)) {
             if (jField.isStatic) CgStaticFieldAccess(this) else CgFieldAccess(variable, this)
         } else {
-            utilsClassId[getFieldValue](variable, stringLiteral(name))
+            utilsClassId[getFieldValue](variable, this.declaringClass.name, this.name)
         }
 
     /**

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgVariableConstructor.kt
@@ -24,7 +24,6 @@ import org.utbot.framework.codegen.model.tree.CgValue
 import org.utbot.framework.codegen.model.tree.CgVariable
 import org.utbot.framework.codegen.model.util.at
 import org.utbot.framework.codegen.model.util.canBeSetIn
-import org.utbot.framework.codegen.model.util.get
 import org.utbot.framework.codegen.model.util.inc
 import org.utbot.framework.codegen.model.util.isAccessibleFrom
 import org.utbot.framework.codegen.model.util.lessThan
@@ -146,7 +145,7 @@ internal class CgVariableConstructor(val context: CgContext) :
                 fieldAccess `=` variableForField
             } else {
                 // composite models must not have info about static fields, hence only non-static fields are set here
-                +utilsClassId[setField](obj, fieldId.name, variableForField)
+                +utilsClassId[setField](obj, fieldId.declaringClass.name, fieldId.name, variableForField)
             }
         }
         return obj
@@ -352,7 +351,7 @@ internal class CgVariableConstructor(val context: CgContext) :
         val init = if (classId.isAccessibleFrom(testClassPackageName)) {
             CgGetJavaClass(classId)
         } else {
-            classId[forName](classId.name)
+            Class::class.id[forName](classId.name)
         }
 
         return newVar(Class::class.id, baseName) { init }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgVariableConstructor.kt
@@ -45,6 +45,7 @@ import org.utbot.framework.plugin.api.UtNullModel
 import org.utbot.framework.plugin.api.UtPrimitiveModel
 import org.utbot.framework.plugin.api.UtReferenceModel
 import org.utbot.framework.plugin.api.UtVoidModel
+import org.utbot.framework.plugin.api.util.classClassId
 import org.utbot.framework.plugin.api.util.defaultValueModel
 import org.utbot.framework.plugin.api.util.jField
 import org.utbot.framework.plugin.api.util.findFieldByIdOrNull
@@ -351,7 +352,7 @@ internal class CgVariableConstructor(val context: CgContext) :
         val init = if (classId.isAccessibleFrom(testClassPackageName)) {
             CgGetJavaClass(classId)
         } else {
-            Class::class.id[forName](classId.name)
+            classClassId[forName](classId.name)
         }
 
         return newVar(Class::class.id, baseName) { init }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/util/DslUtil.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/util/DslUtil.kt
@@ -67,17 +67,6 @@ fun charLiteral(c: Char) = CgLiteral(charClassId, c)
 
 fun stringLiteral(string: String) = CgLiteral(stringClassId, string)
 
-// Field access
-
-// non-static fields
-operator fun CgExpression.get(fieldId: FieldId): CgFieldAccess =
-    CgFieldAccess(this, fieldId)
-
-// static fields
-// TODO: unused receiver
-operator fun ClassId.get(fieldId: FieldId): CgStaticFieldAccess =
-    CgStaticFieldAccess(fieldId)
-
 // Get array length
 
 /**

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/util/ExecutableIdUtil.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/util/ExecutableIdUtil.kt
@@ -8,7 +8,7 @@ import org.utbot.framework.plugin.api.ExecutableId
  *
  * @param packageName name of the package we check accessibility from
  */
-fun ExecutableId.isAccessibleFrom(packageName: String): Boolean {
+infix fun ExecutableId.isAccessibleFrom(packageName: String): Boolean {
     val isAccessibleFromPackageByModifiers = isPublic || (classId.packageName == packageName && (isPackagePrivate || isProtected))
 
     return classId.isAccessibleFrom(packageName) && isAccessibleFromPackageByModifiers

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/util/FieldIdUtil.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/util/FieldIdUtil.kt
@@ -1,7 +1,6 @@
 package org.utbot.framework.codegen.model.util
 
 import org.utbot.framework.plugin.api.FieldId
-import org.utbot.framework.plugin.api.util.id
 
 /**
  * For now we will count field accessible if it is not private and its class is also accessible,
@@ -10,7 +9,7 @@ import org.utbot.framework.plugin.api.util.id
  *
  * @param packageName name of the package we check accessibility from
  */
-fun FieldId.isAccessibleFrom(packageName: String): Boolean {
+infix fun FieldId.isAccessibleFrom(packageName: String): Boolean {
     val isClassAccessible = declaringClass.isAccessibleFrom(packageName)
     val isAccessibleByVisibility = isPublic || (declaringClass.packageName == packageName && (isPackagePrivate || isProtected))
     val isAccessibleFromPackageByModifiers = isAccessibleByVisibility && !isSynthetic

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/UtilMethods.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/UtilMethods.kt
@@ -9,8 +9,8 @@ import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.CodegenLanguage
 import org.utbot.framework.plugin.api.MethodId
 import org.utbot.framework.plugin.api.MockFramework
+import org.utbot.framework.plugin.api.util.fieldClassId
 import org.utbot.framework.plugin.api.util.id
-import java.lang.reflect.Field
 import java.lang.reflect.Modifier
 import java.util.Arrays
 import java.util.Objects
@@ -815,7 +815,6 @@ private fun TestClassUtilMethodProvider.regularImportsByUtilMethod(
     id: MethodId,
     codegenLanguage: CodegenLanguage
 ): List<ClassId> {
-    val fieldClassId = Field::class.id
     return when (id) {
         getUnsafeInstanceMethodId -> listOf(fieldClassId)
         createInstanceMethodId -> listOf(java.lang.reflect.InvocationTargetException::class.id)


### PR DESCRIPTION
# Description

This PR fixes issue #646. Hidden fields have been supported in the engine by @volivan239 . This PR adds support for them on the code generation side.

Let's consider an example. We have `class A { int x; }` and `class B extends A { int x; }`. These fields `x` have the same name, but they are __different__ fields. Let's say we have a variable (of type `A` or `B`) and we want to access field `x` (from class `A` or `B`). There are 4 cases:
- Variable of type `A` accessing `x` of type `A`. Here field can be accessed directly.
- Variable of type `A` accessing `x` of type `B`. Here we need a cast to type `B` and then we are able to access the field.
- Variable of type `B` accessing `x` of type `A`. Here we also need a cast, but to type `A`.
- Variable of type `B` accessing `x` of type `B`. Here field can be accessed directly.

This logic is now implemented in `CgCallableAccessManagerImpl`. This class checks if we can call a method with the given arguments and if we can access a field using the given object. Previously, there were no checks for fields, only for methods. Now we check field for accessibility. There are 3 cases:
- Field can be accessed directly (`myObj.field`)
- Field can be accessed with type cast (`((MyClass) myObj).field`)
- Field can only be accessed via reflection (e.g. private fields)

## Type of Change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Automated Testing

These tests check the hidden fields functionality.

`org.utbot.examples.objects.HiddenFieldAccessModifiersTest`
`org.utbot.examples.objects.HiddenFieldExampleTest`

## Manual Scenario 

TODO

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
