### PR TITLE
Support Android Studio in utbot-intellij

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,13 @@
 kotlin.code.style=official
 
 # IU, IC, PC, PY, WS...
-# AS for AndroidStudio
+# IC for AndroidStudio
 ideType=IC
 
 # In order to run Android Studion instead of community, please, specify the path
 # to your Android Studio installation
 
-androidStudioPath=C:/Program Files/Android/Android Studio
+androidStudioPath=D:/AS2021
 
 pythonCommunityPluginVersion=222.4167.37
 #Version numbers: https://plugins.jetbrains.com/plugin/631-python/versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,10 +4,9 @@ kotlin.code.style=official
 # IC for AndroidStudio
 ideType=IC
 
-# In order to run Android Studion instead of community, please, specify the path
-# to your Android Studio installation
-
-androidStudioPath=D:/AS2021
+# In order to run Android Studion instead of Intellij Community,
+# specify the path to your Android Studio installation
+//androidStudioPath=D:/AS2021
 
 pythonCommunityPluginVersion=222.4167.37
 #Version numbers: https://plugins.jetbrains.com/plugin/631-python/versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,9 @@ kotlin.code.style=official
 # AS for AndroidStudio
 ideType=IC
 
-# In order to run Android Studion instead of community, please, specify the path to your installation
-# of AndroidStudio IDE
+# In order to run Android Studion instead of community, please, specify the path
+# to your Android Studio installation
+
 androidStudioPath=C:/Program Files/Android/Android Studio
 
 pythonCommunityPluginVersion=222.4167.37

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,12 @@
 kotlin.code.style=official
 
 # IU, IC, PC, PY, WS...
+# AS for AndroidStudio
 ideType=IC
+
+# In order to run Android Studion instead of community, please, specify the path to your installation
+# of AndroidStudio IDE
+androidStudioPath=C:/Program Files/Android/Android Studio
 
 pythonCommunityPluginVersion=222.4167.37
 #Version numbers: https://plugins.jetbrains.com/plugin/631-python/versions

--- a/utbot-intellij/build.gradle.kts
+++ b/utbot-intellij/build.gradle.kts
@@ -8,6 +8,10 @@ val pythonUltimatePluginVersion: String? by rootProject
 val sootCommitHash: String? by rootProject
 val kryoVersion: String? by rootProject
 val semVer: String? by rootProject
+val androidStudioPath: String? by rootProject
+
+// https://plugins.jetbrains.com/docs/intellij/android-studio.html#configuring-the-plugin-pluginxml-file
+val ideTypeOrAndroidStudio = if (androidStudioPath == null) ideType else "IC"
 
 plugins {
     id("org.jetbrains.intellij") version "1.7.0"
@@ -40,12 +44,13 @@ intellij {
             "IU" -> jvmPlugins + pythonUltimatePlugins + jsPlugins + androidPlugins
             "PC" -> pythonCommunityPlugins
             "PU" -> pythonUltimatePlugins // something else, JS?
+            "AS" -> jvmPlugins + androidPlugins
             else -> jvmPlugins
         }
     )
 
     version.set("222.4167.29")
-    type.set(ideType)
+    type.set(ideTypeOrAndroidStudio)
 }
 
 tasks {
@@ -64,6 +69,7 @@ tasks {
 
     runIde {
         jvmArgs("-Xmx2048m")
+        androidStudioPath?.let { ideDir.set(file(it)) }
     }
 
     patchPluginXml {

--- a/utbot-intellij/build.gradle.kts
+++ b/utbot-intellij/build.gradle.kts
@@ -21,10 +21,12 @@ intellij {
 
     val androidPlugins = listOf("org.jetbrains.android")
 
-    val jvmPlugins = listOf(
+    val jvmPlugins = mutableListOf(
         "java",
         "org.jetbrains.kotlin:222-1.7.20-release-201-IJ4167.29"
     )
+
+    androidStudioPath?.let { jvmPlugins += androidPlugins }
 
     val pythonCommunityPlugins = listOf(
         "PythonCore:${pythonCommunityPluginVersion}"
@@ -44,7 +46,6 @@ intellij {
             "IU" -> jvmPlugins + pythonUltimatePlugins + jsPlugins + androidPlugins
             "PC" -> pythonCommunityPlugins
             "PU" -> pythonUltimatePlugins // something else, JS?
-            "AS" -> jvmPlugins + androidPlugins
             else -> jvmPlugins
         }
     )


### PR DESCRIPTION
# Description

An ability to run Android Studio is reverted on utbot-intellij after the migration on build.gradle.kts

## Type of Change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Manual Scenario 

Call runIde gradle task and verify that Android Studio is started if required.
