### PR TITLE
Fixed wrong targets for virtual invokes

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/stream/BaseStreamExampleTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/stream/BaseStreamExampleTest.kt
@@ -343,14 +343,13 @@ class BaseStreamExampleTest : UtValueTestCaseChecker(
     }
 
     @Test
-    @Disabled("TODO unsat type constraints https://github.com/UnitTestBot/UTBotJava/issues/253")
     fun testCustomCollectionStreamExample() {
         check(
             BaseStreamExample::customCollectionStreamExample,
             ignoreExecutionsNumber,
             { c, r -> c.isEmpty() && r == 0L },
             { c, r -> c.isNotEmpty() && c.size.toLong() == r },
-            coverage = DoNotCalculate
+            coverage = DoNotCalculate // TODO failed coverage calculation
         )
     }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -2347,14 +2347,12 @@ class Traverser(
         // better than engine.
         val types = instanceOfConstraint?.typeStorage?.possibleConcreteTypes ?: instance.possibleConcreteTypes
 
-        val allConcreteInvocationTargets = findMethodInvocationTargets(types, methodSubSignature)
-        val libraryTargets = findLibraryTargets(instance.type, methodSubSignature)
+        val allPossibleConcreteTypes = typeRegistry.findInheritorsIncludingTypes(instance.type) { setOf(instance.type) }
 
-        // to choose only "good" targets take only library targets in case they present in all targets,
-        // otherwise take all targets
-        val methodInvocationTargets = libraryTargets?.takeIf {
-            allConcreteInvocationTargets.containsAll(it)
-        } ?: allConcreteInvocationTargets
+        val methodInvocationTargets = findLibraryTargets(instance.type, methodSubSignature)?.takeIf {
+            // we have no specified types, so we can take only library targets (if present) for optimization purposes
+            types.size == allPossibleConcreteTypes.size
+        } ?: findMethodInvocationTargets(types, methodSubSignature)
 
         return methodInvocationTargets
             .map { (method, implementationClass, possibleTypes) ->

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -2346,8 +2346,15 @@ class Traverser(
         // for objects (especially objects with type equals to type parameter of generic)
         // better than engine.
         val types = instanceOfConstraint?.typeStorage?.possibleConcreteTypes ?: instance.possibleConcreteTypes
-        val methodInvocationTargets = findLibraryTargets(instance.type, methodSubSignature)
-            ?: findMethodInvocationTargets(types, methodSubSignature)
+
+        val allConcreteInvocationTargets = findMethodInvocationTargets(types, methodSubSignature)
+        val libraryTargets = findLibraryTargets(instance.type, methodSubSignature)
+
+        // to choose only "good" targets take only library targets in case they present in all targets,
+        // otherwise take all targets
+        val methodInvocationTargets = libraryTargets?.takeIf {
+            allConcreteInvocationTargets.containsAll(it)
+        } ?: allConcreteInvocationTargets
 
         return methodInvocationTargets
             .map { (method, implementationClass, possibleTypes) ->

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -2347,7 +2347,9 @@ class Traverser(
         // better than engine.
         val types = instanceOfConstraint?.typeStorage?.possibleConcreteTypes ?: instance.possibleConcreteTypes
 
-        val allPossibleConcreteTypes = typeRegistry.findInheritorsIncludingTypes(instance.type) { setOf(instance.type) }
+        val allPossibleConcreteTypes = typeResolver
+            .constructTypeStorage(instance.type, useConcreteType = false)
+            .possibleConcreteTypes
 
         val methodInvocationTargets = findLibraryTargets(instance.type, methodSubSignature)?.takeIf {
             // we have no specified types, so we can take only library targets (if present) for optimization purposes

--- a/utbot-sample/src/main/java/org/utbot/examples/stream/BaseStreamExample.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/stream/BaseStreamExample.java
@@ -410,21 +410,16 @@ public class BaseStreamExample {
     }
 
     @SuppressWarnings({"ReplaceInefficientStreamCount", "ConstantConditions"})
+    // TODO wrong generic type for data field https://github.com/UnitTestBot/UTBotJava/issues/730
     long customCollectionStreamExample(CustomCollection<Integer> customCollection) {
         UtMock.assume(customCollection != null && customCollection.data != null);
 
+        final Stream<Integer> stream = customCollection.stream();
+
         if (customCollection.isEmpty()) {
-            return customCollection.stream().count();
-
-            // simplified example, does not generate branch too
-            /*customCollection.removeIf(Objects::isNull);
-            return customCollection.toArray().length;*/
+            return stream.count();
         } else {
-            return customCollection.stream().count();
-
-            // simplified example, does not generate branch too
-            /*customCollection.removeIf(Objects::isNull);
-            return customCollection.toArray().length;*/
+            return stream.count();
         }
     }
 


### PR DESCRIPTION
# Description

Fixed wrong targets for virtual invokes when we have a user class that implements an interface for that we have predefined library targets.

Fixes #253.

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

`org.utbot.examples.stream.BaseStreamExampleTest#testCustomCollectionStreamExample`

# Checklist :

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] All tests pass locally with my changes
