### PR TITLE
Disable test generation for Kotlin getters/setters #911

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/PsiClassHelper.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/PsiClassHelper.kt
@@ -7,15 +7,27 @@ import com.intellij.psi.SyntheticElement
 import com.intellij.refactoring.classMembers.MemberInfoBase
 import com.intellij.refactoring.util.classMembers.MemberInfo
 import com.intellij.testIntegration.TestIntegrationUtils
+import org.jetbrains.kotlin.asJava.elements.KtLightMethod
+import org.jetbrains.kotlin.asJava.elements.isGetter
+import org.jetbrains.kotlin.asJava.elements.isSetter
 import org.utbot.common.filterWhen
 import org.utbot.framework.UtSettings
 
 private val MemberInfoBase<out PsiModifierListOwner>.isAbstract: Boolean
     get() = this.member.modifierList?.hasModifierProperty(PsiModifier.ABSTRACT)?: false
 
+
+private val MemberInfo.isKotlinGetterOrSetter: Boolean
+    get() {
+        if (this !is KtLightMethod)
+            return false
+        return this.isGetter || this.isSetter
+    }
+
 private fun Iterable<MemberInfo>.filterTestableMethods(): List<MemberInfo> = this
     .filterWhen(UtSettings.skipTestGenerationForSyntheticMethods) { it.member !is SyntheticElement }
     .filterNot { it.isAbstract }
+    .filterNot { it.isKotlinGetterOrSetter }
 
 private val PsiClass.isPrivateOrProtected: Boolean
     get() = this.modifierList?.let {


### PR DESCRIPTION
# Description

This PR disables test generation for Kotlin getters/setters in plugin. Currently, overridden getters/setters are not tested as well as default ones (generated by Kotlin), but as discussed with @korifey, we take this as the expected behavior.

Fixes #911

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

Launch plugin on any class with properties -- getters/setters won't be proposed for testing (e.g. for the class from #911 the test action is disabled).

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
