### PR TITLE
Correct the conditions when parametrization is enabled

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/ExternalLibraryDescriptors.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/ExternalLibraryDescriptors.kt
@@ -24,7 +24,7 @@ fun mockitoCoreLibraryDescriptor(versionInProject: String?) =
 
 /**
  * TestNg requires JDK 11 since version 7.6.0
- * For projects with JDK 8 version 7.5.0 should be installed.
+ * For projects with JDK 8 version 7.5 should be installed.
  * See https://groups.google.com/g/testng-users/c/BAFB1vk-kok?pli=1 for more details.
  */
 
@@ -32,4 +32,4 @@ fun testNgNewLibraryDescriptor(versionInProject: String?) =
     ExternalLibraryDescriptor("org.testng", "testng", "7.6.0", null, versionInProject ?: "7.6.0")
 
 fun testNgOldLibraryDescriptor() =
-    ExternalLibraryDescriptor("org.testng", "testng", "7.5.0", "7.5.0", "7.5.0")
+    ExternalLibraryDescriptor("org.testng", "testng", "7.5", "7.5", "7.5")


### PR DESCRIPTION
# Description

An option to generate parametrized tests should be active if:

- Test framework is JUnit 5 or Test Ng with version >+ 7.6.0
- Codegen language is Java
- Mocks are disabled

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

Verify that there are no invalid combinations in plugin UI and all valid combinations are enabled. 

