### PR TITLE
Render links in the invokes part of JavaDocs

### DIFF
--- a/utbot-summary-tests/src/test/kotlin/examples/structures/SummaryMinStackTest.kt
+++ b/utbot-summary-tests/src/test/kotlin/examples/structures/SummaryMinStackTest.kt
@@ -130,7 +130,7 @@ class SummaryMinStackTest : SummaryTestCaseGeneratorTest(
         val summary7 = "@utbot.classUnderTest {@link MinStack}\n" +
                 "@utbot.methodUnderTest {@link org.utbot.examples.structures.MinStack#addValue(long)}\n" +
                 "@utbot.executesCondition {@code (size == 0): False}\n" +
-                "@utbot.invokes {@code {@link java.lang.Math#min(long,long)}}\n" +
+                "@utbot.invokes {@link java.lang.Math#min(long,long)}\n" +
                 "@utbot.throwsException {@link java.lang.ArrayIndexOutOfBoundsException} in: minStack[size] = Math.min(minStack[size - 1], value);"
         val summary8 = "@utbot.classUnderTest {@link MinStack}\n" +
                 "@utbot.methodUnderTest {@link org.utbot.examples.structures.MinStack#addValue(long)}\n" +
@@ -138,7 +138,7 @@ class SummaryMinStackTest : SummaryTestCaseGeneratorTest(
         val summary9 = "@utbot.classUnderTest {@link MinStack}\n" +
                 "@utbot.methodUnderTest {@link org.utbot.examples.structures.MinStack#addValue(long)}\n" +
                 "@utbot.executesCondition {@code (size == 0): False}\n" +
-                "@utbot.invokes {@code {@link java.lang.Math#min(long,long)}}\n"
+                "@utbot.invokes {@link java.lang.Math#min(long,long)}\n"
 
         val methodName1 = "testAddValue_ThrowArrayIndexOutOfBoundsException"
         val methodName2 = "testAddValue_ThrowNullPointerException"

--- a/utbot-summary/src/main/kotlin/org/utbot/summary/comment/CustomJavaDocCommentBuilder.kt
+++ b/utbot-summary/src/main/kotlin/org/utbot/summary/comment/CustomJavaDocCommentBuilder.kt
@@ -84,7 +84,7 @@ class CustomJavaDocCommentBuilder(
         comment: CustomJavaDocComment
     ) {
         when (statement.stmtType) {
-            StmtType.Invoke -> comment.invokes += "{@code ${statement.description.replace(CARRIAGE_RETURN, "")}}"
+            StmtType.Invoke -> comment.invokes += statement.description.replace(CARRIAGE_RETURN, "")
             StmtType.Condition -> comment.executesCondition += "{@code ${statement.description.replace(CARRIAGE_RETURN, "")}}"
             StmtType.Return -> comment.returnsFrom = "{@code ${statement.description.replace(CARRIAGE_RETURN, "")}}"
             StmtType.CaughtException -> comment.caughtException = "{@code ${statement.description.replace(CARRIAGE_RETURN, "")}}"


### PR DESCRIPTION
# Description

Render links in the invokes part of JavaDocs.

Fixes #1036 

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Automated Testing

See tests changed in this PR.

# Checklist (remove irrelevant options):

- [ ] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [ ] No new warnings
- [ ] New tests have been added
- [x] All tests pass locally with my changes
