### PR TITLE
Only one of generated tests is run with Generate and Run #1149

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/RunConfigurationHelper.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/RunConfigurationHelper.kt
@@ -64,7 +64,7 @@ class RunConfigurationHelper {
     companion object {
         private val logger = KotlinLogging.logger {}
 
-        private fun RunConfiguration.isPatternBased() = this is JavaTestConfigurationBase && testType == "pattern"
+        private fun RunConfiguration.isPatternBased() = this is JavaTestConfigurationBase && "pattern".contentEquals(testType, true)
 
         // In case we do "generate and run" for many files at once,
         // desired run configuration has to be one of "pattern" typed test configuration that may run many tests at once.


### PR DESCRIPTION
Additional fix for TestNG

# Description

Additional fox for #1149 for TestNG framework where corresponding configuration type is named "PATTERN" instead of "pattern"

Fixes #1149 

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

See #1149 

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
