### PR TITLE
Use read action to access documents #850

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerationController.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerationController.kt
@@ -274,9 +274,11 @@ object CodeGenerationController {
             reformat(model, SmartPointerManager.getInstance(model.project).createSmartPsiElementPointer(utUtilsFile), utUtilsClass)
         })
 
-        val utUtilsDocument = PsiDocumentManager
-            .getInstance(model.project)
-            .getDocument(utUtilsFile) ?: error("Failed to get a Document for UtUtils file")
+        val utUtilsDocument = runReadAction {
+            PsiDocumentManager
+                .getInstance(model.project)
+                .getDocument(utUtilsFile) ?: error("Failed to get a Document for UtUtils file")
+        }
 
         unblockDocument(model.project, utUtilsDocument)
     }
@@ -286,10 +288,12 @@ object CodeGenerationController {
         utilClassKind: UtilClassKind,
         model: GenerateTestsModel
     ): PsiFile {
-        val utilsClassDocument = PsiDocumentManager
-            .getInstance(model.project)
-            .getDocument(existingUtilClass)
-            ?: error("Failed to get Document for UtUtils class PsiFile: ${existingUtilClass.name}")
+        val utilsClassDocument = runReadAction {
+            PsiDocumentManager
+                .getInstance(model.project)
+                .getDocument(existingUtilClass)
+                ?: error("Failed to get Document for UtUtils class PsiFile: ${existingUtilClass.name}")
+        }
 
         val utUtilsText = utilClassKind.getUtilClassText(model.codegenLanguage)
 


### PR DESCRIPTION
# Description

I could not reproduce issue #850, but it seems like the exception occurs because the read lock is not acquired. In this MR I add the read lock acquisition for accessing the Document instances.

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

It is important that after this change util class generation still functions normally. I manually checked how it works in different possible cases.
- `org.utbot.examples.structures.StandardStructures` (without mocks) - util class with no mock support is generated
- `org.utbot.examples.mock.CommonMocksExample` (mock strategy: mock class environment) - util class generated at previous step is updated to support mocks
- generated tests on `org.utbot.examples.objects.AnonymousClassesExample` into a different test source root of the same module - util methods are imported from the existing util class from another test source root (no new util class is created)

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
