### PR TITLE
Fix static mocking

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/InstrumentationContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/InstrumentationContext.kt
@@ -1,8 +1,8 @@
 package org.utbot.framework.concrete
 
-import org.utbot.framework.plugin.api.util.signature
 import java.lang.reflect.Method
 import java.util.IdentityHashMap
+import org.utbot.instrumentation.instrumentation.mock.computeKeyForMethod
 
 /**
  * Some information, which is computed after classes instrumentation.
@@ -66,7 +66,7 @@ class InstrumentationContext {
         }
 
         fun updateMocks(obj: Any?, method: Method, values: List<*>) {
-            updateMocks(obj, method.signature, values)
+            updateMocks(obj, computeKeyForMethod(method), values)
         }
     }
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/MethodMockController.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/MethodMockController.kt
@@ -1,11 +1,11 @@
 package org.utbot.framework.concrete
 
-import org.utbot.common.withAccessibility
-import org.utbot.framework.plugin.api.util.signature
-import org.utbot.instrumentation.instrumentation.mock.MockConfig
 import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
+import org.utbot.common.withAccessibility
+import org.utbot.instrumentation.instrumentation.mock.MockConfig
+import org.utbot.instrumentation.instrumentation.mock.computeKeyForMethod
 
 
 /**
@@ -31,7 +31,8 @@ class MethodMockController(
             error("$method is an instance method, but instance is null!")
         }
 
-        val id = instrumentationContext.methodSignatureToId[method.signature]
+        val computedSignature = computeKeyForMethod(method)
+        val id = instrumentationContext.methodSignatureToId[computedSignature]
 
         isMockField = clazz.declaredFields.firstOrNull { it.name == MockConfig.IS_MOCK_FIELD + id }
             ?: error("No field ${MockConfig.IS_MOCK_FIELD + id} in $clazz")

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/mock/MockClassVisitor.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/mock/MockClassVisitor.kt
@@ -10,10 +10,20 @@ import org.objectweb.asm.Opcodes
 import org.objectweb.asm.Type
 import org.objectweb.asm.commons.AdviceAdapter
 import org.objectweb.asm.commons.Method.getMethod
+import org.utbot.framework.plugin.api.util.signature
 
 object MockConfig {
     const val IS_MOCK_FIELD = "\$__is_mock_"
 }
+
+/**
+ * Computes key for method that is used for mocking.
+ */
+fun computeKeyForMethod(internalType: String, methodSignature: String) =
+    "$internalType@$methodSignature"
+
+fun computeKeyForMethod(method: Method) =
+    computeKeyForMethod(Type.getInternalName(method.declaringClass), method.signature)
 
 class MockClassVisitor(
     classVisitor: ClassVisitor,
@@ -73,7 +83,7 @@ class MockClassVisitor(
         val isStatic = access and Opcodes.ACC_STATIC != 0
         val isVoidMethod = Type.getReturnType(descriptor) == Type.VOID_TYPE
 
-        val computedSignature = name + descriptor
+        val computedSignature = computeKeyForMethod(internalClassName, "$name$descriptor")
         val id = signatureToId.size
         signatureToId[computedSignature] = id
 

--- a/utbot-instrumentation/src/test/kotlin/org/utbot/instrumentation/examples/mock/MockHelper.kt
+++ b/utbot-instrumentation/src/test/kotlin/org/utbot/instrumentation/examples/mock/MockHelper.kt
@@ -1,14 +1,14 @@
 package org.utbot.instrumentation.examples.mock
 
-import org.utbot.common.withAccessibility
-import org.utbot.framework.plugin.api.util.signature
-import org.utbot.instrumentation.instrumentation.instrumenter.Instrumenter
-import org.utbot.instrumentation.instrumentation.mock.MockClassVisitor
-import org.utbot.instrumentation.instrumentation.mock.MockConfig
 import java.lang.reflect.Method
 import java.util.IdentityHashMap
 import kotlin.reflect.jvm.javaMethod
 import org.objectweb.asm.Type
+import org.utbot.common.withAccessibility
+import org.utbot.instrumentation.instrumentation.instrumenter.Instrumenter
+import org.utbot.instrumentation.instrumentation.mock.MockClassVisitor
+import org.utbot.instrumentation.instrumentation.mock.MockConfig
+import org.utbot.instrumentation.instrumentation.mock.computeKeyForMethod
 
 /**
  * Helper for generating tests with methods mocks.
@@ -52,8 +52,8 @@ class MockHelper(
             error("Can't mock function returning void!")
         }
 
-        val sign = method.signature
-        val methodId = mockClassVisitor.signatureToId[sign]
+        val computedSignature = computeKeyForMethod(method)
+        val methodId = mockClassVisitor.signatureToId[computedSignature]
 
         val isMockField = instrumentedClazz.getDeclaredField(MockConfig.IS_MOCK_FIELD + methodId)
         MockGetter.updateMocks(instance, method, mockedValues)
@@ -129,7 +129,7 @@ class MockHelper(
         }
 
         fun updateMocks(obj: Any?, method: Method, values: List<*>) {
-            updateMocks(obj, method.signature, values)
+            updateMocks(obj, computeKeyForMethod(method), values)
         }
     }
 }


### PR DESCRIPTION
# Description

Mocking in concrete executor respected only method signature without any information about declaring class. Therefore, when we wanted to mock two methods with the same signatures but in different classes, we ignored mocking one of them.
Now, new signature of method includes fully qualified name of declaring class.

Fixes #1128 

## Type of Change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

Described in issue #1128 

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [x] All tests pass locally with my changes
