### PR TITLE
Adapt force mock listener for plugin

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/CgMethodTestSet.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/CgMethodTestSet.kt
@@ -8,6 +8,7 @@ import org.utbot.framework.plugin.api.UtExecution
 import org.utbot.framework.plugin.api.UtExecutionFailure
 import org.utbot.framework.plugin.api.UtExecutionSuccess
 import org.utbot.framework.plugin.api.UtMethodTestSet
+import org.utbot.framework.plugin.api.UtSymbolicExecution
 import org.utbot.framework.plugin.api.util.executableId
 import org.utbot.framework.plugin.api.util.objectClassId
 import org.utbot.framework.plugin.api.util.voidClassId
@@ -64,6 +65,12 @@ data class CgMethodTestSet private constructor(
             executions.groupBy { it.stateBefore.statics.keys }
 
         return executionsByStaticsUsage.map { (_, executions) -> substituteExecutions(executions) }
+    }
+
+    fun extractSymbolicExecutions(): CgMethodTestSet {
+        val executionsBySource = executions.filterIsInstance<UtSymbolicExecution>()
+
+        return substituteExecutions(executionsBySource)
     }
 
     /**

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgTestClassConstructor.kt
@@ -147,14 +147,20 @@ internal class CgTestClassConstructor(val context: CgContext) :
                 }
             }
             ParametrizedTestSource.PARAMETRIZE -> {
-                for (splitByExecutionTestSet in testSet.splitExecutionsByResult()) {
-                    for (splitByChangedStaticsTestSet in splitByExecutionTestSet.splitExecutionsByChangedStatics()) {
-                        createParametrizedTestAndDataProvider(
-                            splitByChangedStaticsTestSet,
-                            requiredFields,
-                            regions,
-                            methodUnderTest
-                        )
+                // We filter out Fuzzer executions because sometimes we need to turn off
+                // Symbolic Engine and stop the test generation in case of mocking taking place
+                // and do not collect this execution. But having Fuzzer executions may cause
+                // unwanted executions being present.
+                testSet.extractSymbolicExecutions().also {
+                    for (splitByExecutionTestSet in it.splitExecutionsByResult()) {
+                        for (splitByChangedStaticsTestSet in splitByExecutionTestSet.splitExecutionsByChangedStatics()) {
+                            createParametrizedTestAndDataProvider(
+                                splitByChangedStaticsTestSet,
+                                requiredFields,
+                                regions,
+                                methodUnderTest
+                            )
+                        }
                     }
                 }
             }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/EngineActionsController.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/EngineActionsController.kt
@@ -1,0 +1,16 @@
+package org.utbot.framework.plugin.api
+
+import org.utbot.engine.UtBotSymbolicEngine
+
+class EngineActionsController {
+    private val actions: MutableList<(UtBotSymbolicEngine) -> Unit> = mutableListOf()
+
+    fun add(action: (UtBotSymbolicEngine) -> Unit) {
+        actions.add(action)
+    }
+
+    fun apply(symbolicEngine: UtBotSymbolicEngine) {
+        actions.forEach { symbolicEngine.apply(it) }
+        actions.clear()
+    }
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestCaseGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestCaseGenerator.kt
@@ -163,6 +163,7 @@ open class TestCaseGenerator(
                         )
 
                         engineActions.map { engine.apply(it) }
+                        engineActions.clear()
 
                         generate(engine)
                             .catch {

--- a/utbot-framework/src/main/kotlin/org/utbot/tests/infrastructure/TestSpecificTestCaseGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/tests/infrastructure/TestSpecificTestCaseGenerator.kt
@@ -29,9 +29,8 @@ class TestSpecificTestCaseGenerator(
     buildDir: Path,
     classpath: String?,
     dependencyPaths: String,
-    engineActions: MutableList<(UtBotSymbolicEngine) -> Unit> = mutableListOf(),
     isCanceled: () -> Boolean = { false },
-): TestCaseGenerator(buildDir, classpath, dependencyPaths, engineActions, isCanceled, forceSootReload = false) {
+): TestCaseGenerator(buildDir, classpath, dependencyPaths, isCanceled, forceSootReload = false) {
 
     private val logger = KotlinLogging.logger {}
 

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -206,32 +206,24 @@ object UtTestsDialogProcessor {
                                     .executeSynchronously()
 
                                 withStaticsSubstitutionRequired(true) {
-                                    val mockFrameworkInstalled = model.mockFramework?.isInstalled ?: true
+                                    val mockFrameworkInstalled = model.mockFramework.isInstalled
                                     var forceMockListener: ForceMockListener? = null
                                     var forceStaticMockListener: ForceStaticMockListener? = null
 
                                     when (model.parametrizedTestSource) {
-                                        ParametrizedTestSource.PARAMETRIZE -> {
-                                            forceMockListener = ForceMockListener.create(testCaseGenerator, model.conflictTriggers)
-                                            forceStaticMockListener = ForceStaticMockListener.create(
-                                                testCaseGenerator,
-                                                model.conflictTriggers
-                                            )
-                                        }
-
                                         ParametrizedTestSource.DO_NOT_PARAMETRIZE -> {
                                             when {
-                                                !mockFrameworkInstalled -> forceMockListener = ForceMockListener.create(
-                                                    testCaseGenerator,
-                                                    model.conflictTriggers
-                                                )
+                                                !mockFrameworkInstalled -> forceMockListener =
+                                                    ForceMockListener.create(testCaseGenerator, model.conflictTriggers)
 
-                                                !model.staticsMocking.isConfigured -> forceStaticMockListener =
-                                                    ForceStaticMockListener.create(
-                                                        testCaseGenerator,
-                                                        model.conflictTriggers
-                                                    )
+                                                !model.staticsMocking.isConfigured ->
+                                                    forceStaticMockListener = ForceStaticMockListener.create(testCaseGenerator, model.conflictTriggers)
                                             }
+                                        }
+
+                                        ParametrizedTestSource.PARAMETRIZE -> {
+                                            forceMockListener = ForceMockListener.create(testCaseGenerator, model.conflictTriggers)
+                                            forceStaticMockListener = ForceStaticMockListener.create(testCaseGenerator, model.conflictTriggers)
                                         }
                                     }
 


### PR DESCRIPTION
# Description

Before the PR we listened to force mocking occurrence events in parameterized test generation only in utbot-samples runs.
This PR adapts the feature for plugin.

Fixes # ([844](https://github.com/UnitTestBot/UTBotJava/issues/844))

## Type of Change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Automated Testing

Run tests from *utbot-samples*

## Manual Scenario 

Generate a parameterized test for a method *vertexSum* from *RecursionTest* in plugin. Verify that there is only one data provider (one processed execution without *Random()* mock) out of two.