### PR TITLE
Fix duplication of nested testclasses #779

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/TestClassModel.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/TestClassModel.kt
@@ -20,18 +20,18 @@ data class TestClassModel(
             val class2methodTestSets = testSets.groupBy { it.executableId.classId }
 
             val classesWithMethodsUnderTest = testSets
-                .distinctBy { it.executableId.classId }
                 .map { it.executableId.classId }
+                .distinct()
 
             // For each class stores list of its "direct" nested classes
-            val class2nestedClasses = mutableMapOf<ClassId, MutableList<ClassId>>()
+            val class2nestedClasses = mutableMapOf<ClassId, MutableSet<ClassId>>()
 
             for (classId in classesWithMethodsUnderTest) {
                 var currentClass = classId
                 var enclosingClass = currentClass.enclosingClass
                 // while we haven't reached the top of nested class hierarchy or the main class under test
                 while (enclosingClass != null && currentClass != classUnderTest) {
-                    class2nestedClasses.getOrPut(enclosingClass) { mutableListOf() } += currentClass
+                    class2nestedClasses.getOrPut(enclosingClass) { mutableSetOf() } += currentClass
                     currentClass = enclosingClass
                     enclosingClass = enclosingClass.enclosingClass
                 }
@@ -42,7 +42,7 @@ data class TestClassModel(
         private fun constructRecursively(
             clazz: ClassId,
             class2methodTestSets: Map<ClassId, List<CgMethodTestSet>>,
-            class2nestedClasses: Map<ClassId, List<ClassId>>
+            class2nestedClasses: Map<ClassId, Set<ClassId>>
         ): TestClassModel {
             val currentNestedClasses = class2nestedClasses.getOrDefault(clazz, listOf())
             val currentMethodTestSets = class2methodTestSets.getOrDefault(clazz, listOf())

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/context/CgContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/context/CgContext.kt
@@ -33,7 +33,6 @@ import org.utbot.framework.codegen.model.tree.CgTestMethod
 import org.utbot.framework.codegen.model.tree.CgThisInstance
 import org.utbot.framework.codegen.model.tree.CgValue
 import org.utbot.framework.codegen.model.tree.CgVariable
-import org.utbot.framework.codegen.model.util.createTestClassName
 import java.util.IdentityHashMap
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.PersistentMap
@@ -449,7 +448,7 @@ internal data class CgContext(
 
     override val outerMostTestClass: ClassId by lazy {
         val packagePrefix = if (testClassPackageName.isNotEmpty()) "$testClassPackageName." else ""
-        val simpleName = testClassCustomName ?: "${createTestClassName(classUnderTest.name)}Test"
+        val simpleName = testClassCustomName ?: "${classUnderTest.simpleName}Test"
         val name = "$packagePrefix$simpleName"
         BuiltinClassId(
             name = name,


### PR DESCRIPTION
# Description

Fixed bugs after adding nested testclasses generation

Fixes #779

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

Add this changes to (branch)[https://github.com/UnitTestBot/UTBotJava/tree/volivan239/support_for_nested_class_in_ui] and run on examples from #779 -- works as expected

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
