### PR TITLE
Make UtExecution abstract, introduce UtFailedExecution as its child

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -144,7 +144,7 @@ sealed class UtResult
  * - coverage information (instructions) if this execution was obtained from the concrete execution.
  * - comments, method names and display names created by utbot-summary module.
  */
-open class UtExecution(
+abstract class UtExecution(
     val stateBefore: EnvironmentModels,
     val stateAfter: EnvironmentModels,
     val result: UtExecutionResult,
@@ -223,6 +223,27 @@ class UtSymbolicExecution(
         )
     }
 }
+
+/**
+ * Execution that result in an error (e.g., JVM crash or another concrete execution error).
+ *
+ * Contains:
+ * - state before the execution;
+ * - result (a [UtExecutionFailure] or its subclass);
+ * - coverage information (instructions) if this execution was obtained from the concrete execution.
+ * - comments, method names and display names created by utbot-summary module.
+ *
+ * This execution does not contain any "after" state, as it is generally impossible to obtain
+ * in case of failure. [MissingState] is used instead.
+ */
+class UtFailedExecution(
+    stateBefore: EnvironmentModels,
+    result: UtExecutionFailure,
+    coverage: Coverage? = null,
+    summary: List<DocStatement>? = null,
+    testMethodName: String? = null,
+    displayName: String? = null
+) : UtExecution(stateBefore, MissingState, result, coverage, summary, testMethodName, displayName)
 
 open class EnvironmentModels(
     val thisInstance: UtModel?,

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
@@ -68,6 +68,7 @@ import org.utbot.framework.plugin.api.UtAssembleModel
 import org.utbot.framework.plugin.api.UtConcreteExecutionFailure
 import org.utbot.framework.plugin.api.UtError
 import org.utbot.framework.plugin.api.UtExecution
+import org.utbot.framework.plugin.api.UtFailedExecution
 import org.utbot.framework.plugin.api.UtInstrumentation
 import org.utbot.framework.plugin.api.UtMethod
 import org.utbot.framework.plugin.api.UtNullModel
@@ -518,9 +519,8 @@ class UtBotSymbolicEngine(
         stateBefore: EnvironmentModels,
         e: ConcreteExecutionFailureException
     ) {
-        val failedConcreteExecution = UtExecution(
+        val failedConcreteExecution = UtFailedExecution(
             stateBefore = stateBefore,
-            stateAfter = MissingState,
             result = UtConcreteExecutionFailure(e)
         )
 


### PR DESCRIPTION
# Description

Make `UtExecution` abstract, introduce `UtFailedExecution` as its child.

*Rationale*

There is a `UtExecution` class that represent any execution regardless of the way it has been found. It has two subclasses, `UtSymbolicExecution` and `UtFuzzedExecution`. The separation of these entities is artificial: `UtSymbolicExecution` contains data provided by the symbolic engine and used by the summarizer that `UtFuzzedExecution` does not have. Having two distinct child classes instead of a single `UtExecution` allowed the summarizer to correctly handle executions coming from two sources, the symbolic engine and the fuzzer.

There is another special kind of execution: an execution that is produced by a concrete executor when running the method leads to a failure (e.g., JVM crash). It is not possible to produce any "after state" in this case, and the execution result is always a failure.

Currently these executions are created as just `UtExecution` instances, and summarizer ignores them (see #800). As a result, executions may be lost.

It is necessary to correctly process these failed executions in the summarizer, and to distinguish them from "normal" executions. It seems not very convenient to make explicit checks to distinguish between a parent class and its subclasses.

This PR uses the following approach.

1. Introduce a new class, `UtFailedExecution`, that is a subclass of `UtExecution` but has a restricted set of parameters so we can't create a "successful" failed execution instance by mistake.
2. Make `UtExecution` abstract to prevent creating "unclassified" execution instances.

That way the summarizer can explicitly handle failed executions and generate correct summaries for them.

*Limitations*

This solution seems not to be "final" in any way. We have to properly define the interface between execution producers (fuzzer, symbolic engine, concrete executor, or any other kind of producer that can be added in the future) and the summarizer. In particular, it seems right to separate executions not by their source but by a set of available information (e.g., basic executions, executions with attached Jimple/bytecode/source code information, summarizer-annotated executions and so on). Maybe the additional data can be attached in some general form as annotations instead. This "correct" refactoring is a major enterprise and can't be performed immediately.

At the same time, we need to fix the issue with lost executions, so an "intermediate" refactoring is necessary.

Related issue: #800

## Type of Change

- Refactoring (typos and non-functional changes) 

# How Has This Been Tested?

## Automated Testing

All existing unit tests should pass.

## Manual Scenario 

None (it will be possible to test the fix for #800, for which this refactoring is a prerequisite).

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [X] The change followed the style guidelines of the UTBot project
- [X] Self-review of the code is passed
- [X] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [X] No new warnings
- [ ] New tests have been added
- [X] All tests pass locally with my changes
