### PR TITLE
Mark distinct test for Stream as slow

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/stream/BaseStreamExampleTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/stream/BaseStreamExampleTest.kt
@@ -87,6 +87,7 @@ class BaseStreamExampleTest : UtValueTestCaseChecker(
     }
 
     @Test
+    @Tag("slow")
     fun testDistinctExample() {
         check(
             BaseStreamExample::distinctExample,


### PR DESCRIPTION
# Description

Mark `org.utbot.examples.stream.BaseStreamExampleTest#testDistinctExample` as slow (average 25 minutes).