### PR TITLE
Fix 'Cannot expand zip as it does not exist' when build utbot-cli

### DIFF
--- a/utbot-cli/build.gradle
+++ b/utbot-cli/build.gradle
@@ -6,9 +6,9 @@ configurations {
 }
 
 dependencies {
-    api project(':utbot-framework-api')
+    implementation project(':utbot-framework-api')
     implementation project(':utbot-framework')
-    api project(':utbot-summary')
+    implementation project(':utbot-summary')
 
     implementation group: 'org.mockito', name: 'mockito-core', version: mockito_version
     // Without this dependency testng tests do not run.
@@ -49,10 +49,6 @@ classes {
 }
 
 jar {
-    dependsOn project(':utbot-framework').tasks.jar
-    dependsOn project(':utbot-summary').tasks.jar
-    dependsOn project(':utbot-fuzzers').tasks.jar
-
     manifest {
         attributes 'Main-Class': 'org.utbot.cli.ApplicationKt'
         attributes 'Bundle-SymbolicName': 'org.utbot.cli'
@@ -63,6 +59,7 @@ jar {
 
     archiveVersion.set(project.version as String)
 
+    dependsOn configurations.runtimeClasspath
     from {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }


### PR DESCRIPTION
# Description

Fixes an issue when utbot-cli cannot be built because it can't find other jars. To wait until all jars are built for cli `dependsOn configurations.runtimeClasspath` is used as it's described in [gradle documentation about fat jar](https://docs.gradle.org/current/userguide/working_with_files.html#sec:creating_uber_jar_example).

It can be changed shadowJar in the future, but we need to unify workflows that build utbot-cli.jar. Right now one runs with tests, other without.

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

All relative workflows should be passed (publish-cli-build)

## Manual Scenario 

1. Clean all project
2. Change directory `cd utbot-cli`
3. Run build for it without tests: `gradle build -x test --no-daemon`

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [x] All tests pass locally with my changes
