### PR TITLE
Do not generate JavaDocs for empty comments #280

### DIFF
--- a/utbot-summary/src/main/kotlin/org/utbot/summary/comment/SimpleClusterCommentBuilder.kt
+++ b/utbot-summary/src/main/kotlin/org/utbot/summary/comment/SimpleClusterCommentBuilder.kt
@@ -33,9 +33,11 @@ class SimpleClusterCommentBuilder(
         skippedIterations()
         buildSentenceBlock(traceTag.rootStatementTag, root, currentMethod)
         var sentence = toSentence(root)
+
         if (sentence.isEmpty()) {
-            return genWarnNotification()
+            return EMPTY_STRING
         }
+
         sentence = splitLongSentence(sentence)
         sentence = lastCommaToDot(sentence)
 
@@ -50,7 +52,7 @@ class SimpleClusterCommentBuilder(
         val sentence = toDocStmts(root)
 
         if (sentence.isEmpty()) {
-            return listOf(DocRegularStmt(genWarnNotification())) //TODO SAT-1310
+            return emptyList()
         }
 //        sentence = splitLongSentence(sentence) //TODO SAT-1309
 //        sentence = lastCommaToDot(sentence) //TODO SAT-1309

--- a/utbot-summary/src/main/kotlin/org/utbot/summary/comment/SimpleCommentBuilder.kt
+++ b/utbot-summary/src/main/kotlin/org/utbot/summary/comment/SimpleCommentBuilder.kt
@@ -29,6 +29,7 @@ import soot.jimple.internal.JInvokeStmt
 import soot.jimple.internal.JVirtualInvokeExpr
 
 private const val JVM_CRASH_REASON = "JVM crash"
+const val EMPTY_STRING = ""
 
 open class SimpleCommentBuilder(
     traceTag: TraceTagWithoutExecution,
@@ -46,7 +47,11 @@ open class SimpleCommentBuilder(
         skippedIterations()
         buildSentenceBlock(traceTag.rootStatementTag, root, currentMethod)
         var sentence = toSentence(root)
-        if (sentence.isEmpty()) return genWarnNotification()
+
+        if (sentence.isEmpty()) {
+            return EMPTY_STRING
+        }
+
         sentence = splitLongSentence(sentence)
         sentence = lastCommaToDot(sentence)
 
@@ -72,7 +77,7 @@ open class SimpleCommentBuilder(
         val docStmts = toDocStmts(sentenceBlock)
 
         if (docStmts.isEmpty()) {
-            return listOf(DocRegularStmt(genWarnNotification())) //TODO SAT-1310
+            return emptyList()
         }
 //        sentence = splitLongSentence(sentence) //TODO SAT-1309
 //        sentence = lastCommaToDot(sentence) //TODO SAT-1309
@@ -87,8 +92,6 @@ open class SimpleCommentBuilder(
         buildSentenceBlock(traceTag.rootStatementTag, rootSentenceBlock, currentMethod)
         return rootSentenceBlock
     }
-
-    protected fun genWarnNotification(): String = " " //why is it empty?
 
     /**
      * Transforms rootSentenceBlock into String

--- a/utbot-summary/src/test/kotlin/org/utbot/summary/comment/SimpleClusterCommentBuilderTest.kt
+++ b/utbot-summary/src/test/kotlin/org/utbot/summary/comment/SimpleClusterCommentBuilderTest.kt
@@ -15,6 +15,8 @@ import soot.SootMethod
 import soot.jimple.Stmt
 import soot.jimple.internal.JReturnStmt
 
+private const val EMPTY_STRING = ""
+
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class SimpleClusterCommentBuilderTest {
     private lateinit var traceTag: TraceTag
@@ -48,7 +50,7 @@ class SimpleClusterCommentBuilderTest {
     fun `builds empty comment if execution result is null`() {
         val commentBuilder = SimpleClusterCommentBuilder(traceTag, sootToAst)
         val comment = commentBuilder.buildString(sootMethod)
-        assertEquals("", comment)
+        assertEquals(EMPTY_STRING, comment)
     }
 
     @Test
@@ -57,5 +59,4 @@ class SimpleClusterCommentBuilderTest {
         val statements = commentBuilder.buildDocStmts(sootMethod)
         assertEquals(statements.size, 0)
     }
-
 }

--- a/utbot-summary/src/test/kotlin/org/utbot/summary/comment/SimpleClusterCommentBuilderTest.kt
+++ b/utbot-summary/src/test/kotlin/org/utbot/summary/comment/SimpleClusterCommentBuilderTest.kt
@@ -48,15 +48,14 @@ class SimpleClusterCommentBuilderTest {
     fun `builds empty comment if execution result is null`() {
         val commentBuilder = SimpleClusterCommentBuilder(traceTag, sootToAst)
         val comment = commentBuilder.buildString(sootMethod)
-        assertEquals(" ", comment)
+        assertEquals("", comment)
     }
 
     @Test
-    fun `builds empty doc statement if execution result is null`() {
+    fun `does not build any statements for javadoc if execution result is null`() {
         val commentBuilder = SimpleClusterCommentBuilder(traceTag, sootToAst)
         val statements = commentBuilder.buildDocStmts(sootMethod)
-        assertEquals(statements.size, 1)
-        assertEquals(statements[0].toString(), " ")
+        assertEquals(statements.size, 0)
     }
 
 }


### PR DESCRIPTION
# Description

Do not generate JavaDocs for empty comments. 
Fixes #280

## Type of Change

Please delete options that are not relevant.

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Automated Testing

Run tests in summary-tests module.

## Manual Scenario 
Run it on the example provided in the issue #280

# Checklist (remove irrelevant options):

- [ ] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [ ] No new warnings
- [ ] New tests have been added
- [x] All tests pass locally with my changes
