### PR TITLE
Add JavaDoc comment style setting #774

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -155,7 +155,7 @@ object UtSettings : AbstractSettings(
     /**
      * Generate summaries using plugin's custom JavaDoc tags.
      */
-    var useCustomJavaDocTags by getBooleanProperty(false)
+    var useCustomJavaDocTags by getBooleanProperty(true)
 
     /**
      * Enable the machine learning module to generate summaries for methods under test.

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -1167,6 +1167,27 @@ enum class TreatOverflowAsError(
     }
 }
 
+enum class JavaDocCommentStyle(
+    override val displayName: String,
+    override val description: String
+) : CodeGenerationSettingItem {
+    CUSTOM_JAVADOC_TAGS(
+        displayName = "Structured via JavaDoc tags",
+        description = "Uses custom JavaDoc tags to describe test's execution path."
+    ),
+    FULL_SENTENCE_WRITTEN(
+        displayName = "Full sentence written",
+        description = "Describes test's execution path using full sentences."
+    );
+
+    override fun toString(): String = displayName
+
+    companion object : CodeGenerationSettingBox {
+        override val defaultItem = if (UtSettings.useCustomJavaDocTags) CUSTOM_JAVADOC_TAGS else FULL_SENTENCE_WRITTEN
+        override val allItems = JavaDocCommentStyle.values().toList()
+    }
+}
+
 enum class MockFramework(
     override val displayName: String,
     override val description: String = "Use $displayName as mock framework",

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -1172,12 +1172,12 @@ enum class JavaDocCommentStyle(
     override val description: String
 ) : CodeGenerationSettingItem {
     CUSTOM_JAVADOC_TAGS(
-        displayName = "Structured via JavaDoc tags",
-        description = "Uses custom JavaDoc tags to describe test's execution path."
+        displayName = "Structured via custom Javadoc tags",
+        description = "Uses custom Javadoc tags to describe test's execution path."
     ),
     FULL_SENTENCE_WRITTEN(
-        displayName = "Full sentence written",
-        description = "Describes test's execution path using full sentences."
+        displayName = "Plain text",
+        description = "Uses plain text to describe test's execution path."
     );
 
     override fun toString(): String = displayName

--- a/utbot-framework/src/main/kotlin/org/utbot/tests/infrastructure/UtValueTestCaseChecker.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/tests/infrastructure/UtValueTestCaseChecker.kt
@@ -87,6 +87,7 @@ abstract class UtValueTestCaseChecker(
         UtSettings.useAssembleModelGenerator = true
         UtSettings.saveRemainingStatesForConcreteExecution = false
         UtSettings.useFuzzing = false
+        UtSettings.useCustomJavaDocTags = false
     }
 
     // checks paramsBefore and result

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -54,6 +54,7 @@ import java.util.concurrent.TimeUnit
 import org.utbot.engine.util.mockListeners.ForceStaticMockListener
 import org.utbot.framework.PathSelectorType
 import org.utbot.framework.plugin.api.ExecutableId
+import org.utbot.framework.plugin.api.JavaDocCommentStyle
 import org.utbot.framework.plugin.api.util.executableId
 import org.utbot.framework.plugin.services.WorkingDirService
 import org.utbot.intellij.plugin.models.packageName
@@ -196,6 +197,8 @@ object UtTestsDialogProcessor {
 
                                 // set timeout for concrete execution and for generated tests
                                 UtSettings.concreteExecutionTimeoutInChildProcess = model.hangingTestsTimeout.timeoutMs
+
+                                UtSettings.useCustomJavaDocTags = model.commentStyle == JavaDocCommentStyle.CUSTOM_JAVADOC_TAGS
 
                                 val searchDirectory = ReadAction
                                     .nonBlocking<Path> {

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/GenerateTestsModel.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/GenerateTestsModel.kt
@@ -19,6 +19,7 @@ import com.intellij.openapi.vfs.newvfs.impl.FakeVirtualFile
 import com.intellij.psi.PsiClass
 import com.intellij.refactoring.util.classMembers.MemberInfo
 import org.jetbrains.kotlin.idea.core.getPackage
+import org.utbot.framework.plugin.api.JavaDocCommentStyle
 import org.utbot.framework.util.ConflictTriggers
 import org.utbot.intellij.plugin.ui.utils.jdkVersion
 
@@ -65,6 +66,7 @@ data class GenerateTestsModel(
     lateinit var hangingTestsTimeout: HangingTestsTimeout
     lateinit var forceStaticMocking: ForceStaticMocking
     lateinit var chosenClassesToMockAlways: Set<ClassId>
+    lateinit var commentStyle: JavaDocCommentStyle
 
     val conflictTriggers: ConflictTriggers = ConflictTriggers()
 

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/Settings.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/Settings.kt
@@ -25,6 +25,7 @@ import org.utbot.framework.codegen.TestNg
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.CodeGenerationSettingItem
 import org.utbot.framework.plugin.api.CodegenLanguage
+import org.utbot.framework.plugin.api.JavaDocCommentStyle
 import org.utbot.framework.plugin.api.MockFramework
 import org.utbot.framework.plugin.api.MockStrategyApi
 import org.utbot.framework.plugin.api.TreatOverflowAsError
@@ -53,7 +54,8 @@ class Settings(val project: Project) : PersistentStateComponent<Settings.State> 
         var parametrizedTestSource: ParametrizedTestSource = ParametrizedTestSource.defaultItem,
         var classesToMockAlways: Array<String> = Mocker.defaultSuperClassesToMockAlwaysNames.toTypedArray(),
         var fuzzingValue: Double = 0.05,
-        var runGeneratedTestsWithCoverage : Boolean = false,
+        var runGeneratedTestsWithCoverage: Boolean = false,
+        var commentStyle: JavaDocCommentStyle = JavaDocCommentStyle.defaultItem
     ) {
         constructor(model: GenerateTestsModel) : this(
             codegenLanguage = model.codegenLanguage,
@@ -67,7 +69,8 @@ class Settings(val project: Project) : PersistentStateComponent<Settings.State> 
             parametrizedTestSource = model.parametrizedTestSource,
             classesToMockAlways = model.chosenClassesToMockAlways.mapTo(mutableSetOf()) { it.name }.toTypedArray(),
             fuzzingValue = model.fuzzingValue,
-            runGeneratedTestsWithCoverage = model.runGeneratedTestsWithCoverage
+            runGeneratedTestsWithCoverage = model.runGeneratedTestsWithCoverage,
+            commentStyle = model.commentStyle
         )
 
         override fun equals(other: Any?): Boolean {
@@ -137,6 +140,8 @@ class Settings(val project: Project) : PersistentStateComponent<Settings.State> 
 
     val classesToMockAlways: Set<String> get() = state.classesToMockAlways.toSet()
 
+    val javaDocCommentStyle: JavaDocCommentStyle get() = state.commentStyle
+
     var fuzzingValue: Double
         get() = state.fuzzingValue
         set(value) {
@@ -182,6 +187,7 @@ class Settings(val project: Project) : PersistentStateComponent<Settings.State> 
                 state.treatOverflowAsError = provider as TreatOverflowAsError
                 UtSettings.treatOverflowAsError = provider == TreatOverflowAsError.AS_ERROR
             }
+            JavaDocCommentStyle::class -> state.commentStyle = provider as JavaDocCommentStyle
             // TODO: add error processing
             else -> error("Unknown class [$loader] to map value [$provider]")
         }
@@ -196,6 +202,7 @@ class Settings(val project: Project) : PersistentStateComponent<Settings.State> 
             RuntimeExceptionTestsBehaviour::class -> runtimeExceptionTestsBehaviour
             ForceStaticMocking::class -> forceStaticMocking
             TreatOverflowAsError::class -> treatOverflowAsError
+            JavaDocCommentStyle::class -> javaDocCommentStyle
             // TODO: add error processing
             else -> error("Unknown service loader: $loader")
         }

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/SettingsWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/SettingsWindow.kt
@@ -39,7 +39,7 @@ class SettingsWindow(val project: Project) {
                 CodegenLanguage::class to "Generated test language:",
                 RuntimeExceptionTestsBehaviour::class to "Test with exceptions:",
                 TreatOverflowAsError::class to "Overflow detection:",
-                JavaDocCommentStyle::class to "JavaDoc comment style:"
+                JavaDocCommentStyle::class to "Javadoc comment style:"
             )
             val tooltipLabels = mapOf(
                 CodegenLanguage::class to "You can generate test methods in Java or Kotlin regardless of your source code language."

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/SettingsWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/SettingsWindow.kt
@@ -23,6 +23,7 @@ import org.utbot.framework.codegen.HangingTestsTimeout
 import org.utbot.framework.codegen.RuntimeExceptionTestsBehaviour
 import org.utbot.framework.plugin.api.CodeGenerationSettingItem
 import org.utbot.framework.plugin.api.CodegenLanguage
+import org.utbot.framework.plugin.api.JavaDocCommentStyle
 import org.utbot.framework.plugin.api.TreatOverflowAsError
 
 class SettingsWindow(val project: Project) {
@@ -38,6 +39,7 @@ class SettingsWindow(val project: Project) {
                 CodegenLanguage::class to "Generated test language:",
                 RuntimeExceptionTestsBehaviour::class to "Test with exceptions:",
                 TreatOverflowAsError::class to "Overflow detection:",
+                JavaDocCommentStyle::class to "JavaDoc comment style:"
             )
             val tooltipLabels = mapOf(
                 CodegenLanguage::class to "You can generate test methods in Java or Kotlin regardless of your source code language."
@@ -80,14 +82,14 @@ class SettingsWindow(val project: Project) {
                     }
             }
         }
+
         mapOf(
             RuntimeExceptionTestsBehaviour::class to RuntimeExceptionTestsBehaviour.values(),
-            TreatOverflowAsError::class to TreatOverflowAsError.values()
+            TreatOverflowAsError::class to TreatOverflowAsError.values(),
+            JavaDocCommentStyle::class to JavaDocCommentStyle.values()
         ).forEach { (loader, values) ->
             valuesComboBox(loader, values)
         }
-
-
 
         row {
             cell {

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -499,6 +499,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
             model.forceStaticMocking = forceStaticMocking
             model.chosenClassesToMockAlways = chosenClassesToMockAlways()
             model.fuzzingValue = fuzzingValue
+            model.commentStyle = javaDocCommentStyle
             UtSettings.treatOverflowAsError = treatOverflowAsError == TreatOverflowAsError.AS_ERROR
         }
 


### PR DESCRIPTION
# Description

Add **JavaDoc comment style** setting to the **Settings** window to provide users a possibility to choose comment style.

Fixes #774 

TODO: **Need** to discuss naming with @olganaumenko.

## Type of Change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Manual Scenario 

Run plugin, open the UTBot's **Settings** window (`File -> Settings -> UTBot`), click at the drop-down list **JavaDoc comment style**, choose any value and run test generation. Check if the comments match the selected style.

# Checklist (remove irrelevant options):

- [ ] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [ ] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
