### PR TITLE
Move getting srcClassName inside ReadAction in plugin #729

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -162,7 +162,7 @@ object UtTestsDialogProcessor {
                             )
 
                             for (srcClass in model.srcClasses) {
-                                val methods = ReadAction.nonBlocking<List<ExecutableId>> {
+                                val (methods, className) = ReadAction.nonBlocking<Pair<List<ExecutableId>, String?>> {
                                     val canonicalName = srcClass.canonicalName
                                     val clazz = classLoader.loadClass(canonicalName).kotlin
                                     psi2KClass[srcClass] = clazz
@@ -180,10 +180,9 @@ object UtTestsDialogProcessor {
                                         clazz.allNestedClasses.flatMap {
                                             findMethodsInClassMatchingSelected(it, srcMethods)
                                         }
-                                    })
+                                    }) to srcClass.name
                                 }.executeSynchronously()
 
-                                val className = srcClass.name
                                 if (methods.isEmpty()) {
                                     logger.error { "No methods matching selected found in class $className." }
                                     continue


### PR DESCRIPTION
# Description

Moved call to PsiClass.name inside ReadAction block in plugin, so that `java.lang.Throwable: Read access is allowed from event dispatch thread or inside read-action only` is not thrown anymore.

Fixes #729

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

Launch plugin on any Kotlin code -- the exception is not thrown anymore.

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
