### PR TITLE
Select Kotlin test src root by default when generating for Kotlin #949

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerationController.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerationController.kt
@@ -416,8 +416,8 @@ object CodeGenerationController {
         // all test roots for the given test module
         val testRoots = runReadAction {
             testModule
-                .suitableTestSourceRoots(this)
-                .mapNotNull { psiManager.findDirectory(it) }
+                .suitableTestSourceRoots()
+                .mapNotNull { psiManager.findDirectory(it.dir) }
         }
 
         // return an util class from one of the test source roots or null if no util class was found

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/GenerateTestsModel.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/GenerateTestsModel.kt
@@ -19,6 +19,7 @@ import com.intellij.openapi.vfs.newvfs.impl.FakeVirtualFile
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiJavaFile
 import com.intellij.refactoring.util.classMembers.MemberInfo
+import org.jetbrains.kotlin.asJava.classes.KtUltraLightClass
 import org.jetbrains.kotlin.psi.KtFile
 import org.utbot.framework.plugin.api.JavaDocCommentStyle
 import org.utbot.framework.util.ConflictTriggers
@@ -56,13 +57,14 @@ data class GenerateTestsModel(
             ?: error("Could not find module for $newTestSourceRoot")
     }
 
+    var codegenLanguage = if (srcClasses.all { it is KtUltraLightClass }) CodegenLanguage.KOTLIN else CodegenLanguage.JAVA
+
     var testPackageName: String? = null
     lateinit var testFramework: TestFramework
     lateinit var mockStrategy: MockStrategyApi
     lateinit var mockFramework: MockFramework
     lateinit var staticsMocking: StaticsMocking
     lateinit var parametrizedTestSource: ParametrizedTestSource
-    lateinit var codegenLanguage: CodegenLanguage
     lateinit var runtimeExceptionTestsBehaviour: RuntimeExceptionTestsBehaviour
     lateinit var hangingTestsTimeout: HangingTestsTimeout
     lateinit var forceStaticMocking: ForceStaticMocking

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -95,7 +95,6 @@ import javax.swing.JSpinner
 import javax.swing.text.DefaultFormatter
 import org.jetbrains.concurrency.Promise
 import org.jetbrains.concurrency.thenRun
-import org.jetbrains.kotlin.asJava.classes.KtUltraLightClass
 import org.utbot.common.PathUtil.toPath
 import org.utbot.framework.UtSettings
 import org.utbot.framework.codegen.ForceStaticMocking
@@ -651,8 +650,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
         mockStrategies.isEnabled = areMocksSupported
         staticsMocking.isEnabled = areMocksSupported && mockStrategies.item != MockStrategyApi.NO_MOCKS
 
-        codegenLanguages.item =
-            if (model.srcClasses.all { it is KtUltraLightClass }) CodegenLanguage.KOTLIN else CodegenLanguage.JAVA
+        codegenLanguages.item = model.codegenLanguage
 
         val installedTestFramework = TestFramework.allItems.singleOrNull { it.isInstalled }
         currentFrameworkItem = when (parametrizedTestSources.isSelected) {

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/ModuleUtils.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/ModuleUtils.kt
@@ -37,6 +37,11 @@ import org.jetbrains.kotlin.platform.TargetPlatformVersion
 
 private val logger = KotlinLogging.logger {}
 
+data class TestSourceRoot(
+    val dir: VirtualFile,
+    val expectedLanguage: CodegenLanguage
+)
+
 /**
  * @return jdk version of the module
  */
@@ -59,12 +64,6 @@ fun Module.kotlinTargetPlatform(): TargetPlatformVersion {
         ?.map { it.targetPlatformVersion }
         ?.singleOrNull() ?: error("Can't determine target platform for module $this")
 }
-
-fun Module.suitableTestSourceRoots(): List<VirtualFile> =
-    suitableTestSourceRoots(CodegenLanguage.JAVA) + suitableTestSourceRoots(CodegenLanguage.KOTLIN)
-
-fun Module.suitableTestSourceFolders(): List<SourceFolder> =
-    suitableTestSourceFolders(CodegenLanguage.JAVA) + suitableTestSourceFolders(CodegenLanguage.KOTLIN)
 
 /**
  * Gets a path to test resources source root.
@@ -121,8 +120,8 @@ private fun findPotentialModulesForTests(project: Project, srcModule: Module): L
 /**
  * Finds all suitable test root virtual files.
  */
-fun Module.suitableTestSourceRoots(codegenLanguage: CodegenLanguage): List<VirtualFile> {
-    val sourceRootsInModule = suitableTestSourceFolders(codegenLanguage).mapNotNull { it.file }
+fun Module.suitableTestSourceRoots(): List<TestSourceRoot> {
+    val sourceRootsInModule = suitableTestSourceFolders().mapNotNull { it.testSourceRoot }
 
     if (sourceRootsInModule.isNotEmpty()) {
         return sourceRootsInModule
@@ -133,11 +132,20 @@ fun Module.suitableTestSourceRoots(codegenLanguage: CodegenLanguage): List<Virtu
     ModuleUtilCore.collectModulesDependsOn(this, dependentModules)
 
     return dependentModules
-        .flatMap { it.suitableTestSourceFolders(codegenLanguage) }
-        .mapNotNull { it.file }
+        .flatMap { it.suitableTestSourceFolders() }
+        .mapNotNull { it.testSourceRoot }
 }
 
-private fun Module.suitableTestSourceFolders(codegenLanguage: CodegenLanguage): List<SourceFolder> {
+private val SourceFolder.testSourceRoot:TestSourceRoot?
+    get() {
+        val file = file
+        val expectedLanguage = expectedLanguageForTests
+        if (file != null && expectedLanguage != null)
+            return TestSourceRoot(file, expectedLanguage)
+        return null
+    }
+
+private fun Module.suitableTestSourceFolders(): List<SourceFolder> {
     val sourceFolders = ModuleRootManager.getInstance(this)
         .contentEntries
         .flatMap { it.sourceFolders.toList() }
@@ -146,10 +154,8 @@ private fun Module.suitableTestSourceFolders(codegenLanguage: CodegenLanguage): 
     return sourceFolders
         .filterNot { it.isForGeneratedSources() }
         .filter { it.isTestSource }
-        .filter { it.expectedLanguageForTests == codegenLanguage }
-        // Heuristics: User is more likely to choose the shorter path
-        .sortedBy { it.url.length }
 }
+
 private val GRADLE_SYSTEM_ID = ProjectSystemId("GRADLE")
 
 val Project.isBuildWithGradle get() =
@@ -158,11 +164,12 @@ val Project.isBuildWithGradle get() =
          }
 
 private const val dedicatedTestSourceRootName = "utbot_tests"
-fun Module.addDedicatedTestRoot(testSourceRoots: MutableList<VirtualFile>): VirtualFile? {
+
+fun Module.addDedicatedTestRoot(testSourceRoots: MutableList<TestSourceRoot>, language: CodegenLanguage): VirtualFile? {
     // Don't suggest new test source roots for Gradle project where 'unexpected' test roots won't work
     if (project.isBuildWithGradle) return null
     // Dedicated test root already exists
-    if (testSourceRoots.any { file -> file.name == dedicatedTestSourceRootName }) return null
+    if (testSourceRoots.any { root -> root.dir.name == dedicatedTestSourceRootName }) return null
 
     val moduleInstance = ModuleRootManager.getInstance(this)
     val testFolder = moduleInstance.contentEntries.flatMap { it.sourceFolders.toList() }
@@ -170,7 +177,7 @@ fun Module.addDedicatedTestRoot(testSourceRoots: MutableList<VirtualFile>): Virt
     (testFolder?.let { testFolder.file?.parent }
         ?: testFolder?.contentEntry?.file ?: this.guessModuleDir())?.let {
         val file = FakeVirtualFile(it, dedicatedTestSourceRootName)
-        testSourceRoots.add(file)
+        testSourceRoots.add(TestSourceRoot(file, language))
         // We return "true" IFF it's case of not yet created fake directory
         return if (VfsUtil.findRelativeFile(it, dedicatedTestSourceRootName) == null) file else null
     }


### PR DESCRIPTION
# Description

Now, if project has both Java and Kotlin tests source roots, UTBot by default selects one that matches code generation language. 

Note that currently there is no proper way to check whether source root is for Java or for Kotlin, so we mainly decide this by folder name (see `org.utbot.intellij.plugin.ui.utils.ModuleUtilsKt#getExpectedLanguageForTests` and comment there).

Fixes #949

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

Repeated scenario from #949 -- works as expected.

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
