### PR TITLE
Concrete execution fails for a static method using a static field #711

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
@@ -436,6 +436,10 @@ class UtBotSymbolicEngine(
         var attempts = 0
         val attemptsLimit = UtSettings.fuzzingMaxAttempts
         val hasMethodUnderTestParametersToFuzz = methodUnderTest.parameters.isNotEmpty()
+        if (!hasMethodUnderTestParametersToFuzz && methodUnderTest.isStatic) {
+            // Currently, fuzzer doesn't work with static methods with empty parameters
+            return@flow
+        }
         val fuzzedValues = if (hasMethodUnderTestParametersToFuzz) {
             fuzz(methodUnderTestDescription, modelProvider(defaultModelProviders(defaultIdGenerator)))
         } else {


### PR DESCRIPTION
# Description

Fuzzer shouldn't try to work with static method that has no parameters.

Fixes #711

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Automated Testing

All tests should pass

## Manual Scenario 

Example in the issue works as exptected.

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [x] All fuzzers tests pass locally with my changes
