### PR TITLE
Codegen unable to properly instantiate public inner classes #761

### DIFF
--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/ObjectModelProvider.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzer/providers/ObjectModelProvider.kt
@@ -48,8 +48,11 @@ class ObjectModelProvider(
         parameterIndex: Int,
         classId: ClassId,
     ): Sequence<ModelConstructor> = sequence {
-        if (unwantedConstructorsClasses.contains(classId) ||
-            classId.isPrimitiveWrapper || classId.isEnum || classId.isAbstract
+        if (unwantedConstructorsClasses.contains(classId)
+            || classId.isPrimitiveWrapper
+            || classId.isEnum
+            || classId.isAbstract
+            || (classId.isInner && !classId.isStatic)
         ) return@sequence
 
         val constructors = collectConstructors(classId) { javaConstructor ->


### PR DESCRIPTION
# Description

Fuzzer now won't create object that is inner class

Fixes #761

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Automated Testing

org.utbot.framework.plugin.api.ModelProviderTest

## Manual Scenario 

See example from the issue

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [ ] No new warnings
- [x] New tests have been added
- [ ] All tests pass locally with my changes
