### PR TITLE
Use regex for generating string when regex pattern is found #778

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/fuzzer/FuzzerFunctions.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/fuzzer/FuzzerFunctions.kt
@@ -11,6 +11,7 @@ import org.utbot.framework.plugin.api.util.longClassId
 import org.utbot.framework.plugin.api.util.shortClassId
 import org.utbot.framework.plugin.api.util.stringClassId
 import mu.KotlinLogging
+import org.utbot.framework.util.executableId
 import soot.BooleanType
 import soot.ByteType
 import soot.CharType
@@ -39,6 +40,7 @@ import soot.jimple.internal.JLeExpr
 import soot.jimple.internal.JLookupSwitchStmt
 import soot.jimple.internal.JLtExpr
 import soot.jimple.internal.JNeExpr
+import soot.jimple.internal.JStaticInvokeExpr
 import soot.jimple.internal.JTableSwitchStmt
 import soot.jimple.internal.JVirtualInvokeExpr
 import soot.toolkits.graph.ExceptionalUnitGraph
@@ -64,6 +66,7 @@ fun collectConstantsForFuzzer(graph: ExceptionalUnitGraph): Set<FuzzedConcreteVa
                 ConstantsFromSwitchCase,
                 BoundValuesForDoubleChecks,
                 StringConstant,
+                RegexByVarStringConstant,
             ).flatMap { finder ->
                 try {
                     finder.find(graph, unit, value)
@@ -113,8 +116,8 @@ private object ConstantsFromIfStatement: ConstantsFinder {
             val exactValue = value.plainValue
             val local = useBoxes[(valueIndex + 1) % 2]
             var op = sootIfToFuzzedOp(ifStatement)
-            if (valueIndex == 0) {
-                op = op.reverseOrElse { it }
+            if (valueIndex == 0 && op is FuzzedContext.Comparison) {
+                op = op.reverse()
             }
             // Soot loads any integer type as an Int,
             // therefore we try to guess target type using second value
@@ -146,7 +149,7 @@ private object ConstantsFromCast: ConstantsFinder {
         if (next is JAssignStmt) {
             val const = next.useBoxes.findFirstInstanceOf<Constant>()
             if (const != null) {
-                val op = (nextDirectUnit(graph, next) as? JIfStmt)?.let(::sootIfToFuzzedOp) ?: FuzzedOp.NONE
+                val op = (nextDirectUnit(graph, next) as? JIfStmt)?.let(::sootIfToFuzzedOp) ?: FuzzedContext.Unknown
                 val exactValue = const.plainValue as Number
                 return listOfNotNull(
                     when (value.op.type) {
@@ -170,12 +173,12 @@ private object ConstantsFromSwitchCase: ConstantsFinder {
         val result = mutableListOf<FuzzedConcreteValue>()
         if (unit is JTableSwitchStmt) {
             for (i in unit.lowIndex..unit.highIndex) {
-                result.add(FuzzedConcreteValue(intClassId, i, FuzzedOp.EQ))
+                result.add(FuzzedConcreteValue(intClassId, i, FuzzedContext.Comparison.EQ))
             }
         }
         if (unit is JLookupSwitchStmt) {
             unit.lookupValues.asSequence().filterIsInstance<IntConstant>().forEach {
-                result.add(FuzzedConcreteValue(intClassId, it.value, FuzzedOp.EQ))
+                result.add(FuzzedConcreteValue(intClassId, it.value, FuzzedContext.Comparison.EQ))
             }
         }
         return result
@@ -205,7 +208,7 @@ private object StringConstant: ConstantsFinder {
         if (value.method.declaringClass.name == "java.lang.String") {
             val stringConstantWasPassedAsArg = unit.useBoxes.findFirstInstanceOf<Constant>()?.plainValue
             if (stringConstantWasPassedAsArg != null && stringConstantWasPassedAsArg is String) {
-                return listOf(FuzzedConcreteValue(stringClassId, stringConstantWasPassedAsArg, FuzzedOp.CH))
+                return listOf(FuzzedConcreteValue(stringClassId, stringConstantWasPassedAsArg, FuzzedContext.Call(value.method.executableId)))
             }
             val stringConstantWasPassedAsThis = graph.getPredsOf(unit)
                 ?.filterIsInstance<JAssignStmt>()
@@ -214,12 +217,29 @@ private object StringConstant: ConstantsFinder {
                 ?.findFirstInstanceOf<Constant>()
                 ?.plainValue
             if (stringConstantWasPassedAsThis != null && stringConstantWasPassedAsThis is String) {
-                return listOf(FuzzedConcreteValue(stringClassId, stringConstantWasPassedAsThis, FuzzedOp.CH))
+                return listOf(FuzzedConcreteValue(stringClassId, stringConstantWasPassedAsThis, FuzzedContext.Call(value.method.executableId)))
             }
         }
         return emptyList()
     }
+}
 
+/**
+ * Finds strings that are used inside Pattern's methods.
+ *
+ * Due to compiler optimizations it should work when a string is assigned to a variable or static final field.
+ */
+private object RegexByVarStringConstant: ConstantsFinder {
+    override fun find(graph: ExceptionalUnitGraph, unit: Unit, value: Value): List<FuzzedConcreteValue> {
+        if (unit !is JAssignStmt || value !is JStaticInvokeExpr) return emptyList()
+        if (value.method.declaringClass.name == "java.util.regex.Pattern") {
+            val stringConstantWasPassedAsArg = unit.useBoxes.findFirstInstanceOf<Constant>()?.plainValue
+            if (stringConstantWasPassedAsArg != null && stringConstantWasPassedAsArg is String) {
+                return listOf(FuzzedConcreteValue(stringClassId, stringConstantWasPassedAsArg, FuzzedContext.Call(value.method.executableId)))
+            }
+        }
+        return emptyList()
+    }
 }
 
 private object ConstantsAsIs: ConstantsFinder {
@@ -241,13 +261,13 @@ private val Constant.plainValue
     get() = javaClass.getField("value")[this]
 
 private fun sootIfToFuzzedOp(unit: JIfStmt) = when (unit.condition) {
-    is JEqExpr -> FuzzedOp.NE
-    is JNeExpr -> FuzzedOp.EQ
-    is JGtExpr -> FuzzedOp.LE
-    is JGeExpr -> FuzzedOp.LT
-    is JLtExpr -> FuzzedOp.GE
-    is JLeExpr -> FuzzedOp.GT
-    else -> FuzzedOp.NONE
+    is JEqExpr -> FuzzedContext.Comparison.NE
+    is JNeExpr -> FuzzedContext.Comparison.EQ
+    is JGtExpr -> FuzzedContext.Comparison.LE
+    is JGeExpr -> FuzzedContext.Comparison.LT
+    is JLtExpr -> FuzzedContext.Comparison.GE
+    is JLeExpr -> FuzzedContext.Comparison.GT
+    else -> FuzzedContext.Unknown
 }
 
 private fun nextDirectUnit(graph: ExceptionalUnitGraph, unit: Unit): Unit? = graph.getSuccsOf(unit).takeIf { it.size == 1 }?.first()

--- a/utbot-fuzzers/build.gradle
+++ b/utbot-fuzzers/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     api project(':utbot-framework-api')
     implementation "com.github.UnitTestBot:soot:${soot_commit_hash}"
     implementation group: 'io.github.microutils', name: 'kotlin-logging', version: kotlin_logging_version
+    implementation group: 'com.github.curious-odd-man', name: 'rgxgen', version: rgxgen_version
 }
 
 compileJava {

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/FuzzedConcreteValue.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/FuzzedConcreteValue.kt
@@ -1,0 +1,12 @@
+package org.utbot.fuzzer
+
+import org.utbot.framework.plugin.api.ClassId
+
+/**
+ * Object to pass concrete values to fuzzer
+ */
+data class FuzzedConcreteValue(
+    val classId: ClassId,
+    val value: Any,
+    val fuzzedContext: FuzzedContext = FuzzedContext.Unknown,
+)

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/FuzzedContext.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/FuzzedContext.kt
@@ -1,0 +1,45 @@
+package org.utbot.fuzzer
+
+import org.utbot.framework.plugin.api.ExecutableId
+
+/**
+ * Context is a bit of information about [FuzzedConcreteValue]'s conditions.
+ *
+ * For example, it can be:
+ *
+ * 1. Comparison operations: `a > 2`
+ * 2. Method call: `Double.isNaN(2.0)`
+ */
+sealed interface FuzzedContext {
+
+    object Unknown : FuzzedContext
+
+    class Call(
+        val method: ExecutableId
+    ) : FuzzedContext {
+        override fun toString(): String {
+            return method.toString()
+        }
+    }
+
+    enum class Comparison(
+        val sign: String
+    ) : FuzzedContext {
+        EQ("=="),
+        NE("!="),
+        GT(">"),
+        GE(">="),
+        LT("<"),
+        LE("<="),
+        ;
+
+        fun reverse(): Comparison = when (this) {
+            EQ -> NE
+            NE -> EQ
+            GT -> LE
+            LT -> GE
+            LE -> GT
+            GE -> LT
+        }
+    }
+}

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/FuzzedMethodDescription.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/FuzzedMethodDescription.kt
@@ -58,39 +58,3 @@ class FuzzedMethodDescription(
         concreteValues
     )
 }
-
-/**
- * Object to pass concrete values to fuzzer
- */
-data class FuzzedConcreteValue(
-    val classId: ClassId,
-    val value: Any,
-    val relativeOp: FuzzedOp = FuzzedOp.NONE,
-)
-
-enum class FuzzedOp(val sign: String?) {
-    NONE(null),
-    EQ("=="),
-    NE("!="),
-    GT(">"),
-    GE(">="),
-    LT("<"),
-    LE("<="),
-    CH(null), // changed or called
-    ;
-
-    fun isComparisonOp() = this == EQ || this == NE || this == GT || this == GE || this == LT || this == LE
-
-    fun reverseOrNull() : FuzzedOp? = when(this) {
-        EQ -> NE
-        NE -> EQ
-        GT -> LE
-        LT -> GE
-        LE -> GT
-        GE -> LT
-        else -> null
-    }
-
-    fun reverseOrElse(another: (FuzzedOp) -> FuzzedOp): FuzzedOp =
-        reverseOrNull() ?: another(this)
-}

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/FuzzedValue.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/FuzzedValue.kt
@@ -6,7 +6,7 @@ import org.utbot.framework.plugin.api.UtModel
  * Fuzzed Value stores information about concrete UtModel, reference to [ModelProvider]
  * and reasons about why this value was generated.
  */
-class FuzzedValue(
+open class FuzzedValue(
     val model: UtModel,
     val createdBy: ModelProvider? = null,
 ) {

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/Fuzzer.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/Fuzzer.kt
@@ -2,6 +2,7 @@ package org.utbot.fuzzer
 
 import mu.KotlinLogging
 import org.utbot.fuzzer.mutators.NumberRandomMutator
+import org.utbot.fuzzer.mutators.RegexStringModelMutator
 import org.utbot.fuzzer.mutators.StringRandomMutator
 import org.utbot.fuzzer.providers.ArrayModelProvider
 import org.utbot.fuzzer.providers.CharToStringModelProvider
@@ -12,6 +13,7 @@ import org.utbot.fuzzer.providers.ObjectModelProvider
 import org.utbot.fuzzer.providers.PrimitiveDefaultsModelProvider
 import org.utbot.fuzzer.providers.PrimitiveWrapperModelProvider
 import org.utbot.fuzzer.providers.PrimitivesModelProvider
+import org.utbot.fuzzer.providers.RegexModelProvider
 import org.utbot.fuzzer.providers.StringConstantModelProvider
 import java.util.*
 import java.util.concurrent.atomic.AtomicInteger
@@ -154,6 +156,7 @@ fun defaultModelProviders(idGenerator: IdentityPreservingIdGenerator<Int>): Mode
         EnumModelProvider(idGenerator),
         ConstantsModelProvider,
         StringConstantModelProvider,
+        RegexModelProvider,
         CharToStringModelProvider,
         PrimitivesModelProvider,
         PrimitiveWrapperModelProvider,
@@ -169,6 +172,7 @@ fun objectModelProviders(idGenerator: IdentityPreservingIdGenerator<Int>): Model
         ArrayModelProvider(idGenerator),
         EnumModelProvider(idGenerator),
         StringConstantModelProvider,
+        RegexModelProvider,
         CharToStringModelProvider,
         ConstantsModelProvider,
         PrimitiveDefaultsModelProvider,
@@ -176,7 +180,11 @@ fun objectModelProviders(idGenerator: IdentityPreservingIdGenerator<Int>): Model
     )
 }
 
-fun defaultModelMutators(): List<ModelMutator> = listOf(StringRandomMutator, NumberRandomMutator)
+fun defaultModelMutators(): List<ModelMutator> = listOf(
+    StringRandomMutator,
+    RegexStringModelMutator,
+    NumberRandomMutator,
+)
 
 /**
  * Tries to mutate a random value from the seed.

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/ModelMutator.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/ModelMutator.kt
@@ -36,9 +36,7 @@ interface ModelMutator {
         index: Int,
         value: FuzzedValue,
         random: Random
-    ) : FuzzedValue? {
-        return null
-    }
+    ) : FuzzedValue?
 
     fun UtModel.mutatedFrom(template: FuzzedValue, block: FuzzedValue.() -> Unit = {}): FuzzedValue {
         return FuzzedValue(this, template.createdBy).apply(block)

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/mutators/RegexStringModelMutator.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/mutators/RegexStringModelMutator.kt
@@ -1,0 +1,35 @@
+package org.utbot.fuzzer.mutators
+
+import com.github.curiousoddman.rgxgen.RgxGen
+import org.utbot.framework.plugin.api.UtPrimitiveModel
+import org.utbot.fuzzer.FuzzedMethodDescription
+import org.utbot.fuzzer.FuzzedValue
+import org.utbot.fuzzer.ModelMutator
+import org.utbot.fuzzer.providers.RegexFuzzedValue
+import org.utbot.fuzzer.providers.RegexModelProvider
+import kotlin.random.Random
+import kotlin.random.asJavaRandom
+
+/**
+ * Provides different regex value for a concrete regex pattern
+ */
+object RegexStringModelMutator : ModelMutator {
+
+    override fun mutate(
+        description: FuzzedMethodDescription,
+        index: Int,
+        value: FuzzedValue,
+        random: Random
+    ): FuzzedValue? {
+        if (value is RegexFuzzedValue) {
+            val string = RgxGen(value.regex).apply {
+                setProperties(RegexModelProvider.rgxGenProperties)
+            }.generate(random.asJavaRandom())
+            return RegexFuzzedValue(UtPrimitiveModel(string).mutatedFrom(value) {
+                summary = "%var% = mutated regex ${value.regex}"
+            }, value.regex)
+        }
+        return null
+    }
+
+}

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/mutators/StringRandomMutator.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/mutators/StringRandomMutator.kt
@@ -37,7 +37,7 @@ object StringRandomMutator : ModelMutator {
         if (random.flipCoin(probability = 50)) {
             result = tryRemoveChar(random, result, position) ?: string
         }
-        if (random.flipCoin(probability = 50)) {
+        if (random.flipCoin(probability = 50) && result.length < 1000) {
             result = tryAddChar(random, result, position)
         }
         return result

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/ConstantsModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/ConstantsModelProvider.kt
@@ -2,8 +2,8 @@ package org.utbot.fuzzer.providers
 
 import org.utbot.framework.plugin.api.UtPrimitiveModel
 import org.utbot.framework.plugin.api.util.isPrimitive
+import org.utbot.fuzzer.FuzzedContext
 import org.utbot.fuzzer.FuzzedMethodDescription
-import org.utbot.fuzzer.FuzzedOp
 import org.utbot.fuzzer.FuzzedParameter
 import org.utbot.fuzzer.FuzzedValue
 import org.utbot.fuzzer.ModelProvider
@@ -32,9 +32,9 @@ object ConstantsModelProvider : ModelProvider {
         }
     }
 
-    private fun modifyValue(value: Any, op: FuzzedOp): FuzzedValue? {
-        if (!op.isComparisonOp()) return null
-        val multiplier = if (op == FuzzedOp.LT || op == FuzzedOp.GE) -1 else 1
+    private fun modifyValue(value: Any, op: FuzzedContext): FuzzedValue? {
+        if (op !is FuzzedContext.Comparison) return null
+        val multiplier = if (op == FuzzedContext.Comparison.LT || op == FuzzedContext.Comparison.GE) -1 else 1
         return when(value) {
             is Boolean -> value.not()
             is Byte -> value + multiplier.toByte()
@@ -46,8 +46,8 @@ object ConstantsModelProvider : ModelProvider {
             is Double -> value + multiplier.toDouble()
             else -> null
         }?.let { UtPrimitiveModel(it).fuzzed { summary = "%var% ${
-            (if (op == FuzzedOp.EQ || op == FuzzedOp.LE || op == FuzzedOp.GE) {
-                op.reverseOrNull() ?: error("cannot find reverse operation for $op")
+            (if (op == FuzzedContext.Comparison.EQ || op == FuzzedContext.Comparison.LE || op == FuzzedContext.Comparison.GE) { 
+                op.reverse() 
             } else op).sign
         } $value" } }
     }

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/RegexModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/RegexModelProvider.kt
@@ -1,0 +1,67 @@
+package org.utbot.fuzzer.providers
+
+import com.github.curiousoddman.rgxgen.RgxGen
+import com.github.curiousoddman.rgxgen.config.RgxGenOption
+import com.github.curiousoddman.rgxgen.config.RgxGenProperties
+import org.utbot.framework.plugin.api.UtPrimitiveModel
+import org.utbot.framework.plugin.api.util.id
+import org.utbot.framework.plugin.api.util.stringClassId
+import org.utbot.fuzzer.FuzzedContext
+import org.utbot.fuzzer.FuzzedMethodDescription
+import org.utbot.fuzzer.FuzzedParameter
+import org.utbot.fuzzer.FuzzedValue
+import org.utbot.fuzzer.ModelProvider
+import org.utbot.fuzzer.ModelProvider.Companion.yieldAllValues
+import java.util.regex.Pattern
+import java.util.regex.PatternSyntaxException
+import kotlin.random.Random
+import kotlin.random.asJavaRandom
+
+object RegexModelProvider : ModelProvider {
+
+    val rgxGenProperties = RgxGenProperties().apply {
+        setProperty(RgxGenOption.INFINITE_PATTERN_REPETITION.key, "5")
+    }
+
+    override fun generate(description: FuzzedMethodDescription): Sequence<FuzzedParameter> {
+        val parameters = description.parametersMap[stringClassId]
+        if (parameters.isNullOrEmpty()) {
+            return emptySequence()
+        }
+        val regexes = description.concreteValues
+            .asSequence()
+            .filter { it.classId == stringClassId }
+            .filter { it.fuzzedContext.isPatterMatchingContext()  }
+            .map { it.value as String }
+            .distinct()
+            .filter { it.isNotBlank() }
+            .filter {
+                try {
+                    Pattern.compile(it); true
+                } catch (_: PatternSyntaxException) {
+                    false
+                }
+            }.map {
+                it to RgxGen(it).apply {
+                    setProperties(rgxGenProperties)
+                }.generate(Random(0).asJavaRandom())
+            }
+
+        return sequence {
+            yieldAllValues(parameters, regexes.map {
+                RegexFuzzedValue(UtPrimitiveModel(it.second).fuzzed { summary = "%var% = regex ${it.first}" }, it.first)
+            })
+        }
+    }
+
+    private fun FuzzedContext.isPatterMatchingContext(): Boolean {
+        if (this !is FuzzedContext.Call) return false
+        return when {
+            method.classId == Pattern::class.java.id -> true
+            method.classId == String::class.java.id && method.name == "matches" -> true
+            else -> false
+        }
+    }
+}
+
+class RegexFuzzedValue(value: FuzzedValue, val regex: String) : FuzzedValue(value.model, value.createdBy)

--- a/utbot-fuzzers/src/test/kotlin/org/utbot/framework/plugin/api/FuzzedValueDescriptionTest.kt
+++ b/utbot-fuzzers/src/test/kotlin/org/utbot/framework/plugin/api/FuzzedValueDescriptionTest.kt
@@ -6,7 +6,7 @@ import org.utbot.framework.plugin.api.util.intClassId
 import org.utbot.framework.plugin.api.util.voidClassId
 import org.utbot.fuzzer.FuzzedConcreteValue
 import org.utbot.fuzzer.FuzzedMethodDescription
-import org.utbot.fuzzer.FuzzedOp
+import org.utbot.fuzzer.FuzzedContext
 import org.utbot.fuzzer.FuzzedValue
 import org.utbot.fuzzer.providers.ConstantsModelProvider
 
@@ -16,12 +16,12 @@ class FuzzedValueDescriptionTest {
     fun testConstantModelProviderTest() {
         val values = mutableListOf<FuzzedValue>()
         val concreteValues = listOf(
-            FuzzedConcreteValue(intClassId, 10, FuzzedOp.EQ),
-            FuzzedConcreteValue(intClassId, 20, FuzzedOp.NE),
-            FuzzedConcreteValue(intClassId, 30, FuzzedOp.LT),
-            FuzzedConcreteValue(intClassId, 40, FuzzedOp.LE),
-            FuzzedConcreteValue(intClassId, 50, FuzzedOp.GT),
-            FuzzedConcreteValue(intClassId, 60, FuzzedOp.GE),
+            FuzzedConcreteValue(intClassId, 10, FuzzedContext.Comparison.EQ),
+            FuzzedConcreteValue(intClassId, 20, FuzzedContext.Comparison.NE),
+            FuzzedConcreteValue(intClassId, 30, FuzzedContext.Comparison.LT),
+            FuzzedConcreteValue(intClassId, 40, FuzzedContext.Comparison.LE),
+            FuzzedConcreteValue(intClassId, 50, FuzzedContext.Comparison.GT),
+            FuzzedConcreteValue(intClassId, 60, FuzzedContext.Comparison.GE),
         )
         val summaries = listOf(
             "%var% = 10" to 10,

--- a/utbot-fuzzers/src/test/kotlin/org/utbot/framework/plugin/api/ModelProviderTest.kt
+++ b/utbot-fuzzers/src/test/kotlin/org/utbot/framework/plugin/api/ModelProviderTest.kt
@@ -15,7 +15,6 @@ import org.utbot.framework.plugin.api.util.voidClassId
 import org.utbot.framework.plugin.api.util.withUtContext
 import org.utbot.fuzzer.FuzzedConcreteValue
 import org.utbot.fuzzer.FuzzedMethodDescription
-import org.utbot.fuzzer.FuzzedOp
 import org.utbot.fuzzer.ModelProvider
 import org.utbot.fuzzer.providers.ConstantsModelProvider
 import org.utbot.fuzzer.providers.ObjectModelProvider
@@ -27,16 +26,21 @@ import org.utbot.framework.plugin.api.samples.FieldSetterClass
 import org.utbot.framework.plugin.api.samples.OuterClassWithEnums
 import org.utbot.framework.plugin.api.samples.PackagePrivateFieldAndClass
 import org.utbot.framework.plugin.api.samples.SampleEnum
+import org.utbot.framework.plugin.api.util.executableId
 import org.utbot.framework.plugin.api.util.primitiveByWrapper
 import org.utbot.framework.plugin.api.util.primitiveWrappers
 import org.utbot.framework.plugin.api.util.voidWrapperClassId
+import org.utbot.fuzzer.FuzzedContext
+import org.utbot.fuzzer.FuzzedValue
 import org.utbot.fuzzer.ReferencePreservingIntIdGenerator
 import org.utbot.fuzzer.ModelProvider.Companion.yieldValue
 import org.utbot.fuzzer.defaultModelProviders
+import org.utbot.fuzzer.mutators.StringRandomMutator
 import org.utbot.fuzzer.providers.CharToStringModelProvider.fuzzed
 import org.utbot.fuzzer.providers.EnumModelProvider
 import org.utbot.fuzzer.providers.PrimitiveDefaultsModelProvider
 import java.util.Date
+import kotlin.random.Random
 
 class ModelProviderTest {
 
@@ -105,12 +109,12 @@ class ModelProviderTest {
         val models = collect(ConstantsModelProvider,
             parameters = listOf(intClassId),
             constants = listOf(
-                FuzzedConcreteValue(intClassId, 10, FuzzedOp.EQ),
-                FuzzedConcreteValue(intClassId, 20, FuzzedOp.NE),
-                FuzzedConcreteValue(intClassId, 30, FuzzedOp.LT),
-                FuzzedConcreteValue(intClassId, 40, FuzzedOp.LE),
-                FuzzedConcreteValue(intClassId, 50, FuzzedOp.GT),
-                FuzzedConcreteValue(intClassId, 60, FuzzedOp.GE),
+                FuzzedConcreteValue(intClassId, 10, FuzzedContext.Comparison.EQ),
+                FuzzedConcreteValue(intClassId, 20, FuzzedContext.Comparison.NE),
+                FuzzedConcreteValue(intClassId, 30, FuzzedContext.Comparison.LT),
+                FuzzedConcreteValue(intClassId, 40, FuzzedContext.Comparison.LE),
+                FuzzedConcreteValue(intClassId, 50, FuzzedContext.Comparison.GT),
+                FuzzedConcreteValue(intClassId, 60, FuzzedContext.Comparison.GE),
             )
         )
 
@@ -127,7 +131,7 @@ class ModelProviderTest {
         val models = collect(StringConstantModelProvider,
             parameters = listOf(stringClassId),
             constants = listOf(
-                FuzzedConcreteValue(stringClassId, "", FuzzedOp.CH),
+                FuzzedConcreteValue(stringClassId, ""),
             )
         )
 
@@ -141,7 +145,7 @@ class ModelProviderTest {
         val models = collect(StringConstantModelProvider,
             parameters = listOf(stringClassId),
             constants = listOf(
-                FuzzedConcreteValue(stringClassId, "nonemptystring", FuzzedOp.NONE),
+                FuzzedConcreteValue(stringClassId, "nonemptystring"),
             )
         )
 
@@ -152,18 +156,31 @@ class ModelProviderTest {
 
     @Test
     fun `test non-empty string is mutated if modification operation is set`() {
-        val models = collect(StringConstantModelProvider,
-            parameters = listOf(stringClassId),
-            constants = listOf(
-                FuzzedConcreteValue(stringClassId, "nonemptystring", FuzzedOp.CH),
+        val method = String::class.java.getDeclaredMethod("subSequence", Int::class.java, Int::class.java)
+
+        val description = FuzzedMethodDescription(
+            "method",
+            voidClassId,
+            listOf(stringClassId),
+            listOf(
+                FuzzedConcreteValue(stringClassId, "nonemptystring", FuzzedContext.Call(method.executableId))
             )
         )
 
+        val models = mutableMapOf<Int, MutableList<FuzzedValue>>().apply {
+            StringConstantModelProvider.generate(description).forEach { (i, m) ->
+                computeIfAbsent(i) { mutableListOf() }.add(m)
+            }
+        }
+
         assertEquals(1, models.size)
         assertEquals(1, models[0]!!.size)
-        listOf("nonemptystring").forEach {
-            assertTrue( models[0]!!.contains(UtPrimitiveModel(it))) { "Failed to find string $it in list ${models[0]}" }
-        }
+
+        val mutate = StringRandomMutator.mutate(description, listOf(models[0]!![0]), Random(0))
+
+        assertEquals(1, mutate.size)
+        assertEquals(UtPrimitiveModel("nonemptystring"), models[0]!![0].model)
+        assertEquals(UtPrimitiveModel("nonemptstring"), mutate[0].value.model)
     }
 
     @Test


### PR DESCRIPTION
# Description

Now fuzzer searches for regexes from these places:

```
String.matches(regex)
Pattern.*(regex)
```

If any is found then it generates and mutates string values using found regex.

Fixes #778

## Type of Change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Automated Testing

```
org.utbot.framework.plugin.api.ModelProviderTest
```

## Manual Scenario 

Try this example with only fuzzing:

```java
public boolean isValidDouble(String value) {
    return value.matches("[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?([fFdD]?)\n") && value.contains("E") && value.contains("-");
}
```

It should generate the correct values like `+727498D`, `+0.402E-816f`, `+0046.827E+92629d`.

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
