### PR TITLE
Fix bug in filtering Kotlin getters/setters in plugin

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/PsiClassHelper.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/PsiClassHelper.kt
@@ -1,10 +1,9 @@
 package org.utbot.intellij.plugin.util
 
 import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiMember
 import com.intellij.psi.PsiModifier
-import com.intellij.psi.PsiModifierListOwner
 import com.intellij.psi.SyntheticElement
-import com.intellij.refactoring.classMembers.MemberInfoBase
 import com.intellij.refactoring.util.classMembers.MemberInfo
 import com.intellij.testIntegration.TestIntegrationUtils
 import org.jetbrains.kotlin.asJava.elements.KtLightMethod
@@ -13,21 +12,21 @@ import org.jetbrains.kotlin.asJava.elements.isSetter
 import org.utbot.common.filterWhen
 import org.utbot.framework.UtSettings
 
-private val MemberInfoBase<out PsiModifierListOwner>.isAbstract: Boolean
-    get() = this.member.modifierList?.hasModifierProperty(PsiModifier.ABSTRACT)?: false
+private val PsiMember.isAbstract: Boolean
+    get() = modifierList?.hasModifierProperty(PsiModifier.ABSTRACT)?: false
 
 
-private val MemberInfo.isKotlinGetterOrSetter: Boolean
+private val PsiMember.isKotlinGetterOrSetter: Boolean
     get() {
         if (this !is KtLightMethod)
             return false
-        return this.isGetter || this.isSetter
+        return isGetter || isSetter
     }
 
 private fun Iterable<MemberInfo>.filterTestableMethods(): List<MemberInfo> = this
     .filterWhen(UtSettings.skipTestGenerationForSyntheticMethods) { it.member !is SyntheticElement }
-    .filterNot { it.isAbstract }
-    .filterNot { it.isKotlinGetterOrSetter }
+    .filterNot { it.member.isAbstract }
+    .filterNot { it.member.isKotlinGetterOrSetter }
 
 private val PsiClass.isPrivateOrProtected: Boolean
     get() = this.modifierList?.let {


### PR DESCRIPTION
# Description

Filtering Kotlin getters/setters in plugin was added in #1003, however, there was a major bug in that fix (filter was checking condition that was always true).

Fixes #911 

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

Re-checked on scenario from #1003 -- now works correctly.

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
