### PR TITLE
UTBot doesn't show test source from other modules for Gradle project …

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerationController.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerationController.kt
@@ -19,6 +19,7 @@ import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Computable
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.psi.*
 import com.intellij.psi.codeStyle.CodeStyleManager
@@ -69,6 +70,8 @@ import org.utbot.sarif.SarifReport
 import java.nio.file.Path
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import org.jetbrains.kotlin.idea.util.projectStructure.allModules
+import org.utbot.intellij.plugin.ui.utils.isBuildWithGradle
 
 object CodeGenerationController {
     private val logger = KotlinLogging.logger {}
@@ -373,6 +376,12 @@ object CodeGenerationController {
         return when {
             testPackageName.isNullOrEmpty() -> srcClass.containingFile.containingDirectory.getPackage()?.qualifiedName
             else -> testPackageName
+        }
+    }
+
+    fun GenerateTestsModel.getAllTestSourceRoots() : MutableList<VirtualFile> {
+        with(if (project.isBuildWithGradle) project.allModules() else potentialTestModules) {
+            return this.flatMap { it.suitableTestSourceRoots().toList() }.toMutableList()
         }
     }
 

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -39,9 +39,7 @@ import org.utbot.intellij.plugin.process.EngineProcess
 import org.utbot.intellij.plugin.process.RdTestGenerationResult
 import org.utbot.intellij.plugin.settings.Settings
 import org.utbot.intellij.plugin.ui.GenerateTestsDialogWindow
-import org.utbot.intellij.plugin.ui.utils.isBuildWithGradle
 import org.utbot.intellij.plugin.ui.utils.showErrorDialogLater
-import org.utbot.intellij.plugin.ui.utils.suitableTestSourceRoots
 import org.utbot.intellij.plugin.ui.utils.testModules
 import org.utbot.intellij.plugin.util.*
 import org.utbot.rd.terminateOnException
@@ -50,6 +48,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
 import kotlin.io.path.pathString
+import org.utbot.intellij.plugin.generator.CodeGenerationController.getAllTestSourceRoots
 
 object UtTestsDialogProcessor {
 
@@ -79,7 +78,16 @@ object UtTestsDialogProcessor {
         // we want to start the child process in the same directory as the test runner
         WorkingDirService.workingDirProvider = PluginWorkingDirProvider(project)
 
-        if (project.isBuildWithGradle && testModules.flatMap { it.suitableTestSourceRoots() }.isEmpty()) {
+        val model = GenerateTestsModel(
+            project,
+            srcModule,
+            testModules,
+            srcClasses,
+            extractMembersFromSrcClasses,
+            focusedMethods,
+            UtSettings.utBotGenerationTimeoutInMillis,
+        )
+        if (model.getAllTestSourceRoots().isEmpty()) {
             val errorMessage = """
                 <html>No test source roots found in the project.<br>
                 Please, <a href="https://www.jetbrains.com/help/idea/testing.html#add-test-root">create or configure</a> at least one test source root.
@@ -88,17 +96,7 @@ object UtTestsDialogProcessor {
             return null
         }
 
-        return GenerateTestsDialogWindow(
-            GenerateTestsModel(
-                project,
-                srcModule,
-                testModules,
-                srcClasses,
-                extractMembersFromSrcClasses,
-                focusedMethods,
-                UtSettings.utBotGenerationTimeoutInMillis,
-            )
-        )
+        return GenerateTestsDialogWindow(model)
     }
 
     private fun createTests(project: Project, model: GenerateTestsModel) {

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/components/TestFolderComboWithBrowseButton.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/components/TestFolderComboWithBrowseButton.kt
@@ -16,12 +16,11 @@ import com.intellij.util.ui.UIUtil
 import java.io.File
 import javax.swing.DefaultComboBoxModel
 import javax.swing.JList
-import org.jetbrains.kotlin.idea.util.projectStructure.allModules
 import org.utbot.common.PathUtil
+import org.utbot.intellij.plugin.generator.CodeGenerationController.getAllTestSourceRoots
 import org.utbot.intellij.plugin.models.GenerateTestsModel
 import org.utbot.intellij.plugin.ui.utils.addDedicatedTestRoot
 import org.utbot.intellij.plugin.ui.utils.isBuildWithGradle
-import org.utbot.intellij.plugin.ui.utils.suitableTestSourceRoots
 
 class TestFolderComboWithBrowseButton(private val model: GenerateTestsModel) :
     ComponentWithBrowseButton<ComboBox<Any>>(ComboBox(), null) {
@@ -55,10 +54,7 @@ class TestFolderComboWithBrowseButton(private val model: GenerateTestsModel) :
             }
         }
 
-        val suggestedModules =
-            if (model.project.isBuildWithGradle) model.project.allModules() else model.potentialTestModules
-
-        val testRoots = suggestedModules.flatMap { it.suitableTestSourceRoots().toList() }.toMutableList()
+        val testRoots = model.getAllTestSourceRoots()
         // this method is blocked for Gradle, where multiple test modules can exist
         model.testModule.addDedicatedTestRoot(testRoots)
 


### PR DESCRIPTION
…#1060

# Description

A dedicated method was extracted to collect all test source roots for the model to be used twice at least.

Fixes #1060 

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

See the steps in corresponding issue

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
