### PR TITLE
Get PsiClass' package by declaration in containingFile and not by its directory #1081

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -271,7 +271,7 @@ object UtTestsDialogProcessor {
                 val name = qualifiedName
                     ?.substringAfter("$packageName.")
                     ?.replace(".", "$")
-                    ?: ""
+                    ?: error("Unable to get canonical name for $this")
                 "$packageName.$name"
             }
         }

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/GenerateTestsModel.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/GenerateTestsModel.kt
@@ -17,8 +17,9 @@ import com.intellij.openapi.projectRoots.JavaSdkVersion
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.newvfs.impl.FakeVirtualFile
 import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiJavaFile
 import com.intellij.refactoring.util.classMembers.MemberInfo
-import org.jetbrains.kotlin.idea.core.getPackage
+import org.jetbrains.kotlin.psi.KtFile
 import org.utbot.framework.plugin.api.JavaDocCommentStyle
 import org.utbot.framework.util.ConflictTriggers
 import org.utbot.intellij.plugin.ui.utils.jdkVersion
@@ -84,4 +85,11 @@ data class GenerateTestsModel(
         }
 }
 
-val PsiClass.packageName: String get() = this.containingFile.containingDirectory.getPackage()?.qualifiedName ?: ""
+val PsiClass.packageName: String
+    get() {
+        return when (val currentFile = containingFile) {
+            is PsiJavaFile -> currentFile.packageName
+            is KtFile -> currentFile.packageFqName.asString()
+            else -> error("Can't find package name for $this: it should be located either in Java or Kt file")
+        }
+    }


### PR DESCRIPTION
# Description

If package in which class was put doesn't match its directory, we should use `packageName` of containing `PsiFile` as `packageName` for class (and not the directory of containing file).

Fixes #1081

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Manual Scenario 

Checked on scenario from #1081 (both when we launch action on misplaced class and when we launch action on method in other class where misplaced class is used) -- tests are generated correctly (although, IDEA can't always correctly handle wrong package).

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
