### PR TITLE
Avoid presence of our internal types in generated code

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -382,6 +382,18 @@ object UtSettings : AbstractSettings(
      * and test generation.
      */
     var useSandbox by getBooleanProperty(true)
+
+    /**
+     * If this options set in true, all soot classes will be removed from a Soot Scene,
+     * therefore, you will be unable to test soot classes.
+     */
+    var removeSootClassesFromHierarchy by getBooleanProperty(true)
+
+    /**
+     * If this options set in true, all UtBot classes will be removed from a Soot Scene,
+     * therefore, you will be unable to test UtBot classes.
+     */
+    var removeUtBotClassesFromHierarchy by getBooleanProperty(true)
 }
 
 /**

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ArrayObjectWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ArrayObjectWrappers.kt
@@ -501,7 +501,7 @@ class AssociativeArrayWrapper : WrapperInterface {
             stores = (0 until sizeValue).associateWithTo(mutableMapOf()) { i ->
                 resolver.resolveModel(
                     ObjectValue(
-                        TypeStorage(OBJECT_TYPE),
+                        TypeStorage.constructTypeStorageWithSingleType(OBJECT_TYPE),
                         UtAddrExpression(touchedArrayExpression.select(mkInt(i)))
                     )
                 )
@@ -527,7 +527,7 @@ class AssociativeArrayWrapper : WrapperInterface {
                 val addr = model.getIdOrThrow()
                 addr to resolver.resolveModel(
                     ObjectValue(
-                        TypeStorage(OBJECT_TYPE),
+                        TypeStorage.constructTypeStorageWithSingleType(OBJECT_TYPE),
                         UtAddrExpression(storageArrayExpression.select(mkInt(addr)))
                     )
                 )

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/DataClasses.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/DataClasses.kt
@@ -83,22 +83,25 @@ inline fun <R> SymbolicFailure.fold(
 data class Parameter(private val localVariable: LocalVariable, private val type: Type, val value: SymbolicValue)
 
 /**
- * Keeps most common type and possible types, to resolve types in uncertain situations, like virtual invokes.
+ * Contains type information about some object: set of its [possibleConcreteTypes] and their [leastCommonType].
+ * Note that in some situations [leastCommonType] will not present in [possibleConcreteTypes] set, and
+ * it should not be used to encode this type information into a solver.
  *
  * Note: [leastCommonType] might be an interface or abstract type in opposite to the [possibleConcreteTypes]
  * that **usually** contains only concrete types (so-called appropriate). The only way to create [TypeStorage] with
- * inappropriate possibleType is to create it using constructor with the only type.
+ * inappropriate possibleType is to create it using static methods [constructTypeStorageUnsafe] and
+ * [constructTypeStorageWithSingleType].
+ *
+ * The right way to create an instance of TypeStorage is to use methods provided by [TypeResolver], e.g.,
+ * [TypeResolver.constructTypeStorage].
  *
  * @see isAppropriate
+ * @see TypeResolver.constructTypeStorage
  */
-data class TypeStorage(val leastCommonType: Type, val possibleConcreteTypes: Set<Type>) {
+class TypeStorage private constructor(val leastCommonType: Type, val possibleConcreteTypes: Set<Type>) {
     private val hashCode = Objects.hash(leastCommonType, possibleConcreteTypes)
 
-    /**
-     * Construct a type storage with some type. In this case [possibleConcreteTypes] might contains
-     * abstract class or interface. Usually it means such typeStorage represents wrapper object type.
-     */
-    constructor(concreteType: Type) : this(concreteType, setOf(concreteType))
+    private constructor(concreteType: Type) : this(concreteType, setOf(concreteType))
 
     fun isObjectTypeStorage(): Boolean = possibleConcreteTypes.size == objectTypeStorage.possibleConcreteTypes.size
 
@@ -120,6 +123,29 @@ data class TypeStorage(val leastCommonType: Type, val possibleConcreteTypes: Set
         "$leastCommonType"
     } else {
         "(leastCommonType=$leastCommonType, ${possibleConcreteTypes.size} possibleTypes=${possibleConcreteTypes.take(10)})"
+    }
+
+    companion object {
+        /**
+         * Constructs a type storage with particular leastCommonType and set of possibleConcreteTypes.
+         * This method doesn't give any guarantee on correctness of the constructed type storage and
+         * should not be used directly except the situations where you want to create abnormal type storage,
+         * for example, a one that contains interfaces in [possibleConcreteTypes].
+         *
+         * In regular cases you should use [TypeResolver.constructTypeStorage] method instead.
+         */
+        fun constructTypeStorageUnsafe(
+            leastCommonType: Type,
+            possibleConcreteTypes: Set<Type>
+        ): TypeStorage = TypeStorage(leastCommonType, possibleConcreteTypes)
+
+        /**
+         * Constructs a type storage with some type. In this case [possibleConcreteTypes] might contains
+         * abstract class or interface. Usually it means such typeStorage represents wrapper object type.
+         */
+        fun constructTypeStorageWithSingleType(
+            leastCommonType: Type
+        ): TypeStorage = TypeStorage(leastCommonType)
     }
 }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/DataClasses.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/DataClasses.kt
@@ -140,8 +140,8 @@ class TypeStorage private constructor(val leastCommonType: Type, val possibleCon
         ): TypeStorage = TypeStorage(leastCommonType, possibleConcreteTypes)
 
         /**
-         * Constructs a type storage with some type. In this case [possibleConcreteTypes] might contains
-         * abstract class or interface. Usually it means such typeStorage represents wrapper object type.
+         * Constructs a type storage with some type. In this case [possibleConcreteTypes] might contain
+         * an abstract class or an interface. Usually it means such typeStorage represents wrapper object type.
          */
         fun constructTypeStorageWithSingleType(
             leastCommonType: Type

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Memory.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Memory.kt
@@ -365,8 +365,12 @@ data class Memory( // TODO: split purely symbolic memory and information about s
  */
 class TypeRegistry {
     init {
+        // TODO mistake
         // initializes type storage for OBJECT_TYPE from current scene
-        objectTypeStorage = TypeStorage(OBJECT_TYPE, Scene.v().classes.mapTo(mutableSetOf()) { it.type })
+        objectTypeStorage = TypeStorage.constructTypeStorageUnsafe(
+            OBJECT_TYPE,
+            Scene.v().classes.mapTo(mutableSetOf()) { it.type }
+        )
     }
 
     private val typeIdBiMap = HashBiMap.create<Type, Int>()
@@ -612,9 +616,11 @@ class TypeRegistry {
     fun createClassRef(baseType: Type, numDimensions: Int = 0): MethodResult {
         val addr = classRefBiMap.getOrPut(baseType) { nextClassRefAddr() }
 
-        val objectValue = ObjectValue(TypeStorage(CLASS_REF_TYPE), addr)
+        val objectTypeStorage = TypeStorage.constructTypeStorageWithSingleType(CLASS_REF_TYPE)
+        val objectValue = ObjectValue(objectTypeStorage, addr)
 
-        val typeConstraint = typeConstraint(addr, TypeStorage(CLASS_REF_TYPE)).all()
+        val classRefTypeStorage = TypeStorage.constructTypeStorageWithSingleType(CLASS_REF_TYPE)
+        val typeConstraint = typeConstraint(addr, classRefTypeStorage).all()
 
         val typeId = mkInt(findTypeId(baseType))
         val symNumDimensions = mkInt(numDimensions)

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Memory.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Memory.kt
@@ -365,7 +365,6 @@ data class Memory( // TODO: split purely symbolic memory and information about s
  */
 class TypeRegistry {
     init {
-        // TODO mistake
         // initializes type storage for OBJECT_TYPE from current scene
         objectTypeStorage = TypeStorage.constructTypeStorageUnsafe(
             OBJECT_TYPE,
@@ -616,10 +615,9 @@ class TypeRegistry {
     fun createClassRef(baseType: Type, numDimensions: Int = 0): MethodResult {
         val addr = classRefBiMap.getOrPut(baseType) { nextClassRefAddr() }
 
-        val objectTypeStorage = TypeStorage.constructTypeStorageWithSingleType(CLASS_REF_TYPE)
+        val classRefTypeStorage = TypeStorage.constructTypeStorageWithSingleType(CLASS_REF_TYPE)
         val objectValue = ObjectValue(objectTypeStorage, addr)
 
-        val classRefTypeStorage = TypeStorage.constructTypeStorageWithSingleType(CLASS_REF_TYPE)
         val typeConstraint = typeConstraint(addr, classRefTypeStorage).all()
 
         val typeId = mkInt(findTypeId(baseType))

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/OptionalWrapper.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/OptionalWrapper.kt
@@ -65,7 +65,11 @@ class OptionalWrapper(private val utOptionalClass: UtOptionalClass) : BaseOverri
     ): List<InvokeResult>? {
         when (method.signature) {
             AS_OPTIONAL_METHOD_SIGNATURE -> {
-                return listOf(MethodResult(wrapper.copy(typeStorage = TypeStorage(method.returnType))))
+                val typeStorage = TypeStorage.constructTypeStorageWithSingleType(method.returnType)
+                val resultingWrapper = wrapper.copy(typeStorage = typeStorage)
+                val methodResult = MethodResult(resultingWrapper)
+
+                return listOf(methodResult)
             }
             UT_OPTIONAL_EQ_GENERIC_TYPE_SIGNATURE -> {
                 return listOf(

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Resolver.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Resolver.kt
@@ -427,7 +427,7 @@ class Resolver(
         // if the value is Object, we have to construct array or an object depending on the number of dimensions
         // it is possible if we had an object and we casted it into array
         val constructedType = holder.constructTypeOrNull(value.addr, value.type) ?: return UtNullModel(value.type.id)
-        val typeStorage = TypeStorage(constructedType)
+        val typeStorage = TypeStorage.constructTypeStorageWithSingleType(constructedType)
 
         return if (constructedType is ArrayType) {
             constructArrayModel(ArrayValue(typeStorage, value.addr))
@@ -1034,7 +1034,9 @@ class Resolver(
         val constructedType = holder.constructTypeOrNull(addr, defaultType) ?: return UtNullModel(defaultType.id)
 
         if (defaultType.isJavaLangObject() && constructedType is ArrayType) {
-            return constructArrayModel(ArrayValue(TypeStorage(constructedType), addr))
+            val typeStorage = TypeStorage.constructTypeStorageWithSingleType(constructedType)
+            val arrayValue = ArrayValue(typeStorage, addr)
+            return constructArrayModel(arrayValue)
         } else {
             val concreteType = typeResolver.findAnyConcreteInheritorIncludingOrDefault(
                 constructedType as RefType,

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Strings.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Strings.kt
@@ -23,7 +23,6 @@ import org.utbot.framework.plugin.api.UtAssembleModel
 import org.utbot.framework.plugin.api.UtExecutableCallModel
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtPrimitiveModel
-import org.utbot.framework.plugin.api.UtStatementModel
 import org.utbot.framework.plugin.api.classId
 import org.utbot.framework.plugin.api.id
 import org.utbot.framework.plugin.api.util.charArrayClassId
@@ -60,7 +59,8 @@ class StringWrapper : BaseOverriddenWrapper(utStringClass.name) {
     ): List<InvokeResult>? {
         return when (method.subSignature) {
             toStringMethodSignature -> {
-                listOf(MethodResult(wrapper.copy(typeStorage = TypeStorage(method.returnType))))
+                val typeStorage = TypeStorage.constructTypeStorageWithSingleType(method.returnType)
+                listOf(MethodResult(wrapper.copy(typeStorage = typeStorage)))
             }
             matchesMethodSignature -> {
                 symbolicMatchesMethodImpl(wrapper, parameters)
@@ -200,7 +200,11 @@ sealed class UtAbstractStringBuilderWrapper(className: String) : BaseOverriddenW
         parameters: List<SymbolicValue>
     ): List<InvokeResult>? {
         if (method.subSignature == asStringBuilderMethodSignature) {
-            return listOf(MethodResult(wrapper.copy(typeStorage = TypeStorage(method.returnType))))
+            val typeStorage = TypeStorage.constructTypeStorageWithSingleType(method.returnType)
+            val resultingWrapper = wrapper.copy(typeStorage = typeStorage)
+            val methodResult = MethodResult(resultingWrapper)
+
+            return listOf(methodResult)
         }
 
         return null

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/SymbolicValue.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/SymbolicValue.kt
@@ -51,7 +51,7 @@ data class PrimitiveValue(
     val expr: UtExpression,
     override val concrete: Concrete? = null
 ) : SymbolicValue() {
-    constructor(type: Type, expr: UtExpression) : this(TypeStorage(type), expr)
+    constructor(type: Type, expr: UtExpression) : this(TypeStorage.constructTypeStorageWithSingleType(type), expr)
 
     override val type get() = typeStorage.leastCommonType
 
@@ -179,7 +179,7 @@ fun SymbolicValue.toConcrete(): Any = when (this) {
 
 // TODO: one more constructor?
 fun objectValue(type: RefType, addr: UtAddrExpression, implementation: WrapperInterface) =
-    ObjectValue(TypeStorage(type), addr, Concrete(implementation))
+    ObjectValue(TypeStorage.constructTypeStorageWithSingleType(type), addr, Concrete(implementation))
 
 val voidValue
     get() = PrimitiveValue(VoidType.v(), nullObjectAddr)

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -897,7 +897,7 @@ class Traverser(
             // Ignores the result of resolve().
             resolve(fieldRef)
             val baseObject = resolve(fieldRef.base) as ObjectValue
-            val typeStorage = TypeStorage(fieldRef.field.declaringClass.type)
+            val typeStorage = TypeStorage.constructTypeStorageWithSingleType(fieldRef.field.declaringClass.type)
             baseObject.copy(typeStorage = typeStorage)
         }
         is StaticFieldRef -> {
@@ -1250,7 +1250,12 @@ class Traverser(
         // It is required because we do not want to have situations when some object might have
         // only artificial classes as their possible, that would cause problems in the type constraints.
         val typeStorage = if (leastCommonType in wrapperToClass.keys) {
-            typeStoragePossiblyWithOverriddenTypes.copy(possibleConcreteTypes = wrapperToClass.getValue(leastCommonType))
+            val possibleConcreteTypes = wrapperToClass.getValue(leastCommonType)
+
+            TypeStorage.constructTypeStorageUnsafe(
+                typeStoragePossiblyWithOverriddenTypes.leastCommonType,
+                possibleConcreteTypes
+            )
         } else {
             typeStoragePossiblyWithOverriddenTypes
         }
@@ -1307,7 +1312,10 @@ class Traverser(
                         createObject(addr, refType, useConcreteType = true)
                     }
                 } else {
-                    queuedSymbolicStateUpdates += typeRegistry.typeConstraint(addr, TypeStorage(refType)).all().asHardConstraint()
+                    val typeStorage = TypeStorage.constructTypeStorageWithSingleType(refType)
+                    val typeConstraint = typeRegistry.typeConstraint(addr, typeStorage).all().asHardConstraint()
+
+                    queuedSymbolicStateUpdates += typeConstraint
 
                     objectValue(refType, addr, StringWrapper()).also {
                         initStringLiteral(it, constant.value)
@@ -1417,8 +1425,10 @@ class Traverser(
         }
 
     private fun initStringLiteral(stringWrapper: ObjectValue, value: String) {
+        val typeStorage = TypeStorage.constructTypeStorageWithSingleType(utStringClass.type)
+
         queuedSymbolicStateUpdates += objectUpdate(
-            stringWrapper.copy(typeStorage = TypeStorage(utStringClass.type)),
+            stringWrapper.copy(typeStorage = typeStorage),
             STRING_LENGTH,
             mkInt(value.length)
         )
@@ -1431,7 +1441,7 @@ class Traverser(
             queuedSymbolicStateUpdates += arrayUpdateWithValue(it.addr, arrayType, defaultValue as UtArrayExpressionBase)
         }
         queuedSymbolicStateUpdates += objectUpdate(
-            stringWrapper.copy(typeStorage = TypeStorage(utStringClass.type)),
+            stringWrapper.copy(typeStorage = typeStorage),
             STRING_VALUE,
             arrayValue.addr
         )
@@ -1719,7 +1729,8 @@ class Traverser(
         val chunkId = typeRegistry.arrayChunkId(type)
         touchMemoryChunk(MemoryChunkDescriptor(chunkId, type, elementType))
 
-        return ArrayValue(TypeStorage(type), addr).also {
+        val typeStorage = TypeStorage.constructTypeStorageWithSingleType(type)
+        return ArrayValue(typeStorage, addr).also {
             queuedSymbolicStateUpdates += typeRegistry.typeConstraint(addr, it.typeStorage).all().asHardConstraint()
         }
     }
@@ -2941,7 +2952,9 @@ class Traverser(
 
         val memoryUpdate = MemoryUpdate(touchedChunkDescriptors = persistentSetOf(descriptor))
 
-        val clone = ArrayValue(TypeStorage(array.type), addr)
+        val typeStorage = TypeStorage.constructTypeStorageWithSingleType(array.type)
+        val clone = ArrayValue(typeStorage, addr)
+
         return MethodResult(clone, constraints.asHardConstraint(), memoryUpdates = memoryUpdate)
     }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/TypeResolver.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/TypeResolver.kt
@@ -120,15 +120,13 @@ class TypeResolver(private val typeRegistry: TypeRegistry, private val hierarchy
             return false
         }
 
-        if (baseType.sootClass.packageName.startsWith("org.utbot")) {
-            return true
-        }
-
-        if (baseType.sootClass.packageName.startsWith("soot")) {
-            return true
-        }
-
         val baseSootClass = baseType.sootClass
+
+        // We don't want to have our wrapper's classes as a part of a regular TypeStorage instance
+        // Note that we cannot have here 'isOverridden' since iterators of our wrappers are not wrappers
+        if (wrapperToClass[baseType] != null) {
+            return true
+        }
 
         if (numDimensions == 0 && baseSootClass.isInappropriate) {
             // interface, abstract class, or local, or mock could not be constructed

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/TypeResolver.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/TypeResolver.kt
@@ -120,6 +120,14 @@ class TypeResolver(private val typeRegistry: TypeRegistry, private val hierarchy
             return false
         }
 
+        if (baseType.sootClass.packageName.startsWith("org.utbot")) {
+            return true
+        }
+
+        if (baseType.sootClass.packageName.startsWith("soot")) {
+            return true
+        }
+
         val baseSootClass = baseType.sootClass
 
         if (numDimensions == 0 && baseSootClass.isInappropriate) {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/util/SootUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/util/SootUtils.kt
@@ -3,6 +3,7 @@ package org.utbot.framework.util
 import org.utbot.common.FileUtil
 import org.utbot.engine.jimpleBody
 import org.utbot.engine.pureJavaSignature
+import org.utbot.framework.UtSettings
 import org.utbot.framework.plugin.api.ExecutableId
 import org.utbot.framework.plugin.services.JdkInfo
 import soot.G
@@ -93,7 +94,7 @@ private fun initSoot(buildDirs: List<Path>, classpath: String?, jdkInfo: JdkInfo
         val isUtBotPackage = it.packageName.startsWith(UTBOT_PACKAGE_PREFIX)
 
         // remove our own classes from the soot scene
-        if (isUtBotPackage) {
+        if (UtSettings.removeUtBotClassesFromHierarchy && isUtBotPackage) {
             val isOverriddenPackage = it.packageName.startsWith(UTBOT_OVERRIDDEN_PACKAGE_PREFIX)
             val isExamplesPackage = it.packageName.startsWith(UTBOT_EXAMPLES_PACKAGE_PREFIX)
             val isApiPackage = it.packageName.startsWith(UTBOT_API_PACKAGE_PREFIX)
@@ -106,7 +107,7 @@ private fun initSoot(buildDirs: List<Path>, classpath: String?, jdkInfo: JdkInfo
         }
 
         // remove soot's classes from the scene, because we don't wont to analyze them
-        if (it.packageName.startsWith(SOOT_PACKAGE_PREFIX)) {
+        if (UtSettings.removeSootClassesFromHierarchy && it.packageName.startsWith(SOOT_PACKAGE_PREFIX)) {
             Scene.v().removeClass(it)
             return@forEach
         }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/util/SootUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/util/SootUtils.kt
@@ -89,9 +89,31 @@ private fun initSoot(buildDirs: List<Path>, classpath: String?, jdkInfo: JdkInfo
     Scene.v().loadNecessaryClasses()
     PackManager.v().runPacks()
     // we need this to create hierarchy of classes
-    Scene.v().classes.forEach {
-        if (it.resolvingLevel() < SootClass.HIERARCHY)
+    Scene.v().classes.toList().forEach {
+        val isUtBotPackage = it.packageName.startsWith(UTBOT_PACKAGE_PREFIX)
+
+        // remove our own classes from the soot scene
+        if (isUtBotPackage) {
+            val isOverriddenPackage = it.packageName.startsWith(UTBOT_OVERRIDDEN_PACKAGE_PREFIX)
+            val isExamplesPackage = it.packageName.startsWith(UTBOT_EXAMPLES_PACKAGE_PREFIX)
+            val isApiPackage = it.packageName.startsWith(UTBOT_API_PACKAGE_PREFIX)
+
+            // remove if it is not a part of the examples (CUT), not a part of our API and not an override
+            if (!isOverriddenPackage && !isExamplesPackage && !isApiPackage) {
+                Scene.v().removeClass(it)
+                return@forEach
+            }
+        }
+
+        // remove soot's classes from the scene, because we don't wont to analyze them
+        if (it.packageName.startsWith(SOOT_PACKAGE_PREFIX)) {
+            Scene.v().removeClass(it)
+            return@forEach
+        }
+
+        if (it.resolvingLevel() < SootClass.HIERARCHY) {
             it.setResolvingLevel(SootClass.HIERARCHY)
+        }
     }
 }
 
@@ -172,3 +194,9 @@ private val classesToLoad = arrayOf(
     org.utbot.engine.overrides.stream.LongStream::class,
     org.utbot.engine.overrides.stream.DoubleStream::class,
 ).map { it.java }.toTypedArray()
+
+private const val UTBOT_PACKAGE_PREFIX = "org.utbot"
+private const val UTBOT_EXAMPLES_PACKAGE_PREFIX = "$UTBOT_PACKAGE_PREFIX.examples"
+private const val UTBOT_API_PACKAGE_PREFIX = "$UTBOT_PACKAGE_PREFIX.api"
+private const val UTBOT_OVERRIDDEN_PACKAGE_PREFIX = "$UTBOT_PACKAGE_PREFIX.engine.overrides"
+private const val SOOT_PACKAGE_PREFIX = "soot."


### PR DESCRIPTION
# Description

This request remove soot types and our internal types from soot classes at all, and our classes used for mocks, overrides, etc., from the construction of type storages. At the same time, it changes API for `TypeStorage` class to avoid misunderstanding of what types will it contains after its creation via different constructors. 

Fixes #295 

## Type of Change
- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

## Automated Testing

There was no specific tests added. This request should not break already existed as a proof that we didn't remove anything that was required by our overridden classes. 

## Manual Scenario 

There was no manual testing. 

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] All tests pass locally with my changes
