### PR TITLE
Enable utbot-maven module #867

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -26,7 +26,7 @@ include 'utbot-instrumentation-tests'
 
 include 'utbot-summary'
 include 'utbot-gradle'
-//include 'utbot-maven'
+include 'utbot-maven'
 include 'utbot-summary-tests'
 include 'utbot-framework-test'
 include 'utbot-rd'

--- a/utbot-gradle/docs/utbot-gradle.md
+++ b/utbot-gradle/docs/utbot-gradle.md
@@ -234,4 +234,4 @@ Please note that the maximum archive size for publishing on the Gradle Plugin Po
 
 ### Requirements
 
-UTBot gradle plugin requires Gradle 6.8+
+UTBot gradle plugin requires Gradle 7.4.2+

--- a/utbot-gradle/src/main/kotlin/org/utbot/gradle/plugin/GenerateTestsAndSarifReportTask.kt
+++ b/utbot-gradle/src/main/kotlin/org/utbot/gradle/plugin/GenerateTestsAndSarifReportTask.kt
@@ -64,7 +64,8 @@ open class GenerateTestsAndSarifReportTask @Inject constructor(
     private val logger: KLogger = org.utbot.gradle.plugin.logger
 
     private val dependencyPaths by lazy {
-        val thisClassLoader = this::class.java.classLoader as URLClassLoader
+        val thisClassLoader = this::class.java.classLoader as? URLClassLoader
+            ?: return@lazy System.getProperty("java.class.path")
         thisClassLoader.urLs.joinToString(File.pathSeparator) { it.path }
     }
 

--- a/utbot-maven/build.gradle
+++ b/utbot-maven/build.gradle
@@ -1,17 +1,12 @@
-//noinspection GroovyAssignabilityCheck
-plugins {
-    id 'maven-publish'
-}
+//file:noinspection GroovyAssignabilityCheck
 
 apply from: "${parent.projectDir}/gradle/include/jvm-project.gradle"
 
-//noinspection GroovyAssignabilityCheck
 configurations {
-    mavenEmbedder // it is used to run maven tasks from gradle
+    mavenEmbedder // maven embeddable component, with CLI and logging support
 }
 
 dependencies {
-    // `compile` because `api` dependencies are not included in pom.xml by `install` task
     implementation project(':utbot-framework')
 
     implementation "org.apache.maven:maven-core:$maven_plugin_api_version"
@@ -35,73 +30,36 @@ dependencies {
 
 /**
  * We should run the maven task `install` to build & publish this plugin.
- * But `utbot-maven` is the Gradle module (not Maven), so we have to
- * manually generate the pom.xml file and the plugin descriptor file.
+ * But `utbot-maven` is the Gradle module (not Maven), so there is no `install` task
+ * and we have to manually generate the pom.xml file and the plugin descriptor file.
+ *
+ * The pom.xml file is in the src/main/resources.
+ * It should contain all the information needed at runtime.
+ *
+ * The plugin descriptor file is generated automatically by [generatePluginDescriptor].
  */
 
-def buildDirectory = buildDir.canonicalPath
-def outputDirectory = compileKotlin.destinationDir.canonicalPath
-def pomFile = new File("$buildDir/pom.xml")
-def pluginDescriptorFile = new File(outputDirectory, 'META-INF/maven/plugin.xml')
-
-/**
- * Generates the pom.xml file and saves it to the [pomFile].
- */
-task generatePomFile(dependsOn: compileKotlin) {
-    outputs.file pomFile
-
-    doLast {
-        install.repositories.mavenInstaller.pom.with {
-            groupId = project.group
-            artifactId = project.name
-            version = project.version
-            packaging = 'maven-plugin'
-
-            withXml {
-                asNode().with {
-                    appendNode('build').with {
-                        appendNode('directory', buildDirectory)
-                        appendNode('outputDirectory', outputDirectory)
-                    }
-                    def repositoriesNode = appendNode('repositories')
-                    // `this.project` is the project from Gradle, but `project` is the project from Maven
-                    this.project.repositories.indexed().forEach { index, repository ->
-                        repositoriesNode.with {
-                            appendNode('repository').with {
-                                // `index` is needed for the uniqueness of the IDs
-                                appendNode('id', "${repository.name}_${index}")
-                                appendNode('url', repository.url)
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        install.repositories.mavenInstaller.pom.writeTo(pomFile)
-
-        assert pomFile.file, "${pomFile.canonicalPath}: was not generated"
-        logger.info("POM is generated in ${pomFile.canonicalPath}")
-    }
-}
+def pomFile = file("./src/main/resources/pom.xml")
+def outputDirectory = project.buildDir.toPath().resolve("classes/kotlin/main")
+def pluginDescriptorFile = new File("$outputDirectory/META-INF/maven/plugin.xml")
 
 /**
  * Generates the plugin descriptor file and saves it to the [pluginDescriptorFile].
  */
-task generatePluginDescriptor(type: JavaExec, dependsOn: generatePomFile) {
+task generatePluginDescriptor(type: JavaExec, dependsOn: compileKotlin) {
     inputs.files project.compileKotlin.outputs.files
     outputs.file pluginDescriptorFile
 
     workingDir projectDir
-    mainClass.set('org.apache.maven.cli.MavenCli')
     classpath = configurations.mavenEmbedder
-    //noinspection GroovyAssignabilityCheck
+    mainClass.set('org.apache.maven.cli.MavenCli')
     systemProperties['maven.multiModuleProjectDirectory'] = projectDir
     args = [
-            '--errors',
-            '--batch-mode',
-            '--file', "${pomFile.path}",
-            'org.apache.maven.plugins:maven-plugin-plugin:3.6.0:descriptor',
-            '-Dproject.build.sourceEncoding=UTF-8'
+        '--errors',
+        '--batch-mode',
+        '--file', "${pomFile.path}",
+        'org.apache.maven.plugins:maven-plugin-plugin:3.6.0:descriptor',
+        '-Dproject.build.sourceEncoding=UTF-8'
     ]
 
     doLast {
@@ -110,6 +68,44 @@ task generatePluginDescriptor(type: JavaExec, dependsOn: generatePomFile) {
     }
 }
 
-project.publishToMavenLocal.dependsOn(generatePluginDescriptor)
+publishing {
+    publications {
+        pluginMaven(MavenPublication) {
+            from components.java
+        }
+    }
+}
 
-// Please, use `utbot-maven/other/install` task for publishing
+/**
+ * `publishToMavenLocal` task generates pom.xml file, but that's not what we need.
+ * Therefore, we have to override the generated file with our own, stored in resources.
+ */
+generatePomFileForPluginMavenPublication.doLast {
+    def ourOwnPomXml = new XmlParser().parse(pomFile)
+    def generatedPomFile = new File("./build/publications/pluginMaven/pom-default.xml")
+    def printer = new XmlNodePrinter(new PrintWriter(new FileWriter(generatedPomFile)))
+    printer.with {
+        // pretty print
+        preserveWhitespace = true
+        expandEmptyElements = true
+    }
+    printer.print(ourOwnPomXml)
+}
+
+// the plugin jar file should contain the plugin descriptor file
+jar.dependsOn generatePluginDescriptor
+
+generatePluginDescriptor.dependsOn([
+    project(':utbot-api'),
+    project(':utbot-core'),
+    project(':utbot-instrumentation'),
+    project(':utbot-framework'),
+    project(':utbot-framework-api'),
+    project(':utbot-fuzzers'),
+    project(':utbot-rd'),
+    project(':utbot-summary')
+]*.tasks.publishToMavenLocal)
+
+inspectClassesForKotlinIC.enabled = false
+publishJarPublicationToMavenLocal.enabled = false
+publishPluginMavenPublicationToMavenLocal.enabled = true

--- a/utbot-maven/docs/utbot-maven.md
+++ b/utbot-maven/docs/utbot-maven.md
@@ -135,8 +135,8 @@ For example, the following configuration may be used:
 
 If you want to change the source code of the plugin or even the whole utbot-project,
 you need to do the following:
-- Publish UTBot to the local maven repository using `utbot/publishToMavenLocal` gradle task.
-- Publish `utbot-maven` to the local maven repository using `utbot-maven/other/install` gradle task.
+- Publish plugin to the local maven repository:  
+  `utbot-maven/publishing/publishToMavenLocal`
 - Add the plugin to your project (see the section __How to use__).
 
 ### How to configure the log level

--- a/utbot-maven/src/main/kotlin/org/utbot/maven/plugin/GenerateTestsAndSarifReportMojo.kt
+++ b/utbot-maven/src/main/kotlin/org/utbot/maven/plugin/GenerateTestsAndSarifReportMojo.kt
@@ -139,7 +139,8 @@ class GenerateTestsAndSarifReportMojo : AbstractMojo() {
     lateinit var rootMavenProjectWrapper: MavenProjectWrapper
 
     private val dependencyPaths by lazy {
-        val thisClassLoader = this::class.java.classLoader as URLClassLoader
+        val thisClassLoader = this::class.java.classLoader as? URLClassLoader
+            ?: return@lazy System.getProperty("java.class.path")
         thisClassLoader.urLs.joinToString(File.pathSeparator) { it.path }
     }
 

--- a/utbot-maven/src/main/resources/pom.xml
+++ b/utbot-maven/src/main/resources/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.utbot</groupId>
+    <artifactId>utbot-maven</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>maven-plugin</packaging>
+
+    <build>
+        <!-- paths relative to src/main/resources -->
+        <directory>../../../build</directory>
+        <outputDirectory>../../../build/classes/kotlin/main</outputDirectory>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.utbot</groupId>
+            <artifactId>utbot-framework</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+    </repositories>
+</project>


### PR DESCRIPTION
# Description

- Fixed and enabled the `utbot-maven` module
- Fixed documentation for Maven and Gradle plugins

Fixes #867

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

- `org.utbot.maven.plugin`
- `org.utbot.gradle.plugin`

## Manual Scenario 

Publish both plugins to the maven local repository and try to use them on any projects

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [ ] No new warnings
- [x] New tests have been added
- [x] All tests pass locally with my changes
