### PR TITLE
Progress bar shows the progress stepwise and incorrectly #1196

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -54,9 +54,9 @@ object UtTestsDialogProcessor {
     private val logger = KotlinLogging.logger {}
 
     enum class ProgressRange(val from : Double, val to: Double) {
-        SOLVING(from = 0.0, to = 0.7),
-        CODEGEN(from = 0.7, to = 0.9),
-        SARIF(from = 0.9, to = 1.0)
+        SOLVING(from = 0.0, to = 0.9),
+        CODEGEN(from = 0.9, to = 0.95),
+        SARIF(from = 0.95, to = 1.0)
     }
 
     fun updateIndicator(indicator: ProgressIndicator, range : ProgressRange, text: String? = null, fraction: Double? = null) {


### PR DESCRIPTION
# Description

Actually generation phase (or "solving") takes most of time, now phases are reconfigured to 
0%-90% for tests generation, 
90%-95% for code generation (we write testcases into files),
96%-100% for Sarif-related stuff

Fixes #1196

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

Start generation for set of files, progress should grow until ~100% smoothly

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
