### PR TITLE
Rename `pipelines` argument of `ClassWithPrivateMutableFieldOfPrivateTypeTest`

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/codegen/modifiers/ClassWithPrivateMutableFieldOfPrivateTypeTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/codegen/modifiers/ClassWithPrivateMutableFieldOfPrivateTypeTest.kt
@@ -14,9 +14,9 @@ import org.utbot.tests.infrastructure.UtValueTestCaseChecker
 class ClassWithPrivateMutableFieldOfPrivateTypeTest : UtValueTestCaseChecker(
     testClass = ClassWithPrivateMutableFieldOfPrivateType::class,
     testCodeGeneration = true,
-    languagePipelines = listOf(
-        CodeGenerationLanguageLastStage(CodegenLanguage.JAVA),
-        CodeGenerationLanguageLastStage(CodegenLanguage.KOTLIN, Compilation)
+    pipelines = listOf(
+        TestLastStage(CodegenLanguage.JAVA),
+        TestLastStage(CodegenLanguage.KOTLIN, Compilation)
     )
 ) {
     @Test


### PR DESCRIPTION
# Description

The `languagePipelines` argument of `UtValueTestCaseChecker` has been renamed, as well as its type. This fix renames the corresponding argument of `ClassWithPrivateMutableFieldOfPrivateTypeTest`.

## Type of Change

Please delete options that are not relevant.

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Automated Testing

Code should compile, tests should pass.

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [X] The change followed the style guidelines of the UTBot project
- [X] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [X] All tests pass locally with my changes
