### PR TITLE
passing all secrets into reusable workflow

### DIFF
--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -16,6 +16,7 @@ env:
 jobs:
   build-and-run-tests:
     uses: ./.github/workflows/build-and-run-tests-from-branch.yml
+    secrets: inherit
 
 
   publish-cli-image:

--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/publish-on-github-packages.yml
+++ b/.github/workflows/publish-on-github-packages.yml
@@ -18,6 +18,7 @@ jobs:
     uses: ./.github/workflows/build-and-run-tests-from-branch.yml
     with:
       commit_sha: ${{ github.event.inputs.commit_sha }}
+    secrets: inherit
 
   publish_on_github_packages:
     needs: build-and-run-tests

--- a/.github/workflows/publish-plugin-and-cli.yml
+++ b/.github/workflows/publish-plugin-and-cli.yml
@@ -5,8 +5,10 @@ on:
 
 jobs:
     build_and_run_tests:
-      uses: ./.github/workflows/build-and-run-tests-from-branch.yml      
+      uses: ./.github/workflows/build-and-run-tests-from-branch.yml
+      secrets: inherit
 
     publish_plugin_and_cli:
       needs: build_and_run_tests
       uses: ./.github/workflows/publish-plugin-and-cli-from-branch.yml
+      secrets: inherit


### PR DESCRIPTION
# Description

Checking why metrics are not pushed when workflow_call is used.

Fixes #781

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

Not applicable

## Manual Scenario 

Metrics of the workflow run will be accessible in our monitoring system

# Checklist (remove irrelevant options):

- [x] Test will be run automatically after creating a PR. Wait for test has been done
- [x] Check metrics at monitoring system
