### PR TITLE
Get rid of "Android" plugin dependency #934

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/ModuleUtils.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/ModuleUtils.kt
@@ -1,6 +1,5 @@
 package org.utbot.intellij.plugin.ui.utils
 
-import com.android.tools.idea.gradle.project.GradleProjectInfo
 import org.utbot.common.PathUtil.toPath
 import org.utbot.common.WorkaroundReason
 import org.utbot.common.workaround
@@ -8,6 +7,8 @@ import org.utbot.framework.plugin.api.CodegenLanguage
 import org.utbot.intellij.plugin.ui.CommonErrorNotifier
 import org.utbot.intellij.plugin.ui.UnsupportedJdkNotifier
 import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.externalSystem.model.ProjectSystemId
+import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.module.ModuleUtilCore
@@ -147,8 +148,12 @@ private fun Module.suitableTestSourceFolders(codegenLanguage: CodegenLanguage): 
         // Heuristics: User is more likely to choose the shorter path
         .sortedBy { it.url.length }
 }
-val Project.isBuildWithGradle
-    get() = GradleProjectInfo.getInstance(this).isBuildWithGradle
+private val GRADLE_SYSTEM_ID = ProjectSystemId("GRADLE")
+
+val Project.isBuildWithGradle get() =
+         ModuleManager.getInstance(this).modules.any {
+             ExternalSystemApiUtil.isExternalSystemAwareModule(GRADLE_SYSTEM_ID, it)
+         }
 
 private const val dedicatedTestSourceRootName = "utbot_tests"
 fun Module.addDedicatedTestRoot(testSourceRoots: MutableList<VirtualFile>): VirtualFile? {

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/IntelliJApiHelper.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/IntelliJApiHelper.kt
@@ -1,12 +1,12 @@
 package org.utbot.intellij.plugin.util
 
-import com.android.tools.idea.IdeInfo
-import com.android.tools.idea.gradle.util.GradleProjectSettingsFinder
 import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
+import com.intellij.util.PlatformUtils
+import com.intellij.util.ReflectionUtil
 import com.intellij.util.concurrency.AppExecutorUtil
 import org.jetbrains.kotlin.idea.util.application.invokeLater
 import org.utbot.framework.plugin.api.util.UtContext
@@ -37,10 +37,19 @@ object IntelliJApiHelper {
     private val isAndroidPluginAvailable: Boolean = !PluginManagerCore.isDisabled(PluginId.getId("org.jetbrains.android"))
 
     fun isAndroidStudio(): Boolean =
-        isAndroidPluginAvailable && IdeInfo.getInstance().isAndroidStudio
+        isAndroidPluginAvailable && ("AndroidStudio" == PlatformUtils.getPlatformPrefix())
 
     fun androidGradleSDK(project: Project): String? {
-        return if (isAndroidPluginAvailable) GradleProjectSettingsFinder.getInstance().findGradleProjectSettings(project)?.gradleJvm
-                else null
+        if (!isAndroidPluginAvailable) return null
+        try {
+            val finderClass = Class.forName("com.android.tools.idea.gradle.util.GradleProjectSettingsFinder")
+            var method = ReflectionUtil.getMethod(finderClass, "findGradleProjectSettings", Project::class.java)?: return null
+            val gradleProjectSettings = method.invoke(project)?: return null
+            method = ReflectionUtil.getMethod(gradleProjectSettings.javaClass, "getGradleJvm")?: return null
+            val gradleJvm = method.invoke(gradleProjectSettings)
+            return if (gradleJvm is String) gradleJvm else null
+        } catch (e: Exception) {
+            return null
+        }
     }
 }


### PR DESCRIPTION
# Description

Utility methods from com.android.* were replaced to platform API alternatives plus reflection.

Fixes #934 

- Refactoring

# How Has This Been Tested?

## Manual Scenario 

See the steps in relevant issue

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
