### PR TITLE
Construct assemble models for classes with val-properties in constructor #1190

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssembleModelGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssembleModelGenerator.kt
@@ -254,25 +254,27 @@ class AssembleModelGenerator(private val basePackageName: String) {
                 instantiatedModels[compositeModel] = this
 
                 compositeModel.fields.forEach { (fieldId, fieldModel) ->
+                    //if field value has been filled by constructor or it is default, we suppose that it is already properly initialized
+                    if ((fieldId in constructorInfo.setFields || fieldModel.hasDefaultValue()) && fieldId !in constructorInfo.affectedFields)
+                        return@forEach
+
                     if (fieldId.isStatic) {
                         throw AssembleException("Static field $fieldId can't be set in an object of the class $classId")
                     }
-                    if (fieldId.isFinal) {
-                        throw AssembleException("Final field $fieldId can't be set in an object of the class $classId")
-                    }
+
                     if (!fieldId.type.isAccessibleFrom(basePackageName)) {
                         throw AssembleException(
                             "Field $fieldId can't be set in an object of the class $classId because its type is inaccessible"
                         )
                     }
-                    //fill field value if it hasn't been filled by constructor, and it is not default
-                    if (fieldId in constructorInfo.affectedFields ||
-                            (fieldId !in constructorInfo.setFields && !fieldModel.hasDefaultValue())
-                    ) {
-                        val assembledModel = assembleModel(fieldModel)
-                        val modifierCall = modifierCall(this, fieldId, assembledModel)
-                        callChain.add(modifierCall)
+
+                    if (fieldId.isFinal) {
+                        throw AssembleException("Final field $fieldId can't be set in an object of the class $classId")
                     }
+
+                    val assembledModel = assembleModel(fieldModel)
+                    val modifierCall = modifierCall(this, fieldId, assembledModel)
+                    callChain.add(modifierCall)
                 }
 
                 callChain.toList()


### PR DESCRIPTION
# Description

Modified `assembleCompositeModel(UtCompositeModel)` so that if final fields exist but they all are set by constructor, then we still try to create assemble model (before PR, any final field meant that model can't be assembled).

Fixes #1190

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

Tested on scenario from #1190 -- works as expected.

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
