### PR TITLE
Check for ArrayStoreException on array update

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/arrays/ArrayStoreExceptionExamplesTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/arrays/ArrayStoreExceptionExamplesTest.kt
@@ -1,0 +1,214 @@
+package org.utbot.examples.arrays
+
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.utbot.framework.plugin.api.CodegenLanguage
+import org.utbot.testcheckers.eq
+import org.utbot.tests.infrastructure.AtLeast
+import org.utbot.tests.infrastructure.CodeGeneration
+import org.utbot.tests.infrastructure.UtValueTestCaseChecker
+import org.utbot.tests.infrastructure.isException
+
+class ArrayStoreExceptionExamplesTest : UtValueTestCaseChecker(
+    testClass = ArrayStoreExceptionExamples::class,
+    languagePipelines = listOf(
+        CodeGenerationLanguageLastStage(CodegenLanguage.JAVA),
+        // Type inference errors in generated Kotlin code
+        CodeGenerationLanguageLastStage(CodegenLanguage.KOTLIN, CodeGeneration)
+    )
+) {
+    @Test
+    fun testCorrectAssignmentSamePrimitiveType() {
+        checkWithException(
+            ArrayStoreExceptionExamples::correctAssignmentSamePrimitiveType,
+            eq(3),
+            { data, result -> result.isSuccess && result.getOrNull() == data?.isNotEmpty() }
+        )
+    }
+
+    @Test
+    fun testCorrectAssignmentIntToIntegerArray() {
+        checkWithException(
+            ArrayStoreExceptionExamples::correctAssignmentIntToIntegerArray,
+            eq(3),
+            { data, result -> result.isSuccess && result.getOrNull() == data?.isNotEmpty() }
+        )
+    }
+
+    @Test
+    fun testCorrectAssignmentSubtype() {
+        checkWithException(
+            ArrayStoreExceptionExamples::correctAssignmentSubtype,
+            eq(3),
+            { data, result -> result.isSuccess && result.getOrNull() == data?.isNotEmpty() }
+        )
+    }
+
+    @Test
+    fun testCorrectAssignmentToObjectArray() {
+        checkWithException(
+            ArrayStoreExceptionExamples::correctAssignmentToObjectArray,
+            eq(3),
+            { data, result -> result.isSuccess && result.getOrNull() == data?.isNotEmpty() }
+        )
+    }
+
+    @Test
+    fun testWrongAssignmentUnrelatedType() {
+        checkWithException(
+            ArrayStoreExceptionExamples::wrongAssignmentUnrelatedType,
+            eq(3),
+            { data, result -> data == null && result.isSuccess },
+            { data, result -> data.isEmpty() && result.isSuccess },
+            { data, result -> data.isNotEmpty() && result.isException<ArrayStoreException>() },
+            coverage = AtLeast(91) // TODO: investigate
+        )
+    }
+
+    @Test
+    fun testCheckGenericAssignmentWithCorrectCast() {
+        checkWithException(
+            ArrayStoreExceptionExamples::checkGenericAssignmentWithCorrectCast,
+            eq(1),
+            { result -> result.isSuccess }
+        )
+    }
+
+    @Test
+    fun testCheckGenericAssignmentWithWrongCast() {
+        checkWithException(
+            ArrayStoreExceptionExamples::checkGenericAssignmentWithWrongCast,
+            eq(1),
+            { result -> result.isException<ArrayStoreException>() },
+            coverage = AtLeast(87) // TODO: investigate
+        )
+    }
+
+    @Test
+    fun testCheckGenericAssignmentWithExtendsSubtype() {
+        checkWithException(
+            ArrayStoreExceptionExamples::checkGenericAssignmentWithExtendsSubtype,
+            eq(1),
+            { result -> result.isSuccess }
+        )
+    }
+
+    @Test
+    fun testCheckGenericAssignmentWithExtendsUnrelated() {
+        checkWithException(
+            ArrayStoreExceptionExamples::checkGenericAssignmentWithExtendsUnrelated,
+            eq(1),
+            { result -> result.isException<ArrayStoreException>() },
+            coverage = AtLeast(87) // TODO: investigate
+        )
+    }
+
+    @Test
+    fun testCheckObjectAssignment() {
+        checkWithException(
+            ArrayStoreExceptionExamples::checkObjectAssignment,
+            eq(1),
+            { result -> result.isSuccess }
+        )
+    }
+
+    // Should this be allowed at all?
+    @Test
+    fun testCheckWrongAssignmentOfItself() {
+        checkWithException(
+            ArrayStoreExceptionExamples::checkWrongAssignmentOfItself,
+            eq(1),
+            { result -> result.isException<ArrayStoreException>() },
+            coverage = AtLeast(87)
+        )
+    }
+
+    @Test
+    fun testCheckGoodAssignmentOfItself() {
+        checkWithException(
+            ArrayStoreExceptionExamples::checkGoodAssignmentOfItself,
+            eq(1),
+            { result -> result.isSuccess }
+        )
+    }
+
+    @Test
+    fun testCheckAssignmentToObjectArray() {
+        checkWithException(
+            ArrayStoreExceptionExamples::checkAssignmentToObjectArray,
+            eq(1),
+            { result -> result.isSuccess }
+        )
+    }
+
+    @Test
+    fun testArrayCopyForIncompatiblePrimitiveTypes() {
+        checkWithException(
+            ArrayStoreExceptionExamples::arrayCopyForIncompatiblePrimitiveTypes,
+            eq(3),
+            { data, result -> data == null && result.isSuccess && result.getOrNull() == null },
+            { data, result -> data != null && data.isEmpty() && result.isSuccess && result.getOrNull()?.size == 0 },
+            { data, result -> data != null && data.isNotEmpty() && result.isException<ArrayStoreException>() }
+        )
+    }
+
+    @Test
+    fun testFill2DPrimitiveArray() {
+        checkWithException(
+            ArrayStoreExceptionExamples::fill2DPrimitiveArray,
+            eq(1),
+            { result -> result.isSuccess }
+        )
+    }
+
+    @Test
+    fun testFillObjectArrayWithList() {
+        check(
+            ArrayStoreExceptionExamples::fillObjectArrayWithList,
+            eq(2),
+            { list, result -> list != null && result != null && result[0] != null },
+            { list, result -> list == null && result == null }
+        )
+    }
+
+    @Test
+    fun testFillWithTreeSet() {
+        check(
+            ArrayStoreExceptionExamples::fillWithTreeSet,
+            eq(2),
+            { treeSet, result -> treeSet != null && result != null && result[0] != null },
+            { treeSet, result -> treeSet == null && result == null }
+        )
+    }
+
+    @Test
+    fun testFillSomeInterfaceArrayWithSomeInterface() {
+        check(
+            ArrayStoreExceptionExamples::fillSomeInterfaceArrayWithSomeInterface,
+            eq(2),
+            { impl, result -> impl == null && result == null },
+            { impl, result -> impl != null && result != null && result[0] != null }
+        )
+    }
+
+    @Test
+    @Disabled("TODO: Not null path is not found, need to investigate")
+    fun testFillObjectArrayWithSomeInterface() {
+        check(
+            ArrayStoreExceptionExamples::fillObjectArrayWithSomeInterface,
+            eq(2),
+            { impl, result -> impl == null && result == null },
+            { impl, result -> impl != null && result != null && result[0] != null }
+        )
+    }
+
+    @Test
+    fun testFillWithSomeImplementation() {
+        check(
+            ArrayStoreExceptionExamples::fillWithSomeImplementation,
+            eq(2),
+            { impl, result -> impl == null && result == null },
+            { impl, result -> impl != null && result != null && result[0] != null }
+        )
+    }
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/DataClasses.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/DataClasses.kt
@@ -1,5 +1,7 @@
 package org.utbot.engine
 
+import org.utbot.common.WorkaroundReason
+import org.utbot.common.workaround
 import org.utbot.engine.TypeRegistry.Companion.objectTypeStorage
 import org.utbot.engine.pc.UtAddrExpression
 import org.utbot.engine.pc.UtBoolExpression
@@ -11,6 +13,7 @@ import org.utbot.engine.pc.mkOr
 import org.utbot.engine.symbolic.*
 import org.utbot.framework.plugin.api.FieldId
 import org.utbot.framework.plugin.api.UtInstrumentation
+import soot.RefType
 import java.util.Objects
 import soot.Scene
 import soot.SootMethod

--- a/utbot-sample/src/main/java/org/utbot/examples/arrays/ArrayStoreExceptionExamples.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/arrays/ArrayStoreExceptionExamples.java
@@ -1,0 +1,163 @@
+package org.utbot.examples.arrays;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeSet;
+
+public class ArrayStoreExceptionExamples {
+
+    public boolean correctAssignmentSamePrimitiveType(int[] data) {
+        if (data == null || data.length == 0) return false;
+        data[0] = 1;
+        return true;
+    }
+
+    public boolean correctAssignmentIntToIntegerArray(Integer[] data) {
+        if (data == null || data.length == 0) return false;
+        data[0] = 1;
+        return true;
+    }
+
+    public boolean correctAssignmentSubtype(Number[] data) {
+        if (data == null || data.length == 0) return false;
+        data[0] = 15;
+        return true;
+    }
+
+    public boolean correctAssignmentToObjectArray(Object[] data) {
+        if (data == null || data.length < 2) return false;
+        data[0] = 1;
+        data[1] = new ArrayList<Integer>();
+        return true;
+    }
+
+    public void wrongAssignmentUnrelatedType(Integer[] data) {
+        if (data == null || data.length == 0) return;
+        ((Object[]) data)[0] = "x";
+    }
+
+    public void wrongAssignmentSupertype(Integer[] data) {
+        if (data == null || data.length == 0) return;
+        Number x = 1.2;
+        ((Number[]) data)[0] = x;
+    }
+
+    public void checkGenericAssignmentWithCorrectCast() {
+        Number[] data = new Number[3];
+        genericAssignmentWithCast(data, 5);
+    }
+
+    public void checkGenericAssignmentWithWrongCast() {
+        Number[] data = new Number[3];
+        genericAssignmentWithCast(data, "x");
+    }
+
+    public void checkGenericAssignmentWithExtendsSubtype() {
+        Number[] data = new Number[3];
+        genericAssignmentWithExtends(data, 7);
+    }
+
+    public void checkGenericAssignmentWithExtendsUnrelated() {
+        Number[] data = new Number[3];
+        genericAssignmentWithExtends(data, "x");
+    }
+
+    public void checkObjectAssignment() {
+        Object[] data = new Object[3];
+        data[0] = "x";
+    }
+
+    public void checkAssignmentToObjectArray() {
+        Object[] data = new Object[3];
+        data[0] = 1;
+        data[1] = "a";
+        data[2] = data;
+    }
+
+    public void checkWrongAssignmentOfItself() {
+        Number[] data = new Number[2];
+        genericAssignmentWithCast(data, data);
+    }
+
+    public void checkGoodAssignmentOfItself() {
+        Object[] data = new Object[2];
+        genericAssignmentWithCast(data, data);
+    }
+
+    public int[] arrayCopyForIncompatiblePrimitiveTypes(long[] data) {
+        if (data == null)
+            return null;
+
+        int[] result = new int[data.length];
+        if (data.length != 0) {
+            System.arraycopy(data, 0, result, 0, data.length);
+        }
+
+        return result;
+    }
+
+    public int[][] fill2DPrimitiveArray() {
+        int[][] data = new int[2][3];
+        for (int i = 0; i < 2; i++) {
+            for (int j = 0; j < 3; j++) {
+                data[i][j] = i * 3 + j;
+            }
+        }
+        return data;
+    }
+
+    public Object[] fillObjectArrayWithList(List<Integer> list) {
+        if (list == null)
+            return null;
+
+        Object[] result = new Object[1];
+        result[0] = list;
+        return result;
+    }
+
+    public Object[] fillWithTreeSet(TreeSet<Integer> treeSet) {
+        if (treeSet == null)
+            return null;
+
+        Object[] result = new Object[1];
+        result[0] = treeSet;
+        return result;
+    }
+
+    public SomeInterface[] fillSomeInterfaceArrayWithSomeInterface(SomeInterface impl) {
+        if (impl == null)
+            return null;
+
+        SomeInterface[] result = new SomeInterface[1];
+        result[0] = impl;
+        return result;
+    }
+
+    public Object[] fillObjectArrayWithSomeInterface(SomeInterface impl) {
+        if (impl == null)
+            return null;
+
+        Object[] result = new Object[1];
+        result[0] = impl;
+        return result;
+    }
+
+    public Object[] fillWithSomeImplementation(SomeImplementation impl) {
+        if (impl == null)
+            return null;
+
+        Object[] result = new Object[1];
+        result[0] = impl;
+        return result;
+    }
+
+    private <T, E> void genericAssignmentWithCast(T[] data, E element) {
+        if (data == null || data.length == 0) return;
+        data[0] = (T) element;
+    }
+
+    private <T, E extends T> void genericAssignmentWithExtends(T[] data, E element) {
+        if (data == null || data.length == 0) return;
+        data[0] = element;
+    }
+}

--- a/utbot-sample/src/main/java/org/utbot/examples/arrays/SomeImplementation.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/arrays/SomeImplementation.java
@@ -1,0 +1,8 @@
+package org.utbot.examples.arrays;
+
+public class SomeImplementation implements SomeInterface {
+    @Override
+    public int foo() {
+        return 0;
+    }
+}

--- a/utbot-sample/src/main/java/org/utbot/examples/arrays/SomeInterface.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/arrays/SomeInterface.java
@@ -1,0 +1,5 @@
+package org.utbot.examples.arrays;
+
+public interface SomeInterface {
+    int foo();
+}


### PR DESCRIPTION
# Description

This PR adds a check to `TraversalContext.traverseAssignLeftPart` to detect if `ArrayStoreException` should be thrown for the given array element assignment statement.

The exception is generated if the type of the value on the right-hand side of the assignment is not a subtype of the array elements type and is not null.

This change affects all code that explicitly assigns array elements, as well as all calls to `Objects.arraycopy` and similar `Arrays` static methods.

Fixes #923

## Type of Change

Breaking change (fix or feature that would cause existing functionality to not work as expected)

New executions may be generated for the code that involves array modification.

# How Has This Been Tested?

## Automated Testing

All existing unit tests should pass.

A new test suite `org.utbot.examples.arrays.ArrayStoreExceptionExamplesTest` has been added, it should pass both with and without concrete execution.

## Manual Scenario 

Generate a test suite (with fuzzer turned off) for a method that assigns values to array elements of a incompatible reference type, e.g.:
```
public class Foo {
    public int foo() {
        Integer[] integers = { 1, 2, 3 };
        Object[] objects = integers;
        objects[1] = "";
        return 1;
    }
}
```

A single test should be generated, that corresponds to `ArrayStoreException`:
```
import org.junit.jupiter.api.Test;
import org.junit.jupiter.api.DisplayName;

public class FooTest {
    ///region Test suites for executable basic.Foo.foo

    ///region SYMBOLIC EXECUTION ENGINE: ERROR SUITE for method foo()

    /**
     * @utbot.classUnderTest {@link Foo}
     * @utbot.methodUnderTest {@link Foo#foo()}
     * @utbot.throwsException {@link ArrayStoreException} in: objects[1] = "";
     */
    @Test
    @DisplayName("foo: objects[1] = \"\" -> ThrowArrayStoreException")
    public void testFoo_IntegerValueOf() {
        Foo foo = new Foo();
        
        /* This test fails because method [basic.Foo.foo] produces [java.lang.ArrayStoreException: java.lang.String]
            basic.Foo.foo(Foo.java:9) */
        foo.foo();
    }
    ///endregion

    ///endregion
}
```

## Checklist

_This is the author self-check list_

- [X] The change followed the style guidelines of the UTBot project
- [X] Self-review of the code is passed
- [X] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [X] No new warnings
- [X] New tests have been added
- [X] All tests pass locally with my changes