### PR TITLE
Java 8 RDgen fix

### DIFF
--- a/utbot-core/src/main/kotlin/org/utbot/common/JvmUtil.kt
+++ b/utbot-core/src/main/kotlin/org/utbot/common/JvmUtil.kt
@@ -1,0 +1,5 @@
+package org.utbot.common
+
+private val javaSpecificationVersion = System.getProperty("java.specification.version")
+val isJvm8 = javaSpecificationVersion.equals("1.8")
+val isJvm9Plus = !javaSpecificationVersion.contains(".") && javaSpecificationVersion.toInt() >= 9

--- a/utbot-core/src/main/kotlin/org/utbot/common/OsUtil.kt
+++ b/utbot-core/src/main/kotlin/org/utbot/common/OsUtil.kt
@@ -1,0 +1,8 @@
+package org.utbot.common
+
+import java.util.*
+
+private val os = System.getProperty("os.name").lowercase(Locale.getDefault())
+val isWindows = os.startsWith("windows")
+val isUnix = !isWindows
+val isMac = os.startsWith("mac")

--- a/utbot-core/src/main/kotlin/org/utbot/common/ProcessUtil.kt
+++ b/utbot-core/src/main/kotlin/org/utbot/common/ProcessUtil.kt
@@ -1,0 +1,70 @@
+package org.utbot.common
+
+import com.sun.jna.Library
+import com.sun.jna.Native
+import com.sun.jna.Pointer
+import com.sun.jna.platform.win32.Kernel32
+import com.sun.jna.platform.win32.WinNT
+
+/**
+ * working pid for jvm 8 and 9+
+ */
+val Process.getPid: Long
+    get() = try {
+        if (isJvm9Plus) {
+            // because we cannot reference Java9+ API here
+            ClassLoader.getSystemClassLoader().loadClass("java.lang.Process").getDeclaredMethod("pid").invoke(this) as Long
+        } else {
+            when (javaClass.name) {
+                "java.lang.UNIXProcess" -> {
+                    val fPid = javaClass.getDeclaredField("pid")
+                    fPid.withAccessibility { fPid.getLong(this) }
+
+                }
+
+                "java.lang.Win32Process", "java.lang.ProcessImpl" -> {
+                    val fHandle = javaClass.getDeclaredField("handle")
+                    fHandle.withAccessibility {
+                        val handle = fHandle.getLong(this)
+                        val winntHandle = WinNT.HANDLE()
+                        winntHandle.pointer = Pointer.createConstant(handle)
+                        Kernel32.INSTANCE.GetProcessId(winntHandle).toLong()
+                    }
+                }
+
+                else -> -2
+            }
+        }
+    } catch (e: Exception) {
+        -1
+    }
+
+private interface CLibrary : Library {
+    fun getpid(): Int
+
+    companion object {
+        val INSTANCE = Native.load("c", CLibrary::class.java) as CLibrary
+    }
+}
+
+/**
+ * working for jvm 8 and 9+
+ */
+val currentProcessPid: Long
+    get() =
+        try {
+            if (isJvm9Plus) {
+                ClassLoader.getSystemClassLoader().loadClass("java.lang.ProcessHandle").let {
+                    val handle = it.getDeclaredMethod("current").invoke(it)
+                    it.getDeclaredMethod("pid").invoke(handle) as Long
+                }
+            } else {
+                if (isWindows) {
+                    Kernel32.INSTANCE.GetCurrentProcessId()
+                } else {
+                    CLibrary.INSTANCE.getpid()
+                }.toLong()
+            }
+        } catch (e: Throwable) {
+            -1
+        }

--- a/utbot-instrumentation/build.gradle
+++ b/utbot-instrumentation/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 
     implementation group: 'com.jetbrains.rd', name: 'rd-framework', version: '2022.3.1'
     implementation group: 'com.jetbrains.rd', name: 'rd-core', version: '2022.3.1'
+    implementation group: 'net.java.dev.jna', name: 'jna-platform', version: '5.5.0'
 
 
     // TODO: this is necessary for inline classes mocking in UtExecutionInstrumentation

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/process/ChildProcessRunner.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/process/ChildProcessRunner.kt
@@ -62,7 +62,7 @@ class ChildProcessRunner {
             .directory(directory)
 
         return processBuilder.start().also {
-            logger.debug { "Process started with PID=${it.pid()}" }
+            logger.debug { "Process started with PID=${it.getPid}" }
 
             if (UtSettings.logConcreteExecutionErrors) {
                 logger.debug { "Child process error log: ${errorLogFile.absolutePath}" }
@@ -99,7 +99,7 @@ class ChildProcessRunner {
                 run {
                     logger.debug("Trying to find jar in the resources.")
                     val tempDir = utBotTempDirectory.toFile()
-                    val unzippedJarName = "$UTBOT_INSTRUMENTATION-${ProcessHandle.current().pid()}.jar"
+                    val unzippedJarName = "$UTBOT_INSTRUMENTATION-${currentProcessPid}.jar"
                     val instrumentationJarFile = File(tempDir, unzippedJarName)
 
                     ChildProcessRunner::class.java.classLoader

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/rd/UtInstrumentationProcess.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/rd/UtInstrumentationProcess.kt
@@ -6,6 +6,7 @@ import com.jetbrains.rd.util.lifetime.Lifetime
 import com.jetbrains.rd.util.lifetime.isAlive
 import kotlinx.coroutines.delay
 import mu.KotlinLogging
+import org.utbot.common.getPid
 import org.utbot.instrumentation.instrumentation.Instrumentation
 import org.utbot.instrumentation.process.ChildProcessRunner
 import org.utbot.instrumentation.rd.generated.AddPathsParams
@@ -53,7 +54,7 @@ class UtInstrumentationProcess private constructor(
         // 1. child process will create file "${processId}.created" - this indicates that child process is ready to receive messages
         // 2. we will test the connection via sync RdSignal
         // only then we can successfully start operating
-        val pid = process.toHandle().pid().toInt()
+        val pid = process.getPid.toInt()
         val syncFile = File(processSyncDirectory, childCreatedFileName(pid))
 
         while (lifetime.isAlive) {


### PR DESCRIPTION
# Description

After rdgen merge UTBot ceased to work with jvm 8 projects. Fixing it by returning some java 8 process id API, but reworking it to be compatible with jvm 9+
## Type of Change

- Minor bug fix (non-breaking small changes)

## Automated Testing

All tests should work

## Manual Scenario 

Create java 8 project, test anything  with plugin - test should be generated
- [ ] All tests pass locally with my changes
