### PR TITLE
Generate standard tests for symbolic executions with mocking in parametrized mode

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgTestClassConstructor.kt
@@ -39,6 +39,7 @@ import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.MethodId
 import org.utbot.framework.plugin.api.UtExecutionSuccess
 import org.utbot.framework.plugin.api.UtMethodTestSet
+import org.utbot.framework.plugin.api.UtSymbolicExecution
 import org.utbot.framework.plugin.api.util.description
 import org.utbot.framework.plugin.api.util.humanReadableName
 import org.utbot.fuzzer.UtFuzzedExecution
@@ -211,18 +212,35 @@ internal class CgTestClassConstructor(val context: CgContext) :
             )
         }
 
+        regions += CgSimpleRegion(
+            "Tests for method ${methodUnderTest.humanReadableName} that cannot be presented as parameterized",
+            collectAdditionalTestsForParameterizedMode(testSet),
+        )
+    }
+
+    private fun collectAdditionalTestsForParameterizedMode(testSet: CgMethodTestSet): List<CgTestMethod> {
+        val (methodUnderTest, _, _, _) = testSet
+        val testCaseTestMethods = mutableListOf<CgTestMethod>()
+
         // We cannot track mocking in fuzzed executions,
         // so we generate standard tests for each [UtFuzzedExecution].
         // [https://github.com/UnitTestBot/UTBotJava/issues/1137]
-        val testCaseTestMethods = mutableListOf<CgTestMethod>()
-        for (execution in testSet.executions.filterIsInstance<UtFuzzedExecution>()) {
-            testCaseTestMethods += methodConstructor.createTestMethod(methodUnderTest, execution)
-        }
+        testSet.executions
+            .filterIsInstance<UtFuzzedExecution>()
+            .forEach { execution ->
+                testCaseTestMethods += methodConstructor.createTestMethod(methodUnderTest, execution)
+            }
 
-        regions += CgSimpleRegion(
-            "FUZZER: EXECUTIONS for method ${methodUnderTest.humanReadableName}",
-            testCaseTestMethods,
-        )
+        // Also, we generate standard tests for symbolic executions with force mocking.
+        // [https://github.com/UnitTestBot/UTBotJava/issues/1231]
+        testSet.executions
+            .filterIsInstance<UtSymbolicExecution>()
+            .filter { it.containsMocking }
+            .forEach { execution ->
+                testCaseTestMethods += methodConstructor.createTestMethod(methodUnderTest, execution)
+            }
+
+        return testCaseTestMethods
     }
 
     /**


### PR DESCRIPTION
# Description

This PR adds more coverage by generating previously ignored test cases. Before, we skipped executions with mocking when generating parameterized tests. Now, we generate standard test in these cases.

This behavior is similar to our way of processing fuzzer executions (that may also contain force-mocking) in parametrized mode.

Fixes # ([1231](https://github.com/UnitTestBot/UTBotJava/issues/1231))

## Type of Change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Automated Testing

UTBot samples.

## Manual Scenario 

Run *MockFinalClassTest* for *useFinalClassMethod()* method. Verify that now there are three generated tests instead of two (as it was when we excluded symbolic executions with mocking in them).