### PR TITLE
Wrap method reference into @link tag only if the invoked method is not private

### DIFF
--- a/utbot-summary-tests/src/test/kotlin/examples/inner/SummaryInnerCallsTest.kt
+++ b/utbot-summary-tests/src/test/kotlin/examples/inner/SummaryInnerCallsTest.kt
@@ -136,7 +136,7 @@ class SummaryInnerCallsTest : SummaryTestCaseGeneratorTest(
                 "throws IllegalArgumentException in: return binarySearch.leftBinSearch(array, key);\n"
         val summary7 = "Test calls {@link org.utbot.examples.algorithms.BinarySearch#leftBinSearch(long[],long)},\n" +
                 "    there it invokes:\n" +
-                "        {@link org.utbot.examples.algorithms.BinarySearch#isUnsorted(long[])} once\n" +
+                "        org.utbot.examples.algorithms.BinarySearch#isUnsorted(long[]) once\n" +
                 "    triggers recursion of leftBinSearch once, \n" +
                 "Test throws NullPointerException in: return binarySearch.leftBinSearch(array, key);\n"
 
@@ -378,8 +378,8 @@ class SummaryInnerCallsTest : SummaryTestCaseGeneratorTest(
                 "        (fst < 100): False,\n" +
                 "        (snd < 100): False\n" +
                 "    invokes:\n" +
-                "        {@link org.utbot.examples.invokes.InvokeExample#half(int)} once,\n" +
-                "        {@link org.utbot.examples.invokes.InvokeExample#mult(int,int)} once\n" +
+                "        org.utbot.examples.invokes.InvokeExample#half(int) once,\n" +
+                "        org.utbot.examples.invokes.InvokeExample#mult(int,int) once\n" +
                 "    returns from: return mult(x, y);\n" +
                 "    \n" +
                 "Test then returns from: return invokeExample.simpleFormula(f, s);\n"
@@ -625,8 +625,8 @@ class SummaryInnerCallsTest : SummaryTestCaseGeneratorTest(
                 "            (fst < 100): False,\n" +
                 "            (snd < 100): False\n" +
                 "        invokes:\n" +
-                "            {@link org.utbot.examples.invokes.InvokeExample#half(int)} once,\n" +
-                "            {@link org.utbot.examples.invokes.InvokeExample#mult(int,int)} once\n" +
+                "            org.utbot.examples.invokes.InvokeExample#half(int) once,\n" +
+                "            org.utbot.examples.invokes.InvokeExample#mult(int,int) once\n" +
                 "        returns from: return mult(x, y);\n" +
                 "        \n" +
                 "    Test later returns from: return invokeExample.simpleFormula(f, s);\n" +

--- a/utbot-summary-tests/src/test/kotlin/examples/ternary/SummaryTernaryTest.kt
+++ b/utbot-summary-tests/src/test/kotlin/examples/ternary/SummaryTernaryTest.kt
@@ -475,12 +475,12 @@ class SummaryTernaryTest : SummaryTestCaseGeneratorTest(
         val summary1 = "Test executes conditions:\n" +
                 "    (num1 > num2): True\n" +
                 "invokes:\n" +
-                "    {@link org.utbot.examples.ternary.Ternary#intFunc1()} once\n" +
+                "    org.utbot.examples.ternary.Ternary#intFunc1() once\n" +
                 "returns from: return num1 > num2 ? intFunc1() : intFunc2();\n"
         val summary2 = "Test executes conditions:\n" +
                 "    (num1 > num2): False\n" +
                 "invokes:\n" +
-                "    {@link org.utbot.examples.ternary.Ternary#intFunc2()} once\n" +
+                "    org.utbot.examples.ternary.Ternary#intFunc2() once\n" +
                 "returns from: return num1 > num2 ? intFunc1() : intFunc2();\n"
 
         val methodName1 = "testIntFunc_Num1GreaterThanNum2"

--- a/utbot-summary/src/main/kotlin/org/utbot/summary/comment/CustomJavaDocCommentBuilder.kt
+++ b/utbot-summary/src/main/kotlin/org/utbot/summary/comment/CustomJavaDocCommentBuilder.kt
@@ -30,7 +30,8 @@ class CustomJavaDocCommentBuilder(
         val methodReference = getMethodReference(
             currentMethod.declaringClass.name,
             currentMethod.name,
-            currentMethod.parameterTypes
+            currentMethod.parameterTypes,
+            false
         )
         val classReference = getClassReference(currentMethod.declaringClass.javaStyleName)
 

--- a/utbot-summary/src/main/kotlin/org/utbot/summary/comment/SymbolicExecutionClusterCommentBuilder.kt
+++ b/utbot-summary/src/main/kotlin/org/utbot/summary/comment/SymbolicExecutionClusterCommentBuilder.kt
@@ -90,12 +90,16 @@ class SymbolicExecutionClusterCommentBuilder(
             val className = invokeSootMethod.declaringClass.name
             val methodName = invokeSootMethod.name
             val methodParameterTypes = invokeSootMethod.parameterTypes
+            val isPrivate = invokeSootMethod.isPrivate
             val sentenceInvoke = SimpleSentenceBlock(stringTemplates = StringsTemplatesPlural())
             buildSentenceBlock(invoke, sentenceInvoke, invokeSootMethod)
             sentenceInvoke.squashStmtText()
             if (!sentenceInvoke.isEmpty()) {
                 sentenceBlock.invokeSentenceBlock =
-                    Pair(getMethodReference(className, methodName, methodParameterTypes), sentenceInvoke)
+                    Pair(
+                        getMethodReference(className, methodName, methodParameterTypes, isPrivate),
+                        sentenceInvoke
+                    )
                 createNextBlock = true
                 invokeRegistered = true
             }

--- a/utbot-summary/src/test/kotlin/org/utbot/summary/comment/SimpleCommentBuilderTest.kt
+++ b/utbot-summary/src/test/kotlin/org/utbot/summary/comment/SimpleCommentBuilderTest.kt
@@ -67,7 +67,7 @@ class SimpleCommentBuilderTest {
     @Test
     fun `builds inline link for method`() {
         val commentBuilder = SimpleCommentBuilder(traceTag, sootToAst)
-        val methodReference = commentBuilder.getMethodReference("org.utbot.ClassName", "methodName", listOf())
+        val methodReference = commentBuilder.getMethodReference("org.utbot.ClassName", "methodName", listOf(), false)
         val expectedMethodReference = "{@link org.utbot.ClassName#methodName()}"
         assertEquals(methodReference, expectedMethodReference)
     }
@@ -76,7 +76,7 @@ class SimpleCommentBuilderTest {
     fun `builds inline link for method in nested class`() {
         val commentBuilder = SimpleCommentBuilder(traceTag, sootToAst)
         val methodReference =
-            commentBuilder.getMethodReference("org.utbot.ClassName\$NestedClassName", "methodName", listOf())
+            commentBuilder.getMethodReference("org.utbot.ClassName\$NestedClassName", "methodName", listOf(), false)
         val expectedMethodReference = "{@link org.utbot.ClassName.NestedClassName#methodName()}"
         assertEquals(methodReference, expectedMethodReference)
     }


### PR DESCRIPTION
# Description

Wrap method reference into @link tag only if the invoked method is not private.
Fixes the bug reported by @alisevych and @korifey.

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

Run test generation for `ArraysQuickSort#sort` method.

# Checklist (remove irrelevant options):

- [ ] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] All tests pass locally with my changes
