### PR TITLE
Publish plugin and CLI for minor release

### DIFF
--- a/.github/workflows/publish-plugin-and-cli-from-branch.yml
+++ b/.github/workflows/publish-plugin-and-cli-from-branch.yml
@@ -13,11 +13,11 @@ on:
     inputs:
         minor-release:
           type: choice
-          description: "It adds alpha or beta postfix to version."
+          description: "It adds minor release indicator to version."
           required: true
           default: ''
           options:
-          - ''
+          - 'none'
           - '1'
           - '2'
           - '3'
@@ -62,7 +62,7 @@ jobs:
           echo "VERSION="$(date +%Y).$(date +%-m)"" >> $GITHUB_ENV
 
       - name: Set version for minor release
-        if: ${{ github.event.inputs.minor-release != '' }}
+        if: ${{ github.event.inputs.minor-release != 'none' }}
         run: |
           echo "VERSION=${{ env.VERSION }}.${{ github.event.inputs.minor-release }}" >> $GITHUB_ENV
 

--- a/.github/workflows/publish-plugin-and-cli-from-branch.yml
+++ b/.github/workflows/publish-plugin-and-cli-from-branch.yml
@@ -15,7 +15,7 @@ on:
           type: choice
           description: "It adds minor release indicator to version."
           required: true
-          default: ''
+          default: 'none'
           options:
           - 'none'
           - '1'

--- a/.github/workflows/publish-plugin-and-cli-from-branch.yml
+++ b/.github/workflows/publish-plugin-and-cli-from-branch.yml
@@ -11,6 +11,16 @@ on:
 
   workflow_dispatch:
     inputs:
+        minor-release:
+          type: choice
+          description: "It adds alpha or beta postfix to version."
+          required: false
+          options:
+          - "1"
+          - "2"
+          - "3"
+          - "4"
+
         version-postfix:
           type: choice
           description: "It adds alpha or beta postfix to version."
@@ -48,6 +58,11 @@ jobs:
         if: ${{ github.event.inputs.version-postfix == 'no-postfix-prod' || github.event.inputs.version-postfix == 'alpha' || github.event.inputs.version-postfix == 'beta' }}
         run: |
           echo "VERSION="$(date +%Y).$(date +%-m)"" >> $GITHUB_ENV
+
+      - name: Set version for minor release
+        if: ${{ github.event.inputs.minor-release != '' }}
+        run: |
+          echo "VERSION=${{ env.VERSION }}.${{ github.event.inputs.minor-release }}" >> $GITHUB_ENV
 
       - name: Create version with postfix
         if: ${{ (env.POSTFIX == 'alpha') || (env.POSTFIX == 'beta') }}

--- a/.github/workflows/publish-plugin-and-cli-from-branch.yml
+++ b/.github/workflows/publish-plugin-and-cli-from-branch.yml
@@ -14,12 +14,14 @@ on:
         minor-release:
           type: choice
           description: "It adds alpha or beta postfix to version."
-          required: false
+          required: true
+          default: ''
           options:
-          - "1"
-          - "2"
-          - "3"
-          - "4"
+          - ''
+          - '1'
+          - '2'
+          - '3'
+          - '4'
 
         version-postfix:
           type: choice


### PR DESCRIPTION
# Description

PR's changes let publish plugin and CLI with minor release version.

Fixes #1154 

## Type of Change

Infrastructure changes.

# How Has This Been Tested?

## Automated Testing

Not applicable.

## Manual Scenario 

The script was tested from branch.

# Checklist (remove irrelevant options):

Not applicable.
