### PR TITLE
Fixed unavailable mock classes

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/algorithms/SortTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/algorithms/SortTest.kt
@@ -9,10 +9,20 @@ import org.utbot.framework.plugin.api.DocPreTagStatement
 import org.utbot.framework.plugin.api.DocRegularStmt
 import org.utbot.framework.plugin.api.MockStrategyApi
 import org.junit.jupiter.api.Test
+import org.utbot.framework.plugin.api.CodegenLanguage
 import org.utbot.testcheckers.eq
 import org.utbot.testcheckers.ge
+import org.utbot.tests.infrastructure.CodeGeneration
 
-internal class SortTest : UtValueTestCaseChecker(testClass = Sort::class) {
+// TODO Kotlin mocks generics https://github.com/UnitTestBot/UTBotJava/issues/88
+internal class SortTest : UtValueTestCaseChecker(
+    testClass = Sort::class,
+    testCodeGeneration = true,
+    languagePipelines = listOf(
+        CodeGenerationLanguageLastStage(CodegenLanguage.JAVA),
+        CodeGenerationLanguageLastStage(CodegenLanguage.KOTLIN, CodeGeneration)
+    )
+) {
     @Test
     fun testQuickSort() {
         check(

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/mock/MockRandomTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/mock/MockRandomTest.kt
@@ -11,9 +11,19 @@ import org.utbot.framework.plugin.api.UtCompositeModel
 import org.utbot.framework.plugin.api.UtNewInstanceInstrumentation
 import java.util.Random
 import org.junit.jupiter.api.Test
+import org.utbot.framework.plugin.api.CodegenLanguage
 import org.utbot.testcheckers.eq
+import org.utbot.tests.infrastructure.CodeGeneration
 
-internal class MockRandomTest : UtValueTestCaseChecker(testClass = MockRandomExamples::class) {
+// TODO Kotlin mocks generics https://github.com/UnitTestBot/UTBotJava/issues/88
+internal class MockRandomTest : UtValueTestCaseChecker(
+    testClass = MockRandomExamples::class,
+    testCodeGeneration = true,
+    languagePipelines = listOf(
+        CodeGenerationLanguageLastStage(CodegenLanguage.JAVA),
+        CodeGenerationLanguageLastStage(CodegenLanguage.KOTLIN, CodeGeneration)
+    )
+) {
     @Test
     fun testRandomAsParameter() {
         val method: Random.() -> Int = Random::nextInt

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/mock/MockStaticMethodExampleTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/mock/MockStaticMethodExampleTest.kt
@@ -8,9 +8,19 @@ import org.utbot.framework.util.singleModel
 import org.utbot.framework.util.singleStaticMethod
 import org.utbot.framework.util.singleValue
 import org.junit.jupiter.api.Test
+import org.utbot.framework.plugin.api.CodegenLanguage
 import org.utbot.testcheckers.eq
+import org.utbot.tests.infrastructure.CodeGeneration
 
-internal class MockStaticMethodExampleTest : UtValueTestCaseChecker(testClass = MockStaticMethodExample::class) {
+// TODO Kotlin mocks generics https://github.com/UnitTestBot/UTBotJava/issues/88
+internal class MockStaticMethodExampleTest : UtValueTestCaseChecker(
+    testClass = MockStaticMethodExample::class,
+    testCodeGeneration = true,
+    languagePipelines = listOf(
+        CodeGenerationLanguageLastStage(CodegenLanguage.JAVA),
+        CodeGenerationLanguageLastStage(CodegenLanguage.KOTLIN, CodeGeneration)
+    )
+) {
     @Test
     fun testUseStaticMethod() {
         checkMocksAndInstrumentation(

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/natives/NativeExamplesTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/natives/NativeExamplesTest.kt
@@ -3,11 +3,21 @@ package org.utbot.examples.natives
 import org.utbot.tests.infrastructure.UtValueTestCaseChecker
 import org.utbot.tests.infrastructure.DoNotCalculate
 import org.junit.jupiter.api.Test
+import org.utbot.framework.plugin.api.CodegenLanguage
 import org.utbot.testcheckers.eq
 import org.utbot.testcheckers.ge
 import org.utbot.testcheckers.withSolverTimeoutInMillis
+import org.utbot.tests.infrastructure.CodeGeneration
 
-internal class NativeExamplesTest : UtValueTestCaseChecker(testClass = NativeExamples::class) {
+// TODO Kotlin mocks generics https://github.com/UnitTestBot/UTBotJava/issues/88
+internal class NativeExamplesTest : UtValueTestCaseChecker(
+    testClass = NativeExamples::class,
+    testCodeGeneration = true,
+    languagePipelines = listOf(
+        CodeGenerationLanguageLastStage(CodegenLanguage.JAVA),
+        CodeGenerationLanguageLastStage(CodegenLanguage.KOTLIN, CodeGeneration)
+    )
+) {
 
     @Test
     fun testFindAndPrintSum() {

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/recursion/RecursionTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/recursion/RecursionTest.kt
@@ -13,10 +13,20 @@ import org.utbot.framework.plugin.api.DocStatement
 import kotlin.math.pow
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.utbot.framework.plugin.api.CodegenLanguage
 import org.utbot.testcheckers.eq
 import org.utbot.testcheckers.ge
+import org.utbot.tests.infrastructure.CodeGeneration
 
-internal class RecursionTest : UtValueTestCaseChecker(testClass = Recursion::class) {
+// TODO Kotlin mocks generics https://github.com/UnitTestBot/UTBotJava/issues/88
+internal class RecursionTest : UtValueTestCaseChecker(
+    testClass = Recursion::class,
+    testCodeGeneration = true,
+    languagePipelines = listOf(
+        CodeGenerationLanguageLastStage(CodegenLanguage.JAVA),
+        CodeGenerationLanguageLastStage(CodegenLanguage.KOTLIN, CodeGeneration)
+    )
+) {
     @Test
     fun testFactorial() {
         val factorialSummary = listOf<DocStatement>(

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
@@ -1316,21 +1316,20 @@ internal class CgMethodConstructor(val context: CgContext) : CgContextOwner by c
                     resources.forEach {
                         // First argument for mocked resource declaration initializer is a target type.
                         // Pass this argument as a type parameter for the mocked resource
+
+                        // TODO this type parameter (required for Kotlin test) is unused until the proper implementation
+                        //  of generics in code generation https://github.com/UnitTestBot/UTBotJava/issues/88
+                        @Suppress("UNUSED_VARIABLE")
                         val typeParameter = when (val firstArg = (it.initializer as CgMethodCall).arguments.first()) {
                             is CgGetJavaClass -> firstArg.classId
                             is CgVariable -> firstArg.type
                             else -> error("Unexpected mocked resource declaration argument $firstArg")
                         }
-                        val varType = CgClassId(
-                            it.variableType,
-                            TypeParameters(listOf(typeParameter)),
-                            isNullable = true,
-                        )
+
                         +CgDeclaration(
-                            varType,
+                            it.variableType,
                             it.variableName,
-                            // guard initializer to reuse typecast creation logic
-                            initializer = guardExpression(varType, nullLiteral()).expression,
+                            initializer = nullLiteral(),
                             isMutable = true,
                         )
                     }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/MockFrameworkManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/MockFrameworkManager.kt
@@ -237,7 +237,7 @@ private class MockitoStaticMocker(context: CgContext, private val mocker: Object
             mockClassCounter.variable
         )
         val mockedConstructionDeclaration = CgDeclaration(
-            CgClassId(MockitoStaticMocking.mockedConstructionClassId),
+            MockitoStaticMocking.mockedConstructionClassId,
             variableConstructor.constructVarName(MOCKED_CONSTRUCTION_NAME),
             mockConstructionInitializer
         )
@@ -295,7 +295,7 @@ private class MockitoStaticMocker(context: CgContext, private val mocker: Object
             val classMockStaticCall = mockStatic(modelClass)
             val mockedStaticVariableName = variableConstructor.constructVarName(MOCKED_STATIC_NAME)
             CgDeclaration(
-                CgClassId(MockitoStaticMocking.mockedStaticClassId),
+                MockitoStaticMocking.mockedStaticClassId,
                 mockedStaticVariableName,
                 classMockStaticCall
             ).also {


### PR DESCRIPTION
# Description

After introducing nullability and single type parameter for Kotlin code generation, static mocks became broken - they were no longer considered as `BuiltinClassId`, which means they were tried to load with default class loader which is impossible due to classes from mock frameworks could not be load with it. 

This request makes mock classes builtin again - it fixes the problem but is incorrect for Kotlin code generation. The proper support of it should be designed and implemented together with generics in code generation (as planned in #88).

Fixes #981.

## Type of Change

Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

## Manual Scenario 

Generating tests as mentioned in the issue.

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] All tests pass locally with my changes
