### PR TITLE
Add Junit5-params dependency for projects without it when needed #620

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/Domain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/Domain.kt
@@ -173,6 +173,7 @@ sealed class TestFramework(
     override val displayName: String,
     override val description: String = "Use $displayName as test framework",
 ) : CodeGenerationSettingItem {
+    var isParametrizedTestsConfigured = false
     var isInstalled: Boolean = false
     abstract val mainPackage: String
     abstract val assertionsClass: ClassId

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/util/DependencyPatterns.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/util/DependencyPatterns.kt
@@ -26,6 +26,23 @@ fun TestFramework.patterns(): Patterns {
     return Patterns(moduleLibraryPatterns, libraryPatterns)
 }
 
+
+fun TestFramework.parametrizedTestsPatterns(): Patterns {
+    val moduleLibraryPatterns = when (this) {
+        Junit4 -> emptyList()
+        Junit5 -> emptyList()   // emptyList here because JUnit5 module may not be enough for parametrized tests if :junit-jupiter-params: is not installed
+        TestNg -> testNgModulePatterns
+    }
+    val libraryPatterns = when (this) {
+        Junit4 -> emptyList()
+        Junit5 -> junit5ParametrizedTestsPatterns
+        TestNg -> testNgPatterns
+    }
+
+    return Patterns(moduleLibraryPatterns, libraryPatterns)
+}
+
+
 fun MockFramework.patterns(): Patterns {
     val moduleLibraryPatterns = when (this) {
         MockFramework.MOCKITO -> mockitoModulePatterns
@@ -47,11 +64,16 @@ val JUNIT_5_MVN_PATTERN = Regex("org\\.junit\\.jupiter:junit-jupiter-api:5(\\.[0
 val JUNIT_5_BASIC_PATTERN = Regex("JUnit5\\.4")
 val junit5Patterns = listOf(JUNIT_5_JAR_PATTERN, JUNIT_5_MVN_PATTERN, JUNIT_5_BASIC_PATTERN)
 
+val JUNIT_5_PARAMETRIZED_JAR_PATTERN = Regex("junit-jupiter-params-5(\\.[0-9]+){1,2}")
+val JUNIT_5_PARAMETRIZED_MVN_PATTERN = Regex("org\\.junit\\.jupiter\\.junit-jupiter-params:5(\\.[0-9]+){1,2}")
+val junit5ParametrizedTestsPatterns = listOf(JUNIT_5_JAR_PATTERN, JUNIT_5_BASIC_PATTERN,
+    JUNIT_5_PARAMETRIZED_JAR_PATTERN, JUNIT_5_PARAMETRIZED_MVN_PATTERN)
+
 val JUNIT5_BASIC_MODULE_PATTERN = Regex("junit-jupiter")
 val junit5ModulePatterns = listOf(JUNIT5_BASIC_MODULE_PATTERN)
 
 val TEST_NG_JAR_PATTERN = Regex("testng-[0-9](\\.[0-9]+){2}")
-val TEST_NG_MVN_PATTERN = Regex("org\\.testng:testng:(\\.[0-9]+){3}")
+val TEST_NG_MVN_PATTERN = Regex("org\\.testng:testng:[0-9](\\.[0-9]+){2}")
 val TEST_NG_BASIC_PATTERN = Regex("testng")
 val testNgPatterns = listOf(TEST_NG_JAR_PATTERN, TEST_NG_MVN_PATTERN, TEST_NG_BASIC_PATTERN)
 

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/ExternalLibraryDescriptors.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/ExternalLibraryDescriptors.kt
@@ -12,5 +12,8 @@ fun jUnit5LibraryDescriptor(versionInProject: String?) =
 fun testNgLibraryDescriptor(versionInProject: String?) =
     ExternalLibraryDescriptor("org.testng", "testng", "6.8.8", null, versionInProject ?: "6.9.6")
 
+fun jUnit5ParametrizedTestsLibraryDescriptor(versionInProject: String?) =
+    ExternalLibraryDescriptor("org.junit.jupiter", "junit-jupiter-params", "5.8.1", null, versionInProject ?: "5.8.1")
+
 fun mockitoCoreLibraryDescriptor(versionInProject: String?) =
     ExternalLibraryDescriptor("org.mockito", "mockito-core", "3.5.0", "4.2.0", versionInProject ?: "4.2.0")

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/LibraryMatcher.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/LibraryMatcher.kt
@@ -6,6 +6,7 @@ import org.utbot.framework.plugin.api.MockFramework
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.LibraryOrderEntry
+import org.utbot.framework.codegen.model.util.parametrizedTestsPatterns
 import org.utbot.framework.codegen.model.util.Patterns
 
 fun findFrameworkLibrary(
@@ -23,6 +24,13 @@ fun findFrameworkLibrary(
     mockFramework: MockFramework,
     scope: LibrarySearchScope = LibrarySearchScope.Module,
 ): LibraryOrderEntry? = findMatchingLibrary(project, testModule, mockFramework.patterns(), scope)
+
+fun findParametrizedTestsLibrary(
+    project: Project,
+    testModule: Module,
+    testFramework: TestFramework,
+    scope: LibrarySearchScope = LibrarySearchScope.Module,
+): LibraryOrderEntry? = findMatchingLibrary(project, testModule, testFramework.parametrizedTestsPatterns(), scope)
 
 private fun findMatchingLibrary(
     project: Project,


### PR DESCRIPTION
# Description

Now libraries are configured properly when generating parametrized tests with Junit 5:

* If user has already installed any of `junit` libraries as dependency, check for `junit-jupiter` or `junit-jupiter-params` libraries and if neither of them is installed, install `junit-jupiter-params`
* If user has no `junit` libraries, install `junit-jupiter` (behavior in this case is the same as before PR)

Fixes #620

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

Scenarios on which behavior was checked:

1. User has `junit-jupiter-api` and `junit-jupiter-engine` dependency -- `junit-jupiter-params` dependency is added
2. User has all three dependencies from previous case -- nothing added
3. User has `junit-jupiter` dependency -- nothing added
4. User has no dependencies -- `junit-jupiter` dependency is added

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [ ] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
