### PR TITLE
Many similar sandboxed tests on sockets generated by Fuzzing and not minimized #1129

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
@@ -103,6 +103,7 @@ import kotlinx.coroutines.job
 import kotlinx.coroutines.yield
 import org.utbot.framework.plugin.api.UtExecutionSuccess
 import org.utbot.framework.plugin.api.UtLambdaModel
+import org.utbot.framework.plugin.api.UtSandboxFailure
 import org.utbot.framework.plugin.api.util.executable
 import org.utbot.fuzzer.toFuzzerType
 
@@ -430,6 +431,7 @@ class UtBotSymbolicEngine(
             parameterNameMap = { index -> names?.getOrNull(index) }
             fuzzerType = { try { toFuzzerType(methodUnderTest.executable.genericParameterTypes[it]) } catch (_: Throwable) { null } }
         }
+        val errorStackTraceTracker = Trie(StackTraceElement::toString)
         val coveredInstructionTracker = Trie(Instruction::id)
         val coveredInstructionValues = linkedMapOf<Trie.Node<Instruction>, List<FuzzedValue>>()
         var attempts = 0
@@ -488,6 +490,13 @@ class UtBotSymbolicEngine(
                 coveredInstructionValues[coverageKey] = values
             } else {
                 logger.error { "Coverage is empty for $methodUnderTest with ${values.map { it.model }}" }
+                val result = concreteExecutionResult.result
+                if (result is UtSandboxFailure) {
+                    val stackTraceElements = result.exception.stackTrace.reversed()
+                    if (errorStackTraceTracker.add(stackTraceElements).count > 1) {
+                        return@forEach
+                    }
+                }
             }
 
             emit(


### PR DESCRIPTION
# Description

There's no coverage trace when error occurs before the method is invoked. Therefore, fuzzer generates too many values which are not minimized later. To fix this issue fuzzer now compares stack traces of the error to minimize test number.

Similar behavior can be implemented in other places. 

Fixes #1129

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

All fuzzer tests should work

## Manual Scenario 

Reproduces the example from the issue. After the fix only 8 tests should be found.

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [x] All tests pass locally with my changes
