### PR TITLE
`UtAssembleModel` refactor #812

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -471,26 +471,52 @@ data class UtArrayModel(
 /**
  * Model for complex objects with assemble instructions.
  *
- * @param instantiationChain is a chain of [UtStatementModel] to instantiate represented object
- * @param modificationsChain is a chain of [UtStatementModel] to construct object state
+ * The default constructor is made private to enforce using a safe constructor.
+ *
+ * @param instantiationCall is an [UtExecutableCallModel] to instantiate represented object.
+ * @param modificationsChain is a chain of [UtStatementModel] to construct object state.
  */
-data class UtAssembleModel(
+data class UtAssembleModel private constructor(
     override val id: Int?,
     override val classId: ClassId,
     override val modelName: String,
-    val instantiationChain: List<UtStatementModel> = emptyList(),
-    val modificationsChain: List<UtStatementModel> = emptyList(),
-    val origin: UtCompositeModel? = null
+    val instantiationCall: UtExecutableCallModel,
+    val modificationsChain: List<UtStatementModel>,
+    val origin: UtCompositeModel?
 ) : UtReferenceModel(id, classId, modelName) {
-    val allStatementsChain
-        get() = instantiationChain + modificationsChain
-    val finalInstantiationModel
-        get() = instantiationChain.lastOrNull()
+
+    /**
+     * Creates a new [UtAssembleModel].
+     *
+     * Please note, that it's the caller responsibility to properly cache [UtModel]s to prevent an infinite recursion.
+     * The order of the calling:
+     * 1. [instantiationCall]
+     * 2. [constructor]
+     * 3. [modificationsChainProvider]. Possible caching should be made at the beginning of this method.
+     *
+     * @param instantiationCall defines the single instruction, which provides a [UtAssembleModel]. It could be a
+     * constructor or a method of another class, which returns the object of the [classId] type.
+     *
+     * @param modificationsChainProvider used for creating modifying statements. Its receiver corresponds to newly
+     * created [UtAssembleModel], so you can use it for caching and for creating [UtExecutableCallModel]s with it
+     * as [UtExecutableCallModel.instance].
+     */
+    constructor(
+        id: Int?,
+        classId: ClassId,
+        modelName: String,
+        instantiationCall: UtExecutableCallModel,
+        origin: UtCompositeModel? = null,
+        modificationsChainProvider: UtAssembleModel.() -> List<UtStatementModel> = { emptyList() }
+    ) : this(id, classId, modelName, instantiationCall, mutableListOf(), origin) {
+        val modificationChainStatements = modificationsChainProvider()
+        (modificationsChain as MutableList<UtStatementModel>).addAll(modificationChainStatements)
+    }
 
     override fun toString() = withToStringThreadLocalReentrancyGuard {
         buildString {
             append("UtAssembleModel(${classId.simpleName} $modelName) ")
-            append(instantiationChain.joinToString(" "))
+            append(instantiationCall)
             if (modificationsChain.isNotEmpty()) {
                 append(" ")
                 append(modificationsChain.joinToString(" "))
@@ -562,7 +588,6 @@ sealed class UtStatementModel(
  * Step of assemble instruction that calls executable.
  *
  * Contains executable to call, call parameters and an instance model before call.
- * Return value is used for tracking objects and call others methods with these tracking objects as parameters.
  */
 data class UtExecutableCallModel(
     override val instance: UtReferenceModel?,

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -588,6 +588,8 @@ sealed class UtStatementModel(
  * Step of assemble instruction that calls executable.
  *
  * Contains executable to call, call parameters and an instance model before call.
+ *
+ * @param [instance] **must be** `null` for static methods and constructors
  */
 data class UtExecutableCallModel(
     override val instance: UtReferenceModel?,

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -568,7 +568,6 @@ data class UtExecutableCallModel(
     override val instance: UtReferenceModel?,
     val executable: ExecutableId,
     val params: List<UtModel>,
-    val returnValue: UtReferenceModel? = null,
 ) : UtStatementModel(instance) {
     override fun toString() = withToStringThreadLocalReentrancyGuard {
         buildString {
@@ -578,9 +577,7 @@ data class UtExecutableCallModel(
                 is MethodId -> executable.name
             }
 
-            if (returnValue != null) {
-                append("val ${returnValue.modelName} = ")
-            } else if (instance != null) {
+            if (instance != null) {
                 append("${instance.modelName}.")
             }
 

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -473,7 +473,7 @@ data class UtArrayModel(
  *
  * The default constructor is made private to enforce using a safe constructor.
  *
- * @param instantiationCall is an [UtExecutableCallModel] to instantiate represented object.
+ * @param instantiationCall is an [UtExecutableCallModel] to instantiate represented object. It **must** not return `null`.
  * @param modificationsChain is a chain of [UtStatementModel] to construct object state.
  */
 data class UtAssembleModel private constructor(

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/codegen/deepequals/ClassWithCrossReferenceRelationshipTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/codegen/deepequals/ClassWithCrossReferenceRelationshipTest.kt
@@ -1,12 +1,11 @@
 package org.utbot.examples.codegen.deepequals
 
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
-import org.utbot.tests.infrastructure.DoNotCalculate
-import org.utbot.tests.infrastructure.UtValueTestCaseChecker
 import org.utbot.framework.plugin.api.CodegenLanguage
 import org.utbot.testcheckers.eq
 import org.utbot.tests.infrastructure.CodeGeneration
+import org.utbot.tests.infrastructure.DoNotCalculate
+import org.utbot.tests.infrastructure.UtValueTestCaseChecker
 
 class ClassWithCrossReferenceRelationshipTest : UtValueTestCaseChecker(
     testClass = ClassWithCrossReferenceRelationship::class,

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/codegen/deepequals/ClassWithCrossReferenceRelationshipTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/codegen/deepequals/ClassWithCrossReferenceRelationshipTest.kt
@@ -16,8 +16,6 @@ class ClassWithCrossReferenceRelationshipTest : UtValueTestCaseChecker(
         CodeGenerationLanguageLastStage(CodegenLanguage.KOTLIN, CodeGeneration)
     )
 ) {
-    // TODO: The test is disabled due to [https://github.com/UnitTestBot/UTBotJava/issues/812]
-    @Disabled
     @Test
     fun testClassWithCrossReferenceRelationship() {
         check(

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/models/ModelsIdEqualityChecker.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/models/ModelsIdEqualityChecker.kt
@@ -129,7 +129,7 @@ internal class ModelsIdEqualityChecker : UtModelTestCaseChecker(
 
     private fun UtReferenceModel.findFieldId(): Int? {
         this as UtAssembleModel
-        val fieldModel = this.allStatementsChain
+        val fieldModel = this.modificationsChain
             .filterIsInstance<UtDirectSetFieldModel>()
             .single()
             .fieldModel

--- a/utbot-framework-test/src/test/kotlin/org/utbot/framework/assemble/AssembleModelGeneratorTests.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/framework/assemble/AssembleModelGeneratorTests.kt
@@ -184,7 +184,7 @@ class AssembleModelGeneratorTests {
         val firstExpectedRepresentation = printExpectedModel(testClassId.simpleName, v1, statementsChain.toList())
 
         statementsChain.clear()
-        statementsChain.add("val $v2 = ${innerClassId.canonicalName}()")
+        statementsChain.add("${innerClassId.canonicalName}()")
         statementsChain.add("$v2." + addExpectedSetter("a", 2))
         statementsChain.add("$v2." + ("b" `=` 4))
         val secondExpectedRepresentation = printExpectedModel(innerClassId.simpleName, v2, statementsChain.toList())
@@ -238,7 +238,7 @@ class AssembleModelGeneratorTests {
         val firstExpectedRepresentation = printExpectedModel(listClassId.simpleName, v1, statementsChain.toList())
 
         statementsChain.clear()
-        statementsChain.add("val $v2 = ${listClassId.canonicalName}()")
+        statementsChain.add("${listClassId.canonicalName}()")
         statementsChain.add("$v2." + addExpectedSetter("value", 2))
         val secondExpectedRepresentation = printExpectedModel(listClassId.simpleName, v2, statementsChain.toList())
 
@@ -268,13 +268,13 @@ class AssembleModelGeneratorTests {
         val firstExpectedRepresentation = printExpectedModel(listClassId.simpleName, v1, statementsChain.toList())
 
         statementsChain.clear()
-        statementsChain.add("val $v2 = ${listClassId.canonicalName}()")
+        statementsChain.add("${listClassId.canonicalName}()")
         statementsChain.add("$v2." + addExpectedSetter("value", 2))
         statementsChain.add("$v2." + addExpectedSetter("next", v3))
         val secondExpectedRepresentation = printExpectedModel(listClassId.simpleName, v2, statementsChain.toList())
 
         statementsChain.clear()
-        statementsChain.add("val $v3 = ${listClassId.canonicalName}()")
+        statementsChain.add("${listClassId.canonicalName}()")
         statementsChain.add("$v3." + addExpectedSetter("value", 3))
         statementsChain.add("$v3." + addExpectedSetter("next", v1))
         val thirdExpectedRepresentation = printExpectedModel(listClassId.simpleName, v3, statementsChain.toList())
@@ -989,7 +989,7 @@ class AssembleModelGeneratorTests {
         val firstExpectedRepresentation = printExpectedModel(listClassId.simpleName, v1, statementsChain.toList())
 
         statementsChain.clear()
-        statementsChain.add("val $v2 = ${listClassId.canonicalName}()")
+        statementsChain.add("${listClassId.canonicalName}()")
         statementsChain.add("$v2." + addExpectedSetter("value", 2))
         val secondExpectedRepresentation = printExpectedModel(listClassId.simpleName, v2, statementsChain.toList())
 
@@ -1017,7 +1017,7 @@ class AssembleModelGeneratorTests {
         val firstExpectedRepresentation = printExpectedModel(listClassId.simpleName, v1, statementsChain.toList())
 
         statementsChain.clear()
-        statementsChain.add("val $v2 = ${listClassId.canonicalName}()")
+        statementsChain.add("${listClassId.canonicalName}()")
         statementsChain.add("$v2." + addExpectedSetter("value", 2))
         statementsChain.add("$v2." + addExpectedSetter("next", v1))
         val secondExpectedRepresentation = printExpectedModel(listClassId.simpleName, v2, statementsChain)
@@ -1140,7 +1140,7 @@ class AssembleModelGeneratorTests {
         statementsChain.add(
             "$v1." + ("array" `=` "[" +
                     "null, " +
-                    "UtAssembleModel(${innerClassId.simpleName} $v2) val $v2 = ${innerClassId.canonicalName}() $v2.setA(5), " +
+                    "UtAssembleModel(${innerClassId.simpleName} $v2) ${innerClassId.canonicalName}() $v2.setA(5), " +
                     "null" +
                     "]")
         )
@@ -1240,8 +1240,8 @@ class AssembleModelGeneratorTests {
         val v3 = createExpectedVariableName<PrimitiveFields>()
         statementsChain.add(
             "$v1." + ("array" `=` "[" +
-                    "[UtAssembleModel(${innerClassId.simpleName} $v2) val $v2 = ${innerClassId.canonicalName}() $v2.setA(5), ${null}], " +
-                    "[UtAssembleModel(${innerClassId.simpleName} $v3) val $v3 = ${innerClassId.canonicalName}() $v3.b = 4, ${null}]" +
+                    "[UtAssembleModel(${innerClassId.simpleName} $v2) ${innerClassId.canonicalName}() $v2.setA(5), ${null}], " +
+                    "[UtAssembleModel(${innerClassId.simpleName} $v3) ${innerClassId.canonicalName}() $v3.b = 4, ${null}]" +
                     "]")
         )
 
@@ -1480,7 +1480,7 @@ class AssembleModelGeneratorTests {
         val varName = createExpectedVariableName<T>()
 
         val paramString = if (params.any()) params.joinToString(", ") else ""
-        this.add("val $varName = $fqn($paramString)")
+        this.add("$fqn($paramString)")
 
         return varName
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/CollectionWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/CollectionWrappers.kt
@@ -119,21 +119,15 @@ abstract class BaseContainerWrapper(containerClassName: String) : BaseOverridden
 
         val classId = chooseClassIdWithConstructor(wrapper.type.sootClass.id)
 
-        val instantiationChain = mutableListOf<UtStatementModel>()
-        val modificationsChain = mutableListOf<UtStatementModel>()
+        val instantiationCall = UtExecutableCallModel(
+            instance = null,
+            executable = constructorId(classId),
+            params = emptyList()
+        )
 
-        UtAssembleModel(addr, classId, modelName, instantiationChain, modificationsChain)
-            .apply {
-                instantiationChain += UtExecutableCallModel(
-                    instance = null,
-                    executable = constructorId(classId),
-                    params = emptyList()
-                )
-
-                modificationsChain += parameterModels.map {
-                    UtExecutableCallModel(this, modificationMethodId, it)
-                }
-            }
+        UtAssembleModel(addr, classId, modelName, instantiationCall) {
+            parameterModels.map { UtExecutableCallModel(this, modificationMethodId, it) }
+        }
     }
 
     /**

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/CollectionWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/CollectionWrappers.kt
@@ -127,8 +127,7 @@ abstract class BaseContainerWrapper(containerClassName: String) : BaseOverridden
                 instantiationChain += UtExecutableCallModel(
                     instance = null,
                     executable = constructorId(classId),
-                    params = emptyList(),
-                    returnValue = this
+                    params = emptyList()
                 )
 
                 modificationsChain += parameterModels.map {

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ObjectWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ObjectWrappers.kt
@@ -241,17 +241,15 @@ data class ThrowableWrapper(val throwable: Throwable) : WrapperInterface {
         val addr = resolver.holder.concreteAddr(wrapper.addr)
         val modelName = nextModelName(throwable.javaClass.simpleName.decapitalize())
 
-        val instantiationChain = mutableListOf<UtStatementModel>()
-        return UtAssembleModel(addr, classId, modelName, instantiationChain)
-            .apply {
-                instantiationChain += when (val message = throwable.message) {
-                    null -> UtExecutableCallModel(null, constructorId(classId), emptyList())
-                    else -> UtExecutableCallModel(
-                        null,
-                        constructorId(classId, stringClassId),
-                        listOf(UtPrimitiveModel(message))
-                    )
-                }
-            }
+        val instantiationCall = when (val message = throwable.message) {
+            null -> UtExecutableCallModel(null, constructorId(classId), emptyList())
+            else -> UtExecutableCallModel(
+                null,
+                constructorId(classId, stringClassId),
+                listOf(UtPrimitiveModel(message))
+            )
+        }
+
+        return UtAssembleModel(addr, classId, modelName, instantiationCall)
     }
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ObjectWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ObjectWrappers.kt
@@ -245,12 +245,11 @@ data class ThrowableWrapper(val throwable: Throwable) : WrapperInterface {
         return UtAssembleModel(addr, classId, modelName, instantiationChain)
             .apply {
                 instantiationChain += when (val message = throwable.message) {
-                    null -> UtExecutableCallModel(null, constructorId(classId), emptyList(), this)
+                    null -> UtExecutableCallModel(null, constructorId(classId), emptyList())
                     else -> UtExecutableCallModel(
                         null,
                         constructorId(classId, stringClassId),
-                        listOf(UtPrimitiveModel(message)),
-                        this,
+                        listOf(UtPrimitiveModel(message))
                     )
                 }
             }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ObjectWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ObjectWrappers.kt
@@ -242,9 +242,9 @@ data class ThrowableWrapper(val throwable: Throwable) : WrapperInterface {
         val modelName = nextModelName(throwable.javaClass.simpleName.decapitalize())
 
         val instantiationCall = when (val message = throwable.message) {
-            null -> UtExecutableCallModel(null, constructorId(classId), emptyList())
+            null -> UtExecutableCallModel(instance = null, constructorId(classId), emptyList())
             else -> UtExecutableCallModel(
-                null,
+                instance = null,
                 constructorId(classId, stringClassId),
                 listOf(UtPrimitiveModel(message))
             )

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/OptionalWrapper.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/OptionalWrapper.kt
@@ -90,12 +90,8 @@ class OptionalWrapper(private val utOptionalClass: UtOptionalClass) : BaseOverri
         val addr = holder.concreteAddr(wrapper.addr)
         val modelName = nextModelName(baseModelName)
 
-        val instantiationChain = mutableListOf<UtStatementModel>()
-        val modificationsChain = mutableListOf<UtStatementModel>()
-        return UtAssembleModel(addr, classId, modelName, instantiationChain, modificationsChain)
-            .apply {
-                instantiationChain += instantiationFactoryCallModel(classId, wrapper)
-            }
+        val instantiationCall = instantiationFactoryCallModel(classId, wrapper)
+        return UtAssembleModel(addr, classId, modelName, instantiationCall)
     }
 
     private fun Resolver.instantiationFactoryCallModel(classId: ClassId, wrapper: ObjectValue) : UtExecutableCallModel {

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/OptionalWrapper.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/OptionalWrapper.kt
@@ -106,7 +106,8 @@ class OptionalWrapper(private val utOptionalClass: UtOptionalClass) : BaseOverri
         }
         return if (!isPresent) {
             UtExecutableCallModel(
-                null, MethodId(
+                instance = null,
+                MethodId(
                     classId,
                     "empty",
                     classId,
@@ -115,7 +116,8 @@ class OptionalWrapper(private val utOptionalClass: UtOptionalClass) : BaseOverri
             )
         } else {
             UtExecutableCallModel(
-                null, MethodId(
+                instance = null,
+                MethodId(
                     classId,
                     "of",
                     classId,

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/OptionalWrapper.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/OptionalWrapper.kt
@@ -94,11 +94,11 @@ class OptionalWrapper(private val utOptionalClass: UtOptionalClass) : BaseOverri
         val modificationsChain = mutableListOf<UtStatementModel>()
         return UtAssembleModel(addr, classId, modelName, instantiationChain, modificationsChain)
             .apply {
-                instantiationChain += instantiationFactoryCallModel(classId, wrapper, this)
+                instantiationChain += instantiationFactoryCallModel(classId, wrapper)
             }
     }
 
-    private fun Resolver.instantiationFactoryCallModel(classId: ClassId, wrapper: ObjectValue, model: UtAssembleModel) : UtExecutableCallModel {
+    private fun Resolver.instantiationFactoryCallModel(classId: ClassId, wrapper: ObjectValue) : UtExecutableCallModel {
         val valueField = FieldId(overriddenClass.id, "value")
         val isPresentFieldId = FieldId(overriddenClass.id, "isPresent")
         val values = collectFieldModels(wrapper.addr, overriddenClass.type)
@@ -115,7 +115,7 @@ class OptionalWrapper(private val utOptionalClass: UtOptionalClass) : BaseOverri
                     "empty",
                     classId,
                     emptyList()
-                ), emptyList(), model
+                ), emptyList()
             )
         } else {
             UtExecutableCallModel(
@@ -124,7 +124,7 @@ class OptionalWrapper(private val utOptionalClass: UtOptionalClass) : BaseOverri
                     "of",
                     classId,
                     listOf(utOptionalClass.elementClassId)
-                ), listOf(valueModel), model
+                ), listOf(valueModel)
             )
         }
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Resolver.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Resolver.kt
@@ -553,7 +553,7 @@ class Resolver(
             val instantiationChain = mutableListOf<UtExecutableCallModel>()
             UtAssembleModel(addr, classId, nextModelName(baseModelName), instantiationChain)
                 .apply {
-                    instantiationChain += UtExecutableCallModel(null, constructorId, listOf(valueModel), this)
+                    instantiationChain += UtExecutableCallModel(null, constructorId, listOf(valueModel))
                 }
         }
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Resolver.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Resolver.kt
@@ -550,7 +550,7 @@ class Resolver(
             val baseModelName = primitiveClassId.name
             val constructorId = constructorId(classId, primitiveClassId)
             val valueModel = fields[FieldId(classId, "value")] ?: primitiveClassId.defaultValueModel()
-            val instantiationCall = UtExecutableCallModel(null, constructorId, listOf(valueModel))
+            val instantiationCall = UtExecutableCallModel(instance = null, constructorId, listOf(valueModel))
             UtAssembleModel(addr, classId, nextModelName(baseModelName), instantiationCall)
         }
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Resolver.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Resolver.kt
@@ -550,11 +550,8 @@ class Resolver(
             val baseModelName = primitiveClassId.name
             val constructorId = constructorId(classId, primitiveClassId)
             val valueModel = fields[FieldId(classId, "value")] ?: primitiveClassId.defaultValueModel()
-            val instantiationChain = mutableListOf<UtExecutableCallModel>()
-            UtAssembleModel(addr, classId, nextModelName(baseModelName), instantiationChain)
-                .apply {
-                    instantiationChain += UtExecutableCallModel(null, constructorId, listOf(valueModel))
-                }
+            val instantiationCall = UtExecutableCallModel(null, constructorId, listOf(valueModel))
+            UtAssembleModel(addr, classId, nextModelName(baseModelName), instantiationCall)
         }
     }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/SecurityManagerWrapper.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/SecurityManagerWrapper.kt
@@ -2,9 +2,10 @@ package org.utbot.engine
 
 import org.utbot.engine.overrides.security.UtSecurityManager
 import org.utbot.framework.plugin.api.UtAssembleModel
+import org.utbot.framework.plugin.api.UtExecutableCallModel
 import org.utbot.framework.plugin.api.UtModel
-import org.utbot.framework.plugin.api.UtStatementModel
 import org.utbot.framework.plugin.api.classId
+import org.utbot.framework.plugin.api.util.executableId
 import org.utbot.framework.util.nextModelName
 import soot.Scene
 import soot.SootClass
@@ -27,9 +28,13 @@ class SecurityManagerWrapper : BaseOverriddenWrapper(utSecurityManagerClass.name
         val addr = holder.concreteAddr(wrapper.addr)
         val modelName = nextModelName(baseModelName)
 
-        val instantiationChain = mutableListOf<UtStatementModel>()
-        val modificationChain = mutableListOf<UtStatementModel>()
-        return UtAssembleModel(addr, classId, modelName, instantiationChain, modificationChain)
+        val instantiationCall = UtExecutableCallModel(
+            null,
+            System::getSecurityManager.executableId,
+            emptyList()
+        )
+
+        return UtAssembleModel(addr, classId, modelName, instantiationCall)
     }
 
     companion object {

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/SecurityManagerWrapper.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/SecurityManagerWrapper.kt
@@ -29,7 +29,7 @@ class SecurityManagerWrapper : BaseOverriddenWrapper(utSecurityManagerClass.name
         val modelName = nextModelName(baseModelName)
 
         val instantiationCall = UtExecutableCallModel(
-            null,
+            instance = null,
             System::getSecurityManager.executableId,
             emptyList()
         )

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/StreamWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/StreamWrappers.kt
@@ -75,8 +75,7 @@ abstract class StreamWrapper(
                 instantiationChain += UtExecutableCallModel(
                     instance = null,
                     executable = builder,
-                    params = params,
-                    returnValue = this
+                    params = params
                 )
             }
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/StreamWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/StreamWrappers.kt
@@ -61,23 +61,19 @@ abstract class StreamWrapper(
         val modelName = nextModelName(baseModelName)
         val parametersArrayModel = resolveElementsAsArrayModel(wrapper)
 
-        val instantiationChain = mutableListOf<UtStatementModel>()
-        val modificationsChain = emptyList<UtStatementModel>()
+        val (builder, params) = if (parametersArrayModel == null || parametersArrayModel.length == 0) {
+            streamEmptyMethodId to emptyList()
+        } else {
+            streamOfMethodId to listOf(parametersArrayModel)
+        }
 
-        UtAssembleModel(addr, utStreamClass.overriddenStreamClassId, modelName, instantiationChain, modificationsChain)
-            .apply {
-                val (builder, params) = if (parametersArrayModel == null || parametersArrayModel.length == 0) {
-                    streamEmptyMethodId to emptyList()
-                } else {
-                    streamOfMethodId to listOf(parametersArrayModel)
-                }
+        val instantiationCall = UtExecutableCallModel(
+            instance = null,
+            executable = builder,
+            params = params
+        )
 
-                instantiationChain += UtExecutableCallModel(
-                    instance = null,
-                    executable = builder,
-                    params = params
-                )
-            }
+        UtAssembleModel(addr, utStreamClass.overriddenStreamClassId, modelName, instantiationCall)
     }
 
     override fun chooseClassIdWithConstructor(classId: ClassId): ClassId = error("No constructor for Stream")

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Strings.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Strings.kt
@@ -179,16 +179,12 @@ class StringWrapper : BaseOverriddenWrapper(utStringClass.name) {
         val charValues = CharArray(length) { (values.stores[it] as UtPrimitiveModel).value as Char }
         val stringModel = UtPrimitiveModel(String(charValues))
 
-        val instantiationChain = mutableListOf<UtStatementModel>()
-        val modificationsChain = mutableListOf<UtStatementModel>()
-        return UtAssembleModel(addr, classId, modelName, instantiationChain, modificationsChain)
-            .apply {
-                instantiationChain += UtExecutableCallModel(
-                    instance = null,
-                    constructorId(classId, STRING_TYPE.classId),
-                    listOf(stringModel)
-                )
-            }
+        val instantiationCall = UtExecutableCallModel(
+            instance = null,
+            constructorId(classId, STRING_TYPE.classId),
+            listOf(stringModel)
+        )
+        return UtAssembleModel(addr, classId, modelName, instantiationCall)
     }
 }
 
@@ -332,18 +328,13 @@ sealed class UtAbstractStringBuilderWrapper(className: String) : BaseOverriddenW
 
         val charValues = CharArray(length) { (values.stores[it] as UtPrimitiveModel).value as Char }
         val stringModel = UtPrimitiveModel(String(charValues))
-
-        val instantiationChain = mutableListOf<UtStatementModel>()
-        val modificationsChain = mutableListOf<UtStatementModel>()
         val constructorId = constructorId(wrapper.type.classId, STRING_TYPE.classId)
-        return UtAssembleModel(addr, wrapper.type.classId, modelName, instantiationChain, modificationsChain)
-            .apply {
-                instantiationChain += UtExecutableCallModel(
-                    instance = null,
-                    constructorId,
-                    listOf(stringModel)
-                )
-            }
+        val instantiationChain = UtExecutableCallModel(
+            instance = null,
+            constructorId,
+            listOf(stringModel)
+        )
+        return UtAssembleModel(addr, wrapper.type.classId, modelName, instantiationChain)
     }
 
     private val SootClass.valueField: SootField

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Strings.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Strings.kt
@@ -329,12 +329,12 @@ sealed class UtAbstractStringBuilderWrapper(className: String) : BaseOverriddenW
         val charValues = CharArray(length) { (values.stores[it] as UtPrimitiveModel).value as Char }
         val stringModel = UtPrimitiveModel(String(charValues))
         val constructorId = constructorId(wrapper.type.classId, STRING_TYPE.classId)
-        val instantiationChain = UtExecutableCallModel(
+        val instantiationCall = UtExecutableCallModel(
             instance = null,
             constructorId,
             listOf(stringModel)
         )
-        return UtAssembleModel(addr, wrapper.type.classId, modelName, instantiationChain)
+        return UtAssembleModel(addr, wrapper.type.classId, modelName, instantiationCall)
     }
 
     private val SootClass.valueField: SootField

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Strings.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Strings.kt
@@ -186,8 +186,7 @@ class StringWrapper : BaseOverriddenWrapper(utStringClass.name) {
                 instantiationChain += UtExecutableCallModel(
                     instance = null,
                     constructorId(classId, STRING_TYPE.classId),
-                    listOf(stringModel),
-                    this
+                    listOf(stringModel)
                 )
             }
     }
@@ -342,8 +341,7 @@ sealed class UtAbstractStringBuilderWrapper(className: String) : BaseOverriddenW
                 instantiationChain += UtExecutableCallModel(
                     instance = null,
                     constructorId,
-                    listOf(stringModel),
-                    this
+                    listOf(stringModel)
                 )
             }
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ValueConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ValueConstructor.kt
@@ -328,7 +328,7 @@ class ValueConstructor {
     private fun constructFromAssembleModel(assembleModel: UtAssembleModel): Any {
         constructedObjects[assembleModel]?.let { return it }
 
-        val instantiationExecutableCall = assembleModel.instantiationChain.single() as UtExecutableCallModel
+        val instantiationExecutableCall = assembleModel.instantiationCall
         val result = updateWithExecutableCallModel(instantiationExecutableCall)
         checkNotNull(result) {
             "Tracked instance can't be null for call ${instantiationExecutableCall.executable} in model $assembleModel"

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssembleModelGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssembleModelGenerator.kt
@@ -251,7 +251,7 @@ class AssembleModelGenerator(private val methodPackageName: String) {
                 val constructorInfo = constructorAnalyzer.analyze(constructorId)
 
                 instantiatedModels[compositeModel] = this
-                instantiationChain += constructorCall(compositeModel, this, constructorInfo)
+                instantiationChain += constructorCall(compositeModel, constructorInfo)
 
                 compositeModel.fields.forEach { (fieldId, fieldModel) ->
                     if (fieldId.isStatic) {
@@ -342,7 +342,6 @@ class AssembleModelGenerator(private val methodPackageName: String) {
      */
     private fun constructorCall(
         compositeModel: UtCompositeModel,
-        instance: UtAssembleModel,
         constructorInfo: ConstructorAssembleInfo,
     ): UtExecutableCallModel {
         val constructorParams = constructorInfo.constructorId.parameters.withIndex()
@@ -355,7 +354,7 @@ class AssembleModelGenerator(private val methodPackageName: String) {
                 assembleModel(fieldModel)
             }
 
-        return UtExecutableCallModel(null, constructorInfo.constructorId, constructorParams, instance)
+        return UtExecutableCallModel(null, constructorInfo.constructorId, constructorParams)
     }
 
     /**

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssembleModelGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssembleModelGenerator.kt
@@ -2,7 +2,6 @@ package org.utbot.framework.assemble
 
 import org.utbot.common.isPrivate
 import org.utbot.common.isPublic
-import org.utbot.common.packageName
 import org.utbot.engine.ResolvedExecution
 import org.utbot.engine.ResolvedModels
 import org.utbot.framework.UtSettings

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssembleModelGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssembleModelGenerator.kt
@@ -291,7 +291,7 @@ class AssembleModelGenerator(private val methodPackageName: String) {
             modelBefore.modelName,
             assembleExecutableCallModel(modelBefore.instantiationCall),
             modelBefore.origin
-        ).apply {
+        ) {
             instantiatedModels[modelBefore] = this
             modelBefore.modificationsChain.map { assembleStatementModel(it) }
         }
@@ -361,7 +361,7 @@ class AssembleModelGenerator(private val methodPackageName: String) {
                 assembleModel(fieldModel)
             }
 
-        return UtExecutableCallModel(null, constructorInfo.constructorId, constructorParams)
+        return UtExecutableCallModel(instance = null, constructorInfo.constructorId, constructorParams)
     }
 
     /**

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssemblePrimitiveWrapper.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssemblePrimitiveWrapper.kt
@@ -37,7 +37,6 @@ fun assemble(model: UtPrimitiveModel): UtAssembleModel {
         instance = null,
         executable = constructorCall.executableId,
         params = listOf(model),
-        returnValue = null,
     )
 
     return UtAssembleModel(

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssemblePrimitiveWrapper.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssemblePrimitiveWrapper.kt
@@ -43,7 +43,6 @@ fun assemble(model: UtPrimitiveModel): UtAssembleModel {
         id = null,
         classId = assembledModelType,
         modelName = modelType.canonicalName,
-        instantiationChain = listOf(constructorCallModel),
-        modificationsChain = emptyList(),
+        instantiationCall = constructorCallModel,
     )
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgVariableConstructor.kt
@@ -16,6 +16,7 @@ import org.utbot.framework.codegen.model.constructor.util.typeCast
 import org.utbot.framework.codegen.model.tree.CgAllocateArray
 import org.utbot.framework.codegen.model.tree.CgDeclaration
 import org.utbot.framework.codegen.model.tree.CgEnumConstantAccess
+import org.utbot.framework.codegen.model.tree.CgExecutableCall
 import org.utbot.framework.codegen.model.tree.CgExpression
 import org.utbot.framework.codegen.model.tree.CgFieldAccess
 import org.utbot.framework.codegen.model.tree.CgGetJavaClass
@@ -200,7 +201,10 @@ internal class CgVariableConstructor(val context: CgContext) :
     }
 
     private fun constructAssemble(model: UtAssembleModel, baseName: String?): CgValue {
-        for (statementModel in model.allStatementsChain) {
+        val instantiationExecutableCall = model.instantiationChain.single() as UtExecutableCallModel
+        processInstantiationStatement(model, instantiationExecutableCall, baseName)
+
+        for (statementModel in model.modificationsChain) {
             when (statementModel) {
                 is UtDirectSetFieldModel -> {
                     val instance = declareOrGet(statementModel.instance)
@@ -208,40 +212,50 @@ internal class CgVariableConstructor(val context: CgContext) :
                     instance[statementModel.fieldId] `=` declareOrGet(statementModel.fieldModel)
                 }
                 is UtExecutableCallModel -> {
-                    val executable = statementModel.executable
-                    val params = statementModel.params
-                    val cgCall = when (executable) {
-                        is MethodId -> {
-                            val caller = statementModel.instance?.let { declareOrGet(it) }
-                            val args = params.map { declareOrGet(it) }
-                            caller[executable](*args.toTypedArray())
-                        }
-                        is ConstructorId -> {
-                            val args = params.map { declareOrGet(it) }
-                            executable(*args.toTypedArray())
-                        }
-                    }
-
-                    // if call result is stored in a variable
-                    if (statementModel.returnValue == null) {
-                        +cgCall
-                    } else {
-                        val type = when (executable) {
-                            is MethodId -> executable.returnType
-                            is ConstructorId -> executable.classId
-                        }
-
-                        // Don't use redundant constructors for primitives and String
-                        val initExpr = if (isPrimitiveWrapperOrString(type)) cgLiteralForWrapper(params) else cgCall
-                        newVar(type, statementModel.returnValue, baseName) { initExpr }
-                            .takeIf { statementModel == model.finalInstantiationModel }
-                            ?.also { valueByModelId[model.id] = it }
-                    }
+                    +createCgExecutableCallFromUtExecutableCall(statementModel)
                 }
             }
         }
 
         return valueByModelId.getValue(model.id)
+    }
+
+    private fun processInstantiationStatement(
+        model: UtAssembleModel,
+        executableCall: UtExecutableCallModel,
+        baseName: String?
+    ) {
+        val executable = executableCall.executable
+        val params = executableCall.params
+        val cgCall = createCgExecutableCallFromUtExecutableCall(executableCall)
+
+        val type = when (executable) {
+            is MethodId -> executable.returnType
+            is ConstructorId -> executable.classId
+        }
+        // Don't use redundant constructors for primitives and String
+        val initExpr = if (isPrimitiveWrapperOrString(type)) cgLiteralForWrapper(params) else cgCall
+        newVar(type, model, baseName) { initExpr }
+            .takeIf { executableCall == model.finalInstantiationModel }
+            ?.also { valueByModelId[model.id] = it }
+    }
+
+
+    private fun createCgExecutableCallFromUtExecutableCall(statementModel: UtExecutableCallModel): CgExecutableCall {
+        val executable = statementModel.executable
+        val params = statementModel.params
+        val cgCall = when (executable) {
+            is MethodId -> {
+                val caller = statementModel.instance?.let { declareOrGet(it) }
+                val args = params.map { declareOrGet(it) }
+                caller[executable](*args.toTypedArray())
+            }
+            is ConstructorId -> {
+                val args = params.map { declareOrGet(it) }
+                executable(*args.toTypedArray())
+            }
+        }
+        return cgCall
     }
 
     /**

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgVariableConstructor.kt
@@ -227,17 +227,20 @@ internal class CgVariableConstructor(val context: CgContext) :
     ) {
         val executable = executableCall.executable
         val params = executableCall.params
-        val cgCall = createCgExecutableCallFromUtExecutableCall(executableCall)
 
         val type = when (executable) {
             is MethodId -> executable.returnType
             is ConstructorId -> executable.classId
         }
         // Don't use redundant constructors for primitives and String
-        val initExpr = if (isPrimitiveWrapperOrString(type)) cgLiteralForWrapper(params) else cgCall
-        newVar(type, model, baseName) { initExpr }
-            .takeIf { executableCall == model.instantiationCall }
-            ?.also { valueByModelId[model.id] = it }
+        val initExpr = if (isPrimitiveWrapperOrString(type)) {
+            cgLiteralForWrapper(params)
+        } else {
+            createCgExecutableCallFromUtExecutableCall(executableCall)
+        }
+        newVar(type, model, baseName) {
+            initExpr
+        }.also { valueByModelId[model.id] = it }
     }
 
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgVariableConstructor.kt
@@ -201,7 +201,7 @@ internal class CgVariableConstructor(val context: CgContext) :
     }
 
     private fun constructAssemble(model: UtAssembleModel, baseName: String?): CgValue {
-        val instantiationExecutableCall = model.instantiationChain.single() as UtExecutableCallModel
+        val instantiationExecutableCall = model.instantiationCall
         processInstantiationStatement(model, instantiationExecutableCall, baseName)
 
         for (statementModel in model.modificationsChain) {
@@ -236,7 +236,7 @@ internal class CgVariableConstructor(val context: CgContext) :
         // Don't use redundant constructors for primitives and String
         val initExpr = if (isPrimitiveWrapperOrString(type)) cgLiteralForWrapper(params) else cgCall
         newVar(type, model, baseName) { initExpr }
-            .takeIf { executableCall == model.finalInstantiationModel }
+            .takeIf { executableCall == model.instantiationCall }
             ?.also { valueByModelId[model.id] = it }
     }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgVariableConstructor.kt
@@ -201,8 +201,8 @@ internal class CgVariableConstructor(val context: CgContext) :
     }
 
     private fun constructAssemble(model: UtAssembleModel, baseName: String?): CgValue {
-        val instantiationExecutableCall = model.instantiationCall
-        processInstantiationStatement(model, instantiationExecutableCall, baseName)
+        val instantiationCall = model.instantiationCall
+        processInstantiationStatement(model, instantiationCall, baseName)
 
         for (statementModel in model.modificationsChain) {
             when (statementModel) {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/IterableConstructors.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/IterableConstructors.kt
@@ -19,7 +19,7 @@ internal class CollectionConstructor : UtAssembleModelConstructorBase() {
         @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
         value as java.util.Collection<*>
 
-        // If [valueToConstructFrom] constructed incorrectly (some inner transient fields are null, etc.) this may fail.
+        // If [value] constructed incorrectly (some inner transient fields are null, etc.) this may fail.
         // This value will be constructed as UtCompositeModel.
         val models = value.map { internalConstructor.construct(it, valueToClassId(it)) }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/IterableConstructors.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/IterableConstructors.kt
@@ -1,5 +1,6 @@
 package org.utbot.framework.concrete
 
+import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.ConstructorId
 import org.utbot.framework.plugin.api.MethodId
 import org.utbot.framework.plugin.api.UtAssembleModel
@@ -11,55 +12,61 @@ import org.utbot.framework.plugin.api.util.objectClassId
 import org.utbot.framework.util.valueToClassId
 
 internal class CollectionConstructor : UtAssembleModelConstructorBase() {
-    override fun UtAssembleModel.modifyChains(
+    override fun UtAssembleModel.provideModificationChain(
         internalConstructor: UtModelConstructorInterface,
-        instantiationChain: MutableList<UtStatementModel>,
-        modificationChain: MutableList<UtStatementModel>,
-        valueToConstructFrom: Any
-    ) {
+        value: Any
+    ): List<UtStatementModel> {
         @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
-        valueToConstructFrom as java.util.Collection<*>
+        value as java.util.Collection<*>
 
         // If [valueToConstructFrom] constructed incorrectly (some inner transient fields are null, etc.) this may fail.
         // This value will be constructed as UtCompositeModel.
-        val models = valueToConstructFrom.map { internalConstructor.construct(it, valueToClassId(it)) }
+        val models = value.map { internalConstructor.construct(it, valueToClassId(it)) }
 
-        val classId = valueToConstructFrom::class.java.id
-
-        instantiationChain += UtExecutableCallModel(
-            instance = null,
-            ConstructorId(classId, emptyList()),
-            emptyList()
-        )
+        val classId = value::class.java.id
 
         val addMethodId = MethodId(classId, "add", booleanClassId, listOf(objectClassId))
 
-        modificationChain += models.map { UtExecutableCallModel(this, addMethodId, listOf(it)) }
+        return models.map { UtExecutableCallModel(this, addMethodId, listOf(it)) }
     }
+
+    override fun provideInstantiationCall(
+        internalConstructor: UtModelConstructorInterface,
+        value: Any,
+        classId: ClassId
+    ): UtExecutableCallModel =
+        UtExecutableCallModel(
+            instance = null,
+            ConstructorId(classId, emptyList()),
+            emptyList()
+        )
 }
 
 internal class MapConstructor : UtAssembleModelConstructorBase() {
-    override fun UtAssembleModel.modifyChains(
+    override fun provideInstantiationCall(
         internalConstructor: UtModelConstructorInterface,
-        instantiationChain: MutableList<UtStatementModel>,
-        modificationChain: MutableList<UtStatementModel>,
-        valueToConstructFrom: Any
-    ) {
-        valueToConstructFrom as java.util.AbstractMap<*, *>
-
-        val keyToValueModels = valueToConstructFrom.map { (key, value) ->
-            internalConstructor.run { construct(key, valueToClassId(key)) to construct(value, valueToClassId(value)) }
-        }
-
-        instantiationChain += UtExecutableCallModel(
+        value: Any,
+        classId: ClassId
+    ): UtExecutableCallModel =
+        UtExecutableCallModel(
             instance = null,
             ConstructorId(classId, emptyList()),
             emptyList()
         )
 
+    override fun UtAssembleModel.provideModificationChain(
+        internalConstructor: UtModelConstructorInterface,
+        value: Any
+    ): List<UtStatementModel> {
+        value as java.util.AbstractMap<*, *>
+
+        val keyToValueModels = value.map { (key, value) ->
+            internalConstructor.run { construct(key, valueToClassId(key)) to construct(value, valueToClassId(value)) }
+        }
+
         val putMethodId = MethodId(classId, "put", objectClassId, listOf(objectClassId, objectClassId))
 
-        modificationChain += keyToValueModels.map { (key, value) ->
+        return keyToValueModels.map { (key, value) ->
             UtExecutableCallModel(this, putMethodId, listOf(key, value))
         }
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/IterableConstructors.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/IterableConstructors.kt
@@ -7,7 +7,6 @@ import org.utbot.framework.plugin.api.UtExecutableCallModel
 import org.utbot.framework.plugin.api.UtStatementModel
 import org.utbot.framework.plugin.api.util.booleanClassId
 import org.utbot.framework.plugin.api.util.id
-import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.framework.plugin.api.util.objectClassId
 import org.utbot.framework.util.valueToClassId
 
@@ -30,8 +29,7 @@ internal class CollectionConstructor : UtAssembleModelConstructorBase() {
         instantiationChain += UtExecutableCallModel(
             instance = null,
             ConstructorId(classId, emptyList()),
-            emptyList(),
-            this
+            emptyList()
         )
 
         val addMethodId = MethodId(classId, "add", booleanClassId, listOf(objectClassId))
@@ -56,8 +54,7 @@ internal class MapConstructor : UtAssembleModelConstructorBase() {
         instantiationChain += UtExecutableCallModel(
             instance = null,
             ConstructorId(classId, emptyList()),
-            emptyList(),
-            this
+            emptyList()
         )
 
         val putMethodId = MethodId(classId, "put", objectClassId, listOf(objectClassId, objectClassId))

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/MockValueConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/MockValueConstructor.kt
@@ -358,7 +358,7 @@ class MockValueConstructor(
     private fun constructFromAssembleModel(assembleModel: UtAssembleModel): Any {
         constructedObjects[assembleModel]?.let { return it }
 
-        val instantiationExecutableCall = assembleModel.instantiationChain.single() as UtExecutableCallModel
+        val instantiationExecutableCall = assembleModel.instantiationCall
         val result = updateWithExecutableCallModel(instantiationExecutableCall)
         checkNotNull(result) {
             "Tracked instance can't be null for call ${instantiationExecutableCall.executable} in model $assembleModel"

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/MockValueConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/MockValueConstructor.kt
@@ -358,9 +358,16 @@ class MockValueConstructor(
     private fun constructFromAssembleModel(assembleModel: UtAssembleModel): Any {
         constructedObjects[assembleModel]?.let { return it }
 
-        assembleModel.allStatementsChain.forEach { statementModel ->
+        val instantiationExecutableCall = assembleModel.instantiationChain.single() as UtExecutableCallModel
+        val result = updateWithExecutableCallModel(instantiationExecutableCall)
+        checkNotNull(result) {
+            "Tracked instance can't be null for call ${instantiationExecutableCall.executable} in model $assembleModel"
+        }
+        constructedObjects[assembleModel] = result
+
+        assembleModel.modificationsChain.forEach { statementModel ->
             when (statementModel) {
-                is UtExecutableCallModel -> updateWithExecutableCallModel(statementModel, assembleModel)
+                is UtExecutableCallModel -> updateWithExecutableCallModel(statementModel)
                 is UtDirectSetFieldModel -> updateWithDirectSetFieldModel(statementModel)
             }
         }
@@ -398,12 +405,13 @@ class MockValueConstructor(
     }
 
     /**
-     * Updates instance state with [UtExecutableCallModel] invocation.
+     * Updates instance state with [callModel] invocation.
+     *
+     * @return the result of [callModel] invocation
      */
     private fun updateWithExecutableCallModel(
         callModel: UtExecutableCallModel,
-        assembleModel: UtAssembleModel,
-    ) {
+    ): Any? {
         val executable = callModel.executable
         val instanceValue = callModel.instance?.let { value(it) }
         val params = callModel.params.map { value(it) }
@@ -413,15 +421,7 @@ class MockValueConstructor(
             is ConstructorId -> executable.call(params)
         }
 
-        // Ignore result if returnId is null. Otherwise add it to instance cache.
-        callModel.returnValue?.let {
-            checkNotNull(result) { "Tracked instance can't be null for call $executable in model $assembleModel" }
-
-            //If statement is final instantiating, add result to constructed objects cache
-            if (callModel == assembleModel.finalInstantiationModel) {
-                constructedObjects[assembleModel] = result
-            }
-        }
+        return result
     }
 
     /**

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/OptionalConstructors.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/OptionalConstructors.kt
@@ -38,19 +38,17 @@ internal sealed class OptionalConstructorBase : UtAssembleModelConstructorBase()
             "Can't cast $valueToConstructFrom to ${classId.jClass} in $this assemble constructor."
         }
 
-        modificationChain += if (!isPresent.call(valueToConstructFrom)) {
+        instantiationChain += if (!isPresent.call(valueToConstructFrom)) {
             UtExecutableCallModel(
                 instance = null,
                 emptyMethodId,
-                emptyList(),
-                this
+                emptyList()
             )
         } else {
             UtExecutableCallModel(
                 instance = null,
                 ofMethodId,
-                listOf(internalConstructor.construct(getter.call(valueToConstructFrom), elementClassId)),
-                this
+                listOf(internalConstructor.construct(getter.call(valueToConstructFrom), elementClassId))
             )
         }
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/PrimitiveWrapperConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/PrimitiveWrapperConstructor.kt
@@ -22,8 +22,7 @@ internal class PrimitiveWrapperConstructor : UtAssembleModelConstructorBase() {
         instantiationChain += UtExecutableCallModel(
             null,
             constructorId(classId, classId.unbox()),
-            listOf(UtPrimitiveModel(valueToConstructFrom)),
-            this
+            listOf(UtPrimitiveModel(valueToConstructFrom))
         )
     }
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/PrimitiveWrapperConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/PrimitiveWrapperConstructor.kt
@@ -19,7 +19,7 @@ internal class PrimitiveWrapperConstructor : UtAssembleModelConstructorBase() {
         checkClassCast(classId.jClass, value::class.java)
 
         return UtExecutableCallModel(
-            null,
+            instance = null,
             constructorId(classId, classId.unbox()),
             listOf(UtPrimitiveModel(value))
         )

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/PrimitiveWrapperConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/PrimitiveWrapperConstructor.kt
@@ -11,20 +11,25 @@ import org.utbot.framework.plugin.api.util.primitiveByWrapper
 import org.utbot.framework.plugin.api.util.stringClassId
 
 internal class PrimitiveWrapperConstructor : UtAssembleModelConstructorBase() {
-    override fun UtAssembleModel.modifyChains(
+    override fun provideInstantiationCall(
         internalConstructor: UtModelConstructorInterface,
-        instantiationChain: MutableList<UtStatementModel>,
-        modificationChain: MutableList<UtStatementModel>,
-        valueToConstructFrom: Any
-    ) {
-        checkClassCast(classId.jClass, valueToConstructFrom::class.java)
+        value: Any,
+        classId: ClassId
+    ): UtExecutableCallModel {
+        checkClassCast(classId.jClass, value::class.java)
 
-        instantiationChain += UtExecutableCallModel(
+        return UtExecutableCallModel(
             null,
             constructorId(classId, classId.unbox()),
-            listOf(UtPrimitiveModel(valueToConstructFrom))
+            listOf(UtPrimitiveModel(value))
         )
+        
     }
+
+    override fun UtAssembleModel.provideModificationChain(
+        internalConstructor: UtModelConstructorInterface,
+        value: Any
+    ): List<UtStatementModel> = emptyList()
 }
 
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/UtAssembleModelConstructors.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/UtAssembleModelConstructors.kt
@@ -7,7 +7,6 @@ import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.framework.plugin.api.util.primitiveWrappers
 import org.utbot.framework.plugin.api.util.voidWrapperClassId
 import org.utbot.framework.util.nextModelName
-import java.util.concurrent.CopyOnWriteArrayList
 
 private val predefinedConstructors = mutableMapOf<Class<*>, () -> UtAssembleModelConstructorBase>(
     /**

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/UtAssembleModelConstructors.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/UtAssembleModelConstructors.kt
@@ -2,6 +2,7 @@ package org.utbot.framework.concrete
 
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.UtAssembleModel
+import org.utbot.framework.plugin.api.UtExecutableCallModel
 import org.utbot.framework.plugin.api.UtStatementModel
 import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.framework.plugin.api.util.primitiveWrappers
@@ -92,25 +93,29 @@ internal fun findUtAssembleModelConstructor(classId: ClassId): UtAssembleModelCo
 internal abstract class UtAssembleModelConstructorBase {
     fun constructAssembleModel(
         internalConstructor: UtModelConstructorInterface,
-        valueToConstructFrom: Any,
+        value: Any,
         valueClassId: ClassId,
         id: Int?,
         init: (UtAssembleModel) -> Unit
     ): UtAssembleModel {
-        val instantiationChain = mutableListOf<UtStatementModel>()
-        val modificationChain = mutableListOf<UtStatementModel>()
         val baseName = valueClassId.simpleName.decapitalize()
-        return UtAssembleModel(id, valueClassId, nextModelName(baseName), instantiationChain, modificationChain)
-            .also(init)
-            .apply { modifyChains(internalConstructor, instantiationChain, modificationChain, valueToConstructFrom) }
+        val instantiationCall = provideInstantiationCall(internalConstructor, value, valueClassId)
+        return UtAssembleModel(id, valueClassId, nextModelName(baseName), instantiationCall) {
+            init(this)
+            provideModificationChain(internalConstructor, value)
+        }
     }
 
-    protected abstract fun UtAssembleModel.modifyChains(
+    protected abstract fun provideInstantiationCall(
         internalConstructor: UtModelConstructorInterface,
-        instantiationChain: MutableList<UtStatementModel>,
-        modificationChain: MutableList<UtStatementModel>,
-        valueToConstructFrom: Any
-    )
+        value: Any,
+        classId: ClassId
+    ): UtExecutableCallModel
+
+    protected abstract fun UtAssembleModel.provideModificationChain(
+        internalConstructor: UtModelConstructorInterface,
+        value: Any
+    ): List<UtStatementModel>
 }
 
 internal fun UtAssembleModelConstructorBase.checkClassCast(expected: Class<*>, actual: Class<*>) {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/minimization/Minimization.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/minimization/Minimization.kt
@@ -222,7 +222,9 @@ private fun UtModel.calculateSize(used: MutableSet<UtModel> = mutableSetOf()): I
     return when (this) {
         is UtNullModel, is UtPrimitiveModel, UtVoidModel -> 0
         is UtClassRefModel, is UtEnumConstantModel, is UtArrayModel -> 1
-        is UtAssembleModel -> 1 + allStatementsChain.sumOf { it.calculateSize(used) }
+        is UtAssembleModel -> {
+            1 + instantiationCall.calculateSize(used) + modificationsChain.sumOf { it.calculateSize(used) }
+        }
         is UtCompositeModel -> 1 + fields.values.sumOf { it.calculateSize(used) }
         is UtLambdaModel -> 1 + capturedValues.sumOf { it.calculateSize(used) }
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/fuzzer/FallbackModelProvider.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/fuzzer/FallbackModelProvider.kt
@@ -102,7 +102,7 @@ open class FallbackModelProvider(
                     chain
                 )
                 chain.add(
-                    UtExecutableCallModel(model, defaultConstructor.executableId, listOf(), model)
+                    UtExecutableCallModel(model, defaultConstructor.executableId, listOf())
                 )
                 model
             }

--- a/utbot-framework/src/main/kotlin/org/utbot/fuzzer/FallbackModelProvider.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/fuzzer/FallbackModelProvider.kt
@@ -94,17 +94,12 @@ open class FallbackModelProvider(
                 UtNullModel(kclass.java.id)
             }
             defaultConstructor != null -> {
-                val chain = mutableListOf<UtStatementModel>()
-                val model = UtAssembleModel(
+                UtAssembleModel(
                     id = idGenerator.createId(),
                     kclass.id,
                     kclass.id.toString(),
-                    chain
+                    UtExecutableCallModel(null, defaultConstructor.executableId, listOf())
                 )
-                chain.add(
-                    UtExecutableCallModel(model, defaultConstructor.executableId, listOf())
-                )
-                model
             }
             else -> {
                 UtCompositeModel(

--- a/utbot-framework/src/main/kotlin/org/utbot/fuzzer/FallbackModelProvider.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/fuzzer/FallbackModelProvider.kt
@@ -98,7 +98,7 @@ open class FallbackModelProvider(
                     id = idGenerator.createId(),
                     kclass.id,
                     kclass.id.toString(),
-                    UtExecutableCallModel(null, defaultConstructor.executableId, listOf())
+                    UtExecutableCallModel(instance = null, defaultConstructor.executableId, listOf())
                 )
             }
             else -> {

--- a/utbot-framework/src/main/kotlin/org/utbot/tests/infrastructure/UtModelTestCaseChecker.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/tests/infrastructure/UtModelTestCaseChecker.kt
@@ -186,7 +186,7 @@ abstract class UtModelTestCaseChecker(
     protected fun UtModel.findField(fieldId: FieldId): UtModel = when (this) {
         is UtCompositeModel -> this.fields[fieldId]!!
         is UtAssembleModel -> {
-            val fieldAccess = this.allStatementsChain
+            val fieldAccess = this.modificationsChain
                 .filterIsInstance<UtDirectSetFieldModel>()
                 .singleOrNull { it.fieldId == fieldId }
             fieldAccess?.fieldModel ?: fieldId.type.defaultValueModel()

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/RandomExtensions.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/RandomExtensions.kt
@@ -1,10 +1,6 @@
 package org.utbot.fuzzer
 
 import kotlin.random.Random
-import org.utbot.framework.plugin.api.ConstructorId
-import org.utbot.framework.plugin.api.UtAssembleModel
-import org.utbot.framework.plugin.api.UtExecutableCallModel
-import org.utbot.framework.plugin.api.UtStatementModel
 
 /**
  * Chooses a random value using frequencies.

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/objects/AssembleModelUtils.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/objects/AssembleModelUtils.kt
@@ -18,7 +18,7 @@ fun ModelProvider.assembleModel(id: Int, constructorId: ConstructorId, params: L
         instantiationChain = instantiationChain,
         modificationsChain = mutableListOf()
     ).apply {
-        instantiationChain += UtExecutableCallModel(null, constructorId, params.map { it.model }, this)
+        instantiationChain += UtExecutableCallModel(null, constructorId, params.map { it.model })
     }.fuzzed {
         summary = "%var% = ${constructorId.classId.simpleName}(${constructorId.parameters.joinToString { it.simpleName }})"
     }

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/objects/AssembleModelUtils.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/objects/AssembleModelUtils.kt
@@ -15,7 +15,7 @@ fun ModelProvider.assembleModel(id: Int, constructorId: ConstructorId, params: L
         id,
         constructorId.classId,
         "${constructorId.classId.name}${constructorId.parameters}#" + id.hex(),
-        UtExecutableCallModel(null, constructorId, params.map { it.model })
+        UtExecutableCallModel(instance = null, constructorId, params.map { it.model })
     ).fuzzed {
         summary = "%var% = ${constructorId.classId.simpleName}(${constructorId.parameters.joinToString { it.simpleName }})"
     }

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/objects/AssembleModelUtils.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/objects/AssembleModelUtils.kt
@@ -10,7 +10,6 @@ import org.utbot.fuzzer.hex
 
 
 fun ModelProvider.assembleModel(id: Int, constructorId: ConstructorId, params: List<FuzzedValue>): FuzzedValue {
-    mutableListOf<UtStatementModel>()
     return UtAssembleModel(
         id,
         constructorId.classId,

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/objects/AssembleModelUtils.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/objects/AssembleModelUtils.kt
@@ -10,16 +10,13 @@ import org.utbot.fuzzer.hex
 
 
 fun ModelProvider.assembleModel(id: Int, constructorId: ConstructorId, params: List<FuzzedValue>): FuzzedValue {
-    val instantiationChain = mutableListOf<UtStatementModel>()
+    mutableListOf<UtStatementModel>()
     return UtAssembleModel(
         id,
         constructorId.classId,
         "${constructorId.classId.name}${constructorId.parameters}#" + id.hex(),
-        instantiationChain = instantiationChain,
-        modificationsChain = mutableListOf()
-    ).apply {
-        instantiationChain += UtExecutableCallModel(null, constructorId, params.map { it.model })
-    }.fuzzed {
+        UtExecutableCallModel(null, constructorId, params.map { it.model })
+    ).fuzzed {
         summary = "%var% = ${constructorId.classId.simpleName}(${constructorId.parameters.joinToString { it.simpleName }})"
     }
 }

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/CollectionModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/CollectionModelProvider.kt
@@ -100,7 +100,7 @@ class CollectionModelProvider(
             "${init.classId.name}${init.parameters}#" + genId.toString(16),
             instantiationChain
         ).apply {
-            instantiationChain += UtExecutableCallModel(null, init, params, this)
+            instantiationChain += UtExecutableCallModel(null, init, params)
         }
     }
 }

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/CollectionModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/CollectionModelProvider.kt
@@ -92,15 +92,13 @@ class CollectionModelProvider(
     private fun Class<*>.methodCall(methodName: String, returnType: Class<*>, params: List<Class<*>> = emptyList()) = MethodId(id, methodName, returnType.id, params.map { it.id })
 
     private fun Class<*>.createdBy(init: ExecutableId, params: List<UtModel> = emptyList()): UtAssembleModel {
-        val instantiationChain = mutableListOf<UtStatementModel>()
+        val instantiationCall = UtExecutableCallModel(null, init, params)
         val genId = idGenerator.createId()
         return UtAssembleModel(
             genId,
             id,
             "${init.classId.name}${init.parameters}#" + genId.toString(16),
-            instantiationChain
-        ).apply {
-            instantiationChain += UtExecutableCallModel(null, init, params)
-        }
+            instantiationCall
+        )
     }
 }

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/CollectionModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/CollectionModelProvider.kt
@@ -92,7 +92,7 @@ class CollectionModelProvider(
     private fun Class<*>.methodCall(methodName: String, returnType: Class<*>, params: List<Class<*>> = emptyList()) = MethodId(id, methodName, returnType.id, params.map { it.id })
 
     private fun Class<*>.createdBy(init: ExecutableId, params: List<UtModel> = emptyList()): UtAssembleModel {
-        val instantiationCall = UtExecutableCallModel(null, init, params)
+        val instantiationCall = UtExecutableCallModel(instance = null, init, params)
         val genId = idGenerator.createId()
         return UtAssembleModel(
             genId,

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/DateConstantModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/DateConstantModelProvider.kt
@@ -142,7 +142,6 @@ class DateConstantModelProvider(
             "$dateFormatParse#" + id.hex(),
             instantiationChain
         ).apply {
-            instantiationChain += simpleDateFormatModel.allStatementsChain
             instantiationChain += UtExecutableCallModel(
                 simpleDateFormatModel, dateFormatParse, listOf(UtPrimitiveModel(dateString)), returnValue = this
             )

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/DateConstantModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/DateConstantModelProvider.kt
@@ -143,7 +143,7 @@ class DateConstantModelProvider(
             instantiationChain
         ).apply {
             instantiationChain += UtExecutableCallModel(
-                simpleDateFormatModel, dateFormatParse, listOf(UtPrimitiveModel(dateString)), returnValue = this
+                simpleDateFormatModel, dateFormatParse, listOf(UtPrimitiveModel(dateString))
             )
         }.fuzzed {
             summary = "%var% = $dateFormatParse($stringClassId)"
@@ -168,7 +168,7 @@ class DateConstantModelProvider(
             modificationsChain
         ).apply {
             instantiationChain += UtExecutableCallModel(
-                instance = null, formatStringConstructor, listOf(formatModel), returnValue = this
+                instance = null, formatStringConstructor, listOf(formatModel)
             )
             modificationsChain += UtExecutableCallModel(
                 instance = this, formatSetLenient, listOf(UtPrimitiveModel(false))

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/DateConstantModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/DateConstantModelProvider.kt
@@ -135,17 +135,15 @@ class DateConstantModelProvider(
         val simpleDateFormatModel = assembleSimpleDateFormat(idGenerator.createId(), formatString)
         val dateFormatParse = simpleDateFormatModel.classId.jClass
             .getMethod("parse", String::class.java).executableId
-        val instantiationChain = mutableListOf<UtStatementModel>()
+        val instantiationCall = UtExecutableCallModel(
+            simpleDateFormatModel, dateFormatParse, listOf(UtPrimitiveModel(dateString))
+        )
         return UtAssembleModel(
             id,
             dateClassId,
             "$dateFormatParse#" + id.hex(),
-            instantiationChain
-        ).apply {
-            instantiationChain += UtExecutableCallModel(
-                simpleDateFormatModel, dateFormatParse, listOf(UtPrimitiveModel(dateString))
-            )
-        }.fuzzed {
+            instantiationCall
+        ).fuzzed {
             summary = "%var% = $dateFormatParse($stringClassId)"
         }
     }
@@ -158,21 +156,14 @@ class DateConstantModelProvider(
         val formatSetLenient = SimpleDateFormat::setLenient.executableId
         val formatModel = UtPrimitiveModel(formatString)
 
-        val instantiationChain = mutableListOf<UtStatementModel>()
-        val modificationsChain = mutableListOf<UtStatementModel>()
+        val instantiationCall = UtExecutableCallModel(instance = null, formatStringConstructor, listOf(formatModel))
         return UtAssembleModel(
             id,
             simpleDateFormatId,
             "$simpleDateFormatId[$stringClassId]#" + id.hex(),
-            instantiationChain,
-            modificationsChain
+            instantiationCall
         ).apply {
-            instantiationChain += UtExecutableCallModel(
-                instance = null, formatStringConstructor, listOf(formatModel)
-            )
-            modificationsChain += UtExecutableCallModel(
-                instance = this, formatSetLenient, listOf(UtPrimitiveModel(false))
-            )
+            listOf(UtExecutableCallModel(instance = this, formatSetLenient, listOf(UtPrimitiveModel(false))))
         }
     }
 

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/DateConstantModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/DateConstantModelProvider.kt
@@ -162,7 +162,7 @@ class DateConstantModelProvider(
             simpleDateFormatId,
             "$simpleDateFormatId[$stringClassId]#" + id.hex(),
             instantiationCall
-        ).apply {
+        ) {
             listOf(UtExecutableCallModel(instance = this, formatSetLenient, listOf(UtPrimitiveModel(false))))
         }
     }

--- a/utbot-fuzzers/src/test/kotlin/org/utbot/framework/plugin/api/ModelProviderTest.kt
+++ b/utbot-fuzzers/src/test/kotlin/org/utbot/framework/plugin/api/ModelProviderTest.kt
@@ -206,10 +206,8 @@ class ModelProviderTest {
             assertTrue(models[0]!!.all { it is UtAssembleModel && it.classId == classId })
 
             models[0]!!.filterIsInstance<UtAssembleModel>().forEachIndexed { index, model ->
-                assertEquals(1, model.instantiationChain.size)
-                val stm = model.instantiationChain[0]
-                assertTrue(stm is UtExecutableCallModel)
-                stm as UtExecutableCallModel
+                assertEquals(1, model.instantiationStatement.size)
+                val stm = model.instantiationStatement[0]
                 val paramCountInConstructorAsTheyListed = index + 1
                 assertEquals(paramCountInConstructorAsTheyListed, stm.params.size)
             }
@@ -249,10 +247,9 @@ class ModelProviderTest {
 
             assertEquals(1, models.size)
             assertTrue(models[0]!!.isNotEmpty())
-            val chain = (models[0]!![0] as UtAssembleModel).instantiationChain
+            val chain = (models[0]!![0] as UtAssembleModel).instantiationStatement
             assertEquals(1, chain.size)
-            assertTrue(chain[0] is UtExecutableCallModel)
-            (chain[0] as UtExecutableCallModel).params.forEach {
+            chain[0].params.forEach {
                 assertEquals(intClassId, it.classId)
             }
         }
@@ -369,15 +366,14 @@ class ModelProviderTest {
             assertEquals(1, result[0]!!.size)
             assertInstanceOf(UtAssembleModel::class.java, result[0]!![0])
             assertEquals(A::class.java.id, result[0]!![0].classId)
-            (result[0]!![0] as UtAssembleModel).instantiationChain.forEach {
-                assertTrue(it is UtExecutableCallModel)
-                assertEquals(1, (it as UtExecutableCallModel).params.size)
+            (result[0]!![0] as UtAssembleModel).instantiationStatement.forEach {
+                assertEquals(1, it.params.size)
                 val objectParamInConstructor = it.params[0]
                 assertInstanceOf(UtAssembleModel::class.java, objectParamInConstructor)
                 val innerAssembledModel = objectParamInConstructor as UtAssembleModel
                 assertEquals(Any::class.java.id, innerAssembledModel.classId)
-                assertEquals(1, innerAssembledModel.instantiationChain.size)
-                val objectCreation = innerAssembledModel.instantiationChain.first() as UtExecutableCallModel
+                assertEquals(1, innerAssembledModel.instantiationStatement.size)
+                val objectCreation = innerAssembledModel.instantiationStatement.first()
                 assertEquals(0, objectCreation.params.size)
                 assertInstanceOf(ConstructorId::class.java, objectCreation.executable)
             }
@@ -399,13 +395,13 @@ class ModelProviderTest {
             assertEquals(1, result.size)
             assertEquals(1, result[0]!!.size)
             val outerModel = result[0]!![0] as UtAssembleModel
-            outerModel.instantiationChain.forEach {
-                val constructorParameters = (it as UtExecutableCallModel).params
+            outerModel.instantiationStatement.forEach {
+                val constructorParameters = it.params
                 assertEquals(1, constructorParameters.size)
                 val innerModel = (constructorParameters[0] as UtAssembleModel)
                 assertEquals(MyA::class.java.id, innerModel.classId)
-                assertEquals(1, innerModel.instantiationChain.size)
-                val innerConstructorParameters = innerModel.instantiationChain[0] as UtExecutableCallModel
+                assertEquals(1, innerModel.instantiationStatement.size)
+                val innerConstructorParameters = innerModel.instantiationStatement[0]
                 assertEquals(1, innerConstructorParameters.params.size)
                 assertInstanceOf(UtNullModel::class.java, innerConstructorParameters.params[0])
             }
@@ -441,13 +437,13 @@ class ModelProviderTest {
             assertEquals(1, result.size)
             assertEquals(1, result[0]!!.size)
             val outerModel = result[0]!![0] as UtAssembleModel
-            outerModel.instantiationChain.forEach {
-                val constructorParameters = (it as UtExecutableCallModel).params
+            outerModel.instantiationStatement.forEach {
+                val constructorParameters = it.params
                 assertEquals(1, constructorParameters.size)
                 val innerModel = (constructorParameters[0] as UtAssembleModel)
                 assertEquals(Inner::class.java.id, innerModel.classId)
-                assertEquals(1, innerModel.instantiationChain.size)
-                val innerConstructorParameters = innerModel.instantiationChain[0] as UtExecutableCallModel
+                assertEquals(1, innerModel.instantiationStatement.size)
+                val innerConstructorParameters = innerModel.instantiationStatement[0]
                 assertEquals(2, innerConstructorParameters.params.size)
                 assertTrue(innerConstructorParameters.params.all { param -> param is UtPrimitiveModel })
                 assertEquals(intClassId, innerConstructorParameters.params[0].classId)
@@ -543,7 +539,7 @@ class ModelProviderTest {
 
             for (model in models) {
                 val outerModel = (model as? UtAssembleModel)
-                    ?.finalInstantiationModel as? UtExecutableCallModel
+                    ?.instantiationStatement as? UtExecutableCallModel
                     ?: fail("No final instantiation model found for the outer class")
                 for (param in outerModel.params) {
                     when (param) {
@@ -551,7 +547,7 @@ class ModelProviderTest {
                             assertEquals(expectedIds[param.value], param.id)
                         }
                         is UtAssembleModel -> {
-                            for (enumParam in (param.finalInstantiationModel as UtExecutableCallModel).params) {
+                            for (enumParam in (param.instantiationStatement as UtExecutableCallModel).params) {
                                 enumParam as UtEnumConstantModel
                                 assertEquals(expectedIds[enumParam.value], enumParam.id)
                             }


### PR DESCRIPTION
# Description

Refactored API:
- Removed useless `UtExecutableCallModel::returnValue`. It was providing duplicate information accordingly to our use cases. Rewrote these use cases, with relying on another API.
- Changed `UtAssembleModel::instantiationChain` to `UtAssembleModel::instantiationCall`
- Made the primary constructor of `UtAssembleModel` private due to its unclear syntax with mutable lists. Added a more understandable (in my point of view) constructor. Rewrote all the usages of the previous one.
- Updated in-code documentation.
- Fixed an error in the `AssembleModelGenerator` and turned on a test, which checks this error.

Fixes #812

## Type of Change

- Bug fix (non-breaking change which fixes an issue)
- Refactoring (typos and non-functional changes) 

# How Has This Been Tested?

## Automated Testing

Turned on `org.utbot.examples.codegen.deepequals.ClassWithCrossReferenceRelationshipTest`

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] New tests have been added
- [x] All tests pass locally with my changes
