### PR TITLE
Disable `testIsValidUuid` as flaky

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/strings/StringExamplesTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/strings/StringExamplesTest.kt
@@ -251,6 +251,7 @@ internal class StringExamplesTest : UtValueTestCaseChecker(
     }
 
     @Test
+    @Disabled("Flaky on GitHub: https://github.com/UnitTestBot/UTBotJava/issues/1004")
     fun testIsValidUuid() {
         val pattern = Regex("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
         check(


### PR DESCRIPTION
# Description

This PR disables the `org.utbot.examples.strings.StringExamplesTest#testIsValidUuid` test.

This test is not flaky per se, but it often fails on GitHub (probably some resource issue with Z3).

The test should be restored when the resource issue is investigated and fixed, or in strings PR.

Related to: #1004 

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Automated Testing

A test is disabled, other tests should pass, builds should be green.

