### PR TITLE
Add build number to the published plugin

### DIFF
--- a/.github/workflows/publish-plugin-and-cli-from-branch.yml
+++ b/.github/workflows/publish-plugin-and-cli-from-branch.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           # "You can make an environment variable available to any subsequent steps in a workflow job by 
           # defining or updating the environment variable and writing this to the GITHUB_ENV environment file."
-          echo "VERSION="$(date +%Y).$(date +%-m)"" >> $GITHUB_ENV
+          echo "VERSION="$(date +%Y).$(date +%-m).${GITHUB_RUN_NUMBER}"" >> $GITHUB_ENV
           echo "POSTFIX=${{ github.event.inputs.version-postfix }}" >> $GITHUB_ENV
           
       - name: Create version with postfix


### PR DESCRIPTION
# Description

Suggestion to add build number - run number of the workflow - to the published plugin and cli.
Thus generated file name will be unique.

## Type of Change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Checked here that [such version name is accepted by MarketPlace](https://plugins.jetbrains.com/docs/marketplace/semver.html)

## Manual Scenario 

- [ ] Actions -> [M] Plugin and CLI: publish as archives
- [ ] Run workflow -> main, no-postfix
- [ ] Open when finished and check generated artifacts names
- [ ] Do same for some other branch with some postfix

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
