### PR TITLE
Fix mutated field assertion

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/Domain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/Domain.kt
@@ -219,6 +219,8 @@ sealed class TestFramework(
 
     val assertNull by lazy { assertionId("assertNull", objectClassId) }
 
+    val assertNotNull by lazy { assertionId("assertNotNull", objectClassId) }
+
     val assertFalse by lazy { assertionId("assertFalse", booleanClassId) }
 
     val assertTrue by lazy { assertionId("assertTrue", booleanClassId) }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/TestFrameworkManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/TestFrameworkManager.kt
@@ -60,6 +60,7 @@ internal abstract class TestFrameworkManager(val context: CgContext)
     val assertDoubleEquals = context.testFramework.assertDoubleEquals
 
     val assertNull = context.testFramework.assertNull
+    val assertNotNull = context.testFramework.assertNotNull
     val assertTrue = context.testFramework.assertTrue
     val assertFalse = context.testFramework.assertFalse
 
@@ -153,6 +154,10 @@ internal abstract class TestFrameworkManager(val context: CgContext)
 
     fun assertNull(actual: CgExpression) {
         +assertions[assertNull](actual)
+    }
+
+    fun assertNotNull(actual: CgExpression) {
+        +assertions[assertNotNull](actual)
     }
 
     fun assertBoolean(expected: Boolean, actual: CgExpression) {


### PR DESCRIPTION
# Description

This PR fixes failing generated tests from *antlr* project by rendering *assertNotNull(final)* assertion instead of *assertFalse(initial, final)* in case of *UtNullModel* initial field model.

Fixes # ([372](https://github.com/UnitTestBot/UTBotJava/issues/372))

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

Utbot pipeline.

## Manual Scenario 

Generate a test for *setGrammarPtr* method from *antlr* project. Verify that the generated tests pass.