### PR TITLE
Map don't work without concrete

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -1297,7 +1297,8 @@ enum class CodegenLanguage(
             JAVA -> listOf(
                 "-d", buildDirectory,
                 "-cp", classPath,
-                "-XDignore.symbol.file" // to let javac use classes from rt.jar
+                "-XDignore.symbol.file", // to let javac use classes from rt.jar
+                "--add-exports", "java.base/sun.reflect.generics.repository=ALL-UNNAMED"
             ).plus(sourcesFiles)
 
             KOTLIN -> listOf("-d", buildDirectory, "-jvm-target", jvmTarget, "-cp", classPath).plus(sourcesFiles)

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/arrays/ArrayOfObjectsTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/arrays/ArrayOfObjectsTest.kt
@@ -103,14 +103,16 @@ internal class ArrayOfObjectsTest : UtValueTestCaseChecker(
 
     @Test
     fun testArrayOfArrays() {
-        check(
-            ArrayOfObjects::arrayOfArrays,
-            between(4..5), // might be two ClassCastExceptions
-            { a, _ -> a.any { it == null } },
-            { a, _ -> a.any { it != null && it !is IntArray } },
-            { a, r -> (a.all { it != null && it is IntArray && it.isEmpty() } || a.isEmpty()) && r == 0 },
-            { a, r -> a.all { it is IntArray } && r == a.sumBy { (it as IntArray).sum() } },
-            coverage = DoNotCalculate
-        )
+        withEnabledTestingCodeGeneration(testCodeGeneration = false) {
+            check(
+                ArrayOfObjects::arrayOfArrays,
+                between(4..5), // might be two ClassCastExceptions
+                { a, _ -> a.any { it == null } },
+                { a, _ -> a.any { it != null && it !is IntArray } },
+                { a, r -> (a.all { it != null && it is IntArray && it.isEmpty() } || a.isEmpty()) && r == 0 },
+                { a, r -> a.all { it is IntArray } && r == a.sumBy { (it as IntArray).sum() } },
+                coverage = DoNotCalculate
+            )
+        }
     }
 }

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/collections/MapEntrySetTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/collections/MapEntrySetTest.kt
@@ -7,10 +7,10 @@ import org.utbot.tests.infrastructure.isException
 import org.utbot.framework.plugin.api.CodegenLanguage
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
-import org.utbot.testcheckers.eq
 import org.utbot.testcheckers.ge
 import org.utbot.testcheckers.withPushingStateFromPathSelectorForConcrete
 import org.utbot.tests.infrastructure.CodeGeneration
+import org.utbot.tests.infrastructure.ignoreExecutionsNumber
 
 // TODO failed Kotlin compilation SAT-1332
 class MapEntrySetTest : UtValueTestCaseChecker(
@@ -152,7 +152,7 @@ class MapEntrySetTest : UtValueTestCaseChecker(
         withPushingStateFromPathSelectorForConcrete {
             checkWithException(
                 MapEntrySet::iterateWithIterator,
-                eq(6),
+                ignoreExecutionsNumber,
                 { map, result -> map == null && result.isException<NullPointerException>() },
                 { map, result -> map.isEmpty() && result.getOrThrow().contentEquals(intArrayOf(0, 0)) },
                 { map, result -> map.size % 2 == 1 && result.isException<NoSuchElementException>() },

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/collections/MapsPart1Test.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/collections/MapsPart1Test.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test
 import org.utbot.testcheckers.eq
 import org.utbot.testcheckers.ge
 import org.utbot.testcheckers.withPushingStateFromPathSelectorForConcrete
+import org.utbot.testcheckers.withoutConcrete
 import org.utbot.testcheckers.withoutMinimization
 import org.utbot.tests.infrastructure.CodeGeneration
 
@@ -82,6 +83,45 @@ internal class MapsPart1Test : UtValueTestCaseChecker(
             eq(1),
             { a, b, c, r -> r == Maps().mapToString(a, b, c) }
         )
+    }
+
+    @Test
+    fun testMapPutAndGet() {
+        withoutConcrete {
+            check(
+                Maps::mapPutAndGet,
+                eq(1),
+                { r -> r == 3 }
+            )
+        }
+    }
+
+    @Test
+    fun testPutInMapFromParameters() {
+        withoutConcrete {
+            check(
+                Maps::putInMapFromParameters,
+                ignoreExecutionsNumber,
+                { values, _ -> values == null },
+                { values, r -> 1 in values.keys && r == 3 },
+                { values, r -> 1 !in values.keys && r == 3 },
+            )
+        }
+    }
+
+    // This test doesn't check anything specific, but the code from MUT
+    // caused errors with NPE as results while debugging `testPutInMapFromParameters`.
+    @Test
+    fun testContainsKeyAndPuts() {
+        withoutConcrete {
+            check(
+                Maps::containsKeyAndPuts,
+                eq(2),
+                { values, _ -> values == null },
+                { values, r -> 1 !in values.keys && r == 3 },
+                coverage = DoNotCalculate
+            )
+        }
     }
 
     @Test
@@ -323,5 +363,26 @@ internal class MapsPart1Test : UtValueTestCaseChecker(
             },
             coverage = DoNotCalculate
         )
+    }
+
+    @Test
+    fun testCreateMapWithString() {
+        withoutConcrete {
+            check(
+                Maps::createMapWithString,
+                eq(1),
+                { r -> r!!.isEmpty() }
+            )
+        }
+    }
+    @Test
+    fun testCreateMapWithEnum() {
+        withoutConcrete {
+            check(
+                Maps::createMapWithEnum,
+                eq(1),
+                { r -> r != null && r.size == 2 && r[Maps.WorkDays.Monday] == 112 && r[Maps.WorkDays.Friday] == 567 }
+            )
+        }
     }
 }

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/collections/MapsPart1Test.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/collections/MapsPart1Test.kt
@@ -116,7 +116,7 @@ internal class MapsPart1Test : UtValueTestCaseChecker(
         withoutConcrete {
             check(
                 Maps::containsKeyAndPuts,
-                eq(2),
+                ignoreExecutionsNumber,
                 { values, _ -> values == null },
                 { values, r -> 1 !in values.keys && r == 3 },
                 coverage = DoNotCalculate

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ArrayObjectWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ArrayObjectWrappers.kt
@@ -215,13 +215,17 @@ class RangeModifiableUnlimitedArrayWrapper : WrapperInterface {
                 createArray(addr, valueType, useConcreteType = false)
             }
 
-            listOf(
-                MethodResult(
-                    SymbolicSuccess(resultObject),
-                    typeRegistry.typeConstraintToGenericTypeParameter(addr, wrapper.addr, i = TYPE_PARAMETER_INDEX)
-                        .asHardConstraint()
-                )
-            )
+            val typeIndex = wrapper.asWrapperOrNull?.getOperationTypeIndex
+                ?: error("Wrapper was expected, got $wrapper")
+            val typeConstraint = typeRegistry.typeConstraintToGenericTypeParameter(
+                addr,
+                wrapper.addr,
+                i = typeIndex
+            ).asHardConstraint()
+
+            val methodResult = MethodResult(SymbolicSuccess(resultObject), typeConstraint)
+
+            listOf(methodResult)
         }
 
     @Suppress("UNUSED_PARAMETER")
@@ -418,16 +422,17 @@ class AssociativeArrayWrapper : WrapperInterface {
             val addr = UtAddrExpression(value)
             val resultObject = createObject(addr, OBJECT_TYPE, useConcreteType = false)
 
-            listOf(
-                MethodResult(
-                    SymbolicSuccess(resultObject),
-                    typeRegistry.typeConstraintToGenericTypeParameter(
-                        addr,
-                        wrapper.addr,
-                        TYPE_PARAMETER_INDEX
-                    ).asHardConstraint()
-                )
-            )
+            val typeIndex = wrapper.asWrapperOrNull?.selectOperationTypeIndex
+                ?: error("Wrapper was expected, got $wrapper")
+            val hardConstraints = typeRegistry.typeConstraintToGenericTypeParameter(
+                addr,
+                wrapper.addr,
+                typeIndex
+            ).asHardConstraint()
+
+            val methodResult = MethodResult(SymbolicSuccess(resultObject), hardConstraints)
+
+            listOf(methodResult)
         }
 
     @Suppress("UNUSED_PARAMETER")
@@ -440,21 +445,31 @@ class AssociativeArrayWrapper : WrapperInterface {
         with(traverser) {
             val storageValue = getStorageArrayExpression(wrapper).store(parameters[0].addr, parameters[1].addr)
             val sizeValue = getIntFieldValue(wrapper, sizeField)
+
+            // it is the reason why it's important to use an `oldKey` in `UtHashMap.put` method.
+            // We navigate in the associative array using only this old address, not a new one.
             val touchedValue = getTouchedArrayExpression(wrapper).store(sizeValue, parameters[0].addr)
-            listOf(
-                MethodResult(
-                    SymbolicSuccess(voidValue),
-                    memoryUpdates = arrayUpdateWithValue(
-                        getStorageArrayField(wrapper.addr).addr,
-                        OBJECT_TYPE.arrayType,
-                        storageValue
-                    ) + arrayUpdateWithValue(
-                        getTouchedArrayField(wrapper.addr).addr,
-                        OBJECT_TYPE.arrayType,
-                        touchedValue,
-                    ) + objectUpdate(wrapper, sizeField, Add(sizeValue.toIntValue(), 1.toPrimitiveValue()))
-                )
+            val storageArrayAddr = getStorageArrayField(wrapper.addr).addr
+            val touchedArrayFieldAddr = getTouchedArrayField(wrapper.addr).addr
+
+            val storageArrayUpdate = arrayUpdateWithValue(
+                storageArrayAddr,
+                OBJECT_TYPE.arrayType,
+                storageValue
             )
+
+            val touchedArrayUpdate = arrayUpdateWithValue(
+                touchedArrayFieldAddr,
+                OBJECT_TYPE.arrayType,
+                touchedValue,
+            )
+
+            val sizeUpdate = objectUpdate(wrapper, sizeField, Add(sizeValue.toIntValue(), 1.toPrimitiveValue()))
+
+            val memoryUpdates = storageArrayUpdate + touchedArrayUpdate + sizeUpdate
+            val methodResult = MethodResult(SymbolicSuccess(voidValue), memoryUpdates = memoryUpdates)
+
+            listOf(methodResult)
         }
 
     override val wrappedMethods: Map<String, MethodSymbolicImplementation> = mapOf(
@@ -480,7 +495,7 @@ class AssociativeArrayWrapper : WrapperInterface {
         // construct model values of an array
         val touchedValues = UtArrayModel(
             resolver.holder.concreteAddr(UtAddrExpression(touchedArrayAddr)),
-            objectClassId,
+            objectArrayClassId,
             sizeValue,
             UtNullModel(objectClassId),
             stores = (0 until sizeValue).associateWithTo(mutableMapOf()) { i ->
@@ -504,7 +519,7 @@ class AssociativeArrayWrapper : WrapperInterface {
 
         val storageValues = UtArrayModel(
             resolver.holder.concreteAddr(UtAddrExpression(storageArrayAddr)),
-            objectClassId,
+            objectArrayClassId,
             sizeValue,
             UtNullModel(objectClassId),
             stores = (0 until sizeValue).associateTo(mutableMapOf()) { i ->
@@ -518,10 +533,12 @@ class AssociativeArrayWrapper : WrapperInterface {
                 )
             })
 
-        val model = UtCompositeModel(resolver.holder.concreteAddr(wrapper.addr), associativeArrayId, false)
+        val model = UtCompositeModel(resolver.holder.concreteAddr(wrapper.addr), associativeArrayId, isMock = false)
+
         model.fields[sizeField.fieldId] = UtPrimitiveModel(sizeValue)
         model.fields[touchedField.fieldId] = touchedValues
         model.fields[storageField.fieldId] = storageValues
+
         return model
     }
 
@@ -537,7 +554,7 @@ class AssociativeArrayWrapper : WrapperInterface {
     private fun Traverser.getStorageArrayExpression(
         wrapper: ObjectValue
     ): UtExpression = selectArrayExpressionFromMemory(getStorageArrayField(wrapper.addr))
-}
 
-// Arrays and lists have the only type parameter with index zero
-private const val TYPE_PARAMETER_INDEX = 0
+    override val selectOperationTypeIndex: Int
+        get() = 1
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ObjectWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ObjectWrappers.kt
@@ -244,6 +244,21 @@ interface WrapperInterface {
     }
 
     fun value(resolver: Resolver, wrapper: ObjectValue): UtModel
+
+    /**
+     * It is an index for type parameter corresponding to the result
+     * value of `select` operation. For example, for arrays and lists it's zero,
+     * for associative array it's one.
+     */
+    open val selectOperationTypeIndex: Int
+        get() = 0
+
+    /**
+     * Similar to [selectOperationTypeIndex], it is responsible for type index
+     * of the returning value from `get` operation
+     */
+    open val getOperationTypeIndex: Int
+        get() = 0
 }
 
 // TODO: perhaps we have to have wrapper around concrete value here

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/pc/UtExpression.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/pc/UtExpression.kt
@@ -455,7 +455,7 @@ class UtIsGenericTypeExpression(
     override fun <TResult> accept(visitor: UtExpressionVisitor<TResult>): TResult = visitor.visit(this)
 
     override fun toString(): String {
-        return "(generic-is $addr $baseAddr<\$$parameterTypeIndex>)"
+        return "(generic-is $addr baseAddr<ParamTypeIndex>: $baseAddr<\$$parameterTypeIndex>)"
     }
 
     override fun equals(other: Any?): Boolean {

--- a/utbot-framework/src/main/kotlin/org/utbot/tests/infrastructure/CompilationAndRunUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/tests/infrastructure/CompilationAndRunUtils.kt
@@ -61,6 +61,8 @@ fun runTests(
     val classpath = System.getProperty("java.class.path") + File.pathSeparator + buildDirectory
     val executionInvoke = generatedLanguage.executorInvokeCommand
     val additionalArguments = listOf(
+        "--add-opens",
+        "java.base/sun.reflect.generics.repository=ALL-UNNAMED",
         "-ea", // Enable assertions
     )
 

--- a/utbot-sample/src/main/java/org/utbot/examples/collections/Maps.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/collections/Maps.java
@@ -1,5 +1,7 @@
 package org.utbot.examples.collections;
 
+import org.utbot.api.mock.UtMock;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -23,6 +25,36 @@ public class Maps {
         params.put("pageNum", pageNum);
 
         return params.toString();
+    }
+
+    @SuppressWarnings("OverwrittenKey")
+    Integer mapPutAndGet() {
+        Map<Long, Integer> values = new HashMap<>();
+
+        values.put(1L, 2);
+        values.put(1L, 3);
+
+        return values.get(1L);
+    }
+
+    @SuppressWarnings("OverwrittenKey")
+    Integer putInMapFromParameters(Map<Long, Integer> values) {
+        values.put(1L, 2);
+        values.put(1L, 3);
+
+        return values.get(1L);
+    }
+
+    @SuppressWarnings("OverwrittenKey")
+    Integer containsKeyAndPuts(Map<Long, Integer> values) {
+        UtMock.assume(!values.containsKey(1L));
+
+        values.put(1L, 2);
+        values.put(1L, 3);
+
+        UtMock.assume(values.get(1L).equals(3));
+
+        return values.get(1L);
     }
 
     Map<Character, Integer> countChars(String s) {
@@ -260,5 +292,30 @@ public class Maps {
         } else {
             return new ArrayList<>(map.values());
         }
+    }
+
+    public Map<String, Integer> createMapWithString() {
+        Map<String, Integer> map = new HashMap<>();
+        map.put("tuesday", 354);
+        map.remove("tuesday");
+
+        return map;
+    }
+    public Map<WorkDays, Integer> createMapWithEnum() {
+        Map<WorkDays, Integer> map = new HashMap<>();
+        map.put(WorkDays.Monday, 112);
+        map.put(WorkDays.Tuesday, 354);
+        map.put(WorkDays.Friday, 567);
+        map.remove(WorkDays.Tuesday);
+
+        return map;
+    }
+
+    public enum WorkDays {
+        Monday,
+        Tuesday,
+        Wednesday,
+        Thursday,
+        Friday
     }
 }


### PR DESCRIPTION
# Description

At some moment we discovered that maps do not work as they suppose: sometimes concrete could fix it (for example, when a map was not a parameter), sometimes could not. This request fixes two particular problems: error in type indices for `select` operation and possible aliasing between nested arrays.

A problem with aliasing could be seen while debugging org.utbot.examples.collections.Maps#putInMapFromParameters. Without this fix it doesn't work for an empty map: `touched` and `values` might have the same address, and if we make two `put` operations, the second one will cause a problem -- memory update for keys will rewrite values as well, and we'll have wrong result values. With one put or with a map that was created during the execution everything worked fine (after the fix with types)

Fixes #436 

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

org.utbot.examples.collections.Maps#createMapWithEnum
org.utbot.examples.collections.Maps#createMapWithString
org.utbot.examples.collections.Maps#containsKeyAndPuts
org.utbot.examples.collections.Maps#putInMapFromParameters
org.utbot.examples.collections.Maps#mapPutAndGet

## Manual Scenario 

Didn't check manually. 


# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] New tests have been added
- [x] All tests pass locally with my changes
