### PR TITLE
Run tests on `push` into release branches

### DIFF
--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -2,9 +2,13 @@ name: "UTBot Java: build and run tests"
 
 on:  
   push:
-    branches: [main]
+    branches:
+      - 'main'
+      - 'unit-test-bot/r**'
   pull_request:
-    branches: [main]
+    branches:
+      - 'main'
+      - 'unit-test-bot/r**'
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/publish-plugin-and-cli.yml
+++ b/.github/workflows/publish-plugin-and-cli.yml
@@ -1,7 +1,9 @@
 name: "Plugin and CLI: publish as archives"
 on:
   push:
-    branches: [main]
+    branches:
+      - 'main'
+      - 'unit-test-bot/r**'
 
 jobs:
     publish_plugin_and_cli:


### PR DESCRIPTION
# Description

Workflows scripts were set up for running tests and publishing plugin and CLI on `push` to release branches.

Fixes #1044

## Type of Change

Not applicable.

Infrastructure changes.

# How Has This Been Tested?

## Automated Testing

Not applicable.

## Manual Scenario 

Not applicable.

# Checklist (remove irrelevant options):

_This is the author self-check list_

All of the options were irrelevant.
