### PR TITLE
Implicit unpermitted operations should be sandboxed #791

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ValueConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ValueConstructor.kt
@@ -1,7 +1,6 @@
 package org.utbot.engine
 
 import org.utbot.common.invokeCatching
-import org.utbot.common.withAccessibility
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.ConstructorId
 import org.utbot.framework.plugin.api.EnvironmentModels
@@ -41,6 +40,7 @@ import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.framework.plugin.api.util.method
 import org.utbot.framework.plugin.api.util.utContext
 import org.utbot.framework.util.anyInstance
+import org.utbot.instrumentation.process.runSandbox
 import java.lang.reflect.Field
 import java.lang.reflect.Modifier
 import kotlin.reflect.KClass
@@ -405,17 +405,13 @@ class ValueConstructor {
     private fun value(model: UtModel) = construct(model, null).value
 
     private fun MethodId.call(args: List<Any?>, instance: Any?): Any? =
-        method.run {
-            withAccessibility {
-                invokeCatching(obj = instance, args = args).getOrThrow()
-            }
+        method.runSandbox {
+            invokeCatching(obj = instance, args = args).getOrThrow()
         }
 
     private fun ConstructorId.call(args: List<Any?>): Any? =
-        constructor.run {
-            withAccessibility {
-                newInstance(*args.toTypedArray())
-            }
+        constructor.runSandbox {
+            newInstance(*args.toTypedArray())
         }
 
     /**

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/MockValueConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/MockValueConstructor.kt
@@ -44,7 +44,7 @@ import kotlin.reflect.KClass
 import org.mockito.Mockito
 import org.mockito.stubbing.Answer
 import org.objectweb.asm.Type
-import org.utbot.common.withAccessibility
+import org.utbot.instrumentation.process.runSandbox
 
 /**
  * Constructs values (including mocks) from models.
@@ -441,17 +441,13 @@ class MockValueConstructor(
     }
 
     private fun MethodId.call(args: List<Any?>, instance: Any?): Any? =
-        method.run {
-            withAccessibility {
-                invokeCatching(obj = instance, args = args).getOrThrow()
-            }
+        method.runSandbox {
+            invokeCatching(obj = instance, args = args).getOrThrow()
         }
 
     private fun ConstructorId.call(args: List<Any?>): Any? =
-        constructor.run {
-            withAccessibility {
-                newInstance(*args.toTypedArray())
-            }
+        constructor.runSandbox {
+            newInstance(*args.toTypedArray())
         }
 
     /**

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/InvokeInstrumentation.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/InvokeInstrumentation.kt
@@ -1,8 +1,7 @@
 package org.utbot.instrumentation.instrumentation
 
-import org.utbot.common.withAccessibility
 import org.utbot.framework.plugin.api.util.signature
-import org.utbot.instrumentation.process.sandbox
+import org.utbot.instrumentation.process.runSandbox
 import java.lang.reflect.Constructor
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
@@ -53,18 +52,18 @@ class InvokeInstrumentation : Instrumentation<Result<*>> {
         methodOrConstructor.run {
             val result = when (this) {
                 is Method ->
-                    withAccessibility {
+                    runSandbox {
                         runCatching {
-                            sandbox { invoke(thisObject, *realArgs.toTypedArray()) }.let {
+                            invoke(thisObject, *realArgs.toTypedArray()).let {
                                 if (returnType != Void.TYPE) it else Unit
                             } // invocation on method returning void will return null, so we replace it with Unit
                         }
                     }
 
                 is Constructor<*> ->
-                    withAccessibility {
+                    runSandbox {
                         runCatching {
-                            sandbox { newInstance(*realArgs.toTypedArray()) }
+                            newInstance(*realArgs.toTypedArray())
                         }
                     }
 

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/process/Security.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/process/Security.kt
@@ -2,7 +2,9 @@
 
 package org.utbot.instrumentation.process
 
+import org.utbot.common.withAccessibility
 import sun.security.provider.PolicyFile
+import java.lang.reflect.AccessibleObject
 import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -29,6 +31,15 @@ internal fun permissions(block: SimplePolicy.() -> Unit) {
 }
 
 /**
+ * Make this [AccessibleObject] accessible and run a block inside sandbox.
+ */
+fun <O: AccessibleObject, R> O.runSandbox(block: O.() -> R): R {
+    return withAccessibility {
+        sandbox { block() }
+    }
+}
+
+/**
  * Run [block] in sandbox mode.
  *
  * When running in sandbox by default only necessary to instrumentation permissions are enabled.
@@ -45,12 +56,12 @@ internal fun permissions(block: SimplePolicy.() -> Unit) {
  * ```
  * Read more [about policy file and syntax](https://docs.oracle.com/javase/7/docs/technotes/guides/security/PolicyFiles.html#Examples)
  */
-internal fun <T> sandbox(block: () -> T): T {
+fun <T> sandbox(block: () -> T): T {
     val policyPath = Paths.get(System.getProperty("user.home"), ".utbot", "sandbox.policy")
     return sandbox(policyPath.toUri()) { block() }
 }
 
-internal fun <T> sandbox(file: URI, block: () -> T): T {
+fun <T> sandbox(file: URI, block: () -> T): T {
     val path = Paths.get(file)
     val perms = mutableListOf<Permission>(
         RuntimePermission("accessDeclaredMembers")
@@ -64,12 +75,12 @@ internal fun <T> sandbox(file: URI, block: () -> T): T {
     return sandbox(perms, allCodeSource) { block() }
 }
 
-internal fun <T> sandbox(permission: List<Permission>, cs: CodeSource, block: () -> T): T {
+fun <T> sandbox(permission: List<Permission>, cs: CodeSource, block: () -> T): T {
     val perms = permission.fold(Permissions()) { acc, p -> acc.add(p); acc }
     return sandbox(perms, cs) { block() }
 }
 
-internal fun <T> sandbox(perms: PermissionCollection, cs: CodeSource, block: () -> T): T {
+fun <T> sandbox(perms: PermissionCollection, cs: CodeSource, block: () -> T): T {
     val acc = AccessControlContext(arrayOf(ProtectionDomain(cs, perms)))
     return try {
         AccessController.doPrivileged(PrivilegedAction { block() }, acc)

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/process/Security.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/process/Security.kt
@@ -64,7 +64,9 @@ fun <T> sandbox(block: () -> T): T {
 fun <T> sandbox(file: URI, block: () -> T): T {
     val path = Paths.get(file)
     val perms = mutableListOf<Permission>(
-        RuntimePermission("accessDeclaredMembers")
+        RuntimePermission("accessDeclaredMembers"),
+        RuntimePermission("getStackWalkerWithClassReference"),
+        RuntimePermission("getClassLoader"),
     )
     val allCodeSource = CodeSource(null, emptyArray<Certificate>())
     if (Files.exists(path)) {


### PR DESCRIPTION
# Description

Adds a sandbox block code when creating a new instance of a model.

Fixes #791

## Type of Change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

## Automated Testing

All tests should work as before

## Manual Scenario 

Try to run this example. File a.txt should never be created. Try to uncomment static block too. Errors can differ, but operation must be blocked by default.

```java
class A {
    int anInt = 15;

    static {
//        call();
    }

    A () {
    }

    A (int a) {
        anInt = a;
        call();
    }

    static void call() {
        File a = new File("a.txt");
        try {
            a.createNewFile();
        } catch (IOException e) {
            throw new RuntimeException(e);
        }
    }
}

public class ImplicitSecurityManager {
    public int read(A a)  {
        if (a.anInt < 10) {
            return 0;
        }
        return a.anInt;
    }
}
```

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
