### PR TITLE
Minor refactoring in SimpleCommentBuildr and CustomJavaDocCommentBuilder

### DIFF
--- a/utbot-summary/src/main/kotlin/org/utbot/summary/comment/CustomJavaDocCommentBuilder.kt
+++ b/utbot-summary/src/main/kotlin/org/utbot/summary/comment/CustomJavaDocCommentBuilder.kt
@@ -45,16 +45,14 @@ class CustomJavaDocCommentBuilder(
 
         // builds Throws exception section
         val thrownException = traceTag.result.exceptionOrNull()
-        val exceptionThrow: String? = if (thrownException == null) {
-            traceTag.result.exceptionOrNull()?.let { it::class.qualifiedName }
-        } else {
+        val thrownExceptionDescription: String? = thrownException?.let {
             val exceptionName = thrownException.javaClass.name
             val reason = findExceptionReason(currentMethod, thrownException)
             "{@link $exceptionName} $reason"
         }
 
-        if (exceptionThrow != null) {
-            customJavaDocComment.throwsException = exceptionThrow
+        if (thrownExceptionDescription != null) {
+            customJavaDocComment.throwsException = thrownExceptionDescription
         }
 
         // builds Iterates section

--- a/utbot-summary/src/main/kotlin/org/utbot/summary/comment/CustomJavaDocCommentBuilder.kt
+++ b/utbot-summary/src/main/kotlin/org/utbot/summary/comment/CustomJavaDocCommentBuilder.kt
@@ -45,14 +45,11 @@ class CustomJavaDocCommentBuilder(
 
         // builds Throws exception section
         val thrownException = traceTag.result.exceptionOrNull()
-        val thrownExceptionDescription: String? = thrownException?.let {
+        if (thrownException != null) {
             val exceptionName = thrownException.javaClass.name
             val reason = findExceptionReason(currentMethod, thrownException)
-            "{@link $exceptionName} $reason"
-        }
 
-        if (thrownExceptionDescription != null) {
-            customJavaDocComment.throwsException = thrownExceptionDescription
+            customJavaDocComment.throwsException = "{@link $exceptionName} $reason"
         }
 
         // builds Iterates section

--- a/utbot-summary/src/main/kotlin/org/utbot/summary/comment/SimpleCommentBuilder.kt
+++ b/utbot-summary/src/main/kotlin/org/utbot/summary/comment/SimpleCommentBuilder.kt
@@ -57,12 +57,9 @@ open class SimpleCommentBuilder(
         root: SimpleSentenceBlock,
         currentMethod: SootMethod
     ) {
-        val thrownException = traceTag.result.exceptionOrNull()
-        if (thrownException == null) {
-            root.exceptionThrow = traceTag.result.exceptionOrNull()?.let { it::class.qualifiedName }
-        } else {
-            val exceptionName = thrownException.javaClass.simpleName
-            val reason = findExceptionReason(currentMethod, thrownException)
+        traceTag.result.exceptionOrNull()?.let {
+            val exceptionName = it.javaClass.simpleName
+            val reason = findExceptionReason(currentMethod, it)
             root.exceptionThrow = "$exceptionName $reason"
         }
     }


### PR DESCRIPTION
# Description

There are expressions that are always null in `SimpleCommentBuilder#buildThrownExceptionInfo()` line 49 and `CustomJavaDocCommentBuilder#buildCustomJavaDocComment() ` line 62.
This PR contains minor refactoring of these methods. 

Fixes #787

## Type of Change

Please delete options that are not relevant.

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

Run tests in summaries-test.

## Automated Testing

Run tests in summaries-test.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [x] All tests pass locally with my changes
