### PR TITLE
Don't run tests when publishing plugin and CLI

### DIFF
--- a/.github/workflows/publish-plugin-and-cli.yml
+++ b/.github/workflows/publish-plugin-and-cli.yml
@@ -4,11 +4,6 @@ on:
     branches: [main]
 
 jobs:
-    build_and_run_tests:
-      uses: ./.github/workflows/build-and-run-tests-from-branch.yml
-      secrets: inherit
-
     publish_plugin_and_cli:
-      needs: build_and_run_tests
       uses: ./.github/workflows/publish-plugin-and-cli-from-branch.yml
       secrets: inherit


### PR DESCRIPTION
# Description

`Plugin and CLI: publish as archives` do not trigger running tests anymore.

Fixes #783 

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Automated Testing

Not applicable.

## Manual Scenario 

Not applicable.

# Checklist (remove irrelevant options):

_This is the author self-check list_

Not applicable.
