### PR TITLE
Add an option to show library classes' graphs in visualization

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -124,6 +124,13 @@ object UtSettings : AbstractSettings(
     val copyVisualizationPathToClipboard get() = useDebugVisualization
 
     /**
+     * Set the value to true to show library classes' graphs in visualization.
+     *
+     * False by default.
+     */
+    val showLibraryClassesInVisualization by getBooleanProperty(false)
+
+    /**
      * Method is paused after this timeout to give an opportunity other methods
      * to work
      */

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/strategies/GraphViz.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/strategies/GraphViz.kt
@@ -11,6 +11,7 @@ import org.utbot.engine.isReturn
 import org.utbot.engine.selectors.PathSelector
 import org.utbot.engine.stmts
 import org.utbot.framework.UtSettings.copyVisualizationPathToClipboard
+import org.utbot.framework.UtSettings.showLibraryClassesInVisualization
 import soot.jimple.Stmt
 import soot.toolkits.graph.ExceptionalUnitGraph
 import java.awt.Toolkit
@@ -103,7 +104,11 @@ class GraphViz(
         graph.allEdges.forEach { edge ->
             val (edgeSrc, edgeDst, _) = edge
 
-            if (stmtToSubgraph[edgeSrc] !in libraryGraphs && stmtToSubgraph[edgeDst] !in libraryGraphs) {
+            val srcInLibraryMethod = stmtToSubgraph[edgeSrc] in libraryGraphs
+            val dstInLibraryMethod = stmtToSubgraph[edgeDst] in libraryGraphs
+            val edgeIsRelatedToLibraryMethod = srcInLibraryMethod || dstInLibraryMethod
+
+            if (!edgeIsRelatedToLibraryMethod || showLibraryClassesInVisualization) {
                 dotGlobalGraph.addDotEdge(edge)
             }
         }
@@ -143,8 +148,10 @@ class GraphViz(
         }
 
         // Filter library methods
-        uncompletedStack.removeIf { it.name in libraryGraphs }
-        fullStack.removeIf { it.name in libraryGraphs }
+        if (!showLibraryClassesInVisualization) {
+            uncompletedStack.removeIf { it.name in libraryGraphs }
+            fullStack.removeIf { it.name in libraryGraphs }
+        }
 
         // Update nodes and edges properties
         dotGlobalGraph.updateProperties(executionState)


### PR DESCRIPTION
# Description

I added an option to enable library classes' graphs visualization.

Fixes #946 

## Type of Change
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Automated Testing

Not applicable.

## Manual Scenario 

Set `org.utbot.framework.UtSettings#getShowLibraryClassesInVisualization` in `true` and run generation using the plugin on it. Look at the visualization.  Proof:
![image](https://user-images.githubusercontent.com/31047452/190656614-85abda19-0dab-4f1a-ba2c-909b5573dfee.png)


# Checklist (remove irrelevant options):
- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existing one is altered
- [x] No new warnings
- [x] All tests pass locally with my changes
