### PR TITLE
Fix fuzzing enum in recursion

### DIFF
--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/ObjectModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/ObjectModelProvider.kt
@@ -22,6 +22,7 @@ import java.lang.reflect.Field
 import java.lang.reflect.Member
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier.*
+import org.utbot.framework.plugin.api.util.isEnum
 
 /**
  * Creates [UtAssembleModel] for objects which have public constructors
@@ -42,7 +43,7 @@ class ObjectModelProvider(
         description: FuzzedMethodDescription,
         classId: ClassId
     ): List<ModelConstructor> {
-        if (classId == stringClassId || classId.isPrimitiveWrapper)
+        if (classId == stringClassId || classId.isPrimitiveWrapper || classId.isEnum)
             return listOf()
 
         val constructors = collectConstructors(classId) { javaConstructor ->

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/ObjectModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/ObjectModelProvider.kt
@@ -43,7 +43,7 @@ class ObjectModelProvider(
         description: FuzzedMethodDescription,
         classId: ClassId
     ): List<ModelConstructor> {
-        if (classId == stringClassId || classId.isPrimitiveWrapper || classId.isEnum)
+        if (classId == stringClassId || classId.isPrimitiveWrapper || classId.isEnum || classId.isAbstract)
             return listOf()
 
         val constructors = collectConstructors(classId) { javaConstructor ->


### PR DESCRIPTION
# Description

Fuzzing generates wrong AssembleModels with enums as parameter. I just exclude constructors of enums.

Fixes #619 

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

Described in issue #619 

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [x] All tests pass locally with my changes
