### PR TITLE
Improve verification that static mocking is configured

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/util/DependencyPatterns.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/util/DependencyPatterns.kt
@@ -87,6 +87,6 @@ val mockitoPatterns = listOf(MOCKITO_JAR_PATTERN, MOCKITO_MVN_PATTERN)
 val MOCKITO_BASIC_MODULE_PATTERN = Regex("mockito-core")
 val mockitoModulePatterns = listOf(MOCKITO_BASIC_MODULE_PATTERN)
 
-const val MOCKITO_EXTENSIONS_STORAGE = "mockito-extensions"
+const val MOCKITO_EXTENSIONS_FOLDER = "mockito-extensions"
 const val MOCKITO_MOCKMAKER_FILE_NAME = "org.mockito.plugins.MockMaker"
-val MOCKITO_EXTENSIONS_FILE_CONTENT = listOf("mock-maker-inline")
+val MOCKITO_EXTENSIONS_FILE_CONTENT = "mock-maker-inline"

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -1033,8 +1033,13 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
                 val mockMakerPath = "$entryPath/$MOCKITO_EXTENSIONS_FOLDER/$MOCKITO_MOCKMAKER_FILE_NAME".toPath()
                 if (!Files.exists(mockMakerPath)) return false
 
-                val fileLines = Files.readAllLines(mockMakerPath)
-                fileLines.singleOrNull() == MOCKITO_EXTENSIONS_FILE_CONTENT
+                try {
+                    val fileLines = Files.readAllLines(mockMakerPath)
+                    fileLines.singleOrNull() == MOCKITO_EXTENSIONS_FILE_CONTENT
+                } catch (e: java.io.IOException) {
+                    return false
+                }
+
             }
     }
 }

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -109,7 +109,7 @@ import org.utbot.framework.codegen.StaticsMocking
 import org.utbot.framework.codegen.TestFramework
 import org.utbot.framework.codegen.TestNg
 import org.utbot.framework.codegen.model.util.MOCKITO_EXTENSIONS_FILE_CONTENT
-import org.utbot.framework.codegen.model.util.MOCKITO_EXTENSIONS_STORAGE
+import org.utbot.framework.codegen.model.util.MOCKITO_EXTENSIONS_FOLDER
 import org.utbot.framework.codegen.model.util.MOCKITO_MOCKMAKER_FILE_NAME
 import org.utbot.framework.plugin.api.CodeGenerationSettingItem
 import org.utbot.framework.plugin.api.CodegenLanguage
@@ -762,7 +762,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
      * for further details.
      */
     private fun configureMockitoResources(testResourcesPath: Path) {
-        val mockitoExtensionsPath = "$testResourcesPath/$MOCKITO_EXTENSIONS_STORAGE".toPath()
+        val mockitoExtensionsPath = "$testResourcesPath/$MOCKITO_EXTENSIONS_FOLDER".toPath()
         val mockitoMockMakerPath = "$mockitoExtensionsPath/$MOCKITO_MOCKMAKER_FILE_NAME".toPath()
 
         if (!testResourcesPath.exists()) Files.createDirectory(testResourcesPath)
@@ -770,7 +770,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
 
         if (!mockitoMockMakerPath.exists()) {
             Files.createFile(mockitoMockMakerPath)
-            Files.write(mockitoMockMakerPath, MOCKITO_EXTENSIONS_FILE_CONTENT)
+            Files.write(mockitoMockMakerPath, listOf(MOCKITO_EXTENSIONS_FILE_CONTENT))
         }
     }
 
@@ -1027,14 +1027,15 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
                     .map { f -> Paths.get(urlToPath(f.url)) }
             }
 
-        return entriesPaths.all { path ->
-            if (Files.exists(path)) {
-                val fileNames = Files.walk(path).map { it.fileName }.toList()
-                fileNames.any { it.toString() == MOCKITO_MOCKMAKER_FILE_NAME }
-            } else {
-                false
+        return entriesPaths.all { entryPath ->
+                if (!Files.exists(entryPath)) return false
+
+                val mockMakerPath = "$entryPath/$MOCKITO_EXTENSIONS_FOLDER/$MOCKITO_MOCKMAKER_FILE_NAME".toPath()
+                if (!Files.exists(mockMakerPath)) return false
+
+                val fileLines = Files.readAllLines(mockMakerPath)
+                fileLines.singleOrNull() == MOCKITO_EXTENSIONS_FILE_CONTENT
             }
-        }
     }
 }
 


### PR DESCRIPTION
# Description

Current implementation of searching that static mocking is configured has a problem that we firstly obtain all file names from the content entry and only after that verify that a required name is present. It will lead us to problems if there are millions of files in the content entry.
Implementation was improved in accordance with lazy practices.

## Type of Change

- Refactoring (typos and non-functional changes) 

# How Has This Been Tested?

## Manual Scenario 

Verify that we do not create tests with static mocking if there is no special file in any of test source root resource folders.


