### PR TITLE
Added the ClassId for ParametrizedType

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/IdUtil.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/IdUtil.kt
@@ -14,6 +14,7 @@ import java.lang.reflect.Constructor
 import java.lang.reflect.Executable
 import java.lang.reflect.Field
 import java.lang.reflect.Method
+import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.contracts.ExperimentalContracts
@@ -270,8 +271,8 @@ val Class<*>.id: ClassId
 /**
  * [java.lang.reflect.ParameterizedType.getRawType] now returns [Type] instead of [Class].
  */
-val Type.id: ClassId
-    get() = TODO("Java 11 transition")
+val ParameterizedType.id: ClassId
+    get() = ClassId(this.rawType.typeName)
 
 val KClass<*>.id: ClassId
     get() = java.id

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/IdUtil.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/IdUtil.kt
@@ -269,7 +269,8 @@ val Class<*>.id: ClassId
     }
 
 /**
- * [java.lang.reflect.ParameterizedType.getRawType] now returns [Type] instead of [Class].
+ * We should specially handle the case of a generic type that is a [Type] and not a [Class].
+ * Returns a [ClassId] for the corresponding raw type.
  */
 val ParameterizedType.id: ClassId
     get() = ClassId(this.rawType.typeName)

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
@@ -1292,7 +1292,7 @@ internal class CgMethodConstructor(val context: CgContext) : CgContextOwner by c
 
                 val argumentType = when {
                     paramType is Class<*> && paramType.isArray -> paramType.id
-                    paramType is ParameterizedType -> paramType.rawType.id
+                    paramType is ParameterizedType -> paramType.id
                     else -> ClassId(paramType.typeName)
                 }
 


### PR DESCRIPTION
# Description

After upgrading the versions of JDK, Kotlin and Gradle we have a regression in parametrized tests generation

In method `createParametersDeclaration` we need to define the types of test method parameters.
If parameter type is `ParametrizedType`, we need to be able to convert in to `ClassId`. Such logic is added.


## Type of Change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

Run  org.utbot.examples.algorithms.CorrectBracketSequencesTest or some other tests containing generics in PARAMETRIZED mode.

