### PR TITLE
Fix for filtering anonymous function types

### DIFF
--- a/utbot-core/src/main/kotlin/org/utbot/common/FileUtil.kt
+++ b/utbot-core/src/main/kotlin/org/utbot/common/FileUtil.kt
@@ -224,13 +224,16 @@ object FileUtil {
     }
 
     // https://stackoverflow.com/a/68822715
-    fun byteCountToDisplaySize(bytes: Long): String =
-        when {
-            bytes >= 1 shl 30 -> "%.1f GB".format(bytes / (1 shl 30))
-            bytes >= 1 shl 20 -> "%.1f MB".format(bytes / (1 shl 20))
-            bytes >= 1 shl 10 -> "%.0f kB".format(bytes / (1 shl 10))
-            else -> "$bytes bytes"
+    fun byteCountToDisplaySize(bytes: Long): String {
+        val bytesInDouble = bytes.toDouble()
+
+        return when {
+            bytesInDouble >= 1 shl 30 -> "%.1f GB".format(bytesInDouble / (1 shl 30))
+            bytesInDouble >= 1 shl 20 -> "%.1f MB".format(bytesInDouble / (1 shl 20))
+            bytesInDouble >= 1 shl 10 -> "%.0f kB".format(bytesInDouble / (1 shl 10))
+            else -> "$bytesInDouble bytes"
         }
+    }
 }
 
 /**

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/lambda/PredicateNotExampleTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/lambda/PredicateNotExampleTest.kt
@@ -1,0 +1,17 @@
+package org.utbot.examples.lambda
+
+import org.junit.jupiter.api.Test
+import org.utbot.testcheckers.eq
+import org.utbot.tests.infrastructure.UtValueTestCaseChecker
+
+class PredicateNotExampleTest : UtValueTestCaseChecker(testClass = PredicateNotExample::class) {
+    @Test
+    fun testPredicateNotExample() {
+        check(
+            PredicateNotExample::predicateNotExample,
+            eq(2),
+            { a, r -> a == 5 && r == false },
+            { a, r -> a != 5 && r == true },
+        )
+    }
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/TypeResolver.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/TypeResolver.kt
@@ -206,9 +206,7 @@ class TypeResolver(private val typeRegistry: TypeRegistry, private val hierarchy
             when {
                 sootClass.isUtMock -> unwantedTypes += it
                 sootClass.isArtificialEntity -> {
-                    if (sootClass.isLambda) {
-                        unwantedTypes += it
-                    } else if (keepArtificialEntities) {
+                    if (keepArtificialEntities || sootClass.isLambda) {
                         concreteTypes += it
                     }
                 }

--- a/utbot-sample/src/main/java/org/utbot/examples/lambda/PredicateNotExample.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/lambda/PredicateNotExample.java
@@ -1,0 +1,13 @@
+package org.utbot.examples.lambda;
+
+import java.util.function.*;
+
+public class PredicateNotExample {
+    public boolean predicateNotExample(int a) {
+        if (Predicate.not(i -> i.equals(5)).test(a)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
# Description

Removed filtering out lambda classes in `TypeStorage` for correct work with functional interfaces.

Fixes #555.

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

`org.utbot.examples.lambda.PredicateNotExample#predicateNotExample`

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] New tests have been added
- [x] All tests pass locally with my changes
