### PR TITLE
Fixed checking that the package name starts with java

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/actions/GenerateTestsAction.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/actions/GenerateTestsAction.kt
@@ -176,7 +176,7 @@ class GenerateTestsAction : AnAction(), UpdateInBackground {
             return true
         }
 
-        val packageIsIncorrect =  this.packageName.split(".").firstOrNull() == "java"
+        val packageIsIncorrect = this.packageName.split(".").firstOrNull() == "java"
         if (packageIsIncorrect) {
             if (withWarnings) InvalidClassNotifier.notify("class ${this.name} located in java.* package")
             return true


### PR DESCRIPTION
# Description

Fixed checking that the package name is "java.*"

Fixes #1169

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

Please, repeat the scenario from the issue #1169 

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
- [x] All tests pass locally with my changes
