### PR TITLE
Exclude mocking javax

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/engine/MockStrategy.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/MockStrategy.kt
@@ -47,7 +47,8 @@ private val systemPackages = setOf(
     "sun.misc",
     "jdk.internal",
     "kotlin.jvm.internal",
-    "kotlin.internal"
+    "kotlin.internal",
+    "javax"
 )
 
 private fun isSystemPackage(packageName: String): Boolean = systemPackages.any { packageName.startsWith(it) }


### PR DESCRIPTION
# Description

We cannot mock javax. So, let's just exclude it.

Fixes #714 

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

Described in issue #714 

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [x] All tests pass locally with my changes
