### PR TITLE
Fix utbot-maven compilation

### DIFF
--- a/utbot-maven/src/main/kotlin/org/utbot/maven/plugin/GenerateTestsAndSarifReportMojo.kt
+++ b/utbot-maven/src/main/kotlin/org/utbot/maven/plugin/GenerateTestsAndSarifReportMojo.kt
@@ -177,7 +177,7 @@ class GenerateTestsAndSarifReportMojo : AbstractMojo() {
             withUtContext(UtContext(mavenProjectWrapper.classLoader)) {
                 val testCaseGenerator =
                     TestCaseGenerator(
-                        mavenProjectWrapper.workingDirectory,
+                        listOf(mavenProjectWrapper.workingDirectory),
                         mavenProjectWrapper.runtimeClasspath,
                         dependencyPaths,
                         JdkInfoService.provide()


### PR DESCRIPTION
# Description

It seems that `utbot-maven` project does not compile because of changed interface of `TestCaseGenerator`.
This PR corrects the `buildDirs` argument value to match the new interface.

There is no corresponding issue for this quick fix.

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Automated Testing

`utbot-maven` project should be built. All tests should pass.

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [X] The change followed the style guidelines of the UTBot project
- [X] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [X] No new warnings
- [ ] New tests have been added
- [X] All tests pass locally with my changes

## Additional details

It seems that `utbot-maven` project is missing from the CI scripts. Is it correct?
