### PR TITLE
Make snapshot version calendar-dependant

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import java.text.SimpleDateFormat
 import org.gradle.api.JavaVersion.VERSION_11
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -9,7 +10,7 @@ val coroutinesVersion: String by project
 val collectionsVersion: String by project
 val junit5Version: String by project
 
-version = semVer ?: "1.0-SNAPSHOT"
+version = semVer ?: "${SimpleDateFormat("YYYY.MM").format(System.currentTimeMillis())}-SNAPSHOT"
 
 plugins {
     `java-library`

--- a/utbot-intellij/build.gradle.kts
+++ b/utbot-intellij/build.gradle.kts
@@ -7,6 +7,7 @@ val pythonCommunityPluginVersion: String? by rootProject
 val pythonUltimatePluginVersion: String? by rootProject
 val sootCommitHash: String? by rootProject
 val kryoVersion: String? by rootProject
+val semVer: String? by rootProject
 
 plugins {
     id("org.jetbrains.intellij") version "1.7.0"
@@ -68,6 +69,7 @@ tasks {
     patchPluginXml {
         sinceBuild.set("212")
         untilBuild.set("222.*")
+        version.set(semVer)
     }
 }
 

--- a/utbot-intellij/src/main/resources/META-INF/plugin.xml
+++ b/utbot-intellij/src/main/resources/META-INF/plugin.xml
@@ -4,9 +4,6 @@
     <id>org.utbot.intellij.plugin.id</id>
     <name>UnitTestBot</name>
     <vendor>utbot.org</vendor>
-    <!-- Do not insert, it is updated from build.gradle-->
-    <!-- <idea-version since-build="202.8194.7"/>-->
-    <version>2022.7-beta</version>
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.java</depends>
     <depends>org.jetbrains.kotlin</depends>


### PR DESCRIPTION
# Description

Current time affects snapshot version in format YYYY.MM like 2022.10

## Type of Change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Manual Scenario 

call "runIde" > Go to IDE Settings > check UnitTestBot plugin version, it should look like 2022.10-SNAPSHOT
