### PR TITLE
Concrete executor logs

### DIFF
--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/agent/DynamicClassTransformer.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/agent/DynamicClassTransformer.kt
@@ -2,6 +2,8 @@ package org.utbot.instrumentation.agent
 
 import org.utbot.common.asPathToFile
 import org.utbot.framework.plugin.api.util.UtContext
+import org.utbot.instrumentation.process.logError
+import org.utbot.instrumentation.process.logInfo
 import java.lang.instrument.ClassFileTransformer
 import java.security.ProtectionDomain
 
@@ -30,13 +32,13 @@ class DynamicClassTransformer : ClassFileTransformer {
             return if (pathToClassfile in pathsToUserClasses ||
                 packsToAlwaysTransform.any(className::startsWith)
             ) {
-                System.err.println("Transforming: $className")
+                logInfo { "Transforming: $className" }
                 transformer.transform(loader, className, classBeingRedefined, protectionDomain, classfileBuffer)
             } else {
                 null
             }
         } catch (e: Throwable) {
-            System.err.println("Error while transforming: ${e.stackTraceToString()}")
+            logError { "Error while transforming: ${e.stackTraceToString()}" }
             throw e
         } finally {
             UtContext.currentContext()?.stopWatch?.start()

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/et/TraceHandler.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/et/TraceHandler.kt
@@ -9,6 +9,7 @@ import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.Opcodes
 import org.objectweb.asm.Type
 import org.objectweb.asm.commons.LocalVariablesSorter
+import org.utbot.instrumentation.process.logError
 
 sealed class InstructionData {
     abstract val line: Int
@@ -111,6 +112,8 @@ class ProcessingStorage {
  * Storage to which instrumented classes will write execution data.
  */
 object RuntimeTraceStorage {
+    internal var alreadyLoggedIncreaseStackSizeTip = false
+
     /**
      * Contains ids of instructions in the order of execution.
      */
@@ -151,7 +154,11 @@ object RuntimeTraceStorage {
             this.`$__trace__`[current] = id
             this.`$__counter__` = current + 1
         } else {
-            System.err.println("Stack overflow (increase stack size Settings.TRACE_ARRAY_SIZE)")
+            val loggedTip = alreadyLoggedIncreaseStackSizeTip
+            if (!loggedTip) {
+                alreadyLoggedIncreaseStackSizeTip = true
+                logError { "Stack overflow (increase stack size Settings.TRACE_ARRAY_SIZE)" }
+            }
         }
     }
 }
@@ -289,5 +296,6 @@ class TraceHandler {
     fun resetTrace() {
         instructionsList = null
         RuntimeTraceStorage.`$__counter__` = 0
+        RuntimeTraceStorage.alreadyLoggedIncreaseStackSizeTip = false
     }
 }


### PR DESCRIPTION
# Description

Fixes #870
Moved logs in `RuntimeTraceStorage` and `DynamicClassTransformer` to ChildProcess.kt logging system

## Type of Change

- Bug fix (non-breaking change which fixes an issue)