### PR TITLE
Fix incorrect highlighting of the method call in sarif (#536)

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/sarif/SarifReportTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/sarif/SarifReportTest.kt
@@ -159,7 +159,7 @@ class SarifReportTest {
             it.location.physicalLocation
         }
         assert(codeFlowPhysicalLocations[0].artifactLocation.uri.contains("MainTest.java"))
-        assert(codeFlowPhysicalLocations[0].region.startLine == 3)
+        assert(codeFlowPhysicalLocations[0].region.startLine == 5)
         assert(codeFlowPhysicalLocations[0].region.startColumn == 7)
     }
 
@@ -183,7 +183,7 @@ class SarifReportTest {
             it.location.physicalLocation
         }
         assert(codeFlowPhysicalLocations[0].artifactLocation.uri.contains("MainTest.java"))
-        assert(codeFlowPhysicalLocations[0].region.startLine == 4)
+        assert(codeFlowPhysicalLocations[0].region.startLine == 6)
         assert(codeFlowPhysicalLocations[0].region.startColumn == 5)
     }
 
@@ -330,6 +330,8 @@ class SarifReportTest {
 
     private val generatedTestsCodeMain = """
         public void testMain_ThrowArithmeticException() {
+            /* This test fails because method [Main.main] produces [java.lang.ArithmeticException: / by zero]
+                Main.main(Main.java:15) */
             Main main = new Main();
               main.main(0); // shift for `startColumn` == 7
         }
@@ -337,6 +339,8 @@ class SarifReportTest {
 
     private val generatedTestsCodePrivateMain = """
         public void testMain_ThrowArithmeticException() {
+            /* This test fails because method [Main.main] produces [java.lang.ArithmeticException: / by zero]
+                Main.main(Main.java:15) */
             Main main = new Main();
             // ...
             mainMethod.invoke(main, mainMethodArguments);


### PR DESCRIPTION
# Description

Fixed bug with incorrect highlighting of the method call in the SARIF report.

Fixes #536

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

`org.utbot.sarif.SarifReportTest`

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] New tests have been added
- [x] All tests pass locally with my changes
