### PR TITLE
Fix redundant '.' in name of published artefacts

### DIFF
--- a/.github/workflows/publish-plugin-and-cli.yml
+++ b/.github/workflows/publish-plugin-and-cli.yml
@@ -8,4 +8,6 @@ on:
 jobs:
     publish_plugin_and_cli:
       uses: ./.github/workflows/publish-plugin-and-cli-from-branch.yml
+      with: 
+        minor-release: 'none'
       secrets: inherit


### PR DESCRIPTION
# Description

Suggestion how to fix redundant '.' in plugin build

Fixes #1158 

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

Check workflow output after a PR is merged into main branch.
Check plugin artefact name.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
