### PR TITLE
Fix empty else-branch in parameterized test generation

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/Domain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/Domain.kt
@@ -219,6 +219,8 @@ sealed class TestFramework(
 
     val assertNull by lazy { assertionId("assertNull", objectClassId) }
 
+    val assertNotNull by lazy { assertionId("assertNotNull", objectClassId) }
+
     val assertFalse by lazy { assertionId("assertFalse", booleanClassId) }
 
     val assertTrue by lazy { assertionId("assertTrue", booleanClassId) }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/TestFrameworkManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/TestFrameworkManager.kt
@@ -60,6 +60,7 @@ internal abstract class TestFrameworkManager(val context: CgContext)
     val assertDoubleEquals = context.testFramework.assertDoubleEquals
 
     val assertNull = context.testFramework.assertNull
+    val assertNotNull = context.testFramework.assertNotNull
     val assertTrue = context.testFramework.assertTrue
     val assertFalse = context.testFramework.assertFalse
 


### PR DESCRIPTION
# Description

This PR fixes empty else-branch by adding extra assertion for *actual*.

Fixes # ([518](https://github.com/UnitTestBot/UTBotJava/issues/518))

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

Run utbot-samples pipeline.

## Manual Scenario 

Run parameterized test generation for *streamOf* method in *runIde*. Verify that there are assertions. And generated test looks like this:
![image](https://user-images.githubusercontent.com/54685068/189666083-ce5322bc-3b97-4c0c-9e24-0edea6e1d1d1.png)
