### PR TITLE
Add a common `Simplificator` in the `Traverser`

### DIFF
--- a/utbot-analytics/src/main/kotlin/org/utbot/features/FeatureExtractorImpl.kt
+++ b/utbot-analytics/src/main/kotlin/org/utbot/features/FeatureExtractorImpl.kt
@@ -1,7 +1,7 @@
 package org.utbot.features
 
 import org.utbot.analytics.FeatureExtractor
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.InterProceduralUnitGraph
 import org.utbot.engine.selectors.strategies.StatementsStatistics
 import org.utbot.engine.selectors.strategies.SubpathStatistics

--- a/utbot-analytics/src/main/kotlin/org/utbot/features/FeatureProcessorWithStatesRepetition.kt
+++ b/utbot-analytics/src/main/kotlin/org/utbot/features/FeatureProcessorWithStatesRepetition.kt
@@ -2,7 +2,7 @@ package org.utbot.features
 
 import org.utbot.analytics.EngineAnalyticsContext
 import org.utbot.analytics.FeatureProcessor
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.InterProceduralUnitGraph
 import org.utbot.framework.UtSettings
 import soot.jimple.Stmt

--- a/utbot-framework/src/main/kotlin/org/utbot/analytics/FeatureExtractor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/analytics/FeatureExtractor.kt
@@ -1,6 +1,6 @@
 package org.utbot.analytics
 
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.ExecutionState
 
 /**
  * Class that encapsulates work with FeatureExtractor during symbolic execution.

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/DataClasses.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/DataClasses.kt
@@ -11,6 +11,7 @@ import org.utbot.engine.pc.UtIsExpression
 import org.utbot.engine.pc.UtTrue
 import org.utbot.engine.pc.mkAnd
 import org.utbot.engine.pc.mkOr
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.symbolic.*
 import org.utbot.engine.types.TypeResolver
 import org.utbot.framework.plugin.api.FieldId

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/DataClasses.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/DataClasses.kt
@@ -161,8 +161,6 @@ data class MethodResult(
     val symbolicResult: SymbolicResult,
     val symbolicStateUpdate: SymbolicStateUpdate = SymbolicStateUpdate()
 ) : InvokeResult() {
-    val memoryUpdates by symbolicStateUpdate::memoryUpdates
-
     constructor(
         symbolicResult: SymbolicResult,
         hardConstraints: HardConstraint = emptyHardConstraint(),

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Extensions.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Extensions.kt
@@ -29,6 +29,7 @@ import org.utbot.engine.pc.mkInt
 import org.utbot.engine.pc.mkLong
 import org.utbot.engine.pc.mkShort
 import org.utbot.engine.pc.toSort
+import org.utbot.engine.state.ExecutionState
 import org.utbot.framework.UtSettings.checkNpeInNestedMethods
 import org.utbot.framework.UtSettings.checkNpeInNestedNotPrivateMethods
 import org.utbot.framework.plugin.api.FieldId

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/InterProceduralUnitGraph.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/InterProceduralUnitGraph.kt
@@ -1,6 +1,9 @@
 package org.utbot.engine
 
 import org.utbot.engine.selectors.strategies.TraverseGraphStatistics
+import org.utbot.engine.state.CALL_DECISION_NUM
+import org.utbot.engine.state.Edge
+import org.utbot.engine.state.ExecutionState
 import soot.SootClass
 import soot.SootMethod
 import soot.jimple.Stmt

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Memory.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Memory.kt
@@ -50,28 +50,6 @@ import soot.Type
 
 
 /**
- * Represents a memory associated with a certain method call. For now consists only of local variables mapping.
- * TODO: think on other fields later
- *
- * @param [locals] represents a mapping from [LocalVariable]s of a specific method call to [SymbolicValue]s.
- */
-data class LocalVariableMemory(
-    private val locals: PersistentMap<LocalVariable, SymbolicValue> = persistentHashMapOf()
-) {
-    fun memoryForNestedMethod(): LocalVariableMemory = this.copy(locals = persistentHashMapOf())
-
-    fun update(update: LocalMemoryUpdate): LocalVariableMemory = this.copy(locals = locals.update(update.locals))
-
-    /**
-     * Returns local variable value.
-     */
-    fun local(variable: LocalVariable): SymbolicValue? = locals[variable]
-
-    val localValues: Set<SymbolicValue>
-        get() = locals.values.toSet()
-}
-
-/**
  * Local memory implementation based on arrays.
  *
  * Contains initial and current versions of arrays. Also collects memory updates (stores) and can return them.

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Memory.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Memory.kt
@@ -3,7 +3,6 @@ package org.utbot.engine
 import org.utbot.engine.MemoryState.CURRENT
 import org.utbot.engine.MemoryState.INITIAL
 import org.utbot.engine.MemoryState.STATIC_INITIAL
-import org.utbot.engine.pc.RewritingVisitor
 import org.utbot.engine.pc.UtAddrExpression
 import org.utbot.engine.pc.UtAddrSort
 import org.utbot.engine.pc.UtArrayExpressionBase
@@ -417,20 +416,20 @@ data class UtNamedStore(
 )
 
 /**
- * Create [UtNamedStore] with simplified [index] and [value] expressions.
+ * Create [UtNamedStore] with unsimplified [index] and [value] expressions.
  *
- * @see RewritingVisitor
+ * @note simplifications occur explicitly in [Traverser]
  */
-fun simplifiedNamedStore(
+fun namedStore(
     chunkDescriptor: MemoryChunkDescriptor,
     index: UtExpression,
     value: UtExpression
-) = RewritingVisitor().let { visitor -> UtNamedStore(chunkDescriptor, index.accept(visitor), value.accept(visitor)) }
+) = UtNamedStore(chunkDescriptor, index, value)
 
 /**
  * Updates persistent map where value = null in update means deletion of original key-value
  */
-private fun <K, V> PersistentMap<K, V>.update(update: Map<K, V?>): PersistentMap<K, V> {
+fun <K, V> PersistentMap<K, V>.update(update: Map<K, V?>): PersistentMap<K, V> {
     if (update.isEmpty()) return this
     val deletions = mutableListOf<K>()
     val updates = mutableMapOf<K, V>()

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Resolver.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Resolver.kt
@@ -1272,7 +1272,7 @@ private fun Traverser.arrayToMethodResult(
     }
 
     val memoryUpdate = MemoryUpdate(
-        stores = persistentListOf(simplifiedNamedStore(descriptor, newAddr, updatedArray)),
+        stores = persistentListOf(namedStore(descriptor, newAddr, updatedArray)),
         touchedChunkDescriptors = persistentSetOf(descriptor),
     )
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Strings.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Strings.kt
@@ -4,7 +4,6 @@ import com.github.curiousoddman.rgxgen.RgxGen
 import org.utbot.engine.overrides.strings.UtString
 import org.utbot.engine.overrides.strings.UtStringBuffer
 import org.utbot.engine.overrides.strings.UtStringBuilder
-import org.utbot.engine.pc.RewritingVisitor
 import org.utbot.engine.pc.UtAddrExpression
 import org.utbot.engine.pc.UtBoolExpression
 import org.utbot.engine.pc.UtFalse
@@ -122,17 +121,17 @@ class StringWrapper : BaseOverriddenWrapper(utStringClass.name) {
         parameters: List<SymbolicValue>
     ): List<InvokeResult>? {
         val arg = parameters[0] as ObjectValue
-        val matchingLengthExpr = getIntFieldValue(arg, STRING_LENGTH).accept(RewritingVisitor())
+        val matchingLengthExpr = getIntFieldValue(arg, STRING_LENGTH).accept(this.simplificator)
 
         if (!matchingLengthExpr.isConcrete) return null
 
         val matchingValueExpr =
-            selectArrayExpressionFromMemory(getValueArray(arg.addr)).accept(RewritingVisitor())
+            selectArrayExpressionFromMemory(getValueArray(arg.addr)).accept(this.simplificator)
         val matchingLength = matchingLengthExpr.toConcrete() as Int
         val matchingValue = CharArray(matchingLength)
 
         for (i in 0 until matchingLength) {
-            val charExpr = matchingValueExpr.select(mkInt(i)).accept(RewritingVisitor())
+            val charExpr = matchingValueExpr.select(mkInt(i)).accept(this.simplificator)
 
             if (!charExpr.isConcrete) return null
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/TraversalContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/TraversalContext.kt
@@ -1,5 +1,7 @@
 package org.utbot.engine
 
+import org.utbot.engine.state.ExecutionState
+
 /**
  * Represents a mutable _Context_ during the [ExecutionState] traversing. This _Context_ consists of all mutable and
  * immutable properties and fields which are created and updated during analysis of a **single** Jimple instruction.

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -315,7 +315,7 @@ class Traverser(
     }
 
     internal val simplificator = Simplificator()
-    private val memoryUpdateSimplificator = with(simplificator) { MemoryUpdateSimplificator() }
+    private val memoryUpdateSimplificator = MemoryUpdateSimplificator(simplificator)
 
     private fun TraversalContext.traverseStmt(current: Stmt) {
         if (doPreparatoryWorkIfRequired(current)) return

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -212,8 +212,6 @@ import java.lang.reflect.GenericArrayType
 import java.lang.reflect.TypeVariable
 import java.lang.reflect.WildcardType
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.reflect.full.instanceParameter
-import kotlin.reflect.jvm.javaType
 
 private val CAUGHT_EXCEPTION = LocalVariable("@caughtexception")
 
@@ -682,7 +680,7 @@ class Traverser(
         }
 
     private fun isStaticInstanceInMethodResult(id: ClassId, methodResult: MethodResult?) =
-        methodResult != null && id in methodResult.memoryUpdates.staticInstanceStorage
+        methodResult != null && id in methodResult.symbolicStateUpdate.memoryUpdates.staticInstanceStorage
 
     private fun TraversalContext.skipVerticesForThrowableCreation(current: JAssignStmt) {
         val rightType = current.rightOp.type as RefType
@@ -1030,7 +1028,6 @@ class Traverser(
      */
     private fun updateGenericTypeInfo(identityRef: IdentityRef, value: ReferenceValue) {
         val callable = methodUnderTest.executable
-        val kCallable = ::updateGenericTypeInfo
         val type = if (identityRef is ThisRef) {
             // TODO: for ThisRef both methods don't return parameterized type
             if (methodUnderTest.isConstructor) {
@@ -2359,7 +2356,7 @@ class Traverser(
             MethodResult(
                 mockValue,
                 hardConstraints = additionalConstraint.asHardConstraint(),
-                memoryUpdates = if (isInternalMock) MemoryUpdate() else mockMethodResult.memoryUpdates
+                memoryUpdates = if (isInternalMock) MemoryUpdate() else mockMethodResult.symbolicStateUpdate.memoryUpdates
             )
         )
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -16,6 +16,7 @@ import org.utbot.engine.overrides.UtArrayMock
 import org.utbot.engine.overrides.UtLogicMock
 import org.utbot.engine.overrides.UtOverrideMock
 import org.utbot.engine.pc.NotBoolExpression
+import org.utbot.engine.pc.Simplificator
 import org.utbot.engine.pc.UtAddNoOverflowExpression
 import org.utbot.engine.pc.UtAddrExpression
 import org.utbot.engine.pc.UtAndBoolExpression
@@ -75,6 +76,7 @@ import org.utbot.engine.state.pop
 import org.utbot.engine.state.push
 import org.utbot.engine.state.update
 import org.utbot.engine.state.withLabel
+import org.utbot.engine.symbolic.HardConstraint
 import org.utbot.engine.symbolic.emptyAssumption
 import org.utbot.engine.symbolic.emptyHardConstraint
 import org.utbot.engine.symbolic.emptySoftConstraint
@@ -83,6 +85,9 @@ import org.utbot.engine.symbolic.asHardConstraint
 import org.utbot.engine.symbolic.asSoftConstraint
 import org.utbot.engine.symbolic.asAssumption
 import org.utbot.engine.symbolic.asUpdate
+import org.utbot.engine.simplificators.MemoryUpdateSimplificator
+import org.utbot.engine.simplificators.simplifySymbolicStateUpdate
+import org.utbot.engine.simplificators.simplifySymbolicValue
 import org.utbot.engine.types.ENUM_ORDINAL
 import org.utbot.engine.types.EQUALS_SIGNATURE
 import org.utbot.engine.types.HASHCODE_SIGNATURE
@@ -309,6 +314,9 @@ class Traverser(
         return context.nextStates
     }
 
+    internal val simplificator = Simplificator()
+    private val memoryUpdateSimplificator = with(simplificator) { MemoryUpdateSimplificator() }
+
     private fun TraversalContext.traverseStmt(current: Stmt) {
         if (doPreparatoryWorkIfRequired(current)) return
 
@@ -322,10 +330,10 @@ class Traverser(
             is JReturnVoidStmt -> processResult(SymbolicSuccess(voidValue))
             is JRetStmt -> error("This one should be already removed by Soot: $current")
             is JThrowStmt -> traverseThrowStmt(current)
-            is JBreakpointStmt -> offerState(environment.state.updateQueued(globalGraph.succ(current)))
-            is JGotoStmt -> offerState(environment.state.updateQueued(globalGraph.succ(current)))
-            is JNopStmt -> offerState(environment.state.updateQueued(globalGraph.succ(current)))
-            is MonitorStmt -> offerState(environment.state.updateQueued(globalGraph.succ(current)))
+            is JBreakpointStmt -> offerState(updateQueued(globalGraph.succ(current)))
+            is JGotoStmt -> offerState(updateQueued(globalGraph.succ(current)))
+            is JNopStmt -> offerState(updateQueued(globalGraph.succ(current)))
+            is MonitorStmt -> offerState(updateQueued(globalGraph.succ(current)))
             is DefinitionStmt -> TODO("$current")
             else -> error("Unsupported: ${current::class}")
         }
@@ -445,7 +453,7 @@ class Traverser(
             // This branch could be useful if we have a static field, i.e. x = 5 / 0
             is SymbolicFailure -> traverseException(stmt, result.symbolicResult)
             is SymbolicSuccess -> offerState(
-                environment.state.updateQueued(
+                updateQueued(
                     environment.state.lastEdge!!,
                     result.symbolicStateUpdate
                 )
@@ -532,7 +540,7 @@ class Traverser(
         //      $r0 = <ClassWithEnum$StatusEnum: ClassWithEnum$StatusEnum[] $VALUES>;
         val edge = environment.state.lastEdge ?: globalGraph.succ(stmt)
 
-        val newState = environment.state.updateQueued(edge, updates)
+        val newState = updateQueued(edge, updates)
         offerState(newState)
 
         return true
@@ -692,12 +700,12 @@ class Traverser(
 
         // mark the rest of the path leading to the '<init>' statement as covered
         do {
-            environment.state = environment.state.updateQueued(globalGraph.succ(environment.state.stmt))
+            environment.state = updateQueued(globalGraph.succ(environment.state.stmt))
             globalGraph.visitEdge(environment.state.lastEdge!!)
             globalGraph.visitNode(environment.state)
         } while (!environment.state.stmt.isConstructorCall(currentExceptionJimpleLocal))
 
-        offerState(environment.state.updateQueued(globalGraph.succ(environment.state.stmt)))
+        offerState(updateQueued(globalGraph.succ(environment.state.stmt)))
     }
 
     private fun TraversalContext.traverseAssignStmt(current: JAssignStmt) {
@@ -730,9 +738,9 @@ class Traverser(
                 is SymbolicFailure -> { //exception thrown
                     if (environment.state.executionStack.last().doesntThrow) return@forEach
 
-                    val nextState = environment.state.createExceptionState(
+                    val nextState = createExceptionStateQueued(
                         methodResult.symbolicResult,
-                        queuedSymbolicStateUpdates + methodResult.symbolicStateUpdate
+                        methodResult.symbolicStateUpdate
                     )
                     globalGraph.registerImplicitEdge(nextState.lastEdge!!)
                     offerState(nextState)
@@ -744,7 +752,7 @@ class Traverser(
                         methodResult.symbolicResult.value
                     )
                     offerState(
-                        environment.state.updateQueued(
+                        updateQueued(
                             globalGraph.succ(current),
                             update + methodResult.symbolicStateUpdate
                         )
@@ -991,7 +999,7 @@ class Traverser(
 
                 environment.state.parameters += Parameter(localVariable, identityRef.type, value)
 
-                val nextState = environment.state.updateQueued(
+                val nextState = updateQueued(
                     globalGraph.succ(current),
                     SymbolicStateUpdate(localMemoryUpdates = localMemoryUpdate(localVariable to value))
                 )
@@ -1000,7 +1008,7 @@ class Traverser(
             is JCaughtExceptionRef -> {
                 val value = localVariableMemory.local(CAUGHT_EXCEPTION)
                     ?: error("Exception wasn't caught, stmt: $current, line: ${current.lines}")
-                val nextState = environment.state.updateQueued(
+                val nextState = updateQueued(
                     globalGraph.succ(current),
                     SymbolicStateUpdate(localMemoryUpdates = localMemoryUpdate(localVariable to value, CAUGHT_EXCEPTION to null))
                 )
@@ -1132,7 +1140,7 @@ class Traverser(
         if (!isAssumeExpr) {
             positiveCaseEdge?.let { edge ->
                 environment.state.expectUndefined()
-                val positiveCaseState = environment.state.updateQueued(
+                val positiveCaseState = updateQueued(
                     edge,
                     SymbolicStateUpdate(
                         hardConstraints = positiveCasePathConstraint.asHardConstraint(),
@@ -1147,7 +1155,7 @@ class Traverser(
         val hardConstraints = if (!isAssumeExpr) negativeCasePathConstraint.asHardConstraint() else emptyHardConstraint()
         val assumption = if (isAssumeExpr) negativeCasePathConstraint.asAssumption() else emptyAssumption()
 
-        val negativeCaseState = environment.state.updateQueued(
+        val negativeCaseState = updateQueued(
             negativeCaseEdge,
             SymbolicStateUpdate(
                 hardConstraints = hardConstraints,
@@ -1177,11 +1185,11 @@ class Traverser(
 
             offerState(
                 when (result.symbolicResult) {
-                    is SymbolicFailure -> environment.state.createExceptionState(
+                    is SymbolicFailure -> createExceptionStateQueued(
                         result.symbolicResult,
-                        queuedSymbolicStateUpdates + result.symbolicStateUpdate
+                        result.symbolicStateUpdate
                     )
-                    is SymbolicSuccess -> environment.state.updateQueued(
+                    is SymbolicSuccess -> updateQueued(
                         globalGraph.succ(current),
                         result.symbolicStateUpdate
                     )
@@ -1219,7 +1227,7 @@ class Traverser(
 
         successors.forEach { (target, expr) ->
             offerState(
-                environment.state.updateQueued(
+                updateQueued(
                     target,
                     SymbolicStateUpdate(hardConstraints = expr.asHardConstraint()),
                 )
@@ -1468,7 +1476,7 @@ class Traverser(
         }
 
         queuedSymbolicStateUpdates += arrayUpdateWithValue(arrayValue.addr, CharType.v().arrayType, newArray)
-        environment.state = environment.state.update(queuedSymbolicStateUpdates)
+        environment.state = updateQueued(SymbolicStateUpdate())
         queuedSymbolicStateUpdates = queuedSymbolicStateUpdates.copy(memoryUpdates = MemoryUpdate())
     }
 
@@ -1753,14 +1761,6 @@ class Traverser(
         }
     }
 
-    private fun SymbolicValue.simplify(): SymbolicValue =
-        when (this) {
-            is PrimitiveValue -> copy(expr = expr.accept(solver.rewriter))
-            is ObjectValue -> copy(addr = addr.accept(solver.rewriter) as UtAddrExpression)
-            is ArrayValue -> copy(addr = addr.accept(solver.rewriter) as UtAddrExpression)
-        }
-
-
     // Type is needed for null values: we should know, which null do we require.
     // If valueType is NullType, return typelessNullObject. It can happen in a situation,
     // where we cannot find the type, for example in condition (null == null)
@@ -1770,7 +1770,7 @@ class Traverser(
     ): SymbolicValue = when (value) {
         is JimpleLocal -> localVariableMemory.local(value.variable) ?: error("${value.name} not found in the locals")
         is Constant -> if (value is NullConstant) typeResolver.nullObject(valueType) else resolveConstant(value)
-        is Expr -> resolve(value, valueType).simplify()
+        is Expr -> resolve(value, valueType)
         is JInstanceFieldRef -> {
             val instance = (resolve(value.base) as ObjectValue)
             recordInstanceFieldRead(instance.addr, value.field)
@@ -1836,6 +1836,8 @@ class Traverser(
         }
         is StaticFieldRef -> readStaticField(value)
         else -> error("${value::class} is not supported")
+    }.also {
+        with(simplificator) { simplifySymbolicValue(it) }
     }
 
     private fun readStaticField(fieldRef: StaticFieldRef): SymbolicValue {
@@ -2153,7 +2155,7 @@ class Traverser(
             .select(array.addr)
             .store(index.expr, value)
 
-        return MemoryUpdate(persistentListOf(simplifiedNamedStore(descriptor, array.addr, updatedNestedArray)))
+        return MemoryUpdate(persistentListOf(namedStore(descriptor, array.addr, updatedNestedArray)))
     }
 
     fun objectUpdate(
@@ -2163,7 +2165,7 @@ class Traverser(
     ): MemoryUpdate {
         val chunkId = hierarchy.chunkIdForField(instance.type, field)
         val descriptor = MemoryChunkDescriptor(chunkId, instance.type, field.type)
-        return MemoryUpdate(persistentListOf(simplifiedNamedStore(descriptor, instance.addr, value)))
+        return MemoryUpdate(persistentListOf(namedStore(descriptor, instance.addr, value)))
     }
 
     fun arrayUpdateWithValue(
@@ -2176,7 +2178,7 @@ class Traverser(
         val chunkId = typeRegistry.arrayChunkId(type)
         val descriptor = MemoryChunkDescriptor(chunkId, type, type.elementType)
 
-        return MemoryUpdate(persistentListOf(simplifiedNamedStore(descriptor, addr, newValue)))
+        return MemoryUpdate(persistentListOf(namedStore(descriptor, addr, newValue)))
     }
 
     fun selectArrayExpressionFromMemory(
@@ -2237,7 +2239,7 @@ class Traverser(
         val edge = findCatchBlock(current, classId) ?: return false
 
         offerState(
-            environment.state.updateQueued(
+            updateQueued(
                 edge,
                 SymbolicStateUpdate(
                     hardConstraints = conditions.asHardConstraint(),
@@ -2410,7 +2412,7 @@ class Traverser(
         instance: ObjectValue,
         methodSubSignature: String
     ): List<InvocationTarget> {
-        val visitor = solver.rewriter.axiomInstantiationVisitor
+        val visitor = solver.simplificator.axiomInstantiationVisitor
         val simplifiedAddr = instance.addr.accept(visitor)
         // UtIsExpression for object with address the same as instance.addr
         val instanceOfConstraint = solver.assertions.singleOrNull {
@@ -2684,7 +2686,7 @@ class Traverser(
                     assumptions = assumptions.asAssumption()
                 )
 
-                val stateToContinue = environment.state.updateQueued(
+                val stateToContinue = updateQueued(
                     globalGraph.succ(environment.state.stmt),
                     symbolicStateUpdate
                 )
@@ -2731,7 +2733,7 @@ class Traverser(
                 )
             }
             utOverrideMockDoesntThrowMethodName -> {
-                val stateToContinue = environment.state.updateQueued(
+                val stateToContinue = updateQueued(
                     globalGraph.succ(environment.state.stmt),
                     doesntThrow = true
                 )
@@ -2743,7 +2745,7 @@ class Traverser(
                 when (val param = parameters.single() as ReferenceValue) {
                     is ObjectValue -> {
                         val addr = param.addr.toIntValue()
-                        val stateToContinue = environment.state.updateQueued(
+                        val stateToContinue = updateQueued(
                             globalGraph.succ(environment.state.stmt),
                             SymbolicStateUpdate(
                                 hardConstraints = Le(addr, nullObjectAddr.toIntValue()).asHardConstraint()
@@ -2762,7 +2764,7 @@ class Traverser(
 
                         val update = MemoryUpdate(
                             persistentListOf(
-                                simplifiedNamedStore(
+                                namedStore(
                                     descriptor,
                                     addr,
                                     UtArrayApplyForAll(memory.findArray(descriptor).select(addr)) { array, i ->
@@ -2771,7 +2773,7 @@ class Traverser(
                                 )
                             )
                         )
-                        val stateToContinue = environment.state.updateQueued(
+                        val stateToContinue = updateQueued(
                             edge = globalGraph.succ(environment.state.stmt),
                             SymbolicStateUpdate(
                                 hardConstraints = Le(addr.toIntValue(), nullObjectAddr.toIntValue()).asHardConstraint(),
@@ -3023,24 +3025,9 @@ class Traverser(
         globalGraph.join(environment.state.stmt, graph, !isLibraryMethod)
         val parametersWithThis = listOfNotNull(caller) + callParameters
         offerState(
-            environment.state.push(
-                graph.head,
-                inputArguments = ArrayDeque(parametersWithThis),
-                queuedSymbolicStateUpdates + constraints.asHardConstraint(),
-                graph.body.method
-            )
+            pushQueued(graph, parametersWithThis, constraints.asHardConstraint())
         )
     }
-
-    private fun ExecutionState.updateQueued(
-        edge: Edge,
-        update: SymbolicStateUpdate = SymbolicStateUpdate(),
-        doesntThrow: Boolean = false
-    ) = this.update(
-        edge,
-        queuedSymbolicStateUpdates + update,
-        doesntThrow
-    )
 
     private fun TraversalContext.resolveIfCondition(cond: BinopExpr): ResolvedCondition {
         // We add cond.op.type for null values only. If we have condition like "null == r1"
@@ -3370,7 +3357,7 @@ class Traverser(
         // Expected in the parameters baseType is an RefType because it is either an RefType itself or an array of RefType values
         if (baseTypeAfterCast is RefType) {
             // Find parameterized type for the object if it is a parameter of the method under test and it has generic type
-            val newAddr = addr.accept(solver.rewriter) as UtAddrExpression
+            val newAddr = addr.accept(solver.simplificator) as UtAddrExpression
             val parameterizedType = when (newAddr.internal) {
                 is UtArraySelectExpression -> parameterAddrToGenericType[findTheMostNestedAddr(newAddr.internal)]
                 is UtBvConst -> parameterAddrToGenericType[newAddr]
@@ -3420,11 +3407,9 @@ class Traverser(
         val symException = implicitThrown(exception, findNewAddr(), environment.state.isInNestedMethod())
         if (!traverseCatchBlock(environment.state.stmt, symException, conditions)) {
             environment.state.expectUndefined()
-            val nextState = environment.state.createExceptionState(
+            val nextState = createExceptionStateQueued(
                 symException,
-                queuedSymbolicStateUpdates
-                        + conditions.asHardConstraint()
-                        + softConditions.asSoftConstraint()
+                SymbolicStateUpdate(conditions.asHardConstraint(), softConditions.asSoftConstraint())
             )
             globalGraph.registerImplicitEdge(nextState.lastEdge!!)
             offerState(nextState)
@@ -3564,7 +3549,7 @@ class Traverser(
                 MemoryUpdate() // all memory updates are already added in [environment.state]
             }
             val methodResultWithUpdates = methodResult.copy(symbolicStateUpdate = queuedSymbolicStateUpdates + updates)
-            val stateToOffer = environment.state.pop(methodResultWithUpdates)
+            val stateToOffer = pop(methodResultWithUpdates)
             offerState(stateToOffer)
 
             logger.trace { "processResult<${environment.method.signature}> return from nested method" }
@@ -3603,5 +3588,65 @@ class Traverser(
         } finally {
              queuedSymbolicStateUpdates = prevSymbolicStateUpdate
         }
+    }
+
+    private fun createExceptionStateQueued(exception: SymbolicFailure, update: SymbolicStateUpdate): ExecutionState {
+        val simplifiedUpdates = with (memoryUpdateSimplificator) {
+            simplifySymbolicStateUpdate(queuedSymbolicStateUpdates + update)
+        }
+        val simplifiedResult = with(simplificator) {
+            simplifySymbolicValue(exception.symbolic)
+        }
+        return environment.state.createExceptionState(
+            exception.copy(symbolic = simplifiedResult),
+            update = simplifiedUpdates
+        )
+    }
+
+    private fun updateQueued(update: SymbolicStateUpdate): ExecutionState {
+        val symbolicStateUpdate = with(memoryUpdateSimplificator) {
+            simplifySymbolicStateUpdate(queuedSymbolicStateUpdates + update)
+        }
+
+        return environment.state.update(
+            symbolicStateUpdate,
+        )
+    }
+
+    private fun updateQueued(
+        edge: Edge,
+        update: SymbolicStateUpdate = SymbolicStateUpdate(),
+        doesntThrow: Boolean = false
+    ): ExecutionState {
+        val simplifiedUpdates =
+            with(memoryUpdateSimplificator) {
+                simplifySymbolicStateUpdate(queuedSymbolicStateUpdates + update)
+            }
+
+        return environment.state.update(
+            edge,
+            simplifiedUpdates,
+            doesntThrow
+        )
+    }
+
+    private fun pushQueued(
+        graph: ExceptionalUnitGraph,
+        parametersWithThis: List<SymbolicValue>,
+        hardConstraint: HardConstraint
+    ): ExecutionState {
+        val simplifiedUpdates = with(memoryUpdateSimplificator) {
+            simplifySymbolicStateUpdate(queuedSymbolicStateUpdates + hardConstraint)
+        }
+        return environment.state.push(
+            graph.head,
+            inputArguments = ArrayDeque(parametersWithThis),
+            simplifiedUpdates,
+            graph.body.method
+        )
+    }
+
+    private fun pop(methodResultWithUpdates: MethodResult): ExecutionState {
+        return environment.state.pop(methodResultWithUpdates)
     }
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -66,6 +66,15 @@ import org.utbot.engine.pc.mkNot
 import org.utbot.engine.pc.mkOr
 import org.utbot.engine.pc.select
 import org.utbot.engine.pc.store
+import org.utbot.engine.state.Edge
+import org.utbot.engine.state.ExecutionState
+import org.utbot.engine.state.LocalVariableMemory
+import org.utbot.engine.state.StateLabel
+import org.utbot.engine.state.createExceptionState
+import org.utbot.engine.state.pop
+import org.utbot.engine.state.push
+import org.utbot.engine.state.update
+import org.utbot.engine.state.withLabel
 import org.utbot.engine.symbolic.emptyAssumption
 import org.utbot.engine.symbolic.emptyHardConstraint
 import org.utbot.engine.symbolic.emptySoftConstraint

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
@@ -101,6 +101,9 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.job
 import kotlinx.coroutines.yield
+import org.utbot.engine.state.ExecutionStackElement
+import org.utbot.engine.state.ExecutionState
+import org.utbot.engine.state.StateLabel
 import org.utbot.engine.types.TypeRegistry
 import org.utbot.engine.types.TypeResolver
 import org.utbot.framework.plugin.api.UtExecutionSuccess

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/pc/Query.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/pc/Query.kt
@@ -82,7 +82,7 @@ class UnsatQuery(hard: PersistentSet<UtBoolExpression>) : BaseQuery(
 /**
  * Query of UtExpressions with applying simplifications if [useExpressionSimplification] is true.
  *
- * @see RewritingVisitor
+ * @see Simplificator
  *
  * @param eqs - map that matches symbolic expressions with concrete values.
  * @param lts - map of upper bounds of integral symbolic expressions.
@@ -99,10 +99,10 @@ data class Query(
     private val gts: PersistentMap<UtExpression, Long> = persistentHashMapOf()
 ) : BaseQuery(hard, soft, assumptions, status, lastAdded) {
 
-    val rewriter: RewritingVisitor
-        get() = RewritingVisitor(eqs, lts, gts)
+    val rewriter: Simplificator
+        get() = Simplificator(eqs, lts, gts)
 
-    private fun UtBoolExpression.simplify(visitor: RewritingVisitor): UtBoolExpression =
+    private fun UtBoolExpression.simplify(visitor: Simplificator): UtBoolExpression =
         this.accept(visitor) as UtBoolExpression
 
     private fun simplifyGeneric(expr: UtBoolExpression): UtBoolExpression =
@@ -132,7 +132,7 @@ data class Query(
         eqs: Map<UtExpression, UtExpression> = this@Query.eqs,
         lts: Map<UtExpression, Long> = this@Query.lts,
         gts: Map<UtExpression, Long> = this@Query.gts
-    ) = AxiomInstantiationRewritingVisitor(eqs, lts, gts).let { visitor ->
+    ) = AxiomInstantiationSimplificator(eqs, lts, gts).let { visitor ->
         this.map { it.simplify(visitor) }
             .map { simplifyGeneric(it) }
             .flatMap { splitAnd(it) } + visitor.instantiatedArrayAxioms

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/pc/Query.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/pc/Query.kt
@@ -99,7 +99,7 @@ data class Query(
     private val gts: PersistentMap<UtExpression, Long> = persistentHashMapOf()
 ) : BaseQuery(hard, soft, assumptions, status, lastAdded) {
 
-    val rewriter: Simplificator
+    val simplificator: Simplificator
         get() = Simplificator(eqs, lts, gts)
 
     private fun UtBoolExpression.simplify(visitor: Simplificator): UtBoolExpression =

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/pc/UtSolver.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/pc/UtSolver.kt
@@ -151,8 +151,8 @@ data class UtSolver constructor(
     //protection against solver reusage
     private var canBeCloned: Boolean = true
 
-    val rewriter: RewritingVisitor
-        get() = constraints.let { if (it is Query) it.rewriter else RewritingVisitor() }
+    val simplificator: Simplificator
+        get() = constraints.let { if (it is Query) it.rewriter else Simplificator() }
 
     /**
      * Returns the current status of the constraints.

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/pc/UtSolver.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/pc/UtSolver.kt
@@ -152,7 +152,7 @@ data class UtSolver constructor(
     private var canBeCloned: Boolean = true
 
     val simplificator: Simplificator
-        get() = constraints.let { if (it is Query) it.rewriter else Simplificator() }
+        get() = constraints.let { if (it is Query) it.simplificator else Simplificator() }
 
     /**
      * Returns the current status of the constraints.

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/pc/UtSolverStatus.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/pc/UtSolverStatus.kt
@@ -40,16 +40,12 @@ data class UtSolverStatusUNSAT(override val statusKind: UtSolverStatusKind) : Ut
 }
 
 class UtSolverStatusSAT(
-    private val translator: Z3TranslatorVisitor,
+    translator: Z3TranslatorVisitor,
     z3Solver: Solver
 ) : UtSolverStatus(SAT) {
     private val model = z3Solver.model
 
     private val evaluator: Z3EvaluatorVisitor = translator.evaluator(model)
-
-    //TODO put special markers inside expressionTranslationCache for detecting circular dependencies
-    fun translate(expression: UtExpression): Expr =
-        translator.translate(expression)
 
     fun eval(expression: UtExpression): Expr = evaluator.eval(expression)
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/BFSSelector.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/BFSSelector.kt
@@ -1,6 +1,6 @@
 package org.utbot.engine.selectors
 
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.selectors.strategies.ChoosingStrategy
 import org.utbot.engine.selectors.strategies.StoppingStrategy
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/BasePathSelector.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/BasePathSelector.kt
@@ -1,6 +1,6 @@
 package org.utbot.engine.selectors
 
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.isPreconditionCheckMethod
 import org.utbot.engine.pathLogger
 import org.utbot.engine.pc.UtSolver

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/DFSSelector.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/DFSSelector.kt
@@ -1,6 +1,6 @@
 package org.utbot.engine.selectors
 
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.selectors.strategies.ChoosingStrategy
 import org.utbot.engine.selectors.strategies.StoppingStrategy
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/InterleavedSelector.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/InterleavedSelector.kt
@@ -1,6 +1,6 @@
 package org.utbot.engine.selectors
 
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.ExecutionState
 
 /**
  * Retrieves states from different pathSelectors in rotation.

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/MLSelector.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/MLSelector.kt
@@ -2,7 +2,7 @@ package org.utbot.engine.selectors
 
 import org.utbot.analytics.EngineAnalyticsContext
 import org.utbot.analytics.Predictors
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.InterProceduralUnitGraph
 import org.utbot.engine.selectors.nurs.GreedySearch
 import org.utbot.engine.selectors.strategies.ChoosingStrategy

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/PathSelector.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/PathSelector.kt
@@ -1,6 +1,6 @@
 package org.utbot.engine.selectors
 
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.pc.UtSolverStatusKind
 
 /**

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/PathsTree.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/PathsTree.kt
@@ -1,6 +1,6 @@
 package org.utbot.engine.selectors
 
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.ExecutionState
 import java.util.NoSuchElementException
 import kotlin.random.Random
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/RandomPathSelector.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/RandomPathSelector.kt
@@ -1,6 +1,6 @@
 package org.utbot.engine.selectors
 
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.selectors.strategies.ChoosingStrategy
 import org.utbot.engine.selectors.strategies.StoppingStrategy
 import kotlin.random.Random

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/RandomSelector.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/RandomSelector.kt
@@ -1,6 +1,6 @@
 package org.utbot.engine.selectors
 
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.selectors.strategies.ChoosingStrategy
 import org.utbot.engine.selectors.strategies.StoppingStrategy
 import kotlin.random.Random

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/nurs/CPInstSelector.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/nurs/CPInstSelector.kt
@@ -1,6 +1,6 @@
 package org.utbot.engine.selectors.nurs
 
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.selectors.strategies.ChoosingStrategy
 import org.utbot.engine.selectors.strategies.StatementsStatistics
 import org.utbot.engine.selectors.strategies.StoppingStrategy

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/nurs/CoveredNewSelector.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/nurs/CoveredNewSelector.kt
@@ -1,6 +1,6 @@
 package org.utbot.engine.selectors.nurs
 
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.selectors.strategies.DistanceStatistics
 import org.utbot.engine.selectors.strategies.StoppingStrategy
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/nurs/DepthSelector.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/nurs/DepthSelector.kt
@@ -1,6 +1,6 @@
 package org.utbot.engine.selectors.nurs
 
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.selectors.strategies.ChoosingStrategy
 import org.utbot.engine.selectors.strategies.StoppingStrategy
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/nurs/ForkDepthSelector.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/nurs/ForkDepthSelector.kt
@@ -1,6 +1,6 @@
 package org.utbot.engine.selectors.nurs
 
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.selectors.strategies.ChoosingStrategy
 import org.utbot.engine.selectors.strategies.StoppingStrategy
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/nurs/GreedySearch.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/nurs/GreedySearch.kt
@@ -1,6 +1,6 @@
 package org.utbot.engine.selectors.nurs
 
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.selectors.BasePathSelector
 import org.utbot.engine.selectors.strategies.ChoosingStrategy
 import org.utbot.engine.selectors.strategies.StoppingStrategy

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/nurs/InheritorsSelector.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/nurs/InheritorsSelector.kt
@@ -1,6 +1,6 @@
 package org.utbot.engine.selectors.nurs
 
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.types.TypeRegistry
 import org.utbot.engine.selectors.strategies.DistanceStatistics
 import org.utbot.engine.selectors.strategies.StoppingStrategy

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/nurs/MinimalDistanceToUncovered.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/nurs/MinimalDistanceToUncovered.kt
@@ -1,6 +1,6 @@
 package org.utbot.engine.selectors.nurs
 
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.selectors.strategies.DistanceStatistics
 import org.utbot.engine.selectors.strategies.StoppingStrategy
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/nurs/NeuroSatSelector.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/nurs/NeuroSatSelector.kt
@@ -1,7 +1,7 @@
 package org.utbot.engine.selectors.nurs
 
 import org.utbot.analytics.Predictors
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.selectors.strategies.ChoosingStrategy
 import org.utbot.engine.selectors.strategies.StoppingStrategy
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/nurs/NonUniformRandomSearch.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/nurs/NonUniformRandomSearch.kt
@@ -1,6 +1,6 @@
 package org.utbot.engine.selectors.nurs
 
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.selectors.BasePathSelector
 import org.utbot.engine.selectors.strategies.ChoosingStrategy
 import org.utbot.engine.selectors.strategies.StoppingStrategy

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/nurs/RPSelector.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/nurs/RPSelector.kt
@@ -1,6 +1,6 @@
 package org.utbot.engine.selectors.nurs
 
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.selectors.strategies.ChoosingStrategy
 import org.utbot.engine.selectors.strategies.StoppingStrategy
 import kotlin.math.pow

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/nurs/SubpathGuidedSelector.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/nurs/SubpathGuidedSelector.kt
@@ -1,6 +1,6 @@
 package org.utbot.engine.selectors.nurs
 
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.selectors.strategies.ChoosingStrategy
 import org.utbot.engine.selectors.strategies.StoppingStrategy
 import org.utbot.engine.selectors.strategies.SubpathStatistics

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/nurs/VisitCountingSelector.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/nurs/VisitCountingSelector.kt
@@ -1,6 +1,6 @@
 package org.utbot.engine.selectors.nurs
 
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.selectors.strategies.EdgeVisitCountingStatistics
 import org.utbot.engine.selectors.strategies.StoppingStrategy
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/strategies/ChoosingStrategy.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/strategies/ChoosingStrategy.kt
@@ -1,6 +1,6 @@
 package org.utbot.engine.selectors.strategies
 
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.InterProceduralUnitGraph
 
 /**

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/strategies/DistanceStatistics.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/strategies/DistanceStatistics.kt
@@ -1,7 +1,7 @@
 package org.utbot.engine.selectors.strategies
 
-import org.utbot.engine.Edge
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.Edge
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.InterProceduralUnitGraph
 import org.utbot.engine.isReturn
 import org.utbot.engine.pathLogger

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/strategies/EdgeVisitCountingStatistics.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/strategies/EdgeVisitCountingStatistics.kt
@@ -1,7 +1,7 @@
 package org.utbot.engine.selectors.strategies
 
-import org.utbot.engine.Edge
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.Edge
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.InterProceduralUnitGraph
 import org.utbot.engine.pathLogger
 import org.utbot.framework.UtSettings.enableLoggingForDroppedStates

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/strategies/GeneratedTestCountingStatistics.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/strategies/GeneratedTestCountingStatistics.kt
@@ -1,6 +1,6 @@
 package org.utbot.engine.selectors.strategies
 
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.InterProceduralUnitGraph
 
 class GeneratedTestCountingStatistics(

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/strategies/GraphViz.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/strategies/GraphViz.kt
@@ -2,9 +2,9 @@ package org.utbot.engine.selectors.strategies
 
 import mu.KotlinLogging
 import org.utbot.common.FileUtil.createNewFileWithParentDirectories
-import org.utbot.engine.CALL_DECISION_NUM
-import org.utbot.engine.Edge
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.CALL_DECISION_NUM
+import org.utbot.engine.state.Edge
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.InterProceduralUnitGraph
 import org.utbot.engine.isLibraryNonOverriddenClass
 import org.utbot.engine.isReturn
@@ -17,7 +17,6 @@ import soot.toolkits.graph.ExceptionalUnitGraph
 import java.awt.Toolkit
 import java.awt.datatransfer.StringSelection
 import java.io.FileWriter
-import java.nio.file.Files
 import java.nio.file.Paths
 import org.utbot.common.FileUtil
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/strategies/StatementsStatistics.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/strategies/StatementsStatistics.kt
@@ -1,6 +1,6 @@
 package org.utbot.engine.selectors.strategies
 
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.InterProceduralUnitGraph
 import soot.SootMethod
 import soot.jimple.Stmt

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/strategies/StepsLimitStoppingStrategy.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/strategies/StepsLimitStoppingStrategy.kt
@@ -1,7 +1,7 @@
 package org.utbot.engine.selectors.strategies
 
-import org.utbot.engine.Edge
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.Edge
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.InterProceduralUnitGraph
 import org.utbot.engine.pathLogger
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/strategies/SubpathStatistics.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/strategies/SubpathStatistics.kt
@@ -1,8 +1,8 @@
 package org.utbot.engine.selectors.strategies
 
-import org.utbot.engine.CALL_DECISION_NUM
-import org.utbot.engine.Edge
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.CALL_DECISION_NUM
+import org.utbot.engine.state.Edge
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.InterProceduralUnitGraph
 import org.utbot.framework.UtSettings
 import kotlin.math.pow

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/strategies/TraverseGraphStatistics.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/strategies/TraverseGraphStatistics.kt
@@ -1,7 +1,7 @@
 package org.utbot.engine.selectors.strategies
 
-import org.utbot.engine.Edge
-import org.utbot.engine.ExecutionState
+import org.utbot.engine.state.Edge
+import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.InterProceduralUnitGraph
 import soot.jimple.Stmt
 import soot.toolkits.graph.ExceptionalUnitGraph

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/simplificators/MemoryUpdateSimplificator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/simplificators/MemoryUpdateSimplificator.kt
@@ -41,24 +41,24 @@ typealias SymbolicEnumValuesType = PersistentList<ObjectValue>
 class MemoryUpdateSimplificator(
     private val simplificator: Simplificator
 ) : CachingSimplificatorAdapter<MemoryUpdate>() {
-    override fun simplifyImpl(expression: MemoryUpdate): MemoryUpdate {
-        val stores = simplifyStores(expression.stores)
-        val touchedChunkDescriptors = simplifyTocuhedChunkDescriptors(expression.touchedChunkDescriptors)
-        val concrete = simplifyConcrete(expression.concrete)
-        val mockInfos = simplifyMockInfos(expression.mockInfos)
-        val staticInstanceStorage = simplifyStaticInstanceStorage(expression.staticInstanceStorage)
-        val initializedStaticFields = simplifyInitializedStaticFields(expression.initializedStaticFields)
-        val staticFieldsUpdates = simplifyStaticFieldsUpdates(expression.staticFieldsUpdates)
-        val meaningfulStaticFields = simplifyMeaningfulStaticFields(expression.meaningfulStaticFields)
-        val addrToArrayType = simplifyAddrToArrayType(expression.addrToArrayType)
-        val addrToMockInfo = simplifyAddToMockInfo(expression.addrToMockInfo)
-        val visitedValues = simplifyVisitedValues(expression.visitedValues)
-        val touchedAddresses = simplifyTouchedAddresses(expression.touchedAddresses)
-        val classIdToClearStatics = simplifyClassIdToClearStatics(expression.classIdToClearStatics)
-        val instanceFieldReads = simplifyInstanceFieldReads(expression.instanceFieldReads)
+    override fun simplifyImpl(expression: MemoryUpdate): MemoryUpdate = with(expression) {
+        val stores = simplifyStores(stores)
+        val touchedChunkDescriptors = simplifyTouchedChunkDescriptors(touchedChunkDescriptors)
+        val concrete = simplifyConcrete(concrete)
+        val mockInfos = simplifyMockInfos(mockInfos)
+        val staticInstanceStorage = simplifyStaticInstanceStorage(staticInstanceStorage)
+        val initializedStaticFields = simplifyInitializedStaticFields(initializedStaticFields)
+        val staticFieldsUpdates = simplifyStaticFieldsUpdates(staticFieldsUpdates)
+        val meaningfulStaticFields = simplifyMeaningfulStaticFields(meaningfulStaticFields)
+        val addrToArrayType = simplifyAddrToArrayType(addrToArrayType)
+        val addrToMockInfo = simplifyAddrToMockInfo(addrToMockInfo)
+        val visitedValues = simplifyVisitedValues(visitedValues)
+        val touchedAddresses = simplifyTouchedAddresses(touchedAddresses)
+        val classIdToClearStatics = simplifyClassIdToClearStatics(classIdToClearStatics)
+        val instanceFieldReads = simplifyInstanceFieldReads(instanceFieldReads)
         val speculativelyNotNullAddresses =
-            simplifySpeculativelyNotNullAddresses(expression.speculativelyNotNullAddresses)
-        val symbolicEnumValues = simplifyEnumValues(expression.symbolicEnumValues)
+            simplifySpeculativelyNotNullAddresses(speculativelyNotNullAddresses)
+        val symbolicEnumValues = simplifyEnumValues(symbolicEnumValues)
         return MemoryUpdate(
             stores,
             touchedChunkDescriptors,
@@ -90,7 +90,7 @@ class MemoryUpdateSimplificator(
                 }
             }
 
-    private fun simplifyTocuhedChunkDescriptors(touchedChunkDescriptors: TouchedChunkDescriptorsType): TouchedChunkDescriptorsType =
+    private fun simplifyTouchedChunkDescriptors(touchedChunkDescriptors: TouchedChunkDescriptorsType): TouchedChunkDescriptorsType =
         touchedChunkDescriptors
 
     private fun simplifyConcrete(concrete: ConcreteType): ConcreteType =
@@ -131,7 +131,7 @@ class MemoryUpdateSimplificator(
             .toPersistentMap()
 
 
-    private fun simplifyAddToMockInfo(addrToMockInfo: AddrToMockInfoType): AddrToMockInfoType =
+    private fun simplifyAddrToMockInfo(addrToMockInfo: AddrToMockInfoType): AddrToMockInfoType =
         addrToMockInfo
             .mapKeys { (k, _) -> k.accept(simplificator) as UtAddrExpression }
             .toPersistentMap()

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/simplificators/MemoryUpdateSimplificator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/simplificators/MemoryUpdateSimplificator.kt
@@ -1,0 +1,163 @@
+package org.utbot.engine.simplificators
+
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.PersistentMap
+import kotlinx.collections.immutable.PersistentSet
+import kotlinx.collections.immutable.mutate
+import kotlinx.collections.immutable.toPersistentMap
+import kotlinx.collections.immutable.toPersistentSet
+import org.utbot.engine.Concrete
+import org.utbot.engine.InstanceFieldReadOperation
+import org.utbot.engine.MemoryChunkDescriptor
+import org.utbot.engine.MemoryUpdate
+import org.utbot.engine.MockInfoEnriched
+import org.utbot.engine.ObjectValue
+import org.utbot.engine.StaticFieldMemoryUpdateInfo
+import org.utbot.engine.UtMockInfo
+import org.utbot.engine.UtNamedStore
+import org.utbot.engine.pc.Simplificator
+import org.utbot.engine.pc.UtAddrExpression
+import org.utbot.framework.plugin.api.ClassId
+import org.utbot.framework.plugin.api.FieldId
+import soot.ArrayType
+
+typealias StoresType = PersistentList<UtNamedStore>
+typealias TouchedChunkDescriptorsType = PersistentSet<MemoryChunkDescriptor>
+typealias ConcreteType = PersistentMap<UtAddrExpression, Concrete>
+typealias MockInfosType = PersistentList<MockInfoEnriched>
+typealias StaticInstanceStorageType = PersistentMap<ClassId, ObjectValue>
+typealias InitializedStaticFieldsType = PersistentSet<FieldId>
+typealias StaticFieldsUpdatesType = PersistentList<StaticFieldMemoryUpdateInfo>
+typealias MeaningfulStaticFieldsType = PersistentSet<FieldId>
+typealias AddrToArrayTypeType = PersistentMap<UtAddrExpression, ArrayType>
+typealias AddrToMockInfoType = PersistentMap<UtAddrExpression, UtMockInfo>
+typealias VisitedValuesType = PersistentList<UtAddrExpression>
+typealias TouchedAddressesType = PersistentList<UtAddrExpression>
+typealias ClassIdToClearStaticsType = ClassId?
+typealias InstanceFieldReadsType = PersistentSet<InstanceFieldReadOperation>
+typealias SpeculativelyNotNullAddressesType = PersistentList<UtAddrExpression>
+typealias SymbolicEnumValuesType = PersistentList<ObjectValue>
+
+context(Simplificator)
+class MemoryUpdateSimplificator : CachingSimplificatorAdapter<MemoryUpdate>() {
+    override fun simplifyImpl(expression: MemoryUpdate): MemoryUpdate {
+        val stores = simplifyStores(expression.stores)
+        val touchedChunkDescriptors = simplifyTocuhedChunkDescriptors(expression.touchedChunkDescriptors)
+        val concrete = simplifyConcrete(expression.concrete)
+        val mockInfos = simplifyMockInfos(expression.mockInfos)
+        val staticInstanceStorage = simplifyStaticInstanceStorage(expression.staticInstanceStorage)
+        val initializedStaticFields = simplifyInitializedStaticFields(expression.initializedStaticFields)
+        val staticFieldsUpdates = simplifyStaticFieldsUpdates(expression.staticFieldsUpdates)
+        val meaningfulStaticFields = simplifyMeaningfulStaticFields(expression.meaningfulStaticFields)
+        val addrToArrayType = simplifyAddrToArrayType(expression.addrToArrayType)
+        val addrToMockInfo = simplifyAddToMockInfo(expression.addrToMockInfo)
+        val visitedValues = simplifyVisitedValues(expression.visitedValues)
+        val touchedAddresses = simplifyTouchedAddresses(expression.touchedAddresses)
+        val classIdToClearStatics = simplifyClassIdToClearStatics(expression.classIdToClearStatics)
+        val instanceFieldReads = simplifyInstanceFieldReads(expression.instanceFieldReads)
+        val speculativelyNotNullAddresses =
+            simplifySpeculativelyNotNullAddresses(expression.speculativelyNotNullAddresses)
+        val symbolicEnumValues = simplifyEnumValues(expression.symbolicEnumValues)
+        return MemoryUpdate(
+            stores,
+            touchedChunkDescriptors,
+            concrete,
+            mockInfos,
+            staticInstanceStorage,
+            initializedStaticFields,
+            staticFieldsUpdates,
+            meaningfulStaticFields,
+            addrToArrayType,
+            addrToMockInfo,
+            visitedValues,
+            touchedAddresses,
+            classIdToClearStatics,
+            instanceFieldReads,
+            speculativelyNotNullAddresses,
+            symbolicEnumValues
+        )
+    }
+
+    private fun simplifyStores(stores: StoresType): StoresType =
+        stores
+            .mutate { prevStores ->
+                prevStores.replaceAll { store ->
+                    store.copy(
+                        index = store.index.accept(this@Simplificator),
+                        value = store.value.accept(this@Simplificator)
+                    )
+                }
+            }
+
+    private fun simplifyTocuhedChunkDescriptors(touchedChunkDescriptors: TouchedChunkDescriptorsType): TouchedChunkDescriptorsType =
+        touchedChunkDescriptors
+
+    private fun simplifyConcrete(concrete: ConcreteType): ConcreteType =
+        concrete
+            .mapKeys { (k, _) -> k.accept(this@Simplificator) as UtAddrExpression }
+            .toPersistentMap()
+
+    private fun simplifyMockInfos(mockInfos: MockInfosType): MockInfosType =
+        mockInfos.mutate { prevMockInfos ->
+            prevMockInfos.replaceAll {
+                simplifyMockInfoEnriched(it)
+            }
+        }
+
+
+    private fun simplifyStaticInstanceStorage(staticInstanceStorage: StaticInstanceStorageType): StaticInstanceStorageType =
+        staticInstanceStorage.mutate { prevStorage ->
+            prevStorage.replaceAll { _, v -> simplifySymbolicValue(v) as ObjectValue }
+        }
+
+    private fun simplifyInitializedStaticFields(initializedStaticFields: InitializedStaticFieldsType): InitializedStaticFieldsType =
+        initializedStaticFields
+
+    private fun simplifyStaticFieldsUpdates(staticFieldsUpdates: StaticFieldsUpdatesType): StaticFieldsUpdatesType =
+        staticFieldsUpdates.mutate { prevUpdates ->
+            prevUpdates.replaceAll { staticFieldMemoryUpdateInfo(it) }
+        }
+
+    private fun simplifyMeaningfulStaticFields(meaningfulStaticFields: MeaningfulStaticFieldsType): MeaningfulStaticFieldsType =
+        meaningfulStaticFields
+
+
+    private fun simplifyAddrToArrayType(addrToArrayType: AddrToArrayTypeType): AddrToArrayTypeType =
+        addrToArrayType
+            .mapKeys { (k, _) -> k.accept(this@Simplificator) as UtAddrExpression }
+            .toPersistentMap()
+
+
+    private fun simplifyAddToMockInfo(addrToMockInfo: AddrToMockInfoType): AddrToMockInfoType =
+        addrToMockInfo
+            .mapKeys { (k, _) -> k.accept(this@Simplificator) as UtAddrExpression }
+            .toPersistentMap()
+
+    private fun simplifyVisitedValues(visitedValues: VisitedValuesType): VisitedValuesType =
+        visitedValues.mutate { prevValues ->
+            prevValues.replaceAll { it.accept(this@Simplificator) as UtAddrExpression }
+        }
+
+    private fun simplifyTouchedAddresses(touchedAddresses: TouchedAddressesType): TouchedAddressesType =
+        touchedAddresses.mutate { prevAddresses ->
+            prevAddresses.replaceAll { it.accept(this@Simplificator) as UtAddrExpression }
+        }
+
+    private fun simplifyClassIdToClearStatics(classIdToClearStatics: ClassIdToClearStaticsType): ClassIdToClearStaticsType =
+        classIdToClearStatics
+
+    private fun simplifyInstanceFieldReads(instanceFieldReads: InstanceFieldReadsType): InstanceFieldReadsType =
+        instanceFieldReads
+            .map { it.copy(addr = it.addr.accept(this@Simplificator) as UtAddrExpression) }
+            .toPersistentSet()
+
+    private fun simplifySpeculativelyNotNullAddresses(speculativelyNotNullAddresses: SpeculativelyNotNullAddressesType): SpeculativelyNotNullAddressesType =
+        speculativelyNotNullAddresses.mutate { prevAddresses ->
+            prevAddresses.replaceAll { it.accept(this@Simplificator) as UtAddrExpression }
+        }
+
+    private fun simplifyEnumValues(symbolicEnumValues: SymbolicEnumValuesType): SymbolicEnumValuesType =
+        symbolicEnumValues.mutate { values ->
+            values.replaceAll { simplifySymbolicValue(it) as ObjectValue }
+        }
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/simplificators/SimplificatorAdapter.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/simplificators/SimplificatorAdapter.kt
@@ -1,0 +1,18 @@
+package org.utbot.engine.simplificators
+
+import java.util.IdentityHashMap
+
+
+interface SimplificatorAdapter<T> {
+    fun simplify(expression: T): T
+}
+
+abstract class CachingSimplificatorAdapter<T> : SimplificatorAdapter<T> {
+    private val cache: IdentityHashMap<T, T> = IdentityHashMap()
+
+    final override fun simplify(expression: T): T =
+        cache.getOrPut(expression) { simplifyImpl(expression) }
+
+    protected abstract fun simplifyImpl(expression: T): T
+}
+

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/simplificators/Util.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/simplificators/Util.kt
@@ -1,0 +1,68 @@
+package org.utbot.engine.simplificators
+
+import org.utbot.engine.ArrayValue
+import org.utbot.engine.MockInfoEnriched
+import org.utbot.engine.ObjectValue
+import org.utbot.engine.PrimitiveValue
+import org.utbot.engine.StaticFieldMemoryUpdateInfo
+import org.utbot.engine.SymbolicValue
+import org.utbot.engine.UtFieldMockInfo
+import org.utbot.engine.UtMockInfo
+import org.utbot.engine.UtNewInstanceMockInfo
+import org.utbot.engine.UtObjectMockInfo
+import org.utbot.engine.UtStaticMethodMockInfo
+import org.utbot.engine.UtStaticObjectMockInfo
+import org.utbot.engine.pc.Simplificator
+import org.utbot.engine.pc.UtAddrExpression
+import org.utbot.engine.symbolic.SymbolicStateUpdate
+
+context(Simplificator)
+fun staticFieldMemoryUpdateInfo(staticFieldMemoryUpdateInfo: StaticFieldMemoryUpdateInfo) =
+    with(staticFieldMemoryUpdateInfo) {
+        copy(value = simplifySymbolicValue(value))
+    }
+
+context(Simplificator)
+fun simplifyMockInfoEnriched(mockInfoEnriched: MockInfoEnriched): MockInfoEnriched {
+    val mockInfo: UtMockInfo = simplifyUtMockInfo(mockInfoEnriched.mockInfo)
+    val executables = mockInfoEnriched.executables.mapValues { (_, mockExecutableInstances) ->
+        mockExecutableInstances.map { mockExecutableInstance ->
+            with(mockExecutableInstance) {
+                val symbolicValue = simplifySymbolicValue(value)
+                copy(value = symbolicValue)
+            }
+        }
+    }
+
+    return MockInfoEnriched(mockInfo, executables)
+}
+
+context(Simplificator)
+fun simplifyUtMockInfo(mockInfo: UtMockInfo): UtMockInfo =
+    with(mockInfo) {
+        when (this) {
+            is UtFieldMockInfo -> copy(ownerAddr = ownerAddr?.accept(this@Simplificator) as UtAddrExpression?)
+            is UtNewInstanceMockInfo -> copy(addr = addr.accept(this@Simplificator) as UtAddrExpression)
+            is UtObjectMockInfo -> copy(addr = addr.accept(this@Simplificator) as UtAddrExpression)
+            is UtStaticMethodMockInfo -> copy(addr = addr.accept(this@Simplificator) as UtAddrExpression)
+            is UtStaticObjectMockInfo -> copy(addr = addr.accept(this@Simplificator) as UtAddrExpression)
+        }
+    }
+
+context(Simplificator)
+fun simplifySymbolicValue(value: SymbolicValue): SymbolicValue =
+    with(value) {
+        when (this) {
+            is PrimitiveValue -> copy(expr = expr.accept(this@Simplificator))
+            is ArrayValue -> copy(addr = addr.accept(this@Simplificator) as UtAddrExpression)
+            is ObjectValue -> copy(addr = addr.accept(this@Simplificator) as UtAddrExpression)
+        }
+    }
+
+
+context(MemoryUpdateSimplificator)
+fun simplifySymbolicStateUpdate(update: SymbolicStateUpdate) =
+    with(update) {
+        val memoryUpdates = simplify(memoryUpdates)
+        copy(memoryUpdates = memoryUpdates)
+    }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/state/ExecutionStackElement.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/state/ExecutionStackElement.kt
@@ -1,0 +1,58 @@
+package org.utbot.engine.state
+
+import kotlinx.collections.immutable.PersistentMap
+import kotlinx.collections.immutable.persistentHashMapOf
+import org.utbot.engine.LocalMemoryUpdate
+import org.utbot.engine.LocalVariable
+import org.utbot.engine.Parameter
+import org.utbot.engine.SymbolicValue
+//import org.utbot.engine.symbolic.simplificators.LocalMemoryUpdateSimplificator
+import org.utbot.engine.update
+import soot.SootMethod
+import soot.jimple.Stmt
+
+/**
+ * The stack element of the [ExecutionState].
+ * Contains properties, that are suitable for specified method in call stack.
+ *
+ * @param doesntThrow if true, then engine should drop states with throwing exceptions.
+ * @param localVariableMemory the local memory associated with the current stack element.
+ */
+data class ExecutionStackElement(
+    val caller: Stmt?,
+    val localVariableMemory: LocalVariableMemory = LocalVariableMemory(),
+    val parameters: MutableList<Parameter> = mutableListOf(),
+    val inputArguments: ArrayDeque<SymbolicValue> = ArrayDeque(),
+    val doesntThrow: Boolean = false,
+    val method: SootMethod,
+) {
+    fun update(memoryUpdate: LocalMemoryUpdate, doesntThrow: Boolean = this.doesntThrow) =
+        this.copy(localVariableMemory = localVariableMemory.update(memoryUpdate), doesntThrow = doesntThrow)
+}
+
+/**
+ * Represents a memory associated with a certain method call. For now consists only of local variables mapping.
+ * TODO: think on other fields later
+ *
+ * @param [locals] represents a mapping from [LocalVariable]s of a specific method call to [SymbolicValue]s.
+ */
+data class LocalVariableMemory(
+    private val locals: PersistentMap<LocalVariable, SymbolicValue> = persistentHashMapOf()
+) {
+    fun memoryForNestedMethod(): LocalVariableMemory = this.copy(locals = persistentHashMapOf())
+
+    fun update(update: LocalMemoryUpdate): LocalVariableMemory = this.copy(locals = locals.update(update.locals))
+
+    /**
+     * Returns local variable value.
+     */
+    fun local(variable: LocalVariable): SymbolicValue? = locals[variable]
+
+    val localValues: Set<SymbolicValue>
+        get() = locals.values.toSet()
+}
+//
+//context(LocalMemoryUpdateSimplificator)
+//fun updateSimplified(localVariableMemory: LocalVariableMemory, update: LocalMemoryUpdate): LocalVariableMemory {
+//    return localVariableMemory.update(simplify(update))
+//}

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/state/ExecutionStackElement.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/state/ExecutionStackElement.kt
@@ -6,7 +6,6 @@ import org.utbot.engine.LocalMemoryUpdate
 import org.utbot.engine.LocalVariable
 import org.utbot.engine.Parameter
 import org.utbot.engine.SymbolicValue
-//import org.utbot.engine.symbolic.simplificators.LocalMemoryUpdateSimplificator
 import org.utbot.engine.update
 import soot.SootMethod
 import soot.jimple.Stmt
@@ -32,7 +31,7 @@ data class ExecutionStackElement(
 
 /**
  * Represents a memory associated with a certain method call. For now consists only of local variables mapping.
- * TODO: think on other fields later
+ * TODO: think on other fields later: [#339](https://github.com/UnitTestBot/UTBotJava/issues/339) [#340](https://github.com/UnitTestBot/UTBotJava/issues/340)
  *
  * @param [locals] represents a mapping from [LocalVariable]s of a specific method call to [SymbolicValue]s.
  */
@@ -51,8 +50,3 @@ data class LocalVariableMemory(
     val localValues: Set<SymbolicValue>
         get() = locals.values.toSet()
 }
-//
-//context(LocalMemoryUpdateSimplificator)
-//fun updateSimplified(localVariableMemory: LocalVariableMemory, update: LocalMemoryUpdate): LocalVariableMemory {
-//    return localVariableMemory.update(simplify(update))
-//}

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/state/ExecutionState.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/state/ExecutionState.kt
@@ -1,4 +1,4 @@
-package org.utbot.engine
+package org.utbot.engine.state
 
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.PersistentMap
@@ -6,18 +6,22 @@ import kotlinx.collections.immutable.PersistentSet
 import kotlinx.collections.immutable.persistentHashMapOf
 import kotlinx.collections.immutable.persistentHashSetOf
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.plus
 import org.utbot.common.md5
+import org.utbot.engine.Memory
+import org.utbot.engine.MethodResult
+import org.utbot.engine.SymbolicFailure
 import org.utbot.engine.pc.UtSolver
 import org.utbot.engine.pc.UtSolverStatusUNDEFINED
+import org.utbot.engine.state.StateLabel.CONCRETE
+import org.utbot.engine.state.StateLabel.INTERMEDIATE
+import org.utbot.engine.state.StateLabel.TERMINAL
+import org.utbot.engine.symbolic.Assumption
 import org.utbot.engine.symbolic.SymbolicState
-import org.utbot.engine.symbolic.SymbolicStateUpdate
 import org.utbot.framework.UtSettings
 import org.utbot.framework.plugin.api.Step
 import soot.SootMethod
 import soot.jimple.Stmt
 import java.util.Objects
-import org.utbot.engine.symbolic.Assumption
 
 const val RETURN_DECISION_NUM = -1
 const val CALL_DECISION_NUM = -2
@@ -57,25 +61,6 @@ enum class StateLabel {
     INTERMEDIATE,
     TERMINAL,
     CONCRETE
-}
-
-/**
- * The stack element of the [ExecutionState].
- * Contains properties, that are suitable for specified method in call stack.
- *
- * @param doesntThrow if true, then engine should drop states with throwing exceptions.
- * @param localVariableMemory the local memory associated with the current stack element.
- */
-data class ExecutionStackElement(
-    val caller: Stmt?,
-    val localVariableMemory: LocalVariableMemory = LocalVariableMemory(),
-    val parameters: MutableList<Parameter> = mutableListOf(),
-    val inputArguments: ArrayDeque<SymbolicValue> = ArrayDeque(),
-    val doesntThrow: Boolean = false,
-    val method: SootMethod,
-) {
-    fun update(memoryUpdate: LocalMemoryUpdate, doesntThrow: Boolean = this.doesntThrow) =
-        this.copy(localVariableMemory = localVariableMemory.update(memoryUpdate), doesntThrow = doesntThrow)
 }
 
 /**
@@ -148,14 +133,14 @@ data class ExecutionState(
     val lastMethod: SootMethod? = null,
     val methodResult: MethodResult? = null,
     val exception: SymbolicFailure? = null,
-    val label: StateLabel = StateLabel.INTERMEDIATE,
-    private var stateAnalyticsProperties: StateAnalyticsProperties = StateAnalyticsProperties()
+    val label: StateLabel = INTERMEDIATE,
+    var stateAnalyticsProperties: StateAnalyticsProperties = StateAnalyticsProperties()
 ) : AutoCloseable {
     val solver: UtSolver by symbolicState::solver
 
     val memory: Memory by symbolicState::memory
 
-    private var outgoingEdges = 0
+    var outgoingEdges = 0
 
     fun isInNestedMethod() = executionStack.size > 1
 
@@ -181,144 +166,6 @@ data class ExecutionState(
     val isInsideStaticInitializer
         get() = executionStack.any { it.method.isStaticInitializer }
 
-    fun createExceptionState(
-        exception: SymbolicFailure,
-        update: SymbolicStateUpdate
-    ): ExecutionState {
-        val last = executionStack.last()
-        // go to negative indexing below CALL_DECISION_NUM for exceptions
-        val edge = Edge(stmt, stmt, CALL_DECISION_NUM - (++outgoingEdges))
-        return ExecutionState(
-            stmt = stmt,
-            symbolicState = symbolicState + update,
-            executionStack = executionStack.set(executionStack.lastIndex, last.update(update.localMemoryUpdates)),
-            path = path,
-            visitedStatementsHashesToCountInPath = visitedStatementsHashesToCountInPath,
-            decisionPath = decisionPath + edge.decisionNum,
-            edges = edges + edge,
-            stmts = stmts,
-            pathLength = pathLength + 1,
-            lastEdge = edge,
-            lastMethod = executionStack.last().method,
-            exception = exception,
-            label = label,
-            stateAnalyticsProperties = stateAnalyticsProperties.successorProperties(this)
-        )
-    }
-
-    fun pop(methodResult: MethodResult): ExecutionState {
-        val caller = executionStack.last().caller!!
-        val edge = Edge(stmt, caller, RETURN_DECISION_NUM)
-
-        val stmtHashcode = stmt.hashCode()
-        val stmtCountInPath = (visitedStatementsHashesToCountInPath[stmtHashcode] ?: 0) + 1
-
-        return ExecutionState(
-            stmt = caller,
-            symbolicState = symbolicState,
-            executionStack = executionStack.removeAt(executionStack.lastIndex),
-            path = path + stmt,
-            visitedStatementsHashesToCountInPath = visitedStatementsHashesToCountInPath.put(
-                stmtHashcode,
-                stmtCountInPath
-            ),
-            decisionPath = decisionPath + edge.decisionNum,
-            edges = edges + edge,
-            stmts = stmts.putIfAbsent(stmt, pathLength),
-            pathLength = pathLength + 1,
-            lastEdge = edge,
-            lastMethod = executionStack.last().method,
-            methodResult = methodResult,
-            label = label,
-            stateAnalyticsProperties = stateAnalyticsProperties.successorProperties(this)
-        )
-    }
-
-    fun push(
-        stmt: Stmt,
-        inputArguments: ArrayDeque<SymbolicValue>,
-        update: SymbolicStateUpdate,
-        method: SootMethod
-    ): ExecutionState {
-        val edge = Edge(this.stmt, stmt, CALL_DECISION_NUM)
-        val stackElement = ExecutionStackElement(
-            this.stmt,
-            localVariableMemory = localVariableMemory.memoryForNestedMethod().update(update.localMemoryUpdates),
-            inputArguments = inputArguments,
-            method = method,
-            doesntThrow = executionStack.last().doesntThrow
-        )
-        outgoingEdges++
-
-        val stmtHashCode = this.stmt.hashCode()
-        val stmtCountInPath = (visitedStatementsHashesToCountInPath[stmtHashCode] ?: 0) + 1
-
-        return ExecutionState(
-            stmt = stmt,
-            symbolicState = symbolicState.stateForNestedMethod() + update,
-            executionStack = executionStack + stackElement,
-            path = path + this.stmt,
-            visitedStatementsHashesToCountInPath = visitedStatementsHashesToCountInPath.put(
-                stmtHashCode,
-                stmtCountInPath
-            ),
-            decisionPath = decisionPath + edge.decisionNum,
-            edges = edges + edge,
-            stmts = stmts.putIfAbsent(this.stmt, pathLength),
-            pathLength = pathLength + 1,
-            lastEdge = edge,
-            lastMethod = stackElement.method,
-            label = label,
-            stateAnalyticsProperties = stateAnalyticsProperties.successorProperties(this)
-        )
-    }
-
-    fun update(
-        stateUpdate: SymbolicStateUpdate
-    ): ExecutionState {
-        val last = executionStack.last()
-        val stackElement = last.update(stateUpdate.localMemoryUpdates)
-        return copy(
-            symbolicState = symbolicState + stateUpdate,
-            executionStack = executionStack.set(executionStack.lastIndex, stackElement)
-        )
-    }
-
-    fun update(
-        edge: Edge,
-        symbolicStateUpdate: SymbolicStateUpdate,
-        doesntThrow: Boolean,
-    ): ExecutionState {
-        val last = executionStack.last()
-        val stackElement = last.update(
-            symbolicStateUpdate.localMemoryUpdates,
-            last.doesntThrow || doesntThrow
-        )
-        outgoingEdges++
-
-        val stmtHashCode = stmt.hashCode()
-        val stmtCountInPath = (visitedStatementsHashesToCountInPath[stmtHashCode] ?: 0) + 1
-
-        return ExecutionState(
-            stmt = edge.dst,
-            symbolicState = symbolicState + symbolicStateUpdate,
-            executionStack = executionStack.set(executionStack.lastIndex, stackElement),
-            path = path + stmt,
-            visitedStatementsHashesToCountInPath = visitedStatementsHashesToCountInPath.put(
-                stmtHashCode,
-                stmtCountInPath
-            ),
-            decisionPath = decisionPath + edge.decisionNum,
-            edges = edges + edge,
-            stmts = stmts.putIfAbsent(stmt, pathLength),
-            pathLength = pathLength + 1,
-            lastEdge = edge,
-            lastMethod = stackElement.method,
-            label = label,
-            stateAnalyticsProperties = stateAnalyticsProperties.successorProperties(this)
-        )
-    }
-
     /**
      * Tell to solver that states with status [UtSolverStatusUNDEFINED] can be created from current state.
      *
@@ -327,8 +174,6 @@ data class ExecutionState(
     fun expectUndefined() {
         solver.expectUndefined = true
     }
-
-    fun withLabel(newLabel: StateLabel) = copy(label = newLabel)
 
     override fun close() {
         solver.close()
@@ -417,7 +262,7 @@ data class ExecutionState(
 
     private val hashCode by lazy {
         Objects.hash(
-            stmt, symbolicState, executionStack, path, visitedStatementsHashesToCountInPath, decisionPath,
+            stmt, executionStack, path, visitedStatementsHashesToCountInPath, decisionPath,
             edges, stmts, pathLength, lastEdge, lastMethod, methodResult, exception
         )
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/state/ExecutionStateUpdates.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/state/ExecutionStateUpdates.kt
@@ -1,0 +1,152 @@
+package org.utbot.engine.state
+
+import kotlinx.collections.immutable.plus
+import org.utbot.engine.MethodResult
+import org.utbot.engine.SymbolicFailure
+import org.utbot.engine.SymbolicValue
+import org.utbot.engine.putIfAbsent
+import org.utbot.engine.symbolic.SymbolicStateUpdate
+import soot.SootMethod
+import soot.jimple.Stmt
+
+fun ExecutionState.createExceptionState(
+    exception: SymbolicFailure,
+    update: SymbolicStateUpdate
+): ExecutionState {
+    val last = executionStack.last()
+    // go to negative indexing below CALL_DECISION_NUM for exceptions
+    val edge = Edge(stmt, stmt, CALL_DECISION_NUM - (++outgoingEdges))
+    val localMemory = last.update(update.localMemoryUpdates)
+    return ExecutionState(
+        stmt = stmt,
+        symbolicState = symbolicState + update,
+        executionStack = executionStack.set(executionStack.lastIndex, localMemory),
+        path = path,
+        visitedStatementsHashesToCountInPath = visitedStatementsHashesToCountInPath,
+        decisionPath = decisionPath + edge.decisionNum,
+        edges = edges + edge,
+        stmts = stmts,
+        pathLength = pathLength + 1,
+        lastEdge = edge,
+        lastMethod = executionStack.last().method,
+        exception = exception,
+        label = label,
+        stateAnalyticsProperties = stateAnalyticsProperties.successorProperties(this)
+    )
+}
+
+fun ExecutionState.update(
+    edge: Edge,
+    symbolicStateUpdate: SymbolicStateUpdate,
+    doesntThrow: Boolean,
+): ExecutionState {
+    val last = executionStack.last()
+    val stackElement = last.update(
+        symbolicStateUpdate.localMemoryUpdates,
+        last.doesntThrow || doesntThrow
+    )
+    outgoingEdges++
+
+    val stmtHashCode = stmt.hashCode()
+    val stmtCountInPath = (visitedStatementsHashesToCountInPath[stmtHashCode] ?: 0) + 1
+
+    return ExecutionState(
+        stmt = edge.dst,
+        symbolicState = symbolicState + symbolicStateUpdate,
+        executionStack = executionStack.set(executionStack.lastIndex, stackElement),
+        path = path + stmt,
+        visitedStatementsHashesToCountInPath = visitedStatementsHashesToCountInPath.put(
+            stmtHashCode,
+            stmtCountInPath
+        ),
+        decisionPath = decisionPath + edge.decisionNum,
+        edges = edges + edge,
+        stmts = stmts.putIfAbsent(stmt, pathLength),
+        pathLength = pathLength + 1,
+        lastEdge = edge,
+        lastMethod = stackElement.method,
+        label = label,
+        stateAnalyticsProperties = stateAnalyticsProperties.successorProperties(this)
+    )
+}
+
+fun ExecutionState.withLabel(newLabel: StateLabel) = copy(label = newLabel)
+
+
+fun ExecutionState.update(
+    stateUpdate: SymbolicStateUpdate
+): ExecutionState {
+    val last = executionStack.last()
+    val stackElement = last.update(stateUpdate.localMemoryUpdates)
+    return copy(
+        symbolicState = symbolicState + stateUpdate,
+        executionStack = executionStack.set(executionStack.lastIndex, stackElement)
+    )
+}
+
+fun ExecutionState.push(
+    stmt: Stmt,
+    inputArguments: ArrayDeque<SymbolicValue>,
+    update: SymbolicStateUpdate,
+    method: SootMethod
+): ExecutionState {
+    val edge = Edge(this.stmt, stmt, CALL_DECISION_NUM)
+    val stackElement = ExecutionStackElement(
+        this.stmt,
+        localVariableMemory.memoryForNestedMethod().update(update.localMemoryUpdates),
+        inputArguments = inputArguments,
+        method = method,
+        doesntThrow = executionStack.last().doesntThrow
+    )
+    outgoingEdges++
+
+    val stmtHashCode = this.stmt.hashCode()
+    val stmtCountInPath = (visitedStatementsHashesToCountInPath[stmtHashCode] ?: 0) + 1
+
+    return ExecutionState(
+        stmt = stmt,
+        symbolicState = symbolicState.stateForNestedMethod() + update,
+        executionStack = executionStack + stackElement,
+        path = path + this.stmt,
+        visitedStatementsHashesToCountInPath = visitedStatementsHashesToCountInPath.put(
+            stmtHashCode,
+            stmtCountInPath
+        ),
+        decisionPath = decisionPath + edge.decisionNum,
+        edges = edges + edge,
+        stmts = stmts.putIfAbsent(this.stmt, pathLength),
+        pathLength = pathLength + 1,
+        lastEdge = edge,
+        lastMethod = stackElement.method,
+        label = label,
+        stateAnalyticsProperties = stateAnalyticsProperties.successorProperties(this)
+    )
+}
+
+fun ExecutionState.pop(methodResult: MethodResult): ExecutionState {
+    val caller = executionStack.last().caller!!
+    val edge = Edge(stmt, caller, RETURN_DECISION_NUM)
+
+    val stmtHashcode = stmt.hashCode()
+    val stmtCountInPath = (visitedStatementsHashesToCountInPath[stmtHashcode] ?: 0) + 1
+
+    return ExecutionState(
+        stmt = caller,
+        symbolicState = symbolicState,
+        executionStack = executionStack.removeAt(executionStack.lastIndex),
+        path = path + stmt,
+        visitedStatementsHashesToCountInPath = visitedStatementsHashesToCountInPath.put(
+            stmtHashcode,
+            stmtCountInPath
+        ),
+        decisionPath = decisionPath + edge.decisionNum,
+        edges = edges + edge,
+        stmts = stmts.putIfAbsent(stmt, pathLength),
+        pathLength = pathLength + 1,
+        lastEdge = edge,
+        lastMethod = executionStack.last().method,
+        methodResult = methodResult,
+        label = label,
+        stateAnalyticsProperties = stateAnalyticsProperties.successorProperties(this)
+    )
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/symbolic/SymbolicState.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/symbolic/SymbolicState.kt
@@ -35,5 +35,4 @@ data class SymbolicState(
     fun stateForNestedMethod() = copy(
         memory = memory.memoryForNestedMethod()
     )
-
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/types/TypeRegistry.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/types/TypeRegistry.kt
@@ -45,7 +45,7 @@ import org.utbot.engine.pc.mkNot
 import org.utbot.engine.pc.mkOr
 import org.utbot.engine.pc.select
 import org.utbot.engine.pc.store
-import org.utbot.engine.simplifiedNamedStore
+import org.utbot.engine.namedStore
 import org.utbot.engine.symbolic.asHardConstraint
 import org.utbot.engine.toIntValue
 import org.utbot.engine.toPrimitiveValue
@@ -337,8 +337,8 @@ class TypeRegistry {
         val symNumDimensions = mkInt(numDimensions)
 
         val stores = persistentListOf(
-            simplifiedNamedStore(CLASS_REF_TYPE_DESCRIPTOR, addr, typeId),
-            simplifiedNamedStore(CLASS_REF_NUM_DIMENSIONS_DESCRIPTOR, addr, symNumDimensions)
+            namedStore(CLASS_REF_TYPE_DESCRIPTOR, addr, typeId),
+            namedStore(CLASS_REF_NUM_DIMENSIONS_DESCRIPTOR, addr, symNumDimensions)
         )
 
         val touchedDescriptors = persistentSetOf(CLASS_REF_TYPE_DESCRIPTOR, CLASS_REF_NUM_DIMENSIONS_DESCRIPTOR)


### PR DESCRIPTION
# Description

Refactor: 
 - Removed `runBlockingWithCancellationPredicate` in our tests pipeline
 - Moved `ExecutionState` to `org.utbot.engine.state` package. Moved out succeeding operations for `ExecutionState` to `ExecutionStateUpdates.kt`
 - Some minor refactorings

Add:
- A common `Simplifer` which holds a cache for a whole `Traverser`.
- A `MemoryUpdateSimplifier` which simplifies `MemoryUpdate`s.

Problems:
- Also tried to add simplified local memory updates, but didn't succeed. `SetsTest::testSetContainsInteger` was continuously failing. Now they aren't being simplified explicitly, but simplified implicitly with `Traverser::resolve(Value)` function.


## Type of Change

- Refactoring (typos and non-functional changes) 

# How Has This Been Tested?

## Automated Testing

Tests are passing.

## Manual Scenario 

I checked our engine on synthetic test with ~200 groups of array store and array select expressions (see code), and now it's 50 times faster.
```java
public int longMethod(int x, int y) {
    int[] arr = new int[201];
    int cur = 1;

    arr[cur] = arr[cur - 1] + x - y;
    cur++;

    arr[cur] = arr[cur - 1] + x - y;
    cur++;

    // ^^^^
    // 200 times
   
    if (arr[cur - 1] == 400) {
        return 1;
    }
    return 2;
}
```

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] No new warnings
- [x] All tests pass locally with my changes
