### PR TITLE
Migration ComboboxWithBrowseButton -> ComponentWithBrowseButton

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/components/TestFolderComboWithBrowseButton.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/components/TestFolderComboWithBrowseButton.kt
@@ -4,12 +4,15 @@ import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.fileChooser.FileChooser
 import com.intellij.openapi.fileChooser.FileChooserDescriptor
 import com.intellij.openapi.project.guessProjectDir
+import com.intellij.openapi.ui.ComboBox
+import com.intellij.openapi.ui.ComponentWithBrowseButton
+import com.intellij.openapi.ui.FixedSizeButton
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.newvfs.impl.FakeVirtualFile
 import com.intellij.ui.ColoredListCellRenderer
-import com.intellij.ui.ComboboxWithBrowseButton
 import com.intellij.ui.SimpleTextAttributes
 import com.intellij.util.ArrayUtil
+import com.intellij.util.ui.UIUtil
 import java.io.File
 import javax.swing.DefaultComboBoxModel
 import javax.swing.JList
@@ -20,14 +23,15 @@ import org.utbot.intellij.plugin.ui.utils.addDedicatedTestRoot
 import org.utbot.intellij.plugin.ui.utils.isBuildWithGradle
 import org.utbot.intellij.plugin.ui.utils.suitableTestSourceRoots
 
-class TestFolderComboWithBrowseButton(private val model: GenerateTestsModel) : ComboboxWithBrowseButton() {
+class TestFolderComboWithBrowseButton(private val model: GenerateTestsModel) :
+    ComponentWithBrowseButton<ComboBox<Any>>(ComboBox(), null) {
 
     private val SET_TEST_FOLDER = "set test folder"
 
     init {
         if (model.project.isBuildWithGradle) {
             setButtonEnabled(false)
-            button.toolTipText = "Please define custom test source root via Gradle"
+            UIUtil.findComponentOfType(this, FixedSizeButton::class.java)?.toolTipText = "Please define custom test source root via Gradle"
         }
         childComponent.isEditable = false
         childComponent.renderer = object : ColoredListCellRenderer<Any?>() {


### PR DESCRIPTION
# Description

As com.intellij.openapi.ui.ComponentWithBrowseButton#getButton is also deprecated, direct method call was replaced to a workaround

## Type of Change

- Refactoring (typos and non-functional changes) 

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings