### PR TITLE
Proper IntelliJ version constraints

### DIFF
--- a/utbot-intellij/build.gradle
+++ b/utbot-intellij/build.gradle
@@ -44,7 +44,9 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version = "2021.2"
+    // https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html#intellij-platform-based-products-of-recent-ide-versions
+    // https://confluence.jetbrains.com/display/IDEADEV/IDEA+2021.2+latest+builds
+    version = "212.5712.43"
     type = "IC"
     plugins = ['java',
                // TODO: SAT-1539 - specify version of android plugin to be supported by our kotlin version.
@@ -53,7 +55,8 @@ intellij {
                'org.jetbrains.android']
 
     patchPluginXml {
-        version = project.version
+        sinceBuild = '212'
+        untilBuild = '221.*'
     }
 }
 

--- a/utbot-intellij/src/main/resources/META-INF/plugin.xml
+++ b/utbot-intellij/src/main/resources/META-INF/plugin.xml
@@ -4,7 +4,8 @@
     <id>org.utbot.intellij.plugin.id</id>
     <name>UnitTestBot</name>
     <vendor>utbot.org</vendor>
-    <idea-version since-build="202.8194.7"/>
+    <!-- Do not insert, it is updated from build.gradle-->
+    <!-- <idea-version since-build="202.8194.7"/>-->
     <version>2022.7-beta</version>
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.java</depends>


### PR DESCRIPTION
# Description

IntelliJ Gradle plugin that we currently use ignores since and until values of plugin.xml. The pull request adds some more comments on IntelliJ documentation and uses Gradle plugin routine to set the values.

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

Automatic test have been run.

## Manual Scenario 

The plugin is installed manually in 
Build #IU-221.6008.13, built on July 19, 2022

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [x] All tests pass locally with my changes
