### PR TITLE
Too many tests generated by Fuzzer #1225

### DIFF
--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/agent/DynamicClassTransformer.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/agent/DynamicClassTransformer.kt
@@ -6,7 +6,9 @@ import com.jetbrains.rd.util.info
 import org.utbot.common.asPathToFile
 import org.utbot.framework.plugin.api.util.UtContext
 import java.lang.instrument.ClassFileTransformer
+import java.nio.file.Paths
 import java.security.ProtectionDomain
+import kotlin.io.path.absolutePathString
 
 
 private val logger = getLogger("DynamicClassTransformer")
@@ -32,7 +34,7 @@ class DynamicClassTransformer : ClassFileTransformer {
     ): ByteArray? {
         try {
             UtContext.currentContext()?.stopWatch?.stop()
-            val pathToClassfile = protectionDomain.codeSource?.location?.path?.asPathToFile()
+            val pathToClassfile = protectionDomain.codeSource?.location?.toURI()?.let(Paths::get)?.absolutePathString()
             return if (pathToClassfile in pathsToUserClasses ||
                 packsToAlwaysTransform.any(className::startsWith)
             ) {


### PR DESCRIPTION
# Description

The problem was the instrumentation doesn't change bytecode for classes which have space-character in the path on Windows. java.net.URL can keep both options: with character "`%20`" or "` `" in the path. Because of this the code source path (that contains `%20`) cannot be found in the list of sources to be transformed.

Therefore instrumentation doesn't supply any coverage to minimization and plenty of tests are generated.

To fix this, URL is converted into URI first and then full path of file is requested.

Fixes #1225

## Type of Change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

## Automated Testing

All tests should pass

## Manual Scenario 

Try to reproduce example from the issue. Nearly 29 tests should be generated.

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
