### PR TITLE
Cancel test generation if compilation was not successful #1100

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -108,6 +108,9 @@ object UtTestsDialogProcessor {
             *model.srcClasses.map { it.containingFile.virtualFile }.toTypedArray()
         )
         promise.onSuccess {
+            if (it.hasErrors() || it.isAborted)
+                return@onSuccess
+
             (object : Task.Backgroundable(project, "Generate tests") {
 
                 override fun run(indicator: ProgressIndicator) {


### PR DESCRIPTION
# Description

Now, if src classes were not compiled successfully, we do not try to generate tests (this was already working, but seems to have been broken in #1019)

Fixes #1100

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

Checked on scenarios from issue -- works as expected.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
