### PR TITLE
Notify and reason to the user that UtBot can't be run on the class in editor

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/Notifications.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/Notifications.kt
@@ -64,6 +64,12 @@ object UnsupportedJdkNotifier : ErrorNotifier() {
             "JDK versions older than 8 are not supported. This project's JDK version is $info"
 }
 
+object InvalidClassNotifier : WarningNotifier() {
+    override val displayId: String = "Invalid class"
+    override fun content(project: Project?, module: Module?, info: String): String =
+        "Generate tests with UtBot for the $info is not supported"
+}
+
 object MissingLibrariesNotifier : WarningNotifier() {
     override val displayId: String = "Missing libraries"
     override fun content(project: Project?, module: Module?, info: String): String =

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/Notifications.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/Notifications.kt
@@ -67,7 +67,7 @@ object UnsupportedJdkNotifier : ErrorNotifier() {
 object InvalidClassNotifier : WarningNotifier() {
     override val displayId: String = "Invalid class"
     override fun content(project: Project?, module: Module?, info: String): String =
-        "Generate tests with UtBot for the $info is not supported"
+        "Generate tests with UtBot for the $info is not supported."
 }
 
 object MissingLibrariesNotifier : WarningNotifier() {

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/PsiClassHelper.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/PsiClassHelper.kt
@@ -12,9 +12,8 @@ import org.jetbrains.kotlin.asJava.elements.isSetter
 import org.utbot.common.filterWhen
 import org.utbot.framework.UtSettings
 
-private val PsiMember.isAbstract: Boolean
+val PsiMember.isAbstract: Boolean
     get() = modifierList?.hasModifierProperty(PsiModifier.ABSTRACT)?: false
-
 
 private val PsiMember.isKotlinGetterOrSetter: Boolean
     get() {


### PR DESCRIPTION
# Description

Some notifications are shown to the user if he runs tests generation on the class that does not satisfy the requirements

Fixes # ([1077](https://github.com/UnitTestBot/UTBotJava/issues/1077))
Fixes # ([873](https://github.com/UnitTestBot/UTBotJava/issues/873))

## Type of Change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Manual Scenario 

Run Generate tests with UtBot from editor and project tree in standard test scenarios and on data sets described in the issues.