### PR TITLE
Built-in SARIF reports visualizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target/
 .idea/
 .gradle/
 *.log
+.rdgen

--- a/utbot-cli/src/main/kotlin/org/utbot/cli/GenerateTestsCommand.kt
+++ b/utbot-cli/src/main/kotlin/org/utbot/cli/GenerateTestsCommand.kt
@@ -149,7 +149,7 @@ class GenerateTestsCommand :
             else -> {
                 val sourceFinding =
                     SourceFindingStrategyDefault(classFqn, sourceCodeFile, testsFilePath, projectRootPath)
-                val report = SarifReport(testSets, testClassBody, sourceFinding).createReport()
+                val report = SarifReport(testSets, testClassBody, sourceFinding).createReport().toJson()
                 saveToFile(report, sarifReport)
                 println("The report was saved to \"$sarifReport\".")
             }

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -279,7 +279,7 @@ object UtSettings : AbstractSettings(
      *
      * False by default (for saving disk space).
      */
-    var logConcreteExecutionErrors by getBooleanProperty(false)
+    var logConcreteExecutionErrors by getBooleanProperty(true)
 
     /**
      * Number of branch instructions using for clustering executions in the test minimization phase.

--- a/utbot-framework-test/src/test/kotlin/org/utbot/sarif/SarifReportTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/sarif/SarifReportTest.kt
@@ -1,7 +1,5 @@
 package org.utbot.sarif
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.Test
 import org.mockito.Mockito
 import org.utbot.framework.plugin.api.ExecutableId
@@ -19,7 +17,7 @@ class SarifReportTest {
             testSets = listOf(),
             generatedTestsCode = "",
             sourceFindingEmpty
-        ).createReport()
+        ).createReport().toJson()
 
         assert(actualReport.isNotEmpty())
     }
@@ -30,7 +28,7 @@ class SarifReportTest {
             testSets = listOf(testSet),
             generatedTestsCode = "",
             sourceFindingEmpty
-        ).createReport().toSarif()
+        ).createReport()
 
         assert(sarif.runs.first().results.isEmpty())
     }
@@ -60,7 +58,7 @@ class SarifReportTest {
             testSets = testSets,
             generatedTestsCode = "",
             sourceFindingEmpty
-        ).createReport().toSarif()
+        ).createReport()
 
         assert(report.runs.first().results[0].message.text.contains("NullPointerException"))
         assert(report.runs.first().results[1].message.text.contains("ArrayIndexOutOfBoundsException"))
@@ -77,7 +75,7 @@ class SarifReportTest {
         Mockito.`when`(mockUtExecution.path.lastOrNull()?.stmt?.javaSourceStartLineNumber).thenReturn(1337)
         Mockito.`when`(mockUtExecution.testMethodName).thenReturn("testMain_ThrowArithmeticException")
 
-        val report = sarifReportMain.createReport().toSarif()
+        val report = sarifReportMain.createReport()
 
         val result = report.runs.first().results.first()
         val location = result.locations.first().physicalLocation
@@ -105,7 +103,7 @@ class SarifReportTest {
             )
         )
 
-        val report = sarifReportMain.createReport().toSarif()
+        val report = sarifReportMain.createReport()
 
         val result = report.runs.first().results.first()
         assert(result.message.text.contains("227"))
@@ -128,7 +126,7 @@ class SarifReportTest {
         )
         Mockito.`when`(mockUtExecution.stateBefore.parameters).thenReturn(listOf())
 
-        val report = sarifReportMain.createReport().toSarif()
+        val report = sarifReportMain.createReport()
 
         val result = report.runs.first().results.first().codeFlows.first().threadFlows.first().locations.map {
             it.location.physicalLocation
@@ -153,7 +151,7 @@ class SarifReportTest {
         Mockito.`when`(mockUtExecution.stateBefore.parameters).thenReturn(listOf())
         Mockito.`when`(mockUtExecution.testMethodName).thenReturn("testMain_ThrowArithmeticException")
 
-        val report = sarifReportMain.createReport().toSarif()
+        val report = sarifReportMain.createReport()
 
         val codeFlowPhysicalLocations = report.runs[0].results[0].codeFlows[0].threadFlows[0].locations.map {
             it.location.physicalLocation
@@ -177,7 +175,7 @@ class SarifReportTest {
         Mockito.`when`(mockUtExecution.stateBefore.parameters).thenReturn(listOf())
         Mockito.`when`(mockUtExecution.testMethodName).thenReturn("testMain_ThrowArithmeticException")
 
-        val report = sarifReportPrivateMain.createReport().toSarif()
+        val report = sarifReportPrivateMain.createReport()
 
         val codeFlowPhysicalLocations = report.runs[0].results[0].codeFlows[0].threadFlows[0].locations.map {
             it.location.physicalLocation
@@ -203,7 +201,7 @@ class SarifReportTest {
             testSets = testSets,
             generatedTestsCode = "",
             sourceFindingMain
-        ).createReport().toSarif()
+        ).createReport()
 
         assert(report.runs.first().results.size == 1) // no duplicates
     }
@@ -228,7 +226,7 @@ class SarifReportTest {
             testSets = testSets,
             generatedTestsCode = "",
             sourceFindingMain
-        ).createReport().toSarif()
+        ).createReport()
 
         assert(report.runs.first().results.size == 2) // no results have been removed
     }
@@ -257,7 +255,7 @@ class SarifReportTest {
             testSets = testSets,
             generatedTestsCode = "",
             sourceFindingMain
-        ).createReport().toSarif()
+        ).createReport()
 
         assert(report.runs.first().results.size == 2) // no results have been removed
     }
@@ -291,7 +289,7 @@ class SarifReportTest {
             testSets = testSets,
             generatedTestsCode = "",
             sourceFindingMain
-        ).createReport().toSarif()
+        ).createReport()
 
         assert(report.runs.first().results.size == 1) // no duplicates
         assert(report.runs.first().results.first().totalCodeFlowLocations() == 1) // with a shorter stack trace
@@ -309,8 +307,6 @@ class SarifReportTest {
         Mockito.`when`(mockExecutableId.name).thenReturn("main")
         Mockito.`when`(mockExecutableId.classId.name).thenReturn("Main")
     }
-
-    private fun String.toSarif(): Sarif = jacksonObjectMapper().readValue(this)
 
     // constants
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/sarif/GenerateTestsAndSarifReportFacade.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/sarif/GenerateTestsAndSarifReportFacade.kt
@@ -91,7 +91,7 @@ class GenerateTestsAndSarifReportFacade(
         testClassBody: String,
         sourceFinding: SourceFindingStrategy
     ) {
-        val sarifReport = SarifReport(testSets, testClassBody, sourceFinding).createReport()
+        val sarifReport = SarifReport(testSets, testClassBody, sourceFinding).createReport().toJson()
         targetClass.sarifReportFile.writeText(sarifReport)
     }
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineMain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineMain.kt
@@ -182,12 +182,19 @@ private fun EngineProcessModel.setup(
         lg.error(reportFilePath.toString()); repeat(5) { lg.error("\n") }
         lg.error(testSets[params.testSetsId].toString()); repeat(5) { lg.error("\n") }
         lg.error(params.generatedTestsCode); repeat(5) { lg.error("\n") }
-        val rdSourceFindingStrategy = RdSourceFindingStrategyFacade(realProtocol.rdSourceFindingStrategy)
-        lg.error(rdSourceFindingStrategy.toString()); repeat(5) { lg.error("\n") }
+//        val rdSourceFindingStrategy = RdSourceFindingStrategyFacade(realProtocol.rdSourceFindingStrategy)
+        val sfs = SourceFindingStrategyDefault(
+            "io.github.ideaseeker.Main",
+            "C:/Users/sWX1137517/IdeaProjects/SarifTest/src/main/java/io/github/ideaseeker/Main.java",
+            "C:/Users/sWX1137517/IdeaProjects/SarifTest/src/test/java/io/github/ideaseeker/MainTest.java",
+            "C:/Users/sWX1137517/IdeaProjects/SarifTest/",
+        )
+//        lg.error(rdSourceFindingStrategy.toString()); repeat(5) { lg.error("\n") }
         val sarifReportAsJson = SarifReport(
             testSets[params.testSetsId]!!,
             params.generatedTestsCode,
-            rdSourceFindingStrategy
+            sfs
+//            rdSourceFindingStrategy
         ).createReport().toJson()
         lg.error(sarifReportAsJson); repeat(5) { lg.error("\n") }
         reportFilePath.toFile().writeText(sarifReportAsJson)

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineMain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineMain.kt
@@ -32,6 +32,7 @@ import org.utbot.rd.findRdPort
 import org.utbot.rd.loggers.UtRdKLoggerFactory
 import org.utbot.sarif.RdSourceFindingStrategyFacade
 import org.utbot.sarif.SarifReport
+import org.utbot.sarif.SourceFindingStrategyDefault
 import org.utbot.summary.summarize
 import soot.SootMethod
 import soot.UnitPatchingChain
@@ -174,13 +175,23 @@ private fun EngineProcessModel.setup(
         ))
     }
     synchronizer.measureExecutionForTermination(writeSarifReport) { params ->
+        val lg = org.utbot.framework.process.logger
+        lg.error("START")
         val reportFilePath = Paths.get(params.reportFilePath)
+        repeat(10) { lg.error("EEEEEEEEEEEEEEEEEEEEEEEEEEE") }
+        lg.error(reportFilePath.toString()); repeat(5) { lg.error("\n") }
+        lg.error(testSets[params.testSetsId].toString()); repeat(5) { lg.error("\n") }
+        lg.error(params.generatedTestsCode); repeat(5) { lg.error("\n") }
+        val rdSourceFindingStrategy = RdSourceFindingStrategyFacade(realProtocol.rdSourceFindingStrategy)
+        lg.error(rdSourceFindingStrategy.toString()); repeat(5) { lg.error("\n") }
         val sarifReportAsJson = SarifReport(
             testSets[params.testSetsId]!!,
             params.generatedTestsCode,
-            RdSourceFindingStrategyFacade(realProtocol.rdSourceFindingStrategy)
+            rdSourceFindingStrategy
         ).createReport().toJson()
+        lg.error(sarifReportAsJson); repeat(5) { lg.error("\n") }
         reportFilePath.toFile().writeText(sarifReportAsJson)
+        lg.error("Success!")
         sarifReportAsJson
     }
     synchronizer.measureExecutionForTermination(generateTestReport) { params ->

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineMain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineMain.kt
@@ -175,13 +175,13 @@ private fun EngineProcessModel.setup(
     }
     synchronizer.measureExecutionForTermination(writeSarifReport) { params ->
         val reportFilePath = Paths.get(params.reportFilePath)
-        reportFilePath.toFile().writeText(
-            SarifReport(
-                testSets[params.testSetsId]!!,
-                params.generatedTestsCode,
-                RdSourceFindingStrategyFacade(realProtocol.rdSourceFindingStrategy)
-            ).createReport()
-        )
+        val sarifReportAsJson = SarifReport(
+            testSets[params.testSetsId]!!,
+            params.generatedTestsCode,
+            RdSourceFindingStrategyFacade(realProtocol.rdSourceFindingStrategy)
+        ).createReport().toJson()
+        reportFilePath.toFile().writeText(sarifReportAsJson)
+        sarifReportAsJson
     }
     synchronizer.measureExecutionForTermination(generateTestReport) { params ->
         val eventLogMessage = params.eventLogMessage

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/process/generated/EngineProcessModel.Generated.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/process/generated/EngineProcessModel.Generated.kt
@@ -9,7 +9,6 @@ import com.jetbrains.rd.util.lifetime.*
 import com.jetbrains.rd.util.reactive.*
 import com.jetbrains.rd.util.string.*
 import com.jetbrains.rd.util.*
-import org.utbot.sarif.Sarif
 import kotlin.reflect.KClass
 import kotlin.jvm.JvmStatic
 
@@ -74,7 +73,7 @@ class EngineProcessModel private constructor(
         }
         
         
-        const val serializationHash = 4674749231408610997L
+        const val serializationHash = 1019152229801641560L
         
     }
     override val serializersOwner: ISerializersOwner get() = EngineProcessModel

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/process/generated/EngineProcessModel.Generated.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/process/generated/EngineProcessModel.Generated.kt
@@ -9,6 +9,7 @@ import com.jetbrains.rd.util.lifetime.*
 import com.jetbrains.rd.util.reactive.*
 import com.jetbrains.rd.util.string.*
 import com.jetbrains.rd.util.*
+import org.utbot.sarif.Sarif
 import kotlin.reflect.KClass
 import kotlin.jvm.JvmStatic
 
@@ -27,7 +28,7 @@ class EngineProcessModel private constructor(
     private val _obtainClassId: RdCall<String, ByteArray>,
     private val _findMethodsInClassMatchingSelected: RdCall<FindMethodsInClassMatchingSelectedArguments, FindMethodsInClassMatchingSelectedResult>,
     private val _findMethodParamNames: RdCall<FindMethodParamNamesArguments, FindMethodParamNamesResult>,
-    private val _writeSarifReport: RdCall<WriteSarifReportArguments, Unit>,
+    private val _writeSarifReport: RdCall<WriteSarifReportArguments, String>,
     private val _generateTestReport: RdCall<GenerateTestReportArgs, GenerateTestReportResult>
 ) : RdExtBase() {
     //companion
@@ -89,7 +90,7 @@ class EngineProcessModel private constructor(
     val obtainClassId: RdCall<String, ByteArray> get() = _obtainClassId
     val findMethodsInClassMatchingSelected: RdCall<FindMethodsInClassMatchingSelectedArguments, FindMethodsInClassMatchingSelectedResult> get() = _findMethodsInClassMatchingSelected
     val findMethodParamNames: RdCall<FindMethodParamNamesArguments, FindMethodParamNamesResult> get() = _findMethodParamNames
-    val writeSarifReport: RdCall<WriteSarifReportArguments, Unit> get() = _writeSarifReport
+    val writeSarifReport: RdCall<WriteSarifReportArguments, String> get() = _writeSarifReport
     val generateTestReport: RdCall<GenerateTestReportArgs, GenerateTestReportResult> get() = _generateTestReport
     //methods
     //initializer
@@ -133,7 +134,7 @@ class EngineProcessModel private constructor(
         RdCall<String, ByteArray>(FrameworkMarshallers.String, FrameworkMarshallers.ByteArray),
         RdCall<FindMethodsInClassMatchingSelectedArguments, FindMethodsInClassMatchingSelectedResult>(FindMethodsInClassMatchingSelectedArguments, FindMethodsInClassMatchingSelectedResult),
         RdCall<FindMethodParamNamesArguments, FindMethodParamNamesResult>(FindMethodParamNamesArguments, FindMethodParamNamesResult),
-        RdCall<WriteSarifReportArguments, Unit>(WriteSarifReportArguments, FrameworkMarshallers.Void),
+        RdCall<WriteSarifReportArguments, String>(WriteSarifReportArguments, FrameworkMarshallers.String),
         RdCall<GenerateTestReportArgs, GenerateTestReportResult>(GenerateTestReportArgs, GenerateTestReportResult)
     )
     

--- a/utbot-framework/src/main/kotlin/org/utbot/sarif/DataClasses.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/sarif/DataClasses.kt
@@ -1,7 +1,10 @@
 package org.utbot.sarif
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonValue
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 
 /**
  * Useful links:
@@ -24,7 +27,19 @@ data class Sarif(
 
         fun fromRun(run: SarifRun) =
             Sarif(defaultSchema, defaultVersion, listOf(run))
+
+        fun fromJson(reportInJson: String): Sarif =
+            jacksonObjectMapper().readValue(reportInJson)
     }
+
+    fun toJson(): String =
+        jacksonObjectMapper()
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            .writerWithDefaultPrettyPrinter()
+            .writeValueAsString(this)
+
+    fun getAllResults(): List<SarifResult> =
+        runs.flatMap { it.results }
 }
 
 /**
@@ -104,8 +119,8 @@ data class SarifResult(
      * Returns the total number of locations in all [codeFlows].
      */
     fun totalCodeFlowLocations() =
-        codeFlows.sumBy { codeFlow ->
-            codeFlow.threadFlows.sumBy { threadFlow ->
+        codeFlows.sumOf { codeFlow ->
+            codeFlow.threadFlows.sumOf { threadFlow ->
                 threadFlow.locations.size
             }
         }

--- a/utbot-framework/src/main/kotlin/org/utbot/sarif/RdSourceFindingStrategy.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/sarif/RdSourceFindingStrategy.kt
@@ -1,6 +1,7 @@
 package org.utbot.sarif
 
 import kotlinx.coroutines.runBlocking
+import org.utbot.engine.logger
 import org.utbot.framework.process.generated.RdSourceFindingStrategy
 import org.utbot.framework.process.generated.SourceStrategeMethodArgs
 import java.io.File
@@ -10,11 +11,14 @@ class RdSourceFindingStrategyFacade(private val realStrategy: RdSourceFindingStr
         get() = runBlocking { realStrategy.testsRelativePath.startSuspending(Unit) }
 
     override fun getSourceRelativePath(classFqn: String, extension: String?): String = runBlocking {
+        logger.error("getSourceRelativePath for $classFqn, $extension")
         realStrategy.getSourceRelativePath.startSuspending(SourceStrategeMethodArgs(classFqn, extension))
     }
 
     override fun getSourceFile(classFqn: String, extension: String?): File? = runBlocking {
+        logger.error("getSourceFile for $classFqn, $extension")
         realStrategy.getSourceFile.startSuspending(SourceStrategeMethodArgs(classFqn, extension))?.let {
+            logger.error("it: $it")
             File(it)
         }
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/sarif/SarifReport.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/sarif/SarifReport.kt
@@ -1,8 +1,5 @@
 package org.utbot.sarif
 
-import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import org.utbot.common.PathUtil.fileExtension
 import org.utbot.common.PathUtil.toPath
 import org.utbot.framework.UtSettings
@@ -21,45 +18,20 @@ class SarifReport(
     private val generatedTestsCode: String,
     private val sourceFinding: SourceFindingStrategy
 ) {
-
     companion object {
-
         /**
          * Merges several SARIF reports given as JSON-strings into one
          */
         fun mergeReports(reports: List<String>): String =
             reports.fold(Sarif.empty()) { sarif: Sarif, report: String ->
-                sarif.copy(runs = sarif.runs + report.jsonToSarif().runs)
-            }.sarifToJson()
-
-        // internal
-
-        private fun String.jsonToSarif(): Sarif =
-            jacksonObjectMapper().readValue(this)
-
-        private fun Sarif.sarifToJson(): String =
-            jacksonObjectMapper()
-                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-                .writerWithDefaultPrettyPrinter()
-                .writeValueAsString(this)
+                sarif.copy(runs = sarif.runs + Sarif.fromJson(report).runs)
+            }.toJson()
     }
 
     /**
-     * Creates a SARIF report and returns it as string
+     * Creates a SARIF report.
      */
-    fun createReport(): String =
-        constructSarif().sarifToJson()
-
-    // internal
-
-    private val defaultLineNumber = 1 // if the line in the source code where the exception is thrown is unknown
-
-    /**
-     * [Read more about links to locations](https://github.com/microsoft/sarif-tutorials/blob/main/docs/3-Beyond-basics.md#msg-links-location)
-     */
-    private val relatedLocationId = 1 // for attaching link to generated test in related locations
-
-    private fun constructSarif(): Sarif {
+    fun createReport(): Sarif {
         val sarifResults = mutableListOf<SarifResult>()
         val sarifRules = mutableSetOf<SarifRule>()
 
@@ -84,6 +56,15 @@ class SarifReport(
             )
         )
     }
+
+    // internal
+
+    private val defaultLineNumber = 1 // if the line in the source code where the exception is thrown is unknown
+
+    /**
+     * [Read more about links to locations](https://github.com/microsoft/sarif-tutorials/blob/main/docs/3-Beyond-basics.md#msg-links-location)
+     */
+    private val relatedLocationId = 1 // for attaching link to generated test in related locations
 
     /**
      * Minimizes detected errors and removes duplicates.

--- a/utbot-framework/src/main/kotlin/org/utbot/sarif/SarifReport.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/sarif/SarifReport.kt
@@ -4,6 +4,7 @@ import org.utbot.common.PathUtil.fileExtension
 import org.utbot.common.PathUtil.toPath
 import org.utbot.framework.UtSettings
 import org.utbot.framework.plugin.api.*
+import kotlin.io.path.nameWithoutExtension
 
 /**
  * Used for the SARIF report creation by given test cases and generated tests code.
@@ -208,10 +209,14 @@ class SarifReport(
         val methodCallLocation: SarifPhysicalLocation? =
             findMethodCallInTestBody(utExecution.testMethodName, method.name)
         if (methodCallLocation != null) {
+            val testFileName = sourceFinding.testsRelativePath.toPath().fileName
+            val testClassName = testFileName.nameWithoutExtension
+            val testMethodName = utExecution.testMethodName
+            val methodCallLineNumber = methodCallLocation.region.startLine
             val methodCallLocationWrapper = SarifFlowLocationWrapper(
                 SarifFlowLocation(
                     message = Message(
-                        text = "${sourceFinding.testsRelativePath.toPath().fileName}:${methodCallLocation.region.startLine}"
+                        text = "$testClassName.$testMethodName($testFileName:$methodCallLineNumber)"
                     ),
                     physicalLocation = methodCallLocation
                 )

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerationController.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerationController.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.command.WriteCommandAction.runWriteCommandAction
 import com.intellij.openapi.command.executeCommand
+import com.intellij.openapi.components.service
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.fileEditor.FileDocumentManager
@@ -57,6 +58,7 @@ import org.utbot.intellij.plugin.process.EngineProcess
 import org.utbot.intellij.plugin.process.RdTestGenerationResult
 import org.utbot.intellij.plugin.sarif.SarifReportIdea
 import org.utbot.intellij.plugin.sarif.SourceFindingStrategyIdea
+import org.utbot.intellij.plugin.settings.Settings
 import org.utbot.intellij.plugin.ui.*
 import org.utbot.intellij.plugin.ui.utils.getOrCreateSarifReportsPath
 import org.utbot.intellij.plugin.ui.utils.showErrorDialogLater
@@ -151,6 +153,8 @@ object CodeGenerationController {
         project: Project,
         srcClassPathToSarifReport: MutableMap<Path, Sarif>
     ) {
+        if (!project.service<Settings>().runInspectionAfterTestGeneration)
+            return
         val sarifHasResults = srcClassPathToSarifReport.any { (_, sarif) ->
             sarif.getAllResults().isNotEmpty()
         }

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/AnalyzeStackTraceFix.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/AnalyzeStackTraceFix.kt
@@ -7,6 +7,12 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.unscramble.AnalyzeStacktraceUtil
 
+/**
+ * Button that launches the built-in "Analyze Stack Trace" action. Displayed as a quick fix.
+ *
+ * @param exceptionMessage short description of the detected exception.
+ * @param stackTraceLines list of strings of the form "className.methodName(fileName:lineNumber)".
+ */
 class AnalyzeStackTraceFix(
     private val exceptionMessage: String,
     private val stackTraceLines: List<String>
@@ -30,6 +36,9 @@ class AnalyzeStackTraceFix(
         }
     }
 
+    /**
+     * This text is displayed on the quick fix button.
+     */
     override fun getName() = "Analyze stack trace"
 
     override fun getFamilyName() = name

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/AnalyzeStackTraceFix.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/AnalyzeStackTraceFix.kt
@@ -1,0 +1,36 @@
+package org.utbot.intellij.plugin.inspection
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
+import com.intellij.unscramble.AnalyzeStacktraceUtil
+
+class AnalyzeStackTraceFix(
+    private val exceptionMessage: String,
+    private val stackTraceLines: List<String>
+) : LocalQuickFix {
+
+    /**
+     * Without `invokeLater` the [com.intellij.execution.impl.ConsoleViewImpl.myPredefinedFilters] will not be filled.
+     *
+     * See [com.intellij.execution.impl.ConsoleViewImpl.createCompositeFilter] for more details.
+     */
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val stackTraceContent = stackTraceLines.joinToString("\n") { "at $it" }
+        ApplicationManager.getApplication().invokeLater {
+            AnalyzeStacktraceUtil.addConsole(
+                /* project = */ project,
+                /* consoleFactory = */ null,
+                /* tabTitle = */ "StackTrace",
+                /* text = */ "$exceptionMessage\n\n$stackTraceContent",
+                /* icon = */ AllIcons.Actions.Lightning
+            )
+        }
+    }
+
+    override fun getName() = "Analyze stack trace"
+
+    override fun getFamilyName() = name
+}

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/UTBotInspectionContext.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/UTBotInspectionContext.kt
@@ -1,0 +1,28 @@
+package org.utbot.intellij.plugin.inspection
+
+import com.intellij.codeInspection.ex.*
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.NotNullLazyValue
+import com.intellij.ui.content.ContentManager
+import org.utbot.sarif.Sarif
+import java.nio.file.Path
+
+/**
+ * Provides [InspectionProfileImpl] with only one inspection tool - [UTBotInspectionTool].
+ *
+ * @see GlobalInspectionContextImpl
+ */
+class UTBotInspectionContext(
+    project: Project,
+    contentManager: NotNullLazyValue<out ContentManager>,
+    val sarifReports: MutableMap<Path, Sarif>
+) : GlobalInspectionContextImpl(project, contentManager) {
+
+    override fun getCurrentProfile(): InspectionProfileImpl {
+        val utbotInspectionTool = UTBotInspectionTool.getInstance(sarifReports)
+        val globalInspectionToolWrapper = GlobalInspectionToolWrapper(utbotInspectionTool)
+        globalInspectionToolWrapper.initialize(this)
+        val supplier = InspectionToolsSupplier.Simple(listOf(globalInspectionToolWrapper))
+        return InspectionProfileImpl("UTBotInspectionToolProfile", supplier, BASE_PROFILE)
+    }
+}

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/UTBotInspectionContext.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/UTBotInspectionContext.kt
@@ -1,28 +1,62 @@
 package org.utbot.intellij.plugin.inspection
 
 import com.intellij.codeInspection.ex.*
+import com.intellij.codeInspection.ui.InspectionToolPresentation
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.NotNullLazyValue
 import com.intellij.ui.content.ContentManager
 import org.utbot.sarif.Sarif
 import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
 
 /**
- * Provides [InspectionProfileImpl] with only one inspection tool - [UTBotInspectionTool].
- *
- * @see GlobalInspectionContextImpl
+ * Overrides some methods of [GlobalInspectionContextImpl] to satisfy the logic of [UTBotInspectionTool].
  */
 class UTBotInspectionContext(
     project: Project,
     contentManager: NotNullLazyValue<out ContentManager>,
-    val sarifReports: MutableMap<Path, Sarif>
+    val srcClassPathToSarifReport: MutableMap<Path, Sarif>
 ) : GlobalInspectionContextImpl(project, contentManager) {
 
+    /**
+     * See [GlobalInspectionContextImpl.myPresentationMap] for more details.
+     */
+    private val myPresentationMap: ConcurrentMap<InspectionToolWrapper<*, *>, InspectionToolPresentation> =
+        ConcurrentHashMap()
+
+    private val globalInspectionToolWrapper by lazy {
+        val utbotInspectionTool = UTBotInspectionTool.getInstance(srcClassPathToSarifReport)
+        GlobalInspectionToolWrapper(utbotInspectionTool).also {
+            it.initialize(/* context = */ this)
+        }
+    }
+
+    /**
+     * Returns [InspectionProfileImpl] with only one inspection tool - [UTBotInspectionTool].
+     */
     override fun getCurrentProfile(): InspectionProfileImpl {
-        val utbotInspectionTool = UTBotInspectionTool.getInstance(sarifReports)
-        val globalInspectionToolWrapper = GlobalInspectionToolWrapper(utbotInspectionTool)
-        globalInspectionToolWrapper.initialize(this)
         val supplier = InspectionToolsSupplier.Simple(listOf(globalInspectionToolWrapper))
         return InspectionProfileImpl("UTBotInspectionToolProfile", supplier, BASE_PROFILE)
+    }
+
+    override fun close(noSuspiciousCodeFound: Boolean) {
+        myPresentationMap.clear()
+        super.close(noSuspiciousCodeFound)
+    }
+
+    override fun cleanup() {
+        myPresentationMap.clear()
+        super.cleanup()
+    }
+
+    /**
+     * Overriding is needed to provide [UTBotInspectionToolPresentation]
+     * instead of the standard implementation of the [InspectionToolPresentation].
+     */
+    override fun getPresentation(toolWrapper: InspectionToolWrapper<*, *>): InspectionToolPresentation {
+        return myPresentationMap.computeIfAbsent(toolWrapper) {
+            UTBotInspectionToolPresentation(globalInspectionToolWrapper, context = this)
+        }
     }
 }

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/UTBotInspectionManager.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/UTBotInspectionManager.kt
@@ -1,0 +1,37 @@
+package org.utbot.intellij.plugin.inspection
+
+import com.intellij.codeInspection.ex.GlobalInspectionContextImpl
+import com.intellij.codeInspection.ex.InspectionManagerEx
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.NotNullLazyValue
+import com.intellij.ui.content.ContentManager
+import org.utbot.sarif.Sarif
+import java.nio.file.Path
+
+/**
+ * Creates [UTBotInspectionContext] with right arguments.
+ *
+ * Inheritance is needed to provide [UTBotInspectionContext] instead of [GlobalInspectionContextImpl].
+ *
+ * See [com.intellij.codeInspection.ex.InspectionManagerEx] for details.
+ */
+class UTBotInspectionManager(project: Project) : InspectionManagerEx(project) {
+
+    companion object {
+        fun getInstance(project: Project, sarifReports: MutableMap<Path, Sarif>) =
+            UTBotInspectionManager(project).also {
+                it.sarifReports = sarifReports
+            }
+    }
+
+    private val myContentManager: NotNullLazyValue<ContentManager> by lazy {
+        NotNullLazyValue.createValue {
+            getProblemsViewContentManager(project)
+        }
+    }
+
+    private var sarifReports: MutableMap<Path, Sarif> = mutableMapOf()
+
+    override fun createNewGlobalContext(): GlobalInspectionContextImpl =
+        UTBotInspectionContext(project, myContentManager, sarifReports)
+}

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/UTBotInspectionManager.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/UTBotInspectionManager.kt
@@ -9,29 +9,31 @@ import org.utbot.sarif.Sarif
 import java.nio.file.Path
 
 /**
- * Creates [UTBotInspectionContext] with right arguments.
- *
- * Inheritance is needed to provide [UTBotInspectionContext] instead of [GlobalInspectionContextImpl].
- *
- * See [com.intellij.codeInspection.ex.InspectionManagerEx] for details.
+ * Overrides some methods of [InspectionManagerEx] to satisfy the logic of [UTBotInspectionTool].
  */
 class UTBotInspectionManager(project: Project) : InspectionManagerEx(project) {
 
+    private var srcClassPathToSarifReport: MutableMap<Path, Sarif> = mutableMapOf()
+
     companion object {
-        fun getInstance(project: Project, sarifReports: MutableMap<Path, Sarif>) =
+        fun getInstance(project: Project, srcClassPathToSarifReport: MutableMap<Path, Sarif>) =
             UTBotInspectionManager(project).also {
-                it.sarifReports = sarifReports
+                it.srcClassPathToSarifReport = srcClassPathToSarifReport
             }
     }
 
+    /**
+     * See [InspectionManagerEx.myContentManager] for more details.
+     */
     private val myContentManager: NotNullLazyValue<ContentManager> by lazy {
         NotNullLazyValue.createValue {
             getProblemsViewContentManager(project)
         }
     }
 
-    private var sarifReports: MutableMap<Path, Sarif> = mutableMapOf()
-
+    /**
+     * Overriding is needed to provide [UTBotInspectionContext] instead of [GlobalInspectionContextImpl].
+     */
     override fun createNewGlobalContext(): GlobalInspectionContextImpl =
-        UTBotInspectionContext(project, myContentManager, sarifReports)
+        UTBotInspectionContext(project, myContentManager, srcClassPathToSarifReport)
 }

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/UTBotInspectionTool.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/UTBotInspectionTool.kt
@@ -1,0 +1,89 @@
+package org.utbot.intellij.plugin.inspection
+
+import com.intellij.codeInspection.*
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiFile
+import org.utbot.sarif.Sarif
+import org.utbot.sarif.SarifRegion
+import java.nio.file.Path
+
+/**
+ * Global inspection tool that displays detected errors from the SARIF report.
+ */
+class UTBotInspectionTool : GlobalSimpleInspectionTool() {
+
+    private var sarifReports: MutableMap<Path, Sarif> = mutableMapOf()
+
+    companion object {
+        fun getInstance(sarifReports: MutableMap<Path, Sarif>) =
+            UTBotInspectionTool().also {
+                it.sarifReports = sarifReports
+            }
+    }
+
+    override fun getShortName() = "UTBotInspectionTool"
+
+    override fun getDisplayName() = "Unchecked exceptions"
+
+    override fun getGroupDisplayName() = "Errors detected by UTBot"
+
+    override fun checkFile(
+        psiFile: PsiFile,
+        manager: InspectionManager,
+        problemsHolder: ProblemsHolder,
+        globalContext: GlobalInspectionContext,
+        problemDescriptionsProcessor: ProblemDescriptionsProcessor
+    ) {
+        val sarifReport = sarifReports[psiFile.virtualFile.toNioPath()]
+            ?: return // no results for this file
+
+        for (sarifResult in sarifReport.getAllResults()) {
+            val srcFileLocation = sarifResult.locations.firstOrNull() ?: continue
+            val errorRegion = srcFileLocation.physicalLocation.region
+            val errorTextRange = getTextRange(problemsHolder.project, psiFile, errorRegion)
+
+            // see `org.utbot.sarif.SarifReport.processUncheckedException` for the message template
+            val errorMessage = sarifResult.message.text.split('\n').take(2).joinToString(" ")
+
+            val testFileLocation = sarifResult.relatedLocations.firstOrNull()?.physicalLocation
+            val viewGeneratedTestFix = testFileLocation?.let {
+                ViewGeneratedTestFix(
+                    testFileRelativePath = it.artifactLocation.uri,
+                    lineNumber = it.region.startLine,
+                    columnNumber = it.region.startColumn ?: 1
+                )
+            }
+
+            val problemDescriptor = problemsHolder.manager.createProblemDescriptor(
+                psiFile,
+                errorTextRange,
+                errorMessage,
+                ProblemHighlightType.ERROR,
+                /* onTheFly = */ true,
+                viewGeneratedTestFix
+            )
+            problemDescriptionsProcessor.addProblemElement(
+                globalContext.refManager.getReference(psiFile),
+                problemDescriptor
+            )
+        }
+    }
+
+    // internal
+
+    private fun getTextRange(project: Project, file: PsiFile, region: SarifRegion): TextRange {
+        val documentManager = PsiDocumentManager.getInstance(project)
+        val document = documentManager.getDocument(file.containingFile)
+            ?: return TextRange.EMPTY_RANGE
+
+        val lineNumber = region.startLine - 1 // to 0-based
+        val columnNumber = region.startColumn ?: 1
+
+        val lineStartOffset = document.getLineStartOffset(lineNumber) + columnNumber - 1
+        val lineEndOffset = document.getLineEndOffset(lineNumber)
+        return TextRange(lineStartOffset, lineEndOffset)
+    }
+}
+

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/UTBotInspectionToolPresentation.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/UTBotInspectionToolPresentation.kt
@@ -5,7 +5,7 @@ import com.intellij.codeInspection.ex.InspectionToolWrapper
 import com.intellij.codeInspection.ui.DefaultInspectionToolPresentation
 
 /**
- * Overrides [resolveProblem] to avoid suppressing the button [ViewGeneratedTestFix].
+ * Overrides [resolveProblem] to avoid suppressing quick fix buttons.
  */
 class UTBotInspectionToolPresentation(
     toolWrapper: InspectionToolWrapper<*, *>,

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/UTBotInspectionToolPresentation.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/UTBotInspectionToolPresentation.kt
@@ -1,0 +1,24 @@
+package org.utbot.intellij.plugin.inspection
+
+import com.intellij.codeInspection.CommonProblemDescriptor
+import com.intellij.codeInspection.ex.InspectionToolWrapper
+import com.intellij.codeInspection.ui.DefaultInspectionToolPresentation
+
+/**
+ * Overrides [resolveProblem] to avoid suppressing the button [ViewGeneratedTestFix].
+ */
+class UTBotInspectionToolPresentation(
+    toolWrapper: InspectionToolWrapper<*, *>,
+    context: UTBotInspectionContext
+) : DefaultInspectionToolPresentation(toolWrapper, context) {
+
+    /**
+     * This method is called when the user clicks on the quick fix button.
+     * In the case of [UTBotInspectionTool] we do not want to remove the button after applying the fix.
+     *
+     * See [DefaultInspectionToolPresentation.resolveProblem] for more details.
+     */
+    override fun resolveProblem(descriptor: CommonProblemDescriptor) {
+        // nothing
+    }
+}

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/ViewGeneratedTestFix.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/ViewGeneratedTestFix.kt
@@ -9,8 +9,7 @@ import com.intellij.openapi.vfs.VfsUtil
 import org.utbot.common.PathUtil.toPath
 
 /**
- * Button with a link to the [testFileRelativePath].
- * Displayed as "quick fix".
+ * Button with a link to the [testFileRelativePath]. Displayed as a quick fix.
  *
  * @param testFileRelativePath path to the generated test file.
  *                             Should be relative to the project root

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/ViewGeneratedTestFix.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/ViewGeneratedTestFix.kt
@@ -1,0 +1,41 @@
+package org.utbot.intellij.plugin.inspection
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.editor.LogicalPosition
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VfsUtil
+import org.utbot.common.PathUtil.toPath
+
+/**
+ * Button with a link to the [testFileRelativePath].
+ * Displayed as "quick fix".
+ *
+ * @param testFileRelativePath path to the generated test file.
+ *                             Should be relative to the project root
+ * @param lineNumber one-based line number
+ * @param columnNumber one-based column number
+ */
+class ViewGeneratedTestFix(
+    val testFileRelativePath: String,
+    val lineNumber: Int,
+    val columnNumber: Int
+) : LocalQuickFix {
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val testFileAbsolutePath = project.basePath?.toPath()?.resolve(testFileRelativePath) ?: return
+        val virtualFile = VfsUtil.findFile(testFileAbsolutePath, /* refreshIfNeeded = */ true) ?: return
+        val editor = FileEditorManager.getInstance(project)
+        editor.openFile(virtualFile, /* focusEditor = */ true)
+        val caretModel = editor.selectedTextEditor?.caretModel ?: return
+        val zeroBasedPosition = LogicalPosition(lineNumber - 1, columnNumber - 1)
+        caretModel.moveToLogicalPosition(zeroBasedPosition)
+        val selectionModel = editor.selectedTextEditor?.selectionModel ?: return
+        selectionModel.selectLineAtCaret()
+    }
+
+    override fun getName() = "View generated test"
+
+    override fun getFamilyName() = name
+}

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/ViewGeneratedTestFix.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/ViewGeneratedTestFix.kt
@@ -22,6 +22,9 @@ class ViewGeneratedTestFix(
     val columnNumber: Int
 ) : LocalQuickFix {
 
+    /**
+     * Navigates the user to the [lineNumber] line of the [testFileRelativePath] file.
+     */
     override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
         val testFileAbsolutePath = project.basePath?.toPath()?.resolve(testFileRelativePath) ?: return
         val virtualFile = VfsUtil.findFile(testFileAbsolutePath, /* refreshIfNeeded = */ true) ?: return
@@ -34,6 +37,9 @@ class ViewGeneratedTestFix(
         selectionModel.selectLineAtCaret()
     }
 
+    /**
+     * This text is displayed on the quick fix button.
+     */
     override fun getName() = "View generated test"
 
     override fun getFamilyName() = name

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/process/EngineProcess.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/process/EngineProcess.kt
@@ -36,6 +36,7 @@ import org.utbot.intellij.plugin.util.signature
 import org.utbot.rd.ProcessWithRdServer
 import org.utbot.rd.rdPortArgument
 import org.utbot.rd.startUtProcessWithRdServer
+import org.utbot.sarif.Sarif
 import org.utbot.sarif.SourceFindingStrategy
 import java.io.File
 import java.nio.file.Path
@@ -301,7 +302,7 @@ class EngineProcess(parent: Lifetime, val project: Project) {
                    testSetsId: Long,
                    generatedTestsCode: String,
                    sourceFindingStrategy: SourceFindingStrategy
-    ) = runBlocking {
+    ): Sarif = runBlocking {
         current!!.protocol.rdSourceFindingStrategy.let {
             it.getSourceFile.set { params ->
                 DumbService.getInstance(project).runReadActionInSmartMode<String?> {
@@ -325,7 +326,10 @@ class EngineProcess(parent: Lifetime, val project: Project) {
                 }
             }
         }
-        engineModel().writeSarifReport.startSuspending(WriteSarifReportArguments(testSetsId, reportFilePath.pathString, generatedTestsCode))
+        val sarifReportAsJson = engineModel().writeSarifReport.startSuspending(
+            WriteSarifReportArguments(testSetsId, reportFilePath.pathString, generatedTestsCode)
+        )
+        Sarif.fromJson(sarifReportAsJson)
     }
 
     fun generateTestsReport(model: GenerateTestsModel, eventLogMessage: String?): Triple<String, String?, Boolean> = runBlocking {

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/sarif/SarifReportIdea.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/sarif/SarifReportIdea.kt
@@ -1,12 +1,20 @@
 package org.utbot.intellij.plugin.sarif
 
-import org.utbot.common.PathUtil.classFqnToPath
-import org.utbot.intellij.plugin.ui.utils.getOrCreateSarifReportsPath
+import com.intellij.openapi.command.executeCommand
 import com.intellij.openapi.vfs.VfsUtil
 import org.jetbrains.kotlin.idea.util.application.runWriteAction
-import org.utbot.framework.plugin.api.ClassId
+import org.utbot.common.HTML_LINE_SEPARATOR
+import org.utbot.common.PathUtil
+import org.utbot.common.PathUtil.classFqnToPath
+import org.utbot.intellij.plugin.generator.CodeGenerationController
 import org.utbot.intellij.plugin.models.GenerateTestsModel
 import org.utbot.intellij.plugin.process.EngineProcess
+import org.utbot.intellij.plugin.ui.SarifReportNotifier
+import org.utbot.intellij.plugin.ui.utils.getOrCreateSarifReportsPath
+import org.utbot.intellij.plugin.ui.utils.showErrorDialogLater
+import org.utbot.sarif.Sarif
+import org.utbot.sarif.SarifReport
+import java.nio.file.Path
 
 object SarifReportIdea {
 
@@ -17,20 +25,61 @@ object SarifReportIdea {
     fun createAndSave(
         proc: EngineProcess,
         testSetsId: Long,
-        classId: ClassId,
+        srcClassFqn: String,
         model: GenerateTestsModel,
         generatedTestsCode: String,
         sourceFinding: SourceFindingStrategyIdea
-    ) {
-        // building the path to the report file
-        val classFqn = classId.name
-        val sarifReportsPath = model.testModule.getOrCreateSarifReportsPath(model.testSourceRoot)
-        val reportFilePath = sarifReportsPath.resolve("${classFqnToPath(classFqn)}Report.sarif")
+    ): Sarif {
+        var resultSarif = Sarif.empty()
+        try {
+            executeCommand(model.project, "Saving SARIF report") {
+                // building the path to the report file
+                val sarifReportsPath = model.testModule.getOrCreateSarifReportsPath(model.testSourceRoot)
+                val reportFilePath = sarifReportsPath.resolve("${classFqnToPath(srcClassFqn)}Report.sarif")
 
-        // creating report related directory
-        runWriteAction { VfsUtil.createDirectoryIfMissing(reportFilePath.parent.toString()) }
+                // creating report related directory
+                runWriteAction { VfsUtil.createDirectoryIfMissing(reportFilePath.parent.toString()) }
 
-        proc.writeSarif(reportFilePath, testSetsId, generatedTestsCode, sourceFinding)
+                // creating & saving the report
+                resultSarif = proc.writeSarif(reportFilePath, testSetsId, generatedTestsCode, sourceFinding)
+            }
+        } catch (e: Exception) {
+            CodeGenerationController.logger.error { e }
+            showErrorDialogLater(
+                model.project,
+                message = "Cannot save Sarif report via generated tests: error occurred '${e.message}'",
+                title = "Failed to save Sarif report"
+            )
+        }
+        return resultSarif
+    }
+
+    /**
+     * Merges all SARIF reports into one large containing all the information.
+     * Saves it to the [sarifReportsPath] and notifies the user.
+     */
+    fun mergeSarifReports(model: GenerateTestsModel, sarifReportsPath: Path) {
+        val mergedReportFile = sarifReportsPath
+            .resolve("${model.project.name}Report.sarif")
+            .toFile()
+        // deleting the old report so that `sarifReports` does not contain it
+        mergedReportFile.delete()
+
+        val sarifReports = sarifReportsPath.toFile()
+            .walkTopDown()
+            .filter { it.extension == "sarif" }
+            .map { it.readText() }
+            .toList()
+
+        val mergedReport = SarifReport.mergeReports(sarifReports)
+        mergedReportFile.writeText(mergedReport)
+
+        // notifying the user
+        SarifReportNotifier.notify(
+            info = """
+                SARIF report was saved to ${PathUtil.toHtmlLinkTag(mergedReportFile.path)}$HTML_LINE_SEPARATOR
+            """.trimIndent()
+        )
     }
 }
 

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/sarif/SarifReportIdea.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/sarif/SarifReportIdea.kt
@@ -2,6 +2,8 @@ package org.utbot.intellij.plugin.sarif
 
 import com.intellij.openapi.command.executeCommand
 import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.psi.PsiClass
+import com.intellij.psi.SmartPsiElementPointer
 import org.jetbrains.kotlin.idea.util.application.runWriteAction
 import org.utbot.common.HTML_LINE_SEPARATOR
 import org.utbot.common.PathUtil
@@ -14,6 +16,7 @@ import org.utbot.intellij.plugin.ui.utils.getOrCreateSarifReportsPath
 import org.utbot.intellij.plugin.ui.utils.showErrorDialogLater
 import org.utbot.sarif.Sarif
 import org.utbot.sarif.SarifReport
+import org.utbot.sarif.SourceFindingStrategyDefault
 import java.nio.file.Path
 
 object SarifReportIdea {
@@ -27,8 +30,8 @@ object SarifReportIdea {
         testSetsId: Long,
         srcClassFqn: String,
         model: GenerateTestsModel,
+        testClassPointer: SmartPsiElementPointer<PsiClass>,
         generatedTestsCode: String,
-        sourceFinding: SourceFindingStrategyIdea
     ): Sarif {
         var resultSarif = Sarif.empty()
         try {
@@ -41,6 +44,12 @@ object SarifReportIdea {
                 runWriteAction { VfsUtil.createDirectoryIfMissing(reportFilePath.parent.toString()) }
 
                 // creating & saving the report
+                val sourceFinding = SourceFindingStrategyDefault(
+                    "io.github.ideaseeker.Main",
+                    "C:/Users/sWX1137517/IdeaProjects/SarifTest/src/main/java/io/github/ideaseeker/Main.java",
+                    "C:/Users/sWX1137517/IdeaProjects/SarifTest/src/test/java/io/github/ideaseeker/MainTest.java",
+                    "C:/Users/sWX1137517/IdeaProjects/SarifTest/",
+                ) //SourceFindingStrategyIdea(testClassPointer)
                 resultSarif = proc.writeSarif(reportFilePath, testSetsId, generatedTestsCode, sourceFinding)
             }
         } catch (e: Exception) {

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/sarif/SourceFindingStrategyIdea.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/sarif/SourceFindingStrategyIdea.kt
@@ -2,6 +2,7 @@ package org.utbot.intellij.plugin.sarif
 
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiClass
+import com.intellij.psi.SmartPsiElementPointer
 import org.jetbrains.kotlin.idea.search.allScope
 import org.utbot.common.PathUtil.classFqnToPath
 import org.utbot.common.PathUtil.safeRelativize
@@ -12,7 +13,9 @@ import java.io.File
 /**
  * The search strategy based on the information available to the PsiClass.
  */
-class SourceFindingStrategyIdea(testClass: PsiClass) : SourceFindingStrategy() {
+class SourceFindingStrategyIdea(
+    testClassPointer: SmartPsiElementPointer<PsiClass>
+) : SourceFindingStrategy() {
 
     /**
      * Returns the relative path (against `project.basePath`) to the file with generated tests.
@@ -44,15 +47,21 @@ class SourceFindingStrategyIdea(testClass: PsiClass) : SourceFindingStrategy() {
 
     // internal
 
-    private val project = testClass.project
+    private val project by lazy {
+        testClassPointer.project
+    }
 
-    private val testsFilePath = testClass.containingFile.virtualFile.path
+    private val testsFilePath by lazy {
+        testClassPointer.virtualFile.path
+    }
 
     /**
      * The file extension to be used in [getSourceRelativePath] if the source file
      * was not found by the class qualified name and the `extension` parameter is null.
      */
-    private val defaultExtension = "." + (testClass.containingFile.virtualFile.extension ?: "java")
+    private val defaultExtension by lazy {
+        "." + (testClassPointer.virtualFile.extension ?: "java")
+    }
 
     /**
      * Returns PsiClass by given [classFqn].

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/Settings.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/Settings.kt
@@ -55,6 +55,7 @@ class Settings(val project: Project) : PersistentStateComponent<Settings.State> 
         var classesToMockAlways: Array<String> = Mocker.defaultSuperClassesToMockAlwaysNames.toTypedArray(),
         var fuzzingValue: Double = 0.05,
         var runGeneratedTestsWithCoverage: Boolean = false,
+        var runInspectionAfterTestGeneration: Boolean = true,
         var commentStyle: JavaDocCommentStyle = JavaDocCommentStyle.defaultItem
     ) {
         constructor(model: GenerateTestsModel) : this(
@@ -92,6 +93,7 @@ class Settings(val project: Project) : PersistentStateComponent<Settings.State> 
             if (!classesToMockAlways.contentEquals(other.classesToMockAlways)) return false
             if (fuzzingValue != other.fuzzingValue) return false
             if (runGeneratedTestsWithCoverage != other.runGeneratedTestsWithCoverage) return false
+            if (runInspectionAfterTestGeneration != other.runInspectionAfterTestGeneration) return false
 
             return true
         }
@@ -109,6 +111,7 @@ class Settings(val project: Project) : PersistentStateComponent<Settings.State> 
             result = 31 * result + classesToMockAlways.contentHashCode()
             result = 31 * result + fuzzingValue.hashCode()
             result = 31 * result + if (runGeneratedTestsWithCoverage) 1 else 0
+            result = 31 * result + if (runInspectionAfterTestGeneration) 1 else 0
 
             return result
         }
@@ -147,7 +150,10 @@ class Settings(val project: Project) : PersistentStateComponent<Settings.State> 
         set(value) {
             state.fuzzingValue = value.coerceIn(0.0, 1.0)
         }
+
     var runGeneratedTestsWithCoverage = state.runGeneratedTestsWithCoverage
+
+    val runInspectionAfterTestGeneration = state.runInspectionAfterTestGeneration
 
     fun setClassesToMockAlways(classesToMockAlways: List<String>) {
         state.classesToMockAlways = classesToMockAlways.distinct().toTypedArray()

--- a/utbot-intellij/src/main/resources/META-INF/plugin.xml
+++ b/utbot-intellij/src/main/resources/META-INF/plugin.xml
@@ -90,7 +90,7 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <globalInspection language="JAVA"
-                          displayName="Errors detected by UTBot"
+                          displayName="Errors detected by UnitTestBot"
                           groupPath="Java"
                           groupBundle="messages.InspectionsBundle"
                           groupKey="group.names.probable.bugs"

--- a/utbot-intellij/src/main/resources/META-INF/plugin.xml
+++ b/utbot-intellij/src/main/resources/META-INF/plugin.xml
@@ -88,4 +88,15 @@
         ]]>
     </change-notes>
 
+    <extensions defaultExtensionNs="com.intellij">
+        <globalInspection language="JAVA"
+                          displayName="Errors detected by UTBot"
+                          groupPath="Java"
+                          groupBundle="messages.InspectionsBundle"
+                          groupKey="group.names.probable.bugs"
+                          enabledByDefault="true"
+                          level="ERROR"
+                          implementationClass="org.utbot.intellij.plugin.inspection.UTBotInspectionTool"/>
+    </extensions>
+
 </idea-plugin>

--- a/utbot-intellij/src/main/resources/inspectionDescriptions/UTBotInspectionTool.html
+++ b/utbot-intellij/src/main/resources/inspectionDescriptions/UTBotInspectionTool.html
@@ -1,0 +1,11 @@
+<html lang="en">
+<body>
+<p>Reports unchecked exceptions detected by UTBot.</p>
+<p>Example:</p>
+<pre>
+void foo(int a) {
+    return 1 / a; // throws ArithmeticException when `a == 0`
+}
+</pre>
+</body>
+</html>

--- a/utbot-intellij/src/main/resources/inspectionDescriptions/UTBotInspectionTool.html
+++ b/utbot-intellij/src/main/resources/inspectionDescriptions/UTBotInspectionTool.html
@@ -1,6 +1,6 @@
 <html lang="en">
 <body>
-<p>Reports unchecked exceptions detected by UTBot.</p>
+<p>Reports unchecked exceptions detected by UnitTestBot.</p>
 <p>Example:</p>
 <pre>
 void foo(int a) {

--- a/utbot-rd/src/main/rdgen/org/utbot/rd/models/EngineProcessModel.kt
+++ b/utbot-rd/src/main/rdgen/org/utbot/rd/models/EngineProcessModel.kt
@@ -122,7 +122,7 @@ object EngineProcessModel : Ext(EngineProcessProtocolRoot) {
         call("obtainClassId", PredefinedType.string, array(PredefinedType.byte)).async
         call("findMethodsInClassMatchingSelected", findMethodsInClassMatchingSelectedArguments, findMethodsInClassMatchingSelectedResult).async
         call("findMethodParamNames", findMethodParamNamesArguments, findMethodParamNamesResult).async
-        call("writeSarifReport", writeSarifReportArguments, PredefinedType.void).async
+        call("writeSarifReport", writeSarifReportArguments, PredefinedType.string).async
         call("generateTestReport", generateTestReportArgs, generateTestReportResult).async
     }
 }


### PR DESCRIPTION
# Description

The SARIF report visualizer built into the IDEA plugin

All errors detected by UTBot are displayed in the "Problems" tool window automatically after the test is generated:

![image](https://user-images.githubusercontent.com/54814796/192706580-e270eb23-3701-45de-937c-7e246be32d3d.png) 

The user can view the generated test for each error:

![image](https://user-images.githubusercontent.com/54814796/192707331-d8bc1c90-c446-4dad-afcd-9083d0ba638b.png)

The user can also analyze the stack trace of the exception:

![image](https://user-images.githubusercontent.com/54814796/192707597-94abf969-04b7-431a-b550-171aa22de04d.png)

Fixes #972

## Type of Change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Manual Scenario 

1. Run UTBot test generation on your Java project
2. If errors have been detected (the SARIF report contains at least one) the "Problems" tool window will be automatically opened. If not, "Problems" tab will not be opened.
3. For each problem the user has an opportunity to view the generated test and analyze the stack trace
4. Double click on the problem navigates the user to the place in the source code where this problem was detected

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] New tests have been added
- [x] All tests pass locally with my changes
