### PR TITLE
Multiple values for custom javadoc tags

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/javadoc/UtJavaDocInfoGenerator.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/javadoc/UtJavaDocInfoGenerator.kt
@@ -76,8 +76,7 @@ class UtJavaDocInfoGenerator {
                         this.append(", $BR_TAG")
                     }
                 }
-            }
-                .forEach { builder.append(it) }
+            }.forEach { builder.append(it) }
 
             builder.append(DocumentationMarkup.SECTION_END)
         }

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/javadoc/UtJavaDocInfoGenerator.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/javadoc/UtJavaDocInfoGenerator.kt
@@ -6,7 +6,11 @@ import com.intellij.lang.documentation.DocumentationMarkup
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.IndexNotReadyException
 import com.intellij.openapi.util.text.StringUtil
-import com.intellij.psi.*
+import com.intellij.psi.JavaDocTokenType
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiJavaToken
+import com.intellij.psi.PsiRecursiveElementWalkingVisitor
+import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.javadoc.PsiDocComment
 import com.intellij.psi.javadoc.PsiDocTag
 import com.intellij.psi.javadoc.PsiDocToken
@@ -22,6 +26,7 @@ private const val MESSAGE_SEPARATOR = ":"
 private const val PARAGRAPH_TAG = "<p>"
 private const val CODE_TAG_START = "<code>"
 private const val CODE_TAG_END = "</code>"
+private const val BR_TAG = "<br>"
 
 private val logger = KotlinLogging.logger {}
 
@@ -51,22 +56,31 @@ class UtJavaDocInfoGenerator {
     }
 
     /**
-     * Searches for UtBot tag in the comment and generates a related section for it.
+     * Searches for UtBot tags in the comment and generates a related section for it.
      */
     private fun generateUtTagSection(
         builder: StringBuilder,
         comment: PsiDocComment,
         utTag: UtCustomJavaDocTagProvider.UtCustomTagInfo
     ) {
-        val tag = comment.findTagByName(utTag.name) ?: return
-        startHeaderSection(builder, utTag.getMessage()).append(PARAGRAPH_TAG)
-        val sectionContent = buildString {
-            generateValue(this, tag.dataElements)
-            trim()
-        }
+        val tags = comment.findTagsByName(utTag.name)
 
-        builder.append(sectionContent)
-        builder.append(DocumentationMarkup.SECTION_END)
+        if (tags.isNotEmpty()) {
+            startHeaderSection(builder, utTag.getMessage()).append(PARAGRAPH_TAG)
+
+            tags.mapIndexed { index, it ->
+                buildString {
+                    generateValue(this, it.dataElements)
+
+                    if (index < tags.size - 1) {
+                        this.append(", $BR_TAG")
+                    }
+                }
+            }
+                .forEach { builder.append(it) }
+
+            builder.append(DocumentationMarkup.SECTION_END)
+        }
     }
 
     private fun startHeaderSection(builder: StringBuilder, message: String): StringBuilder =

--- a/utbot-summary-tests/src/test/kotlin/examples/exceptions/SummaryExceptionClusteringExamplesTest.kt
+++ b/utbot-summary-tests/src/test/kotlin/examples/exceptions/SummaryExceptionClusteringExamplesTest.kt
@@ -21,20 +21,20 @@ class SummaryExceptionClusteringExamplesTest : SummaryTestCaseGeneratorTest(
 
         val summary2 = "@utbot.classUnderTest {@link ExceptionClusteringExamples}\n" +
                 "@utbot.methodUnderTest {@link org.utbot.examples.exceptions.ExceptionClusteringExamples#differentExceptions(int)}\n" +
-                "@utbot.executesCondition {@code (i == 0): False},\n" +
-                "{@code (i == 1): True}\n" +
+                "@utbot.executesCondition {@code (i == 0): False}\n" +
+                "@utbot.executesCondition {@code (i == 1): True}\n" +
                 "@utbot.throwsException {@link org.utbot.examples.exceptions.MyCheckedException} after condition: i == 1"
         val summary3 = "@utbot.classUnderTest {@link ExceptionClusteringExamples}\n" +
                 "@utbot.methodUnderTest {@link org.utbot.examples.exceptions.ExceptionClusteringExamples#differentExceptions(int)}\n" +
-                "@utbot.executesCondition {@code (i == 0): False},\n" +
-                "{@code (i == 1): False},\n" +
-                "{@code (i == 2): True}\n" +
+                "@utbot.executesCondition {@code (i == 0): False}\n" +
+                "@utbot.executesCondition {@code (i == 1): False}\n" +
+                "@utbot.executesCondition {@code (i == 2): True}\n" +
                 "@utbot.throwsException {@link java.lang.IllegalArgumentException} after condition: i == 2"
         val summary4 = "@utbot.classUnderTest {@link ExceptionClusteringExamples}\n" +
                 "@utbot.methodUnderTest {@link org.utbot.examples.exceptions.ExceptionClusteringExamples#differentExceptions(int)}\n" +
-                "@utbot.executesCondition {@code (i == 0): False},\n" +
-                "{@code (i == 1): False},\n" +
-                "{@code (i == 2): False}\n" +
+                "@utbot.executesCondition {@code (i == 0): False}\n" +
+                "@utbot.executesCondition {@code (i == 1): False}\n" +
+                "@utbot.executesCondition {@code (i == 2): False}\n" +
                 "@utbot.returnsFrom {@code return i * 2;}\n"
 
         val methodName1 = "testDifferentExceptions_IEqualsZero"

--- a/utbot-summary-tests/src/test/kotlin/examples/recursion/SummaryRecursionTest.kt
+++ b/utbot-summary-tests/src/test/kotlin/examples/recursion/SummaryRecursionTest.kt
@@ -16,8 +16,8 @@ class SummaryRecursionTest : SummaryTestCaseGeneratorTest(
     fun testFib() {
         val summary1 = "@utbot.classUnderTest {@link Recursion}\n" +
                 "@utbot.methodUnderTest {@link org.utbot.examples.recursion.Recursion#fib(int)}\n" +
-                "@utbot.executesCondition {@code (n == 0): False},\n" +
-                "{@code (n == 1): True}\n" +
+                "@utbot.executesCondition {@code (n == 0): False}\n" +
+                "@utbot.executesCondition {@code (n == 1): True}\n" +
                 "@utbot.returnsFrom {@code return 1;}"
         val summary2 = "@utbot.classUnderTest {@link Recursion}\n" +
                 "@utbot.methodUnderTest {@link org.utbot.examples.recursion.Recursion#fib(int)}\n" +

--- a/utbot-summary/src/main/kotlin/org/utbot/summary/comment/CustomJavaDocTagProvider.kt
+++ b/utbot-summary/src/main/kotlin/org/utbot/summary/comment/CustomJavaDocTagProvider.kt
@@ -61,9 +61,9 @@ sealed class CustomJavaDocTag(
                 DocRegularStmt("@$name $value\n")
             }
             is List<*> -> value.takeIf { it.isNotEmpty() }?.let {
-                val valueToString = value.joinToString(separator = ",\n", postfix = "\n")
+                val valueToString = value.joinToString(separator = "\n", postfix = "\n") {"@$name $it"}
 
-                DocRegularStmt("@$name $valueToString")
+                DocRegularStmt(valueToString)
             }
             else -> null
         }


### PR DESCRIPTION
# Description

If there are several values for one tag, write them separately in the comment (`tag` `value`).

Fixes # (issue)

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Automated Testing

Specify tests that help to verify the change automatically.  

_Example:_ org.utbot.examples.algorithms.BinarySearchTest

## Manual Scenario 

Please, provide several scenarios that you went through to verify that the change worked as expected.  

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [ ] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [ ] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
