### PR TITLE
Write test method name to the UtExecution for the Sariff needs

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgMethodConstructor.kt
@@ -1253,6 +1253,9 @@ internal class CgMethodConstructor(val context: CgContext) : CgContextOwner by c
     fun createTestMethod(executableId: ExecutableId, execution: UtExecution): CgTestMethod =
         withTestMethodScope(execution) {
             val testMethodName = nameGenerator.testMethodNameFor(executableId, execution.testMethodName)
+            if (execution.testMethodName == null) {
+                execution.testMethodName = testMethodName
+            }
             // TODO: remove this line when SAT-1273 is completed
             execution.displayName = execution.displayName?.let { "${executableId.name}: $it" }
             testMethod(testMethodName, execution.displayName) {


### PR DESCRIPTION
# Description

During the Sarif Report Generation process, it uses the unique testMethodName from UtExecution to match the report to the source code. Unfortunately, this field keeps null for many cases (if summaries are failed or not generated), but in reality, later the default test name is generated.

We decided to write this generated name to the UtExecution to reuse it during Sarif Generation Report

Fixes #1218 

## Type of Change

- Refactoring (typos and non-functional changes) 
