### PR TITLE
Plugin UI. UnsupportedOperationException is thrown when new test sour…

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/GenerateTestsModel.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/GenerateTestsModel.kt
@@ -15,6 +15,7 @@ import com.intellij.openapi.module.ModuleUtil
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.JavaSdkVersion
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.newvfs.impl.FakeVirtualFile
 import com.intellij.psi.PsiClass
 import com.intellij.refactoring.util.classMembers.MemberInfo
 import org.jetbrains.kotlin.idea.core.getPackage
@@ -41,7 +42,15 @@ data class GenerateTestsModel(
     fun setSourceRootAndFindTestModule(newTestSourceRoot: VirtualFile?) {
         requireNotNull(newTestSourceRoot)
         testSourceRoot = newTestSourceRoot
-        testModule = ModuleUtil.findModuleForFile(newTestSourceRoot, project)
+        var target = newTestSourceRoot
+        while(target != null && target is FakeVirtualFile) {
+            target = target.parent
+        }
+        if (target == null) {
+            error("Could not find module for $newTestSourceRoot")
+        }
+
+        testModule = ModuleUtil.findModuleForFile(target, project)
             ?: error("Could not find module for $newTestSourceRoot")
     }
 


### PR DESCRIPTION
…ce root creation is chosen #712

# Description

Cannot find module for not-yet-created files, workaround was implemented

Fixes #712 

## Type of Change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?


## Manual Scenario 

See issue's steps

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings