### PR TITLE
Replace Kotlin setters with direct property access for models from Fuzzer #1241

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -1053,16 +1053,15 @@ sealed class ExecutableId : StatementId() {
             return "$name($args)$retType"
         }
 
+    fun describesSameMethodAs(other: ExecutableId): Boolean {
+        return classId == other.classId && signature == other.signature
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as ExecutableId
-
-        if (classId != other.classId) return false
-        if (signature != other.signature) return false
-
-        return true
+        return describesSameMethodAs(other as ExecutableId)
     }
 
     override fun hashCode(): Int {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/util/ClassIdUtil.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/util/ClassIdUtil.kt
@@ -37,10 +37,10 @@ infix fun ClassId.isAccessibleFrom(packageName: String): Boolean {
  * Returns field of [this], such that [methodId] is a getter for it (or null if methodId doesn't represent a getter)
  */
 internal fun ClassId.fieldThatIsGotWith(methodId: MethodId): FieldId? =
-    allDeclaredFieldIds.singleOrNull { !it.isStatic && it.getter == methodId }
+    allDeclaredFieldIds.singleOrNull { !it.isStatic && it.getter.describesSameMethodAs(methodId) }
 
 /**
  * Returns field of [this], such that [methodId] is a setter for it (or null if methodId doesn't represent a setter)
  */
 internal fun ClassId.fieldThatIsSetWith(methodId: MethodId): FieldId? =
-    allDeclaredFieldIds.singleOrNull { !it.isStatic && it.setter == methodId }
+    allDeclaredFieldIds.singleOrNull { !it.isStatic && it.setter.describesSameMethodAs(methodId) }


### PR DESCRIPTION
# Description

Previously calls to Kotlin setters in Fuzzer models were not replaced with direct accesses because check `fieldId.setter == methodId` failed due to different types of operands (`MethodId` vs `FuzzerMockableMethodId`, see `ExecutableId.equals()`). Now this check is rewritten with new method `describesSameMethodAs` that checks only `declaringClass` and `signature` but ignores javaClass.

Fixes #1241

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

Checked on scenario from #1241 -- works as expected

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
