### PR TITLE
Enabling action and TestNg version depends on the project SDK

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/ExternalLibraryDescriptors.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/ExternalLibraryDescriptors.kt
@@ -7,7 +7,7 @@ val ExternalLibraryDescriptor.mavenCoordinates: String
     get() = "$libraryGroupId:$libraryArtifactId:${preferredVersion ?: RepositoryLibraryDescription.ReleaseVersionId}"
 
 val ExternalLibraryDescriptor.id: String
-        get() = "$libraryGroupId:$libraryArtifactId"
+    get() = "$libraryGroupId:$libraryArtifactId"
 
 //TODO: think about using JUnitExternalLibraryDescriptor from intellij-community sources (difficult to install)
 fun jUnit4LibraryDescriptor(versionInProject: String?) =
@@ -16,11 +16,20 @@ fun jUnit4LibraryDescriptor(versionInProject: String?) =
 fun jUnit5LibraryDescriptor(versionInProject: String?) =
     ExternalLibraryDescriptor("org.junit.jupiter", "junit-jupiter", "5.8.1", null, versionInProject ?: "5.8.1")
 
-fun testNgLibraryDescriptor(versionInProject: String?) =
-    ExternalLibraryDescriptor("org.testng", "testng", "7.6.0", null, versionInProject ?: "7.6.0")
-
 fun jUnit5ParametrizedTestsLibraryDescriptor(versionInProject: String?) =
     ExternalLibraryDescriptor("org.junit.jupiter", "junit-jupiter-params", "5.8.1", null, versionInProject ?: "5.8.1")
 
 fun mockitoCoreLibraryDescriptor(versionInProject: String?) =
     ExternalLibraryDescriptor("org.mockito", "mockito-core", "3.5.0", "4.2.0", versionInProject ?: "4.2.0")
+
+/**
+ * TestNg requires JDK 11 since version 7.6.0
+ * For projects with JDK 8 version 7.5.0 should be installed.
+ * See https://groups.google.com/g/testng-users/c/BAFB1vk-kok?pli=1 for more details.
+ */
+
+fun testNgNewLibraryDescriptor(versionInProject: String?) =
+    ExternalLibraryDescriptor("org.testng", "testng", "7.6.0", null, versionInProject ?: "7.6.0")
+
+fun testNgOldLibraryDescriptor() =
+    ExternalLibraryDescriptor("org.testng", "testng", "7.5.0", "7.5.0", "7.5.0")

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/GenerateTestsModel.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/GenerateTestsModel.kt
@@ -79,14 +79,6 @@ data class GenerateTestsModel(
     }
     var runGeneratedTestsWithCoverage : Boolean = false
     var enableSummariesGeneration : Boolean = true
-
-    val jdkVersion: JavaSdkVersion?
-        get() = try {
-            testModule.jdkVersion()
-        } catch (e: IllegalStateException) {
-            // Just ignore it here, notification will be shown in org.utbot.intellij.plugin.ui.utils.ModuleUtilsKt.jdkVersionBy
-            null
-        }
 }
 
 val PsiClass.packageName: String

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/actions/GenerateTestsAction.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/actions/GenerateTestsAction.kt
@@ -21,6 +21,7 @@ import com.intellij.refactoring.util.classMembers.MemberInfo
 import org.jetbrains.kotlin.idea.core.getPackage
 import org.jetbrains.kotlin.idea.core.util.toPsiDirectory
 import org.jetbrains.kotlin.idea.core.util.toPsiFile
+import org.jetbrains.kotlin.idea.util.module
 import org.utbot.intellij.plugin.util.extractFirstLevelMembers
 import org.utbot.intellij.plugin.util.isVisible
 import java.util.*
@@ -29,6 +30,7 @@ import org.jetbrains.kotlin.utils.addIfNotNull
 import org.utbot.framework.plugin.api.util.LockFile
 import org.utbot.intellij.plugin.models.packageName
 import org.utbot.intellij.plugin.ui.InvalidClassNotifier
+import org.utbot.intellij.plugin.util.findSdkVersionOrNull
 import org.utbot.intellij.plugin.util.isAbstract
 
 class GenerateTestsAction : AnAction(), UpdateInBackground {
@@ -164,6 +166,11 @@ class GenerateTestsAction : AnAction(), UpdateInBackground {
     }
 
     private fun PsiClass.isInvalid(withWarnings: Boolean): Boolean {
+        if (this.module?.let { findSdkVersionOrNull(it) } == null) {
+            if (withWarnings) InvalidClassNotifier.notify("class out of module or with undefined SDK")
+            return true
+        }
+
         val isAbstractOrInterface = this.isInterface || this.isAbstract
         if (isAbstractOrInterface) {
             if (withWarnings) InvalidClassNotifier.notify("abstract class or interface ${this.name}")

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/SdkUtils.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/SdkUtils.kt
@@ -1,0 +1,15 @@
+package org.utbot.intellij.plugin.util
+
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.util.lang.JavaVersion
+
+fun findSdkVersion(module:Module): JavaVersion =
+    findSdkVersionOrNull(module) ?: error("Cannot define sdk version in module $module")
+
+fun findSdkVersionOrNull(module: Module): JavaVersion? {
+    val moduleSdk = ModuleRootManager.getInstance(module).sdk
+    return JavaVersion.tryParse(moduleSdk?.versionString)
+}
+
+


### PR DESCRIPTION
# Description

Projects with JDK 8 require TestNg < 7.6.0 version
Projects with JDK 11 and higher require TestNg >= 7.6.0 version

An ability to select a version of TestNg depending on the current JDK is supported.

Fixes # ([309](https://github.com/UnitTestBot/UTBotJava/issues/309))

Also `Generate tests action` is disabled for classes without source module.

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

Try to generate tests with TestNg for projects with JDK8 and JDK11
