### PR TITLE
Rethrow CancellationException to ensure stop by timeout

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestCaseGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestCaseGenerator.kt
@@ -184,8 +184,11 @@ open class TestCaseGenerator(
                                         is UtError -> method2errors.getValue(method).merge(it.description, 1, Int::plus)
                                     }
                                 }
+                        } catch (e: CancellationException) {
+                            logger.info(e) { "Test generation cancelled" }
+                            throw(e)
                         } catch (e: Exception) {
-                            logger.error(e) {"Error in engine"}
+                            logger.error(e) { "Error in engine" }
                         }
                     }
                     controller.paused = true


### PR DESCRIPTION
# Description

Add `CancellationException` as the special case in the catch-all logging exception handler in `TestCaseGenerator` to ensure
that it is correctly propagated.

Fixes #1141

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

No tests should break, no new automatic tests have been added.  

## Manual Scenario 

Test generation for `StringExamples` should terminate in time.  

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [X] The change followed the style guidelines of the UTBot project
- [X] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [X] No new warnings
- [ ] New tests have been added
- [X] All tests pass locally with my changes
