### PR TITLE
Add support for nullable fields in deep equals

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -282,12 +282,12 @@ sealed class UtReferenceModel(
 ) : UtModel(classId)
 
 /**
- * Checks if [UtModel] is a null.
+ * Checks if [UtModel] is a [UtNullModel].
  */
 fun UtModel.isNull() = this is UtNullModel
 
 /**
- * Checks if [UtModel] is not a null.
+ * Checks if [UtModel] is not a [UtNullModel].
  */
 fun UtModel.isNotNull() = !isNull()
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/CodeGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/CodeGenerator.kt
@@ -40,7 +40,7 @@ class CodeGenerator(
         testFramework = testFramework,
         mockFramework = mockFramework ?: MockFramework.MOCKITO,
         codegenLanguage = codegenLanguage,
-        parameterizedTestSource = parameterizedTestSource,
+        parametrizedTestSource = parameterizedTestSource,
         staticsMocking = staticsMocking,
         forceStaticMocking = forceStaticMocking,
         generateWarningsForStaticMocking = generateWarningsForStaticMocking,

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/context/CgContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/context/CgContext.kt
@@ -139,7 +139,7 @@ internal interface CgContextOwner {
 
     val codegenLanguage: CodegenLanguage
 
-    val parameterizedTestSource: ParametrizedTestSource
+    val parametrizedTestSource: ParametrizedTestSource
 
     // flag indicating whether a mock framework is used in the generated code
     var mockFrameworkUsed: Boolean
@@ -213,6 +213,8 @@ internal interface CgContextOwner {
     val enableTestsTimeout: Boolean
 
     var statesCache: EnvironmentFieldStateCache
+
+    var allExecutions: List<UtExecution>
 
     fun block(init: () -> Unit): Block {
         val prevBlock = currentBlock
@@ -407,7 +409,7 @@ internal data class CgContext(
     override val forceStaticMocking: ForceStaticMocking,
     override val generateWarningsForStaticMocking: Boolean,
     override val codegenLanguage: CodegenLanguage = CodegenLanguage.defaultItem,
-    override val parameterizedTestSource: ParametrizedTestSource = ParametrizedTestSource.DO_NOT_PARAMETRIZE,
+    override val parametrizedTestSource: ParametrizedTestSource = ParametrizedTestSource.DO_NOT_PARAMETRIZE,
     override var mockFrameworkUsed: Boolean = false,
     override var currentBlock: PersistentList<CgStatement> = persistentListOf(),
     override var existingVariableNames: PersistentSet<String> = persistentSetOf(),
@@ -427,6 +429,7 @@ internal data class CgContext(
 ) : CgContextOwner {
     override lateinit var statesCache: EnvironmentFieldStateCache
     override lateinit var actual: CgVariable
+    override lateinit var allExecutions: List<UtExecution>
 
     /**
      * This property cannot be accessed outside of test class file scope

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgTestClassConstructor.kt
@@ -118,11 +118,13 @@ internal class CgTestClassConstructor(val context: CgContext) :
             return null
         }
 
+        allExecutions = testSet.executions
+
         val (methodUnderTest, _, _, clustersInfo) = testSet
         val regions = mutableListOf<CgRegion<CgMethod>>()
         val requiredFields = mutableListOf<CgParameterDeclaration>()
 
-        when (context.parameterizedTestSource) {
+        when (context.parametrizedTestSource) {
             ParametrizedTestSource.DO_NOT_PARAMETRIZE -> {
                 for ((clusterSummary, executionIndices) in clustersInfo) {
                     val currentTestCaseTestMethods = mutableListOf<CgTestMethod>()

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/codegen/deepequals/ClassWithNullableFieldTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/codegen/deepequals/ClassWithNullableFieldTest.kt
@@ -23,4 +23,13 @@ class ClassWithNullableFieldTest : UtValueTestCaseChecker(
             coverage = DoNotCalculate
         )
     }
+
+    @Test
+    fun testClassWithNullableField1() {
+        check(
+            ClassWithNullableField::returnGreatCompoundWithNullableField,
+            eq(3),
+            coverage = DoNotCalculate
+        )
+    }
 }

--- a/utbot-sample/src/main/java/org/utbot/examples/codegen/deepequals/ClassWithNullableField.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/codegen/deepequals/ClassWithNullableField.java
@@ -12,9 +12,23 @@ class Compound {
     }
 }
 
+class GreatCompound {
+    Compound compound;
+
+    GreatCompound(Compound compound) {
+        this.compound = compound;
+    }
+}
+
 public class ClassWithNullableField {
     public Compound returnCompoundWithNullableField(int value) {
         if (value > 0) return new Compound(null);
         else return new Compound(new Component());
+    }
+
+    public GreatCompound returnGreatCompoundWithNullableField(int value) {
+        if (value > 0) return new GreatCompound(null);
+        else if (value == 0) return new GreatCompound(new Compound(new Component()));
+        else return new GreatCompound(new Compound(null));
     }
 }


### PR DESCRIPTION
# Description

Before this PR, there was a test ([PR](https://github.com/UnitTestBot/UTBotJava/pull/698)) that was added in order to improve current deepequals implementation.

This PR improves current deepequals implementation.
When generating parametrized tests, we wrap field access in null check in order to make a generic execution more common for every execution. So, if there is a class with a nullable field, which has a field as well, as a result, in one execution we try to access the field's field, in another we assert it to be null. And we choose only one generic execution which is impossible in this case. 

Fixes # ([767](https://github.com/UnitTestBot/UTBotJava/issues/767))

## Type of Change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Automated Testing

Run utbot-samples with enabled parametrized test generation.

## Manual Scenario 

1. Enable parametrized test generation,
2. Run `testClassWithNullableField` test,
3. Verify that the test passes & is generated correctly.