### PR TITLE
Support for nested classes in cli #830

### DIFF
--- a/utbot-cli/src/main/kotlin/org/utbot/cli/GenerateTestsCommand.kt
+++ b/utbot-cli/src/main/kotlin/org/utbot/cli/GenerateTestsCommand.kt
@@ -21,6 +21,7 @@ import java.nio.file.Paths
 import java.time.temporal.ChronoUnit
 import kotlin.reflect.KClass
 import mu.KotlinLogging
+import org.utbot.common.allNestedClasses
 import org.utbot.common.filterWhen
 import org.utbot.framework.UtSettings
 import org.utbot.framework.util.isKnownSyntheticMethod
@@ -94,9 +95,11 @@ class GenerateTestsCommand :
             logger.debug { "Classpath to be used: ${newline()} $classPath ${newline()}" }
 
             val classUnderTest: KClass<*> = loadClassBySpecifiedFqn(targetClassFqn)
-            val targetMethods = classUnderTest.targetMethods()
-                .filterWhen(UtSettings.skipTestGenerationForSyntheticMethods) { !isKnownSyntheticMethod(it) }
-                .filterNot { it.callable.isAbstract }
+            val targetMethods = classUnderTest.allNestedClasses.flatMap { clazz ->
+                clazz.targetMethods()
+                    .filterWhen(UtSettings.skipTestGenerationForSyntheticMethods) { !isKnownSyntheticMethod(it) }
+                    .filterNot { it.callable.isAbstract }
+            }
             val testCaseGenerator = initializeGenerator(workingDirectory)
 
             if (targetMethods.isEmpty()) {


### PR DESCRIPTION
# Description

Tests for methods from nested classes are now generated if launching from UTBot cli.

Fixes #830

## Type of Change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Manual Scenario 

Launched cli application on example from #830 -- tests for `f()` were generated

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
