### PR TITLE
Replace `disableSandbox` with `useSandbox` in `UtSettings`

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -374,10 +374,15 @@ object UtSettings : AbstractSettings(
     var ignoreStaticsFromTrustedLibraries by getBooleanProperty(true)
 
     /**
-     * Disable sandbox in the concrete executor. All unsafe/dangerous calls will be permitted.
+     * Use the sandbox in the concrete executor.
+     *
+     * If true (default), the sandbox will prevent potentially dangerous calls, e.g., file access, reading
+     * or modifying the environment, calls to `Unsafe` methods etc.
+     *
+     * If false, all these operations will be enabled and may lead to data loss during code analysis
+     * and test generation.
      */
-    var disableSandbox by getBooleanProperty(false)
-
+    var useSandbox by getBooleanProperty(true)
 }
 
 /**

--- a/utbot-framework-api/src/main/kotlin/org/utbot/testcheckers/SettingsModificators.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/testcheckers/SettingsModificators.kt
@@ -113,11 +113,11 @@ inline fun <reified T> withoutConcrete(block: () -> T): T {
  * Run [block] with disabled sandbox in the concrete executor
  */
 inline fun <reified T> withoutSandbox(block: () -> T): T {
-    val prev = UtSettings.disableSandbox
-    UtSettings.disableSandbox = true
+    val prev = UtSettings.useSandbox
+    UtSettings.useSandbox = false
     try {
         return block()
     } finally {
-        UtSettings.disableSandbox = prev
+        UtSettings.useSandbox = prev
     }
 }

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/process/ChildProcessRunner.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/process/ChildProcessRunner.kt
@@ -51,7 +51,7 @@ class ChildProcessRunner {
         val directory = WorkingDirService.provide().toFile()
         val commandsWithOptions = buildList {
             addAll(cmds)
-            if (UtSettings.disableSandbox) {
+            if (!UtSettings.useSandbox) {
                 add(DISABLE_SANDBOX_OPTION)
             }
             add(portArgument)


### PR DESCRIPTION
# Description

PR #797 introduced a new `UtSettings` option, `disableSandbox` (see #785 for motivation). Although `disableSandbox` is a descriptive name, the inverted logic makes it harder to use and does not match the naming of other settings.

This PR removes the `disableSandbox` setting and replaces it with `useSandbox` option (`true` by default).

## Type of Change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

Existing `UtSettings` option is removed. This change may require users to update their `.utbot/settings.properties` to keep the old behavior.

# How Has This Been Tested?

## Automated Testing

All existing unit tests should pass. Informative are tests that use `withoutSandbox` construct:
  * `org.utbot.examples.unsafe.UnsafeOperationsTest`
  * `org.utbot.examples.exceptions.JvmCrashExamplesTest#testCrash`

## Manual Scenario 

Generate a test suite for any Java code that accesses files or environment. An example:

```
package unsafe;

public class EnvironmentExample {
    public String getJavaVersion() {
        return System.getProperty("java.version");
    }
}
```

Concrete execution should be enabled.

if `UtSettings.useSandbox` is set to `false`, a test case corresponding to a successful execution should be generated:
```
package unsafe;

import org.junit.Test;

import static org.junit.Assert.assertEquals;

public class EnvironmentExampleTest {
    ///region Test suites for executable unsafe.EnvironmentExample.getJavaVersion

    ///region

    @Test
    public void testGetJavaVersion() {
        EnvironmentExample environmentExample = new EnvironmentExample();

        String actual = environmentExample.getJavaVersion();

        String expected = "1.8.0_332";
        assertEquals(expected, actual);
    }
    ///endregion

    ///endregion
}
```

If `UtSettings.useSandbox` is `true` (including the case when it is not specified in `.utbot/settings.properties` at all, so the default value is used), a disabled test should be generated:
```
package unsafe;

import org.junit.Ignore;
import org.junit.Test;

public class EnvironmentExampleTest {
    ///region Test suites for executable unsafe.EnvironmentExample.getJavaVersion

    ///region

    @Test
    @Ignore(value = "Disabled due to sandbox")
    public void testGetJavaVersion() {
        EnvironmentExample environmentExample = new EnvironmentExample();
        
        /* This test fails because method [unsafe.EnvironmentExample.getJavaVersion] produces [java.security.AccessControlException: access denied ("java.util.PropertyPermission" "java.version" "read")]
            java.security.AccessControlContext.checkPermission(AccessControlContext.java:472)
            java.security.AccessController.checkPermission(AccessController.java:886)
            java.lang.SecurityManager.checkPermission(SecurityManager.java:549)
            java.lang.SecurityManager.checkPropertyAccess(SecurityManager.java:1294)
            java.lang.System.getProperty(System.java:719)
            unsafe.EnvironmentExample.getJavaVersion(EnvironmentExample.java:5) */
    }
    ///endregion

    ///endregion
}
```

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [X] The change followed the style guidelines of the UTBot project
- [X] Self-review of the code is passed
- [X] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [X] No new warnings
- [ ] New tests have been added
- [X] All tests pass locally with my changes
