### PR TITLE
Fix soot initialization #849

### DIFF
--- a/utbot-framework-test/src/main/java/org/utbot/examples/manual/KotlinWrappers.kt
+++ b/utbot-framework-test/src/main/java/org/utbot/examples/manual/KotlinWrappers.kt
@@ -8,7 +8,7 @@ import org.utbot.framework.plugin.api.UtPrimitiveModel
 object SootUtils {
     @JvmStatic
     fun runSoot(clazz: Class<*>) {
-        org.utbot.framework.util.SootUtils.runSoot(clazz.kotlin)
+        org.utbot.framework.util.SootUtils.runSoot(clazz.kotlin, forceReload = false)
     }
 }
 

--- a/utbot-framework-test/src/test/kotlin/org/utbot/framework/assemble/AssembleModelGeneratorTests.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/framework/assemble/AssembleModelGeneratorTests.kt
@@ -70,7 +70,7 @@ class AssembleModelGeneratorTests {
         instanceCounter.set(0)
         modelIdCounter.set(0)
         statementsChain = mutableListOf()
-        SootUtils.runSoot(AssembleTestUtils::class)
+        SootUtils.runSoot(AssembleTestUtils::class, forceReload = false)
         context = setUtContext(UtContext(AssembleTestUtils::class.java.classLoader))
     }
 

--- a/utbot-framework-test/src/test/kotlin/org/utbot/framework/modificators/UtBotFieldModificatorsTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/framework/modificators/UtBotFieldModificatorsTest.kt
@@ -169,7 +169,7 @@ internal class UtBotFieldModificatorsTest {
     }
 
     private fun initAnalysis() {
-        SootUtils.runSoot(PrimitiveModifications::class)
+        SootUtils.runSoot(PrimitiveModifications::class, forceReload = false)
         fieldsModificatorsSearcher = UtBotFieldsModificatorsSearcher()
     }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestCaseGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestCaseGenerator.kt
@@ -59,6 +59,7 @@ open class TestCaseGenerator(
     private val dependencyPaths: String,
     val engineActions: MutableList<(UtBotSymbolicEngine) -> Unit> = mutableListOf(),
     val isCanceled: () -> Boolean = { false },
+    val forceSootReload: Boolean = true
 ) {
     private val logger: KLogger = KotlinLogging.logger {}
     private val timeoutLogger: KLogger = KotlinLogging.logger(logger.name + ".timeout")
@@ -78,7 +79,7 @@ open class TestCaseGenerator(
             }
 
             timeoutLogger.trace().bracket("Soot initialization") {
-                SootUtils.runSoot(buildDir, classpath)
+                SootUtils.runSoot(buildDir, classpath, forceSootReload)
             }
 
             //warmup

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestCaseGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestCaseGenerator.kt
@@ -52,6 +52,9 @@ import kotlin.reflect.KCallable
  *
  * Note: the instantiating of [TestCaseGenerator] may take some time,
  * because it requires initializing Soot for the current [buildDir] and [classpath].
+ *
+ * @param forceSootReload forces to reinitialize Soot even if the previous buildDir equals to [buildDir] and previous
+ * classpath equals to [classpath]. This is the case for plugin scenario, as the source code may be modified.
  */
 open class TestCaseGenerator(
     private val buildDir: Path,

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/util/SootUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/util/SootUtils.kt
@@ -55,6 +55,8 @@ import soot.toolkits.graph.ExceptionalUnitGraph
 object SootUtils {
     /**
      * Runs Soot in tests if it hasn't already been done.
+     *
+     * @param forceReload forces to reinitialize Soot even if the [previousBuildDir] equals to the class buildDir.
      */
     fun runSoot(clazz: KClass<*>, forceReload: kotlin.Boolean) {
         val buildDir = FileUtil.locateClassPath(clazz) ?: FileUtil.isolateClassFiles(clazz)
@@ -63,6 +65,11 @@ object SootUtils {
         runSoot(buildDirPath, null, forceReload)
     }
 
+
+    /**
+     * @param forceReload forces to reinitialize Soot even if the [previousBuildDir] equals to [buildDirPath] and
+     * [previousClassPath] equals to [classPath].
+     */
     fun runSoot(buildDirPath: Path, classPath: String?, forceReload: kotlin.Boolean) {
         synchronized(this) {
             if (buildDirPath != previousBuildDir || classPath != previousClassPath || forceReload) {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/util/SootUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/util/SootUtils.kt
@@ -56,17 +56,17 @@ object SootUtils {
     /**
      * Runs Soot in tests if it hasn't already been done.
      */
-    fun runSoot(clazz: KClass<*>) {
+    fun runSoot(clazz: KClass<*>, forceReload: kotlin.Boolean) {
         val buildDir = FileUtil.locateClassPath(clazz) ?: FileUtil.isolateClassFiles(clazz)
         val buildDirPath = buildDir.toPath()
 
-        runSoot(buildDirPath, null)
+        runSoot(buildDirPath, null, forceReload)
     }
 
-    fun runSoot(buildDirPath: Path, classPath: String?) {
+    fun runSoot(buildDirPath: Path, classPath: String?, forceReload: kotlin.Boolean) {
         synchronized(this) {
-            if (buildDirPath != previousBuildDir || classPath != previousClassPath) {
-                org.utbot.framework.util.runSoot(buildDirPath, classPath)
+            if (buildDirPath != previousBuildDir || classPath != previousClassPath || forceReload) {
+                initSoot(buildDirPath, classPath)
                 previousBuildDir = buildDirPath
                 previousClassPath = classPath
             }
@@ -80,7 +80,7 @@ object SootUtils {
 /**
 Convert code to Jimple
  */
-private fun runSoot(buildDir: Path, classpath: String?) {
+private fun initSoot(buildDir: Path, classpath: String?) {
     G.reset()
     val options = Options.v()
 

--- a/utbot-framework/src/main/kotlin/org/utbot/tests/infrastructure/TestSpecificTestCaseGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/tests/infrastructure/TestSpecificTestCaseGenerator.kt
@@ -31,7 +31,7 @@ class TestSpecificTestCaseGenerator(
     dependencyPaths: String,
     engineActions: MutableList<(UtBotSymbolicEngine) -> Unit> = mutableListOf(),
     isCanceled: () -> Boolean = { false },
-): TestCaseGenerator(buildDir, classpath, dependencyPaths, engineActions, isCanceled) {
+): TestCaseGenerator(buildDir, classpath, dependencyPaths, engineActions, isCanceled, forceSootReload = false) {
 
     private val logger = KotlinLogging.logger {}
 


### PR DESCRIPTION
# Description

- Add option to reinitialize Soot even if the buildDir is the same. This allows us to reinitialize Soot when the source code is modified.

Fixes #849

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

**To reproduce** section from #849 passes.

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] No new warnings
- [x] All tests pass locally with my changes
