### PR TITLE
Remove redundant `.` in published artifacts

### DIFF
--- a/.github/workflows/publish-plugin-and-cli-from-branch.yml
+++ b/.github/workflows/publish-plugin-and-cli-from-branch.yml
@@ -3,6 +3,12 @@ name: "[M] Plugin and CLI: publish as archives"
 on: 
   workflow_call:
     inputs:
+        minor-release:
+          type: string
+          description: "It adds minor release indicator to version."
+          required: false
+          default: 'none'
+
         version-postfix:
           type: string
           description: "It adds postfix (alpha or beta) to version (optional)."
@@ -27,10 +33,10 @@ on:
           type: choice
           description: "It adds alpha or beta postfix to version."
           required: true
-          default: no-postfix
+          default: no-postfix-prod
           options:
-          - no-postfix
           - no-postfix-prod
+          - no-postfix
           - alpha
           - beta
 


### PR DESCRIPTION
# Description

The PR lets remove redundant `.` in published artifacts.

Fixes #1158 

## Type of Change

Infrastructure changes.

# How Has This Been Tested?

## Automated Testing

Not applicable.

## Manual Scenario 

It was not tested manually.

# Checklist (remove irrelevant options):

Not applicable for infrastructure changes.
