### PR TITLE
Return disabled mock tests for parameterization mode

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/mock/FieldMockTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/mock/FieldMockTest.kt
@@ -18,8 +18,8 @@ import org.utbot.tests.infrastructure.TestExecution
 internal class FieldMockTest : UtValueTestCaseChecker(
     testClass = ServiceWithField::class,
     pipelines = listOf(
-        TestLastStage(CodegenLanguage.JAVA, lastStage = TestExecution, parameterizedModeLastStage = Compilation),
-        TestLastStage(CodegenLanguage.KOTLIN, lastStage = TestExecution)
+        TestLastStage(CodegenLanguage.JAVA),
+        TestLastStage(CodegenLanguage.KOTLIN)
     )
 ) {
     @Test

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/mock/MockFinalClassTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/mock/MockFinalClassTest.kt
@@ -15,8 +15,8 @@ import org.utbot.tests.infrastructure.TestExecution
 internal class MockFinalClassTest : UtValueTestCaseChecker(
     testClass = MockFinalClassExample::class,
     pipelines = listOf(
-        TestLastStage(CodegenLanguage.JAVA, lastStage = TestExecution, parameterizedModeLastStage = Compilation),
-        TestLastStage(CodegenLanguage.KOTLIN, lastStage = TestExecution)
+        TestLastStage(CodegenLanguage.JAVA),
+        TestLastStage(CodegenLanguage.KOTLIN)
     )
 ) {
     @Test

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/mock/MockRandomTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/mock/MockRandomTest.kt
@@ -22,7 +22,7 @@ internal class MockRandomTest : UtValueTestCaseChecker(
     testClass = MockRandomExamples::class,
     testCodeGeneration = true,
     pipelines = listOf(
-        TestLastStage(CodegenLanguage.JAVA, lastStage = TestExecution, parameterizedModeLastStage = Compilation),
+        TestLastStage(CodegenLanguage.JAVA, lastStage = TestExecution),
         TestLastStage(CodegenLanguage.KOTLIN, lastStage = CodeGeneration)
     )
 ) {

--- a/utbot-framework/src/main/kotlin/org/utbot/tests/infrastructure/TestSpecificTestCaseGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/tests/infrastructure/TestSpecificTestCaseGenerator.kt
@@ -73,11 +73,6 @@ class TestSpecificTestCaseGenerator(
                                             conflictTriggers.triggered(Conflict.ForceStaticMockHappened))
                                 ) {
                                     it.containsMocking = true
-
-                                    conflictTriggers.reset(
-                                        Conflict.ForceMockHappened,
-                                        Conflict.ForceStaticMockHappened
-                                    )
                                 }
                                 executions += it
                             }
@@ -87,6 +82,7 @@ class TestSpecificTestCaseGenerator(
             }
         }
 
+        conflictTriggers.reset(Conflict.ForceMockHappened, Conflict.ForceStaticMockHappened)
         forceMockListener.detach(this, forceMockListener)
         forceStaticMockListener.detach(this, forceStaticMockListener)
 


### PR DESCRIPTION
# Description

Getting back the disabled *FieldMockTest*, *MockFinalClassTest*, *MockRandomTest* tests for parameterization mode.

Fixes # ([1136](https://github.com/UnitTestBot/UTBotJava/issues/1136)) partially

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

UTBot-Samples

## Manual Scenario 

Run *FieldMockTest*, *MockFinalClassTest*, *MockRandomTest* tests. Verify that they are green.