### PR TITLE
Prefer symbolic executions during minimization

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -378,6 +378,11 @@ object UtSettings : AbstractSettings(
      */
     var disableSandbox by getBooleanProperty(false)
 
+    /**
+     * Exclude fuzzer-produced executions during minimization if there is an equivalent symbolic execution
+     */
+    var preferSymbolicExecutionsDuringMinimization by getBooleanProperty(true)
+
 }
 
 /**

--- a/utbot-framework-test/src/test/kotlin/org/utbot/framework/minimization/MinimizationGreedyEssentialTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/framework/minimization/MinimizationGreedyEssentialTest.kt
@@ -68,4 +68,46 @@ class MinimizationGreedyEssentialTest {
         val minimizedExecutions = GreedyEssential.minimize(executions)
         assertEquals((1..size).toList(), minimizedExecutions.sorted())
     }
+
+    @Test
+    fun testWithSourcePriority() {
+        val executions = mapOf(
+            10 to listOf(1, 2, 3, 4, 5),
+            20 to listOf(2, 3, 4, 5, 6, 7),
+            21 to listOf(2, 3, 4, 5, 6, 7),
+            25 to listOf(1, 7, 2, 3, 5),
+            30 to listOf(8, 9),
+            50 to listOf(1, 8, 9),
+            60 to listOf(1, 9)
+        )
+
+        val sourcePriorities = mapOf(
+            10 to 0,
+            20 to 1,
+            21 to 0,
+            25 to 0,
+            30 to 1,
+            50 to 1,
+            60 to 0
+        )
+
+        val minimizedExecutions = GreedyEssential.minimize(executions, sourcePriorities)
+        assertEquals(listOf(21, 50), minimizedExecutions)
+    }
+
+    @Test
+    fun testWithoutSourcePriority() {
+        val executions = mapOf(
+            10 to listOf(1, 2, 3, 4, 5),
+            20 to listOf(2, 3, 4, 5, 6, 7),
+            21 to listOf(2, 3, 4, 5, 6, 7),
+            25 to listOf(1, 7, 2, 3, 5),
+            30 to listOf(8, 9),
+            50 to listOf(1, 8, 9),
+            60 to listOf(1, 9)
+        )
+
+        val minimizedExecutions = GreedyEssential.minimize(executions)
+        assertEquals(listOf(20, 50), minimizedExecutions)
+    }
 }


### PR DESCRIPTION
# Description

Suppose we have two executions with the same coverage, one produced by the symbolic engine, and one produced by the fuzzer. From the user's point of view, they are equivalent, and the minimizer can keep any of them. Usually it will be fuzzed one, because fuzzer produces executions earlier that the symbolic engine, and the minimizer orders executions with the same coverage by their order in the execution list.

When parametrized tests are generated, fuzzed tests tend to be excluded due to mock processing issues. If a fuzzed tests has been selected by the minimizer instead of the symbolic one, the corresponding path remains uncovered: one (symbolic) test has been dropped by the minimizer, and another (fuzzed) test has been excluded by the code generator.

The coverage of the entire parametrized test suite may be improved is minimizer selects symbolic executions when possible. It does not guarantee the full coverage (it is possible to have only fuzzed tests for some paths), but we expect that the coverage may be improved that way.

To let users to control the minimizer behavior, new `UtSettings` option is introduced: `preferSymbolicExecutionsDuringMinimization`. When it is set to `true` (default), the minimizer will consider the execution source (specifically, its class: `UtSymbolicExecution` or `UtFuzzedExecution` (`UtFailedExecution` and any potential other direct `UtExecution` subclasses are assigned the lowest priority, but `UtFailedExecution` does not have any coverage anyway, so it is processed separately).

Fixes #843 

## Type of Change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

This fix changes the set of generated tests. It should not decrease coverage, and is expected to increase coverage when generating parametrized tests (_please report a bug if coverage is decreased when `preferSymbolicExecutionsDuringMinimization` is `true`_).

This PR also changes the minimizer interface.

# How Has This Been Tested?

## Automated Testing

All existing minimizer tests should pass.

Two new minimizer tests have been added:
  * `org.utbot.framework.minimization.MinimizationGreedyEssentialTest#testWithSourcePriority`
  * `org.utbot.framework.minimization.MinimizationGreedyEssentialTest#testWithoutSourcePriority`

## Manual Scenario 

Make sure that fuzzer is enabled in `UtSettings`, and both fuzzer and symbolic engine are enabled in the plugin configuration window.

Create any method simple enough so both fuzzer and symbolic engine can cover all branches. An example:
```
package simple;

public class SimpleExample {
    public int foo(int a, int b) {
        if (a > b)
            return a - b;
        else
            return a + b;
    }
}
```

Set `UtSettings.preferSymbolicExecutionsDuringMinimization` to `true` and generate a test suite for `foo`. Test cases produced by the symbolic engine should be generated.

```
package simple;

import org.junit.Test;

import static org.junit.Assert.assertEquals;

public class SimpleExampleTest {
    ///region Test suites for executable simple.SimpleExample.foo

    ///region SUCCESSFUL EXECUTIONS for method foo(int, int)

    /**
     * <pre>
     * Test executes conditions:
     *     {@code (a > b): False }
     * returns from: {@code return a + b; }
     * </pre>
     */
    @Test
    public void testFoo_ALessOrEqualB() {
        SimpleExample simpleExample = new SimpleExample();

        int actual = simpleExample.foo(-240, -240);

        assertEquals(-480, actual);
    }

    /**
     * <pre>
     * Test executes conditions:
     *     {@code (a > b): True }
     * returns from: {@code return a - b; }
     * </pre>
     */
    @Test
    public void testFoo_AGreaterThanB() {
        SimpleExample simpleExample = new SimpleExample();

        int actual = simpleExample.foo(1, 0);

        assertEquals(1, actual);
    }
    ///endregion

    ///endregion
}
```

Set `UtSettings.preferSymbolicExecutionsDuringMinimization` to `false` and generate a test suite for `foo` again. This time, the plugin should generate test cases produced by the fuzzer.

```
package simple;

import org.junit.Test;

import static org.junit.Assert.assertEquals;

public class SimpleExampleTest {
    ///region Test suites for executable simple.SimpleExample.foo

    ///region

    @Test
    public void testFooReturnsZero() {
        SimpleExample simpleExample = new SimpleExample();

        int actual = simpleExample.foo(-1, 1);

        assertEquals(0, actual);
    }

    @Test
    public void testFooWithCornerCase() {
        SimpleExample simpleExample = new SimpleExample();

        int actual = simpleExample.foo(Integer.MAX_VALUE, 1);

        assertEquals(2147483646, actual);
    }
    ///endregion

    ///endregion
}
```

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [X] The change followed the style guidelines of the UTBot project
- [X] Self-review of the code is passed
- [X] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [X] No new warnings
- [X] New tests have been added
- [X] All tests pass locally with my changes
