### PR TITLE
Fix build directory for classes from Kotlin files

### DIFF
--- a/utbot-cli/src/main/kotlin/org/utbot/cli/GenerateTestsAbstractCommand.kt
+++ b/utbot-cli/src/main/kotlin/org/utbot/cli/GenerateTestsAbstractCommand.kt
@@ -197,7 +197,7 @@ abstract class GenerateTestsAbstractCommand(name: String, help: String) :
         UtSettings.treatOverflowAsError = treatOverflowAsError == TreatOverflowAsError.AS_ERROR
 
         return TestCaseGenerator(
-            workingDirectory,
+            listOf(workingDirectory),
             classPathNormalized,
             System.getProperty("java.class.path"),
             JdkInfoDefaultProvider().info

--- a/utbot-framework/src/main/kotlin/org/utbot/external/api/UtBotJavaApi.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/external/api/UtBotJavaApi.kt
@@ -113,7 +113,7 @@ object UtBotJavaApi {
 
         testSets.addAll(withUtContext(utContext) {
             val buildPath = FileUtil.isolateClassFiles(classUnderTest).toPath()
-            TestCaseGenerator(buildPath, classpath, dependencyClassPath, jdkInfo = JdkInfoDefaultProvider().info)
+            TestCaseGenerator(listOf(buildPath), classpath, dependencyClassPath, jdkInfo = JdkInfoDefaultProvider().info)
                 .generate(
                     methodsForAutomaticGeneration.map {
                         it.methodToBeTestedFromUserInput.executableId
@@ -173,7 +173,7 @@ object UtBotJavaApi {
 
         return withUtContext(UtContext(classUnderTest.classLoader)) {
             val buildPath = FileUtil.isolateClassFiles(classUnderTest).toPath()
-            TestCaseGenerator(buildPath, classpath, dependencyClassPath, jdkInfo = JdkInfoDefaultProvider().info)
+            TestCaseGenerator(listOf(buildPath), classpath, dependencyClassPath, jdkInfo = JdkInfoDefaultProvider().info)
                 .generate(
                     methodsForAutomaticGeneration.map {
                         it.methodToBeTestedFromUserInput.executableId

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestCaseGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestCaseGenerator.kt
@@ -52,14 +52,14 @@ import kotlin.reflect.KCallable
  * Generates test cases: one by one or a whole set for the method under test.
  *
  * Note: the instantiating of [TestCaseGenerator] may take some time,
- * because it requires initializing Soot for the current [buildDir] and [classpath].
+ * because it requires initializing Soot for the current [buildDirs] and [classpath].
  *
  * @param jdkInfo specifies the JRE and the runtime library version used for analysing system classes and user's code.
- * @param forceSootReload forces to reinitialize Soot even if the previous buildDir equals to [buildDir] and previous
+ * @param forceSootReload forces to reinitialize Soot even if the previous buildDirs equals to [buildDirs] and previous
  * classpath equals to [classpath]. This is the case for plugin scenario, as the source code may be modified.
  */
 open class TestCaseGenerator(
-    private val buildDir: Path,
+    private val buildDirs: List<Path>,
     private val classpath: String?,
     private val dependencyPaths: String,
     private val jdkInfo: JdkInfo,
@@ -71,13 +71,13 @@ open class TestCaseGenerator(
     private val timeoutLogger: KLogger = KotlinLogging.logger(logger.name + ".timeout")
 
     private val classpathForEngine: String
-        get() = buildDir.toString() + (classpath?.let { File.pathSeparator + it } ?: "")
+        get() = (buildDirs + listOfNotNull(classpath)).joinToString(File.pathSeparator)
 
     init {
         if (!isCanceled()) {
             checkFrameworkDependencies(dependencyPaths)
 
-            logger.trace("Initializing ${this.javaClass.name} with buildDir = $buildDir, classpath = $classpath")
+            logger.trace("Initializing ${this.javaClass.name} with buildDir = $buildDirs, classpath = $classpath")
 
 
             if (disableCoroutinesDebug) {
@@ -85,7 +85,7 @@ open class TestCaseGenerator(
             }
 
             timeoutLogger.trace().bracket("Soot initialization") {
-                SootUtils.runSoot(buildDir, classpath, forceSootReload, jdkInfo)
+                SootUtils.runSoot(buildDirs, classpath, forceSootReload, jdkInfo)
             }
 
             //warmup

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestCaseGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestCaseGenerator.kt
@@ -77,7 +77,7 @@ open class TestCaseGenerator(
         if (!isCanceled()) {
             checkFrameworkDependencies(dependencyPaths)
 
-            logger.trace("Initializing ${this.javaClass.name} with buildDir = $buildDirs, classpath = $classpath")
+            logger.trace("Initializing ${this.javaClass.name} with buildDirs = ${buildDirs.joinToString(File.pathSeparator)}, classpath = $classpath")
 
 
             if (disableCoroutinesDebug) {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/util/SootUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/util/SootUtils.kt
@@ -1,41 +1,7 @@
 package org.utbot.framework.util
 
-import org.utbot.api.mock.UtMock
 import org.utbot.common.FileUtil
-import org.utbot.engine.UtNativeStringWrapper
 import org.utbot.engine.jimpleBody
-import org.utbot.engine.overrides.Boolean
-import org.utbot.engine.overrides.Byte
-import org.utbot.engine.overrides.Character
-import org.utbot.engine.overrides.Class
-import org.utbot.engine.overrides.Integer
-import org.utbot.engine.overrides.Long
-import org.utbot.engine.overrides.PrintStream
-import org.utbot.engine.overrides.Short
-import org.utbot.engine.overrides.System
-import org.utbot.engine.overrides.UtArrayMock
-import org.utbot.engine.overrides.UtLogicMock
-import org.utbot.engine.overrides.UtOverrideMock
-import org.utbot.engine.overrides.collections.AbstractCollection
-import org.utbot.engine.overrides.collections.AssociativeArray
-import org.utbot.engine.overrides.collections.Collection
-import org.utbot.engine.overrides.collections.List as UtList
-import org.utbot.engine.overrides.collections.RangeModifiableUnlimitedArray
-import org.utbot.engine.overrides.collections.UtArrayList
-import org.utbot.engine.overrides.collections.UtGenericAssociative
-import org.utbot.engine.overrides.collections.UtGenericStorage
-import org.utbot.engine.overrides.collections.UtHashMap
-import org.utbot.engine.overrides.collections.UtHashSet
-import org.utbot.engine.overrides.collections.UtLinkedList
-import org.utbot.engine.overrides.collections.UtLinkedListWithNullableCheck
-import org.utbot.engine.overrides.collections.UtOptional
-import org.utbot.engine.overrides.collections.UtOptionalDouble
-import org.utbot.engine.overrides.collections.UtOptionalInt
-import org.utbot.engine.overrides.collections.UtOptionalLong
-import org.utbot.engine.overrides.stream.*
-import org.utbot.engine.overrides.strings.UtString
-import org.utbot.engine.overrides.strings.UtStringBuffer
-import org.utbot.engine.overrides.strings.UtStringBuilder
 import org.utbot.engine.pureJavaSignature
 import org.utbot.framework.plugin.api.ExecutableId
 import org.utbot.framework.plugin.services.JdkInfo
@@ -58,7 +24,7 @@ object SootUtils {
      * code.
      * @param forceReload forces to reinitialize Soot even if the [previousBuildDirs] equals to the class buildDir.
      */
-    fun runSoot(clazz: java.lang.Class<*>, forceReload: kotlin.Boolean, jdkInfo: JdkInfo) {
+    fun runSoot(clazz: Class<*>, forceReload: Boolean, jdkInfo: JdkInfo) {
         val buildDir = FileUtil.locateClassPath(clazz) ?: FileUtil.isolateClassFiles(clazz)
         val buildDirPath = buildDir.toPath()
 
@@ -72,7 +38,7 @@ object SootUtils {
      * @param forceReload forces to reinitialize Soot even if the [previousBuildDirs] equals to [buildDirPaths] and
      * [previousClassPath] equals to [classPath].
      */
-    fun runSoot(buildDirPaths: List<Path>, classPath: String?, forceReload: kotlin.Boolean, jdkInfo: JdkInfo) {
+    fun runSoot(buildDirPaths: List<Path>, classPath: String?, forceReload: Boolean, jdkInfo: JdkInfo) {
         synchronized(this) {
             if (buildDirPaths != previousBuildDirs || classPath != previousClassPath || forceReload) {
                 initSoot(buildDirPaths, classPath, jdkInfo)
@@ -105,7 +71,7 @@ private fun initSoot(buildDirs: List<Path>, classpath: String?, jdkInfo: JdkInfo
                     + if (!classpath.isNullOrEmpty()) File.pathSeparator + "$classpath" else ""
         )
         set_src_prec(Options.src_prec_only_class)
-        set_process_dir(buildDirs.map { "$it" })
+        set_process_dir(buildDirs.map { it.toString() })
         set_keep_line_number(true)
         set_ignore_classpath_errors(true) // gradle/build/resources/main does not exists, but it's not a problem
         set_output_format(Options.output_format_jimple)
@@ -141,69 +107,69 @@ fun jimpleBody(method: ExecutableId): JimpleBody =
     method.sootMethod.jimpleBody()
 
 
-private fun addBasicClasses(vararg classes: java.lang.Class<*>) {
+private fun addBasicClasses(vararg classes: Class<*>) {
     classes.forEach {
         Scene.v().addBasicClass(it.name, SootClass.BODIES)
     }
 }
 
 private val classesToLoad = arrayOf(
-    AbstractCollection::class,
-    UtMock::class,
-    UtOverrideMock::class,
-    UtLogicMock::class,
-    UtArrayMock::class,
-    Boolean::class,
-    Byte::class,
-    Character::class,
-    Class::class,
-    Integer::class,
-    Long::class,
-    Short::class,
-    System::class,
-    UtOptional::class,
-    UtOptionalInt::class,
-    UtOptionalLong::class,
-    UtOptionalDouble::class,
-    UtArrayList::class,
-    UtArrayList.UtArrayListIterator::class,
-    UtLinkedList::class,
-    UtLinkedListWithNullableCheck::class,
-    UtLinkedList.UtLinkedListIterator::class,
-    UtLinkedList.ReverseIteratorWrapper::class,
-    UtHashSet::class,
-    UtHashSet.UtHashSetIterator::class,
-    UtHashMap::class,
-    UtHashMap.Entry::class,
-    UtHashMap.LinkedEntryIterator::class,
-    UtHashMap.LinkedEntrySet::class,
-    UtHashMap.LinkedHashIterator::class,
-    UtHashMap.LinkedKeyIterator::class,
-    UtHashMap.LinkedKeySet::class,
-    UtHashMap.LinkedValueIterator::class,
-    UtHashMap.LinkedValues::class,
-    RangeModifiableUnlimitedArray::class,
-    AssociativeArray::class,
-    UtGenericStorage::class,
-    UtGenericAssociative::class,
-    PrintStream::class,
-    UtNativeStringWrapper::class,
-    UtString::class,
-    UtStringBuilder::class,
-    UtStringBuffer::class,
-    Stream::class,
-    Arrays::class,
-    Collection::class,
-    UtList::class,
-    UtStream::class,
-    UtIntStream::class,
-    UtLongStream::class,
-    UtDoubleStream::class,
-    UtStream.UtStreamIterator::class,
-    UtIntStream.UtIntStreamIterator::class,
-    UtLongStream.UtLongStreamIterator::class,
-    UtDoubleStream.UtDoubleStreamIterator::class,
-    IntStream::class,
-    LongStream::class,
-    DoubleStream::class,
+    org.utbot.engine.overrides.collections.AbstractCollection::class,
+    org.utbot.api.mock.UtMock::class,
+    org.utbot.engine.overrides.UtOverrideMock::class,
+    org.utbot.engine.overrides.UtLogicMock::class,
+    org.utbot.engine.overrides.UtArrayMock::class,
+    org.utbot.engine.overrides.Boolean::class,
+    org.utbot.engine.overrides.Byte::class,
+    org.utbot.engine.overrides.Character::class,
+    org.utbot.engine.overrides.Class::class,
+    org.utbot.engine.overrides.Integer::class,
+    org.utbot.engine.overrides.Long::class,
+    org.utbot.engine.overrides.Short::class,
+    org.utbot.engine.overrides.System::class,
+    org.utbot.engine.overrides.collections.UtOptional::class,
+    org.utbot.engine.overrides.collections.UtOptionalInt::class,
+    org.utbot.engine.overrides.collections.UtOptionalLong::class,
+    org.utbot.engine.overrides.collections.UtOptionalDouble::class,
+    org.utbot.engine.overrides.collections.UtArrayList::class,
+    org.utbot.engine.overrides.collections.UtArrayList.UtArrayListIterator::class,
+    org.utbot.engine.overrides.collections.UtLinkedList::class,
+    org.utbot.engine.overrides.collections.UtLinkedListWithNullableCheck::class,
+    org.utbot.engine.overrides.collections.UtLinkedList.UtLinkedListIterator::class,
+    org.utbot.engine.overrides.collections.UtLinkedList.ReverseIteratorWrapper::class,
+    org.utbot.engine.overrides.collections.UtHashSet::class,
+    org.utbot.engine.overrides.collections.UtHashSet.UtHashSetIterator::class,
+    org.utbot.engine.overrides.collections.UtHashMap::class,
+    org.utbot.engine.overrides.collections.UtHashMap.Entry::class,
+    org.utbot.engine.overrides.collections.UtHashMap.LinkedEntryIterator::class,
+    org.utbot.engine.overrides.collections.UtHashMap.LinkedEntrySet::class,
+    org.utbot.engine.overrides.collections.UtHashMap.LinkedHashIterator::class,
+    org.utbot.engine.overrides.collections.UtHashMap.LinkedKeyIterator::class,
+    org.utbot.engine.overrides.collections.UtHashMap.LinkedKeySet::class,
+    org.utbot.engine.overrides.collections.UtHashMap.LinkedValueIterator::class,
+    org.utbot.engine.overrides.collections.UtHashMap.LinkedValues::class,
+    org.utbot.engine.overrides.collections.RangeModifiableUnlimitedArray::class,
+    org.utbot.engine.overrides.collections.AssociativeArray::class,
+    org.utbot.engine.overrides.collections.UtGenericStorage::class,
+    org.utbot.engine.overrides.collections.UtGenericAssociative::class,
+    org.utbot.engine.overrides.PrintStream::class,
+    org.utbot.engine.UtNativeStringWrapper::class,
+    org.utbot.engine.overrides.strings.UtString::class,
+    org.utbot.engine.overrides.strings.UtStringBuilder::class,
+    org.utbot.engine.overrides.strings.UtStringBuffer::class,
+    org.utbot.engine.overrides.stream.Stream::class,
+    org.utbot.engine.overrides.stream.Arrays::class,
+    org.utbot.engine.overrides.collections.Collection::class,
+    org.utbot.engine.overrides.collections.List::class,
+    org.utbot.engine.overrides.stream.UtStream::class,
+    org.utbot.engine.overrides.stream.UtIntStream::class,
+    org.utbot.engine.overrides.stream.UtLongStream::class,
+    org.utbot.engine.overrides.stream.UtDoubleStream::class,
+    org.utbot.engine.overrides.stream.UtStream.UtStreamIterator::class,
+    org.utbot.engine.overrides.stream.UtIntStream.UtIntStreamIterator::class,
+    org.utbot.engine.overrides.stream.UtLongStream.UtLongStreamIterator::class,
+    org.utbot.engine.overrides.stream.UtDoubleStream.UtDoubleStreamIterator::class,
+    org.utbot.engine.overrides.stream.IntStream::class,
+    org.utbot.engine.overrides.stream.LongStream::class,
+    org.utbot.engine.overrides.stream.DoubleStream::class,
 ).map { it.java }.toTypedArray()

--- a/utbot-framework/src/main/kotlin/org/utbot/tests/infrastructure/TestSpecificTestCaseGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/tests/infrastructure/TestSpecificTestCaseGenerator.kt
@@ -33,7 +33,7 @@ class TestSpecificTestCaseGenerator(
     engineActions: MutableList<(UtBotSymbolicEngine) -> Unit> = mutableListOf(),
     isCanceled: () -> Boolean = { false },
 ): TestCaseGenerator(
-    buildDir,
+    listOf(buildDir),
     classpath,
     dependencyPaths,
     JdkInfoDefaultProvider().info,

--- a/utbot-gradle/src/main/kotlin/org/utbot/gradle/plugin/GenerateTestsAndSarifReportTask.kt
+++ b/utbot-gradle/src/main/kotlin/org/utbot/gradle/plugin/GenerateTestsAndSarifReportTask.kt
@@ -90,7 +90,7 @@ open class GenerateTestsAndSarifReportTask @Inject constructor(
             withUtContext(UtContext(sourceSet.classLoader)) {
                 val testCaseGenerator =
                     TestCaseGenerator(
-                        sourceSet.workingDirectory,
+                        listOf(sourceSet.workingDirectory),
                         sourceSet.runtimeClasspath,
                         dependencyPaths,
                         JdkInfoDefaultProvider().info

--- a/utbot-junit-contest/src/main/kotlin/org/utbot/contest/Contest.kt
+++ b/utbot-junit-contest/src/main/kotlin/org/utbot/contest/Contest.kt
@@ -186,7 +186,7 @@ fun runGeneration(
         setOptions()
         //will not be executed in real contest
         logger.info().bracket("warmup: 1st optional soot initialization and executor warmup (not to be counted in time budget)") {
-            TestCaseGenerator(cut.classfileDir.toPath(), classpathString, dependencyPath, JdkInfoService.provide())
+            TestCaseGenerator(listOf(cut.classfileDir.toPath()), classpathString, dependencyPath, JdkInfoService.provide())
         }
         logger.info().bracket("warmup (first): kotlin reflection :: init") {
             prepareClass(ConcreteExecutorPool::class.java, "")
@@ -227,7 +227,7 @@ fun runGeneration(
 
         val testCaseGenerator =
             logger.info().bracket("2nd optional soot initialization") {
-                TestCaseGenerator(cut.classfileDir.toPath(), classpathString, dependencyPath, JdkInfoService.provide())
+                TestCaseGenerator(listOf(cut.classfileDir.toPath()), classpathString, dependencyPath, JdkInfoService.provide())
             }
 
 


### PR DESCRIPTION
# Description

Changed the method used to compile classes so that now Kotlin files are compiled to `build/classes/kotlin` and Java files are compiled to `build/classes/java` (previously the latter directory was used for both). This avoids duplication with classes generated by default IDEA actions.

Also, refactored some methods to support multiple build directories (important when there are both Java and Kotlin files in project).

Fixes #950

## Type of Change

- Bug fix (non-breaking change which fixes an issue)
- Refactoring (typos and non-functional changes) 

# How Has This Been Tested?

## Manual Scenario 

Launched plugin on scenario from #950 and several other scenarios with Kotlin files in projects -- everything works normal.

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
