### PR TITLE
Improve choosing between simpleName and canonicalName in rendered code

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgAbstractRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/visitor/CgAbstractRenderer.kt
@@ -834,7 +834,8 @@ internal abstract class CgAbstractRenderer(
     }
 
     protected open fun isAccessibleBySimpleNameImpl(classId: ClassId): Boolean =
-        classId in context.importedClasses || classId.packageName == context.classPackageName
+        classId in context.importedClasses ||
+                classId.simpleName !in context.importedClasses.map { it.simpleName } && classId.packageName == context.classPackageName
 
     protected abstract fun escapeNamePossibleKeywordImpl(s: String): String
 


### PR DESCRIPTION
# Description

Using caninicalName instead of simpleName to avoid conflicts in generated code.

Fixes # ([1038](https://github.com/UnitTestBot/UTBotJava/issues/1038))

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

Standard utbot pipeline.