### PR TITLE
Disabled concrete execution for lambda results

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -575,6 +575,8 @@ class UtLambdaModel(
             .singleOrNull { it.name == lambdaName }
             ?.executableId // synthetic lambda methods should not have overloads, so we always expect there to be only one method with the given name
             ?: error("More than one method with name $lambdaName found in class: ${declaringClass.canonicalName}")
+
+    override fun toString(): String = "Anonymous function $lambdaName implementing functional interface $declaringClass"
 }
 
 /**

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/lambda/SimpleLambdaExamplesTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/lambda/SimpleLambdaExamplesTest.kt
@@ -1,12 +1,21 @@
 package org.utbot.examples.lambda
 
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.utbot.framework.plugin.api.CodegenLanguage
+import org.utbot.testcheckers.eq
+import org.utbot.tests.infrastructure.CodeGeneration
+import org.utbot.tests.infrastructure.DoNotCalculate
 import org.utbot.tests.infrastructure.UtValueTestCaseChecker
 import org.utbot.tests.infrastructure.isException
-import org.utbot.testcheckers.eq
 
-class SimpleLambdaExamplesTest : UtValueTestCaseChecker(testClass = SimpleLambdaExamples::class) {
+// TODO failed Kotlin compilation (generics) SAT-1332
+class SimpleLambdaExamplesTest : UtValueTestCaseChecker(
+    testClass = SimpleLambdaExamples::class,
+    languagePipelines = listOf(
+        CodeGenerationLanguageLastStage(CodegenLanguage.JAVA),
+        CodeGenerationLanguageLastStage(CodegenLanguage.KOTLIN, CodeGeneration),
+    )
+) {
     @Test
     fun testBiFunctionLambdaExample() {
         checkWithException(
@@ -18,14 +27,13 @@ class SimpleLambdaExamplesTest : UtValueTestCaseChecker(testClass = SimpleLambda
     }
 
     @Test
-    @Disabled("TODO 0 executions https://github.com/UnitTestBot/UTBotJava/issues/192")
     fun testChoosePredicate() {
         check(
             SimpleLambdaExamples::choosePredicate,
             eq(2),
             { b, r -> b && !r!!.test(null) && r.test(0) },
             { b, r -> !b && r!!.test(null) && !r.test(0) },
-            // TODO coverage calculation fails https://github.com/UnitTestBot/UTBotJava/issues/192
+            coverage = DoNotCalculate // coverage could not be calculated since method result is lambda
         )
     }
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
@@ -101,6 +101,8 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.job
 import kotlinx.coroutines.yield
+import org.utbot.framework.plugin.api.UtExecutionSuccess
+import org.utbot.framework.plugin.api.UtLambdaModel
 
 val logger = KotlinLogging.logger {}
 val pathLogger = KotlinLogging.logger(logger.name + ".path")
@@ -558,6 +560,17 @@ class UtBotSymbolicEngine(
                 "processResult<${methodUnderTest}>: no concrete execution allowed, " +
                         "emit purely symbolic result $symbolicUtExecution"
             }
+            emit(symbolicUtExecution)
+            return
+        }
+
+        // Check for lambda result as it cannot be emitted by concrete execution
+        (symbolicExecutionResult as? UtExecutionSuccess)?.takeIf { it.model is UtLambdaModel }?.run {
+            logger.debug {
+                "processResult<${methodUnderTest}>: impossible to create concrete value for lambda result ($model), " +
+                        "emit purely symbolic result $symbolicUtExecution"
+            }
+
             emit(symbolicUtExecution)
             return
         }


### PR DESCRIPTION
# Description

As lambda value could not be converted to `UtLambdaModel`, we cannot use concrete execution when we method result is lambda. So, this PR disables the concrete execution for `UtLambdaModel` results.

Fixes #192, fixes #958.

## Type of Change

Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

`org.utbot.examples.lambda.SimpleLambdaExamplesTest#testChoosePredicate`

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] New tests have been added
- [x] All tests pass locally with my changes
