### PR TITLE
Fix IllegalAccessException in runIde

### DIFF
--- a/utbot-intellij/build.gradle.kts
+++ b/utbot-intellij/build.gradle.kts
@@ -70,6 +70,7 @@ tasks {
 
     runIde {
         jvmArgs("-Xmx2048m")
+        jvmArgs("--add-exports", "java.desktop/sun.awt.windows=ALL-UNNAMED")
         androidStudioPath?.let { ideDir.set(file(it)) }
     }
 


### PR DESCRIPTION
# Description

The exception `java.lang.IllegalAccessException: class com.intellij.ui.Win7TaskBar` is constantly thrown in Intellij IDEA from `runIde` gradle task. This pull request fixes this unexpected behavior. 

## Type of Change

- Minor bug fix (non-breaking small changes)