### PR TITLE
Plugin setting to choose Kotlin generation doesn't work #1075

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -501,7 +501,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
 
         model.mockFramework = MOCKITO
         model.staticsMocking = if (staticsMocking.isSelected) MockitoStaticMocking else NoStaticMocking
-        model.codegenLanguage = model.project.service<Settings>().codegenLanguage//codegenLanguages.item
+        model.codegenLanguage = model.project.service<Settings>().codegenLanguage
         try {
             timeoutSpinner.commitEdit()
         } catch (ignored: ParseException) {

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -93,7 +93,6 @@ import javax.swing.JList
 import javax.swing.JPanel
 import javax.swing.JSpinner
 import javax.swing.text.DefaultFormatter
-import kotlin.streams.toList
 import org.jetbrains.concurrency.Promise
 import org.jetbrains.concurrency.thenRun
 import org.jetbrains.kotlin.asJava.classes.KtUltraLightClass
@@ -502,7 +501,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
 
         model.mockFramework = MOCKITO
         model.staticsMocking = if (staticsMocking.isSelected) MockitoStaticMocking else NoStaticMocking
-        model.codegenLanguage = codegenLanguages.item
+        model.codegenLanguage = model.project.service<Settings>().codegenLanguage//codegenLanguages.item
         try {
             timeoutSpinner.commitEdit()
         } catch (ignored: ParseException) {


### PR DESCRIPTION
# Description

Actual codegen language should depend on settings only

Fixes #1075 

## Type of Change

- Bug fix (non-breaking change which fixes an issue)
# How Has This Been Tested?

## Manual Scenario 

See the issue, generation output has to be exactly the same as it defined in Settings page

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
