### PR TITLE
No true branch test is generated for code with String.split(";\\s") #885

### DIFF
--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/RegexModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/RegexModelProvider.kt
@@ -56,9 +56,10 @@ object RegexModelProvider : ModelProvider {
 
     private fun FuzzedContext.isPatterMatchingContext(): Boolean {
         if (this !is FuzzedContext.Call) return false
+        val stringMethodWithRegexArguments = setOf("matches", "split")
         return when {
             method.classId == Pattern::class.java.id -> true
-            method.classId == String::class.java.id && method.name == "matches" -> true
+            method.classId == String::class.java.id && stringMethodWithRegexArguments.contains(method.name) -> true
             else -> false
         }
     }


### PR DESCRIPTION
# Description

RegexModelProvider now recognize argument of method "String.split" call as a pattern to produce initial string from regex.

Fixes #885

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

## Manual Scenario 

Try to generate test as in #885 

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
