### PR TITLE
Loop and recursion states filtering

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -460,7 +460,7 @@ object UtSettings : AbstractSettings(
 
     /**
      * If this value is positive, the symbolic engine will treat results of all method invocations, which depth in call
-     * graph is more than or equals than this value, as unbounded symbolic variables.
+     * stack is more than or equals than this value, as unbounded symbolic variables.
      *
      * 0 by default (do not "mock" deep methods).
      */
@@ -472,7 +472,20 @@ object UtSettings : AbstractSettings(
     var taintAnalysisCallDepthToMock by getIntProperty(8)
 
     /**
-     * Be set to true, this option sets some settings to specific for taint analysis values.
+     * If this value is positive, a path selector for the symbolic engine will strictly drop loop states
+     * if current step is more than this limit.
+     *
+     * 0 by default (do not strictly drop such states).
+     */
+    var loopStepsLimit by getIntProperty(0)
+
+    /**
+     * Value for [loopStepsLimit] in case [useTaintAnalysisMode] is true.
+     */
+    var taintLoopStepsLimit by getIntProperty(3)
+
+    /**
+     * Being set to true, this option sets some settings to specific for taint analysis values.
      *
      * False by default.
      */
@@ -496,6 +509,8 @@ enum class AnalysisMode(private val triggerOption: KMutableProperty0<Boolean>) {
                 useConcreteExecution = false
                 useSandbox = false
                 callDepthToMock = taintAnalysisCallDepthToMock
+                loopStepsLimit = taintLoopStepsLimit
+                pathSelectorType = PathSelectorType.RANDOM_SELECTOR_WITH_LOOP_ITERATIONS_THRESHOLD
             }
     };
 
@@ -555,7 +570,12 @@ enum class PathSelectorType {
     /**
      * [RandomPathSelector]
      */
-    RANDOM_PATH_SELECTOR
+    RANDOM_PATH_SELECTOR,
+
+    /**
+     * [RandomSelectorWithLoopIterationsThreshold]
+     */
+    RANDOM_SELECTOR_WITH_LOOP_ITERATIONS_THRESHOLD
 }
 
 enum class TestSelectionStrategyType {

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
@@ -101,6 +101,7 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.job
 import kotlinx.coroutines.yield
+import org.utbot.engine.selectors.randomSelectorWithLoopIterationsThreshold
 import org.utbot.engine.state.ExecutionStackElement
 import org.utbot.engine.state.ExecutionState
 import org.utbot.engine.state.StateLabel
@@ -156,6 +157,9 @@ private fun pathSelector(graph: InterProceduralUnitGraph, typeRegistry: TypeRegi
             withStepsLimit(pathSelectorStepsLimit)
         }
         PathSelectorType.RANDOM_PATH_SELECTOR -> randomPathSelector(graph, StrategyOption.DISTANCE) {
+            withStepsLimit(pathSelectorStepsLimit)
+        }
+        PathSelectorType.RANDOM_SELECTOR_WITH_LOOP_ITERATIONS_THRESHOLD -> randomSelectorWithLoopIterationsThreshold(graph, StrategyOption.DISTANCE) {
             withStepsLimit(pathSelectorStepsLimit)
         }
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/PathSelectorBuilder.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/PathSelectorBuilder.kt
@@ -17,6 +17,8 @@ import org.utbot.engine.selectors.nurs.NeuroSatSelector
 import org.utbot.engine.selectors.nurs.RPSelector
 import org.utbot.engine.selectors.nurs.SubpathGuidedSelector
 import org.utbot.engine.selectors.nurs.VisitCountingSelector
+import org.utbot.engine.selectors.random.RandomSelector
+import org.utbot.engine.selectors.random.RandomSelectorWithLoopIterationsThreshold
 import org.utbot.engine.selectors.strategies.ChoosingStrategy
 import org.utbot.engine.selectors.strategies.DistanceStatistics
 import org.utbot.engine.selectors.strategies.EdgeVisitCountingStatistics
@@ -137,13 +139,22 @@ fun randomPathSelector(
 ) = RandomPathSelectorBuilder(graph, strategy).apply(builder).build()
 
 /**
- * build [RandomSelector] using [RandomPathSelectorBuilder]
+ * build [RandomSelector] using [RandomSelectorBuilder]
  */
 fun randomSelector(
     graph: InterProceduralUnitGraph,
     strategy: StrategyOption,
     builder: RandomSelectorBuilder.() -> Unit
 ) = RandomSelectorBuilder(graph, strategy).apply(builder).build()
+
+/**
+ * build [RandomSelectorWithLoopIterationsThreshold] using [RandomSelectorWithLoopIterationsThresholdBuilder]
+ */
+fun randomSelectorWithLoopIterationsThreshold(
+    graph: InterProceduralUnitGraph,
+    strategy: StrategyOption,
+    builder: RandomSelectorWithLoopIterationsThresholdBuilder.() -> Unit
+) = RandomSelectorWithLoopIterationsThresholdBuilder(graph, strategy).apply(builder).build()
 
 /**
  * build [RPSelector] using [RPSelectorBuilder]
@@ -399,6 +410,26 @@ class RandomSelectorBuilder internal constructor(
 ) : PathSelectorBuilder<RandomSelector>(graph, context) {
     var seed: Int = seedInPathSelector ?: 42
     override fun build() = RandomSelector(
+        withChoosingStrategy(strategy),
+        requireNotNull(context.stoppingStrategy) { "StoppingStrategy isn't specified" },
+        seed
+    )
+}
+
+/**
+ * Builder for [RandomSelectorWithLoopIterationsThreshold]. Used in [randomSelectorWithLoopIterationsThreshold]
+ *
+ * [RandomSelectorWithLoopIterationsThresholdBuilder.seed] is seed for random generator (default [seedInPathSelector] ?: 42)
+ *
+ * @param strategy [StrategyOption] for choosingStrategy for this PathSelector
+ */
+class RandomSelectorWithLoopIterationsThresholdBuilder internal constructor(
+    graph: InterProceduralUnitGraph,
+    val strategy: StrategyOption,
+    context: PathSelectorContext = PathSelectorContext(graph)
+) : PathSelectorBuilder<RandomSelectorWithLoopIterationsThreshold>(graph, context) {
+    var seed: Int = seedInPathSelector ?: 42
+    override fun build() = RandomSelectorWithLoopIterationsThreshold(
         withChoosingStrategy(strategy),
         requireNotNull(context.stoppingStrategy) { "StoppingStrategy isn't specified" },
         seed

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/RandomPathSelector.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/RandomPathSelector.kt
@@ -54,8 +54,11 @@ import kotlin.random.Random
  * @see BasePathSelector
  * @see PathSelector
  */
-class RandomPathSelector(choosingStrategy: ChoosingStrategy, stoppingStrategy: StoppingStrategy, seed: Int = 42) :
-    BasePathSelector(choosingStrategy, stoppingStrategy) {
+class RandomPathSelector(
+    choosingStrategy: ChoosingStrategy,
+    stoppingStrategy: StoppingStrategy,
+    seed: Int = 42
+) : BasePathSelector(choosingStrategy, stoppingStrategy) {
     private val tree = PathsTree(Random(seed))
 
     override fun offerImpl(state: ExecutionState) {

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/random/RandomSelector.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/random/RandomSelector.kt
@@ -1,6 +1,7 @@
-package org.utbot.engine.selectors
+package org.utbot.engine.selectors.random
 
 import org.utbot.engine.state.ExecutionState
+import org.utbot.engine.selectors.BasePathSelector
 import org.utbot.engine.selectors.strategies.ChoosingStrategy
 import org.utbot.engine.selectors.strategies.StoppingStrategy
 import kotlin.random.Random
@@ -12,11 +13,14 @@ import kotlin.random.Random
  * @see BasePathSelector
  * @see PathSelector
  */
-class RandomSelector(choosingStrategy: ChoosingStrategy, stoppingStrategy: StoppingStrategy, seed: Int = 42) :
-    BasePathSelector(choosingStrategy, stoppingStrategy) {
-    private val executionStates = mutableListOf<ExecutionState>()
+open class RandomSelector(
+    choosingStrategy: ChoosingStrategy,
+    stoppingStrategy: StoppingStrategy,
+    seed: Int = 42
+) : BasePathSelector(choosingStrategy, stoppingStrategy) {
+    internal val executionStates = mutableListOf<ExecutionState>()
     private val random = Random(seed)
-    private var currentIndex = -1
+    internal var currentIndex = -1
 
     override fun offerImpl(state: ExecutionState) {
         executionStates += state

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/random/RandomSelectorWithLoopIterationsThreshold.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/selectors/random/RandomSelectorWithLoopIterationsThreshold.kt
@@ -1,0 +1,36 @@
+package org.utbot.engine.selectors.random
+
+import org.utbot.engine.selectors.strategies.ChoosingStrategy
+import org.utbot.engine.selectors.strategies.StoppingStrategy
+import org.utbot.engine.state.ExecutionState
+import org.utbot.framework.UtSettings
+
+/**
+ * This selector chooses states like [RandomSelector] does, but drops states from big iteration loops
+ * (based on [UtSettings.loopStepsLimit]).
+ */
+class RandomSelectorWithLoopIterationsThreshold(
+    choosingStrategy: ChoosingStrategy,
+    stoppingStrategy: StoppingStrategy,
+    seed: Int = 42
+) : RandomSelector(choosingStrategy, stoppingStrategy, seed) {
+    override fun offerImpl(state: ExecutionState) {
+        with(state) {
+            val numberOfStmtOccurrencesInPath = visitedStatementsHashesToCountInPath[stmt.hashCode()] ?: 0
+
+            // Drop loop state if it exceeds loop steps limit
+            UtSettings.loopStepsLimit
+                .takeIf { it > 0 }
+                ?.let {
+                    if (numberOfStmtOccurrencesInPath > it) {
+                        return
+                    }
+                }
+        }
+
+        executionStates += state
+        currentIndex = -1
+    }
+
+    override val name: String = this::class.java.simpleName
+}


### PR DESCRIPTION
# Description

Introduced options to drop states from big loop iterations and mock symbolically deep function invocations.

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Automated Testing

For the default pipeline, nothing should change.

## Manual Scenario 

Run `org.utbot.examples.recursion.RecursionTest` and `org.utbot.examples.controlflow.CyclesTest` with `useTaintAnalysisMode = true`.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
