### PR TITLE
Add back cross reference test

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/codegen/deepequals/ClassWithCrossReferenceRelationshipTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/codegen/deepequals/ClassWithCrossReferenceRelationshipTest.kt
@@ -1,0 +1,29 @@
+package org.utbot.examples.codegen.deepequals
+
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.utbot.tests.infrastructure.DoNotCalculate
+import org.utbot.tests.infrastructure.UtValueTestCaseChecker
+import org.utbot.framework.plugin.api.CodegenLanguage
+import org.utbot.testcheckers.eq
+import org.utbot.tests.infrastructure.CodeGeneration
+
+class ClassWithCrossReferenceRelationshipTest : UtValueTestCaseChecker(
+    testClass = ClassWithCrossReferenceRelationship::class,
+    testCodeGeneration = true,
+    languagePipelines = listOf(
+        CodeGenerationLanguageLastStage(CodegenLanguage.JAVA),
+        CodeGenerationLanguageLastStage(CodegenLanguage.KOTLIN, CodeGeneration)
+    )
+) {
+    // TODO: The test is disabled due to [https://github.com/UnitTestBot/UTBotJava/issues/812]
+    @Disabled
+    @Test
+    fun testClassWithCrossReferenceRelationship() {
+        check(
+            ClassWithCrossReferenceRelationship::returnFirstClass,
+            eq(2),
+            coverage = DoNotCalculate
+        )
+    }
+}


### PR DESCRIPTION
# Description

There is a new test for a method that returns an object with cross-reference relationship, which is disabled for now due to [#812](https://github.com/UnitTestBot/UTBotJava/issues/812).

## Type of Change

- New test