### PR TITLE
Restructure gradle dependencies

### DIFF
--- a/utbot-analytics/build.gradle
+++ b/utbot-analytics/build.gradle
@@ -12,12 +12,6 @@ evaluationDependsOn(':utbot-framework')
 compileTestJava.dependsOn tasks.getByPath(':utbot-framework:testClasses')
 
 dependencies {
-    implementation(project(":utbot-api"))
-    implementation(project(":utbot-core"))
-    implementation(project(":utbot-summary"))
-    implementation(project(":utbot-framework-api"))
-    implementation(project(":utbot-fuzzers"))
-    implementation(project(":utbot-instrumentation"))
     implementation(project(":utbot-framework"))
     testImplementation project(':utbot-sample')
     testImplementation group: 'junit', name: 'junit', version: junit4_version

--- a/utbot-cli/build.gradle
+++ b/utbot-cli/build.gradle
@@ -19,9 +19,7 @@ configurations {
 }
 
 dependencies {
-    implementation project(':utbot-framework-api')
     implementation project(':utbot-framework')
-    implementation project(':utbot-summary')
 
     implementation group: 'org.mockito', name: 'mockito-core', version: mockito_version
     // Without this dependency testng tests do not run.

--- a/utbot-framework/build.gradle
+++ b/utbot-framework/build.gradle
@@ -14,9 +14,7 @@ configurations {
 
 dependencies {
 
-    api project(':utbot-api')
     api project(':utbot-fuzzers')
-    api project(':utbot-core')
     api project(':utbot-instrumentation')
     api project(':utbot-summary')
     api project(':utbot-framework-api')

--- a/utbot-fuzzers/build.gradle
+++ b/utbot-fuzzers/build.gradle
@@ -5,7 +5,7 @@ plugins {
 apply from: "${parent.projectDir}/gradle/include/jvm-project.gradle"
 
 dependencies {
-    api project(':utbot-framework-api')
+    implementation project(':utbot-framework-api')
     implementation "com.github.UnitTestBot:soot:${soot_commit_hash}"
     implementation group: 'io.github.microutils', name: 'kotlin-logging', version: kotlin_logging_version
     implementation group: 'com.github.curious-odd-man', name: 'rgxgen', version: rgxgen_version

--- a/utbot-instrumentation/build.gradle
+++ b/utbot-instrumentation/build.gradle
@@ -1,7 +1,7 @@
 apply from: "${parent.projectDir}/gradle/include/jvm-project.gradle"
 
 dependencies {
-    api project(':utbot-framework-api')
+    implementation project(':utbot-framework-api')
     implementation project(':utbot-rd')
 
     implementation group: 'org.ow2.asm', name: 'asm', version: asm_version

--- a/utbot-intellij/build.gradle
+++ b/utbot-intellij/build.gradle
@@ -35,7 +35,6 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: jackson_version
 
     implementation(project(":utbot-framework")) { exclude group: 'org.slf4j', module: 'slf4j-api' }
-    implementation(project(":utbot-fuzzers"))
     // implementation project(':utbot-analytics') // to reduce the plugin size
     testImplementation 'org.mock-server:mockserver-netty:5.4.1'
     testImplementation(project(":utbot-sample"))

--- a/utbot-junit-contest/build.gradle
+++ b/utbot-junit-contest/build.gradle
@@ -51,8 +51,8 @@ jacocoTestReport {
 }
 
 dependencies {
-    api project(":utbot-framework")
-    api project(":utbot-analytics")
+    implementation project(":utbot-framework")
+    implementation project(":utbot-analytics")
 
     implementation "com.github.UnitTestBot:soot:${soot_commit_hash}"
     implementation group: 'org.apache.commons', name: 'commons-exec', version: '1.2'

--- a/utbot-summary/build.gradle
+++ b/utbot-summary/build.gradle
@@ -2,13 +2,12 @@ apply from: "${parent.projectDir}/gradle/include/jvm-project.gradle"
 
 dependencies {
     implementation "com.github.UnitTestBot:soot:${soot_commit_hash}"
-    api project(':utbot-framework-api')
-    api(project(':utbot-instrumentation'))
+    implementation project(':utbot-framework-api')
+    implementation project(':utbot-instrumentation')
+    implementation project(':utbot-fuzzers')
 
     implementation group: 'com.github.haifengl', name: 'smile-kotlin', version: '2.6.0'
     implementation group: 'com.github.haifengl', name: 'smile-core', version: '2.6.0'
-    api project(':utbot-fuzzers')
-    implementation(project(':utbot-instrumentation'))
 
     implementation group: 'io.github.microutils', name: 'kotlin-logging', version: kotlin_logging_version
 


### PR DESCRIPTION
# Description

We haven't specified our modules dependencies structure and now we have very difficult connections between them.
![image](https://user-images.githubusercontent.com/54807972/187661756-ba093725-8651-487c-a752-7731f6606c6e.png)

After restructuring
![image](https://user-images.githubusercontent.com/54807972/187662114-bcf744d5-7132-4af0-88a5-9fa92a707786.png)

That's step for future optimization publishing artifacts weight.

## Type of Change

Please delete options that are not relevant.

- Refactoring (typos and non-functional changes) 

# How Has This Been Tested?

## Manual Scenario 

Called `gradle build -x test` on utbot and run StatisticsMonitoring.kt
