### PR TITLE
Publish without workflow run number

### DIFF
--- a/.github/workflows/publish-plugin-and-cli-from-branch.yml
+++ b/.github/workflows/publish-plugin-and-cli-from-branch.yml
@@ -18,6 +18,7 @@ on:
           default: no-postfix
           options:
           - no-postfix
+          - no-postfix-prod
           - alpha
           - beta
 
@@ -42,7 +43,12 @@ jobs:
           # defining or updating the environment variable and writing this to the GITHUB_ENV environment file."
           echo "VERSION="$(date +%Y).$(date +%-m).${GITHUB_RUN_NUMBER}"" >> $GITHUB_ENV
           echo "POSTFIX=${{ github.event.inputs.version-postfix }}" >> $GITHUB_ENV
-          
+
+      - name: Set production version
+        if: ${{ github.event.inputs.version-postfix == 'no-postfix-prod' || github.event.inputs.version-postfix == 'alpha' || github.event.inputs.version-postfix == 'beta' }}
+        run: |
+          echo "VERSION="$(date +%Y).$(date +%-m)"" >> $GITHUB_ENV
+
       - name: Create version with postfix
         if: ${{ (env.POSTFIX == 'alpha') || (env.POSTFIX == 'beta') }}
         run:


### PR DESCRIPTION
# Description

Changes in workflow lead to possibility to publish plugin and CLI without workflow run number.

Fixes #1052 

## Type of Change

All of the options were irrelevant.

# How Has This Been Tested?

## Automated Testing

Not applicable.

## Manual Scenario 

It was tested on branch.

# Checklist (remove irrelevant options):

All of the options were irrelevant.
