### PR TITLE
Add missing exception in ExecutionState copies

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/mixed/XmlExampleTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/mixed/XmlExampleTest.kt
@@ -1,0 +1,17 @@
+package org.utbot.examples.mixed
+
+import org.junit.jupiter.api.Disabled
+import org.utbot.tests.infrastructure.UtValueTestCaseChecker
+import org.junit.jupiter.api.Test
+import org.utbot.tests.infrastructure.ignoreExecutionsNumber
+
+internal class XmlExampleTest : UtValueTestCaseChecker(testClass = XmlExample::class) {
+    @Test
+    @Disabled("No meaningful branches found https://github.com/UnitTestBot/UTBotJava/issues/943")
+    fun testExample() {
+        check(
+            XmlExample::xmlReader,
+            ignoreExecutionsNumber
+        )
+    }
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ExecutionState.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ExecutionState.kt
@@ -213,6 +213,7 @@ data class ExecutionState(
             lastEdge = edge,
             lastMethod = executionStack.last().method,
             methodResult = methodResult,
+            exception = exception,
             label = label,
             stateAnalyticsProperties = stateAnalyticsProperties.successorProperties(this)
         )
@@ -253,6 +254,7 @@ data class ExecutionState(
             lastEdge = edge,
             lastMethod = stackElement.method,
             label = label,
+            exception = exception,
             stateAnalyticsProperties = stateAnalyticsProperties.successorProperties(this)
         )
     }
@@ -268,10 +270,17 @@ data class ExecutionState(
         )
     }
 
+    /**
+     * If you want to remove information about an exception from the state (for example,
+     * for catch block processing), pass true into [resetException] parameter.
+     *
+     * Otherwise, a new state will contain the same exception as the one being copied.
+     */
     fun update(
         edge: Edge,
         symbolicStateUpdate: SymbolicStateUpdate,
         doesntThrow: Boolean,
+        resetException: Boolean
     ): ExecutionState {
         val last = executionStack.last()
         val stackElement = last.update(
@@ -299,6 +308,7 @@ data class ExecutionState(
             lastEdge = edge,
             lastMethod = stackElement.method,
             label = label,
+            exception = exception?.takeIf { !resetException },
             stateAnalyticsProperties = stateAnalyticsProperties.successorProperties(this)
         )
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -2163,7 +2163,8 @@ class Traverser(
                 SymbolicStateUpdate(
                     hardConstraints = conditions.asHardConstraint(),
                     localMemoryUpdates = localMemoryUpdate(CAUGHT_EXCEPTION to exception.symbolic)
-                )
+                ),
+                resetException = true
             )
         )
         return true
@@ -2914,11 +2915,13 @@ class Traverser(
     private fun ExecutionState.updateQueued(
         edge: Edge,
         update: SymbolicStateUpdate = SymbolicStateUpdate(),
-        doesntThrow: Boolean = false
+        doesntThrow: Boolean = false,
+        resetException: Boolean = false
     ) = this.update(
         edge,
         queuedSymbolicStateUpdates + update,
-        doesntThrow
+        doesntThrow,
+        resetException
     )
 
     private fun TraversalContext.resolveIfCondition(cond: BinopExpr): ResolvedCondition {

--- a/utbot-sample/src/main/java/org/utbot/examples/mixed/XmlExample.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/mixed/XmlExample.java
@@ -1,0 +1,18 @@
+package org.utbot.examples.mixed;
+
+import org.xml.sax.ContentHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.XMLReaderFactory;
+
+import java.io.IOException;
+import java.net.URL;
+
+public class XmlExample {
+    public void xmlReader(ContentHandler handler, String url) throws SAXException, IOException {
+        XMLReader myReader = XMLReaderFactory.createXMLReader();
+        myReader.setContentHandler(handler);
+        myReader.parse(new InputSource(new URL(url).openStream()));
+    }
+}


### PR DESCRIPTION
# Description

We missed information about encountered exceptions during copying of the execution state. In this request, I added them back.

Fixes #656

## Type of Change
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

I added the test from the issue into our test cases: org.utbot.examples.mixed.XmlExampleTest#testExample

## Manual Scenario 

I didn't check it with the plugin. 

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
- [x] New tests have been added
- [ ] All tests pass locally with my changes
