### PR TITLE
Remove unsat states from invokes

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/collections/MapsPart1Test.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/collections/MapsPart1Test.kt
@@ -1,5 +1,6 @@
 package org.utbot.examples.collections
 
+import org.junit.jupiter.api.Tag
 import org.utbot.tests.infrastructure.UtValueTestCaseChecker
 import org.utbot.tests.infrastructure.AtLeast
 import org.utbot.tests.infrastructure.DoNotCalculate
@@ -10,6 +11,7 @@ import org.utbot.framework.plugin.api.MockStrategyApi
 import org.junit.jupiter.api.Test
 import org.utbot.testcheckers.eq
 import org.utbot.testcheckers.ge
+import org.utbot.testcheckers.withPushingStateFromPathSelectorForConcrete
 import org.utbot.testcheckers.withoutMinimization
 import org.utbot.tests.infrastructure.CodeGeneration
 
@@ -147,6 +149,17 @@ internal class MapsPart1Test : UtValueTestCaseChecker(
             { map, i, result -> map.isNotEmpty() && CustomClass(i) in map && result == map[CustomClass(i)] },
             coverage = DoNotCalculate
         )
+    }
+
+    @Test
+    @Tag("slow") // it takes about 20 minutes to execute this test
+    fun testMapOperator() {
+        withPushingStateFromPathSelectorForConcrete {
+            check(
+                Maps::mapOperator,
+                ignoreExecutionsNumber
+            )
+        }
     }
 
     @Test

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -46,6 +46,7 @@ import org.utbot.engine.pc.UtPrimitiveSort
 import org.utbot.engine.pc.UtShortSort
 import org.utbot.engine.pc.UtSolver
 import org.utbot.engine.pc.UtSolverStatusSAT
+import org.utbot.engine.pc.UtSolverStatusUNSAT
 import org.utbot.engine.pc.UtSubNoOverflowExpression
 import org.utbot.engine.pc.UtTrue
 import org.utbot.engine.pc.addrEq
@@ -2534,6 +2535,15 @@ class Traverser(
          * TODO: https://github.com/UnitTestBot/UTBotJava/issues/819 -- Support super calls in inherited wrappers
          */
         val artificialMethodOverride = overrideInvocation(invocation, target = null)
+
+        // The problem here is that we might have an unsat current state.
+        // We get states with `SAT` last status only for traversing,
+        // but during the parameters resolving this status might be changed.
+        // It happens inside the `org.utbot.engine.Traverser.initStringLiteral` function.
+        // So, if it happens, we should just drop the state we processing now.
+        if (environment.state.solver.lastStatus is UtSolverStatusUNSAT) {
+            return emptyList()
+        }
 
         // If so, return the result of the override
         if (artificialMethodOverride.success) {

--- a/utbot-sample/src/main/java/org/utbot/examples/collections/Maps.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/collections/Maps.java
@@ -1,7 +1,9 @@
 package org.utbot.examples.collections;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 public class Maps {
@@ -243,6 +245,20 @@ public class Maps {
             return null;
         } else {
             return removed;
+        }
+    }
+
+    public List<String> mapOperator(Map<String, String> map) {
+        List<String> result = new ArrayList<>();
+        for (Map.Entry<String, String> entry : map.entrySet()) {
+            if (entry.getValue().equals("key")) {
+                result.add(entry.getKey());
+            }
+        }
+        if (result.size() > 1) {
+            return result;
+        } else {
+            return new ArrayList<>(map.values());
         }
     }
 }


### PR DESCRIPTION
# Description

When we process an invocation, we should resolve parameters for a call. During the resolve, our state might become UNSAT (how is it possible is another [question](https://github.com/UnitTestBot/UTBotJava/issues/1070)).

Fixes #107 

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

org.utbot.examples.collections.MapsPart1Test#testMapOperator

## Manual Scenario 

Run idea on the added method for auto testing and check it in plugin with 300s time limit. We should not have any errors

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] New tests have been added
- [x] All tests pass locally with my changes
