### PR TITLE
Updated gradle configuration

### DIFF
--- a/gradle/include/jvm-project.gradle
+++ b/gradle/include/jvm-project.gradle
@@ -36,7 +36,7 @@ java {
 }
 
 compileJava {
-    options.compilerArgs << '-Werror' << '-Xlint:all'
+    options.compilerArgs << '-Xlint:all'
     options.encoding = 'UTF-8'
 }
 

--- a/gradle/include/jvm-project.gradle
+++ b/gradle/include/jvm-project.gradle
@@ -16,7 +16,7 @@ dependencies {
 
 compileKotlin {
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11
+        jvmTarget = JavaVersion.VERSION_1_8
         freeCompilerArgs += ["-Xallow-result-return-type", "-Xsam-conversions=class"]
         allWarningsAsErrors = false
     }
@@ -24,15 +24,15 @@ compileKotlin {
 
 compileTestKotlin {
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11
+        jvmTarget = JavaVersion.VERSION_1_8
         freeCompilerArgs += ["-Xallow-result-return-type", "-Xsam-conversions=class"]
         allWarningsAsErrors = false
     }
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 compileJava {

--- a/utbot-analytics/build.gradle
+++ b/utbot-analytics/build.gradle
@@ -9,7 +9,6 @@ if (osName == "mac") osName = "macosx"
 String classifier = osName + "-x86_64"
 
 evaluationDependsOn(':utbot-framework')
-compileKotlin.dependsOn project(':utbot-instrumentation').tasks.jar
 compileTestJava.dependsOn tasks.getByPath(':utbot-framework:testClasses')
 
 dependencies {

--- a/utbot-cli/build.gradle
+++ b/utbot-cli/build.gradle
@@ -5,13 +5,6 @@ configurations {
     fetchInstrumentationJar
 }
 
-compileKotlin {
-    dependsOn project(':utbot-instrumentation').tasks.jar
-    kotlinOptions {
-        allWarningsAsErrors = false
-    }
-}
-
 dependencies {
     api project(':utbot-framework-api')
     implementation project(':utbot-framework')

--- a/utbot-core/build.gradle
+++ b/utbot-core/build.gradle
@@ -11,19 +11,6 @@ dependencies {
     testImplementation group: 'junit', name: 'junit', version: junit4_version
 }
 
-compileKotlin {
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
-        freeCompilerArgs += ["-Xallow-result-return-type", "-Xsam-conversions=class"]
-        allWarningsAsErrors = false
-    }
-}
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 shadowJar {
   configurations = [project.configurations.compileClasspath]
   archiveClassifier.set('')

--- a/utbot-framework-api/build.gradle
+++ b/utbot-framework-api/build.gradle
@@ -4,20 +4,6 @@ plugins {
 
 apply from: "${parent.projectDir}/gradle/include/jvm-project.gradle"
 
-compileKotlin {
-    dependsOn project(':utbot-api').tasks.jar
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
-        freeCompilerArgs += ["-Xallow-result-return-type", "-Xsam-conversions=class"]
-        allWarningsAsErrors = false
-    }
-}
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 dependencies {
     api project(':utbot-core')
     api project(':utbot-api')

--- a/utbot-framework/build.gradle
+++ b/utbot-framework/build.gradle
@@ -12,20 +12,6 @@ configurations {
     z3native
 }
 
-compileKotlin {
-    dependsOn project(':utbot-fuzzers').tasks.jar
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
-        freeCompilerArgs += ["-Xallow-result-return-type", "-Xsam-conversions=class"]
-        allWarningsAsErrors = false
-    }
-}
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 dependencies {
 
     api project(':utbot-core')

--- a/utbot-instrumentation-tests/build.gradle
+++ b/utbot-instrumentation-tests/build.gradle
@@ -1,7 +1,5 @@
 apply from: "${parent.projectDir}/gradle/include/jvm-project.gradle"
 
-compileTestJava.dependsOn project(':utbot-instrumentation').tasks.jar
-
 //noinspection GroovyAssignabilityCheck
 configurations {
     fetchInstrumentationJar

--- a/utbot-instrumentation/build.gradle
+++ b/utbot-instrumentation/build.gradle
@@ -15,20 +15,6 @@ dependencies {
     implementation group: 'org.mockito', name: 'mockito-inline', version: '4.2.0'
 }
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
-compileKotlin {
-    dependsOn project(':utbot-api').tasks.jar
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
-        freeCompilerArgs += ["-Xallow-result-return-type", "-Xsam-conversions=class"]
-        allWarningsAsErrors = false
-    }
-}
-
 jar {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 

--- a/utbot-intellij/build.gradle
+++ b/utbot-intellij/build.gradle
@@ -9,7 +9,7 @@ compileKotlin {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_11
 }
 

--- a/utbot-intellij/build.gradle
+++ b/utbot-intellij/build.gradle
@@ -2,8 +2,15 @@ apply from: "${parent.projectDir}/gradle/include/jvm-project.gradle"
 
 compileKotlin {
     kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_11
+        freeCompilerArgs += ["-Xallow-result-return-type", "-Xsam-conversions=class"]
         allWarningsAsErrors = false
     }
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 buildscript {

--- a/utbot-sample/build.gradle
+++ b/utbot-sample/build.gradle
@@ -24,15 +24,6 @@ dependencies {
     testImplementation "org.mockito:mockito-inline:+"
 }
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
-compileJava {
-    dependsOn project(':utbot-api').tasks.jar
-}
-
 test {
     minHeapSize = "128m"
     maxHeapSize = "3072m"

--- a/utbot-sample/build.gradle
+++ b/utbot-sample/build.gradle
@@ -3,6 +3,8 @@ plugins {
     id 'java-library'
 }
 
+apply from: "${parent.projectDir}/gradle/include/jvm-project.gradle"
+
 dependencies {
     implementation group: 'org.jetbrains', name: 'annotations', version: '16.0.2'
     implementation group: 'com.github.stephenc.findbugs', name: 'findbugs-annotations', version: '1.3.9-1'

--- a/utbot-summary/build.gradle
+++ b/utbot-summary/build.gradle
@@ -1,19 +1,5 @@
 apply from: "${parent.projectDir}/gradle/include/jvm-project.gradle"
 
-compileKotlin {
-    dependsOn project(':utbot-api').tasks.jar
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
-        freeCompilerArgs += ["-Xallow-result-return-type", "-Xsam-conversions=class"]
-        allWarningsAsErrors = false
-    }
-}
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 dependencies {
     implementation "com.github.UnitTestBot:soot:${soot_commit_hash}"
     api project(':utbot-framework-api')

--- a/utbot-summary/build.gradle
+++ b/utbot-summary/build.gradle
@@ -9,10 +9,6 @@ dependencies {
     implementation group: 'com.github.haifengl', name: 'smile-core', version: '2.6.0'
     api project(':utbot-fuzzers')
     implementation(project(':utbot-instrumentation'))
-    api(project(':utbot-instrumentation'))
-
-    implementation group: 'com.github.haifengl', name: 'smile-kotlin', version: '2.6.0'
-    implementation group: 'com.github.haifengl', name: 'smile-core', version: '2.6.0'
 
     implementation group: 'io.github.microutils', name: 'kotlin-logging', version: kotlin_logging_version
 


### PR DESCRIPTION
# Description

Several changes are done to gradle project model:

1. Set Java 8 by default to all modules
2. Set Java 11 for utbot-intellij module but Java 8 for source. Motivation: To keep all code-base in Java 8 but make it usable by newer version of Intellij
3. Removed all dependencies on task <anymodule>.tasks.jar. Actually, I don't know exactly, why we need them
4. Removed -Werror for java compilation task

This PR fixes an issue with red code for fuzzer module from framework and analytics module.

# How Has This Been Tested?

## Automated Testing

All existing tests are passed both: locally and with actions.

## Manual Scenario

Tried project with 8 and 11 versions of Java. Both generated correct tests.