### PR TITLE
Setting to disable the SARIF reports visualizer

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerationController.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerationController.kt
@@ -160,7 +160,7 @@ object CodeGenerationController {
                                 UtTestsDialogProcessor.updateIndicator(indicator, UtTestsDialogProcessor.ProgressRange.SARIF, "Start tests with coverage", 1.0)
 
                                 invokeLater {
-                                    runInspectionsIfNeeded(model.project, srcClassPathToSarifReport)
+                                    runInspectionsIfNeeded(model, srcClassPathToSarifReport)
                                 }
                             }
                         }
@@ -174,9 +174,12 @@ object CodeGenerationController {
      * Runs the UTBot inspection if there are detected errors.
      */
     private fun runInspectionsIfNeeded(
-        project: Project,
+        model: GenerateTestsModel,
         srcClassPathToSarifReport: MutableMap<Path, Sarif>
     ) {
+        if (!model.runInspectionAfterTestGeneration) {
+            return
+        }
         val sarifHasResults = srcClassPathToSarifReport.any { (_, sarif) ->
             sarif.getAllResults().isNotEmpty()
         }
@@ -184,9 +187,9 @@ object CodeGenerationController {
             return
         }
         UnitTestBotInspectionManager
-            .getInstance(project, srcClassPathToSarifReport)
+            .getInstance(model.project, srcClassPathToSarifReport)
             .createNewGlobalContext()
-            .doInspections(AnalysisScope(project))
+            .doInspections(AnalysisScope(model.project))
     }
 
     private fun proceedTestReport(proc: EngineProcess, model: GenerateTestsModel) {

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/GenerateTestsModel.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/GenerateTestsModel.kt
@@ -67,6 +67,7 @@ data class GenerateTestsModel(
     lateinit var parametrizedTestSource: ParametrizedTestSource
     lateinit var runtimeExceptionTestsBehaviour: RuntimeExceptionTestsBehaviour
     lateinit var hangingTestsTimeout: HangingTestsTimeout
+    var runInspectionAfterTestGeneration: Boolean = false
     lateinit var forceStaticMocking: ForceStaticMocking
     lateinit var chosenClassesToMockAlways: Set<ClassId>
     lateinit var commentStyle: JavaDocCommentStyle

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/Settings.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/Settings.kt
@@ -49,6 +49,7 @@ class Settings(val project: Project) : PersistentStateComponent<Settings.State> 
         var runtimeExceptionTestsBehaviour: RuntimeExceptionTestsBehaviour = RuntimeExceptionTestsBehaviour.defaultItem,
         @OptionTag(converter = HangingTestsTimeoutConverter::class)
         var hangingTestsTimeout: HangingTestsTimeout = HangingTestsTimeout(),
+        var runInspectionAfterTestGeneration: Boolean = false,
         var forceStaticMocking: ForceStaticMocking = ForceStaticMocking.defaultItem,
         var treatOverflowAsError: TreatOverflowAsError = TreatOverflowAsError.defaultItem,
         var parametrizedTestSource: ParametrizedTestSource = ParametrizedTestSource.defaultItem,
@@ -66,6 +67,7 @@ class Settings(val project: Project) : PersistentStateComponent<Settings.State> 
             staticsMocking = model.staticsMocking,
             runtimeExceptionTestsBehaviour = model.runtimeExceptionTestsBehaviour,
             hangingTestsTimeout = model.hangingTestsTimeout,
+            runInspectionAfterTestGeneration = model.runInspectionAfterTestGeneration,
             forceStaticMocking = model.forceStaticMocking,
             parametrizedTestSource = model.parametrizedTestSource,
             classesToMockAlways = model.chosenClassesToMockAlways.mapTo(mutableSetOf()) { it.name }.toTypedArray(),
@@ -88,6 +90,7 @@ class Settings(val project: Project) : PersistentStateComponent<Settings.State> 
             if (staticsMocking != other.staticsMocking) return false
             if (runtimeExceptionTestsBehaviour != other.runtimeExceptionTestsBehaviour) return false
             if (hangingTestsTimeout != other.hangingTestsTimeout) return false
+            if (runInspectionAfterTestGeneration != other.runInspectionAfterTestGeneration) return false
             if (forceStaticMocking != other.forceStaticMocking) return false
             if (treatOverflowAsError != other.treatOverflowAsError) return false
             if (parametrizedTestSource != other.parametrizedTestSource) return false
@@ -107,6 +110,7 @@ class Settings(val project: Project) : PersistentStateComponent<Settings.State> 
             result = 31 * result + staticsMocking.hashCode()
             result = 31 * result + runtimeExceptionTestsBehaviour.hashCode()
             result = 31 * result + hangingTestsTimeout.hashCode()
+            result = 31 * result + runInspectionAfterTestGeneration.hashCode()
             result = 31 * result + forceStaticMocking.hashCode()
             result = 31 * result + treatOverflowAsError.hashCode()
             result = 31 * result + parametrizedTestSource.hashCode()
@@ -136,6 +140,8 @@ class Settings(val project: Project) : PersistentStateComponent<Settings.State> 
         }
 
     val staticsMocking: StaticsMocking get() = state.staticsMocking
+
+    val runInspectionAfterTestGeneration: Boolean get() = state.runInspectionAfterTestGeneration
 
     val forceStaticMocking: ForceStaticMocking get() = state.forceStaticMocking
 

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/SettingsWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/SettingsWindow.kt
@@ -35,6 +35,7 @@ class SettingsWindow(val project: Project) {
 
     // TODO it is better to use something like SearchEverywhere for classes but it is complicated to implement
     private val excludeTable = MockAlwaysClassesTable(project)
+    private lateinit var runInspectionAfterTestGenerationCheckBox: JCheckBox
     private lateinit var forceMockCheckBox: JCheckBox
     private lateinit var enableSummarizationGenerationCheckBox: JCheckBox
 
@@ -97,6 +98,23 @@ class SettingsWindow(val project: Project) {
             JavaDocCommentStyle::class to JavaDocCommentStyle.values()
         ).forEach { (loader, values) ->
             valuesComboBox(loader, values)
+        }
+
+        row {
+            cell {
+                runInspectionAfterTestGenerationCheckBox = checkBox("Display detected errors on the Problems tool window")
+                    .onApply {
+                        settings.state.runInspectionAfterTestGeneration = runInspectionAfterTestGenerationCheckBox.isSelected
+                    }
+                    .onReset {
+                        runInspectionAfterTestGenerationCheckBox.isSelected = settings.state.runInspectionAfterTestGeneration
+                    }
+                    .onIsModified {
+                        runInspectionAfterTestGenerationCheckBox.isSelected xor settings.state.runInspectionAfterTestGeneration
+                    }
+                    // .apply { ContextHelpLabel.create("Automatically run code inspection after test generation")() }
+                    .component
+            }
         }
 
         row {

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -510,6 +510,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
         with(settings) {
             model.runtimeExceptionTestsBehaviour = runtimeExceptionTestsBehaviour
             model.hangingTestsTimeout = hangingTestsTimeout
+            model.runInspectionAfterTestGeneration = runInspectionAfterTestGeneration
             model.forceStaticMocking = forceStaticMocking
             model.chosenClassesToMockAlways = chosenClassesToMockAlways()
             model.fuzzingValue = fuzzingValue


### PR DESCRIPTION
# Description

Added a new checkbox "Display detected errors on the Problems tool window" in the UnitTestBot settings.

![image](https://user-images.githubusercontent.com/54814796/196656221-6dea9521-983e-4c42-9c06-ca52f148cf33.png)

Fixes #1167

## Type of Change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Manual Scenario 

- Checkbox should be disabled by default
- UnitTestBot inspection (see #972) should run only if the checkbox is enabled

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [ ] No new warnings
- [ ] New tests have been added
- [x] All tests pass locally with my changes
