### PR TITLE
DeepEquals: generate absent assertion

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
@@ -839,6 +839,7 @@ internal class CgMethodConstructor(val context: CgContext) : CgContextOwner by c
 
         // if model is already processed, so we don't want to add new statements
         if (fieldModel in visitedModels) {
+            currentBlock += testFrameworkManager.getDeepEqualsAssertion(expected, actual).toStatement()
             return
         }
 

--- a/utbot-framework/src/test/kotlin/org/utbot/examples/codegen/deepequals/ClassWithCrossReferenceRelationshipTest.kt
+++ b/utbot-framework/src/test/kotlin/org/utbot/examples/codegen/deepequals/ClassWithCrossReferenceRelationshipTest.kt
@@ -1,5 +1,6 @@
 package org.utbot.examples.codegen.deepequals
 
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.utbot.examples.DoNotCalculate
 import org.utbot.examples.UtValueTestCaseChecker
@@ -7,28 +8,21 @@ import org.utbot.examples.eq
 import org.utbot.framework.codegen.CodeGeneration
 import org.utbot.framework.plugin.api.CodegenLanguage
 
-class ClassWithNullableFieldTest : UtValueTestCaseChecker(
-    testClass = ClassWithNullableField::class,
+class ClassWithCrossReferenceRelationshipTest : UtValueTestCaseChecker(
+    testClass = ClassWithCrossReferenceRelationship::class,
     testCodeGeneration = true,
     languagePipelines = listOf(
         CodeGenerationLanguageLastStage(CodegenLanguage.JAVA),
         CodeGenerationLanguageLastStage(CodegenLanguage.KOTLIN, CodeGeneration)
     )
 ) {
+    // TODO: The test is disabled due to [https://github.com/UnitTestBot/UTBotJava/issues/812]
+    @Disabled
     @Test
-    fun testClassWithNullableFieldInCompound() {
+    fun testClassWithCrossReferenceRelationship() {
         check(
-            ClassWithNullableField::returnCompoundWithNullableField,
+            ClassWithCrossReferenceRelationship::returnFirstClass,
             eq(2),
-            coverage = DoNotCalculate
-        )
-    }
-
-    @Test
-    fun testClassWithNullableFieldInGreatCompound() {
-        check(
-            ClassWithNullableField::returnGreatCompoundWithNullableField,
-            eq(3),
             coverage = DoNotCalculate
         )
     }

--- a/utbot-sample/src/main/java/org/utbot/examples/codegen/deepequals/ClassWithCrossReferenceRelationship.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/codegen/deepequals/ClassWithCrossReferenceRelationship.java
@@ -1,0 +1,30 @@
+package org.utbot.examples.codegen.deepequals;
+
+class FirstClass {
+    SecondClass secondClass;
+
+    FirstClass(SecondClass second) {
+        this.secondClass = second;
+    }
+}
+
+class SecondClass {
+    FirstClass firstClass;
+
+    SecondClass(FirstClass first) {
+        this.firstClass = first;
+    }
+}
+
+public class ClassWithCrossReferenceRelationship {
+    public FirstClass returnFirstClass(int value) {
+        if (value == 0) {
+            return new FirstClass(new SecondClass(null));
+        } else {
+            FirstClass first = new FirstClass(null);
+            first.secondClass = new SecondClass(first);
+
+            return first;
+        }
+    }
+}


### PR DESCRIPTION
# Description

When we have two classes with fields in cross-reference relationship and these field models are reference models, for instance:
```java
class A {
   B b;
}

class B {
   A a;
}
```
we do not generate assertions by current Deep Equals implementation.

This PR adds support for rendering an assertion in this case.
Also, there is a new test, which is disabled for now due to [#812](https://github.com/UnitTestBot/UTBotJava/issues/812).

Fixes # ([811](https://github.com/UnitTestBot/UTBotJava/issues/811))

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

Run new `ClassWithCrossReferenceRelationshipGenerated` test.

## Manual Scenario 

1. Set useAssembleModelGenerator to *false*,
2. Enable `ClassWithCrossReferenceRelationshipGeneratedTest`,
3. Run `ClassWithCrossReferenceRelationshipGeneratedTest`. Verify that assertTrue is present in the generated test.

