### PR TITLE
Cannot find utbot-fuzzing.jar fix

### DIFF
--- a/utbot-cli/build.gradle
+++ b/utbot-cli/build.gradle
@@ -49,9 +49,6 @@ classes {
 }
 
 jar {
-    dependsOn project(':utbot-framework').tasks.jar
-    dependsOn project(':utbot-summary').tasks.jar
-
     manifest {
         attributes 'Main-Class': 'org.utbot.cli.ApplicationKt'
         attributes 'Bundle-SymbolicName': 'org.utbot.cli'


### PR DESCRIPTION
# Description

This PR tries to fix an action because of `Cannot expand ZIP '/__w/UTBotJava/UTBotJava/utbot-fuzzers/build/libs/utbot-fuzzers-2022.8.jar' as it does not exist`
