### PR TITLE
Stabilize the behavior of ConstructorAnalyzer

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/modifications/ConstructorAnalyzer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/modifications/ConstructorAnalyzer.kt
@@ -108,18 +108,11 @@ class ConstructorAnalyzer {
         return jimpleLocal.name.first() != '$'
     }
 
-    private val visitedConstructors = mutableSetOf<SootMethod>()
-
     private fun analyze(
         sootConstructor: SootMethod,
         setFields: MutableSet<FieldId>,
         affectedFields: MutableSet<FieldId>,
     ): Map<Int, FieldId> {
-        if (sootConstructor in visitedConstructors) {
-            return emptyMap()
-        }
-        visitedConstructors.add(sootConstructor)
-
         val jimpleBody = retrieveJimpleBody(sootConstructor) ?: return emptyMap()
         analyzeAssignments(jimpleBody, setFields, affectedFields)
 


### PR DESCRIPTION
# Description

Removed `vistiedConstructors` from `ConstructorAnalyzer.analyze()` method. The intention of that container was to prevent from infinite recursion and to increase performance when analyzing chain of constructors. However, it lead to possible errors if the outer method was called more then once. Also, infinite recursion isn't actually possible since recursive constructor calls are forbidden both in Java and Kotlin. Performance changes seems to be miserable. 

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

Tested on the following class -- previously incorrect behavior of `ConstructAnalyzer` lead to unnecessary reflection used for `expected` models, after these changes no reflection is used.

```Kotlin
class NullabilityIssuesExample(val x: Int) {
    fun copyWithX(new_x: Int?): NullabilityIssuesExample? {
        if (new_x == null)
            return null
        return NullabilityIssuesExample(x + new_x)
    }
}
```

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
