### PR TITLE
Dockefile of CLI is based on Java 11

### DIFF
--- a/docker/Dockerfile_java_cli
+++ b/docker/Dockerfile_java_cli
@@ -1,4 +1,4 @@
-FROM openjdk:8
+FROM azul/zulu-openjdk:11.0.15-11.56.19
 
 ARG UTBOT_JAVA_CLI
 


### PR DESCRIPTION
# Description

Update to Java in Dockerfile of Java CLI.

Fixes #960

## Type of Change

Infrastructure changes.

# How Has This Been Tested?

## Automated Testing

Not applicable.

## Manual Scenario 

It was tested on local machine.

# Checklist (remove irrelevant options):

_This is the author self-check list_

Not applicable.