### PR TITLE
Plugin Action stays locked even when previous generation is finished …

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/LockFile.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/LockFile.kt
@@ -21,6 +21,7 @@ object LockFile {
     fun lock(): Boolean {
         if (currentLock != null) return false
         return try {
+            Paths.get(utbotHomePath).toFile().mkdirs()
             currentLock = Paths.get(lockFilePath).outputStream(StandardOpenOption.CREATE_NEW, StandardOpenOption.DELETE_ON_CLOSE).also {
                 it.write(DateFormat.getDateTimeInstance().format(System.currentTimeMillis()).toByteArray())
             }

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/LockFile.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/LockFile.kt
@@ -13,7 +13,7 @@ private val lockFilePath = "$utbotHomePath/utbot.lock"
 private var currentLock : OutputStream? = null
 private val logger = KotlinLogging.logger {}
 
-object Lock {
+object LockFile {
     @Synchronized
     fun isLocked() = currentLock != null
 

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/actions/GenerateTestsAction.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/actions/GenerateTestsAction.kt
@@ -26,7 +26,7 @@ import org.utbot.intellij.plugin.util.isVisible
 import java.util.*
 import org.jetbrains.kotlin.j2k.getContainingClass
 import org.jetbrains.kotlin.utils.addIfNotNull
-import org.utbot.framework.plugin.api.util.Lock
+import org.utbot.framework.plugin.api.util.LockFile
 import org.utbot.intellij.plugin.models.packageName
 import org.utbot.intellij.plugin.ui.InvalidClassNotifier
 import org.utbot.intellij.plugin.util.isAbstract
@@ -42,7 +42,7 @@ class GenerateTestsAction : AnAction(), UpdateInBackground {
     }
 
     override fun update(e: AnActionEvent) {
-        if (Lock.isLocked()) {
+        if (LockFile.isLocked()) {
             e.presentation.isEnabled = false
             return
         }


### PR DESCRIPTION
…#1173

# Description

"unlock" calling was put in a wrong place, actually locking process should correspond to "try-finally" concept

Fixes #1173

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?


## Manual Scenario 

See the issue, lock should be removed after tests generation

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
