### PR TITLE
Class not found fix #643

### DIFF
--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/process/ChildProcess.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/process/ChildProcess.kt
@@ -45,7 +45,7 @@ import org.utbot.instrumentation.rd.generated.ComputeStaticFieldResult
  * We use this ClassLoader to separate user's classes and our dependency classes.
  * Our classes won't be instrumented.
  */
-private object HandlerClassesLoader : URLClassLoader(emptyArray()) {
+internal object HandlerClassesLoader : URLClassLoader(emptyArray()) {
     fun addUrls(urls: Iterable<String>) {
         urls.forEach { super.addURL(File(it).toURI().toURL()) }
     }


### PR DESCRIPTION
# Description

There were two problems:
- `<clinit>` executing happens in any thread, so `UtContext` could be empty and resolving classes inside static initializer failed, since we hadn't got the correct classloader. This is exactly what was going on and we were getting `ClassNotFoundException` in concrete execution.
- `AccessControlException` was wrapped in `ExceptionInInitializerError`, but we didn't handle it, so there were no comments about sandboxing.

Fixed these ones.

Fixes #643 

## Type of Change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

**To Reproduce** section from #643 and internal SAT issue passes.

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] No new warnings
- [x] All tests pass locally with my changes
