### PR TITLE
Upscale visual icon size (6x7) -> (600x700) relative pixels to make preview simple

### DIFF
--- a/utbot-intellij/src/main/resources/META-INF/pluginIcon.svg
+++ b/utbot-intellij/src/main/resources/META-INF/pluginIcon.svg
@@ -1,4 +1,4 @@
-<svg width="6" height="7" viewBox="0 0 6 7" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="600" height="700" viewBox="0 0 6 7" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M 2 0 h 1 v 1 h 1 v 1 h 1 v 1 h 1 v 1 h -1 v 1 h -1 v 1 h -1 v 1 h -1 Z" fill="#6CCF64"/>
     <path d="M 0 0 h 1 v 1 h 1 v 1 h 1 v 1 h 1 v 1 h -1 v 1 h -1 v 1 h -1 v 1 h -1 Z" fill="#2E6B39"/>
 </svg>


### PR DESCRIPTION
# Description

It's hard to preview the icon with size 6x7. Actually SVG will be scaled automatically to fix required area.

## Type of Change

- Minor bug fix (non-breaking small changes)