### PR TITLE
Filter generated sources in Android Studio projects

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/RootUtils.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/RootUtils.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.config.ResourceKotlinRootType
 import org.jetbrains.kotlin.config.SourceKotlinRootType
 import org.jetbrains.kotlin.config.TestResourceKotlinRootType
 import org.jetbrains.kotlin.config.TestSourceKotlinRootType
+import org.utbot.intellij.plugin.util.IntelliJApiHelper
 
 val sourceRootTypes: Set<JpsModuleSourceRootType<JavaSourceRootProperties>> = setOf(JavaSourceRootType.SOURCE, SourceKotlinRootType)
 val testSourceRootTypes: Set<JpsModuleSourceRootType<JavaSourceRootProperties>> = setOf(JavaSourceRootType.TEST_SOURCE, TestSourceKotlinRootType)
@@ -37,10 +38,18 @@ fun CodegenLanguage.testResourcesRootType(): JpsModuleSourceRootType<JavaResourc
 
 /**
  * Generalizes [JavaResourceRootProperties.isForGeneratedSources] for both Java and Kotlin.
+ *
+ * Unfortunately, Android Studio has another project model, so we cannot rely on the flag value.
+ * The only way is to find build/generated substring in the folder path.
  */
 fun SourceFolder.isForGeneratedSources(): Boolean {
     val properties = jpsElement.getProperties(sourceRootTypes + testSourceRootTypes)
     val resourceProperties = jpsElement.getProperties(resourceRootTypes + testResourceRootTypes)
 
-    return properties?.isForGeneratedSources == true && resourceProperties?.isForGeneratedSources == true
+    val markedGeneratedSources =
+        properties?.isForGeneratedSources == true && resourceProperties?.isForGeneratedSources == true
+    val androidStudioGeneratedSources =
+        IntelliJApiHelper.isAndroidStudio() && this.file?.path?.contains("build/generated") == true
+
+    return markedGeneratedSources || androidStudioGeneratedSources
 }


### PR DESCRIPTION
# Description

We should not suggest generated sources folders to user to generate tests in. We filter them.
In standard projects we use flag `isForGeneratedSources`. Android Studio does not support this project model, so we can only apply filtering on keywords in the path.

Fixes # ([692](https://github.com/UnitTestBot/UTBotJava/issues/692))

## Type of Change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

Check that there are no generated sources folders in the combobox for test source roots on UI before the first test generated and after it also (when generated sources folder have already aprreared).
