### PR TITLE
Fix settings persistence: we save IDs, thus we should parse IDs inste…

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/Settings.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/Settings.kt
@@ -213,9 +213,9 @@ private class TestFrameworkConverter : Converter<TestFramework>() {
     override fun toString(value: TestFramework): String = "$value"
 
     override fun fromString(value: String): TestFramework = when (value) {
-        Junit4.displayName -> Junit4
-        Junit5.displayName -> Junit5
-        TestNg.displayName -> TestNg
+        Junit4.id -> Junit4
+        Junit5.id -> Junit5
+        TestNg.id -> TestNg
         else -> error("Unknown TestFramework $value")
     }
 }
@@ -225,8 +225,8 @@ private class StaticsMockingConverter : Converter<StaticsMocking>() {
     override fun toString(value: StaticsMocking): String = "$value"
 
     override fun fromString(value: String): StaticsMocking = when (value) {
-        NoStaticMocking.displayName -> NoStaticMocking
-        MockitoStaticMocking.displayName -> MockitoStaticMocking
+        NoStaticMocking.id -> NoStaticMocking
+        MockitoStaticMocking.id -> MockitoStaticMocking
         else -> error("Unknown StaticsMocking $value")
     }
 }


### PR DESCRIPTION
…ad of display names

# Description

The issue appears after recent display name changes (JUnit4 -> JUnit 4 etc.)

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

Start IDE, try generation. Exception appears.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
