### PR TITLE
Fixed FileNotFoundExecption during JavaParser work

### DIFF
--- a/utbot-summary/src/main/kotlin/org/utbot/summary/Summarization.kt
+++ b/utbot-summary/src/main/kotlin/org/utbot/summary/Summarization.kt
@@ -70,7 +70,10 @@ fun UtMethodTestSet.summarize(sourceFile: File?, searchDirectory: Path = Paths.g
 }
 
 fun UtMethodTestSet.summarize(searchDirectory: Path): UtMethodTestSet =
-    this.summarize(Instrumenter.adapter.computeSourceFileByClass(this.method.classId.jClass, searchDirectory), searchDirectory)
+    this.summarize(
+        Instrumenter.adapter.computeSourceFileByClass(this.method.classId.jClass, searchDirectory),
+        searchDirectory
+    )
 
 
 class Summarization(val sourceFile: File?, val invokeDescriptions: List<InvokeDescription>) {
@@ -326,32 +329,34 @@ class Summarization(val sourceFile: File?, val invokeDescriptions: List<InvokeDe
         )
     }
 
-    /*
-    * asts of invokes also included
-    * */
+    /** ASTs of invokes are also included. */
     private fun sootToAST(
         testSet: UtMethodTestSet
     ): MutableMap<SootMethod, JimpleToASTMap>? {
         val sootToAST = mutableMapOf<SootMethod, JimpleToASTMap>()
         val jimpleBody = testSet.jimpleBody
         if (jimpleBody == null) {
-            logger.info { "No jimple body of method under test" }
-            return null
-        }
-        val methodUnderTestAST = sourceFile?.let {
-            SourceCodeParser(it, testSet).methodAST
-        }
-
-        if (methodUnderTestAST == null) {
-            logger.info { "Couldn't parse source file of method under test" }
+            logger.debug { "No jimple body of method under test ${testSet.method.name}." }
             return null
         }
 
-        sootToAST[jimpleBody.method] = JimpleToASTMap(jimpleBody.units, methodUnderTestAST)
-        invokeDescriptions.forEach {
-            sootToAST[it.sootMethod] = JimpleToASTMap(it.sootMethod.jimpleBody().units, it.ast)
+        if (sourceFile != null && sourceFile.exists()) {
+            val methodUnderTestAST = SourceCodeParser(sourceFile, testSet).methodAST
+
+            if (methodUnderTestAST == null) {
+                logger.debug { "Couldn't parse source file with path ${sourceFile.absolutePath} of method under test ${testSet.method.name}." }
+                return null
+            }
+
+            sootToAST[jimpleBody.method] = JimpleToASTMap(jimpleBody.units, methodUnderTestAST)
+            invokeDescriptions.forEach {
+                sootToAST[it.sootMethod] = JimpleToASTMap(it.sootMethod.jimpleBody().units, it.ast)
+            }
+            return sootToAST
+        } else {
+            logger.debug { "Couldn't find source file of method under test ${testSet.method.name}." }
+            return null
         }
-        return sootToAST
     }
 }
 
@@ -386,6 +391,7 @@ private fun makeDiverseExecutions(testSet: UtMethodTestSet) {
 private fun invokeDescriptions(testSet: UtMethodTestSet, searchDirectory: Path): List<InvokeDescription> {
     val sootInvokes =
         testSet.executions.filterIsInstance<UtSymbolicExecution>().flatMap { it.path.invokeJimpleMethods() }.toSet()
+
     return sootInvokes
         //TODO(SAT-1170)
         .filterNot { "\$lambda" in it.declaringClass.name }
@@ -395,10 +401,15 @@ private fun invokeDescriptions(testSet: UtMethodTestSet, searchDirectory: Path):
                 sootMethod.declaringClass.javaPackageName.replace(".", File.separator),
                 searchDirectory
             )
-            val ast = methodFile?.let {
-                SourceCodeParser(sootMethod, it).methodAST
+
+            if (methodFile != null && methodFile.exists()) {
+                val ast = methodFile.let {
+                    SourceCodeParser(sootMethod, it).methodAST
+                }
+                if (ast != null) InvokeDescription(sootMethod, ast) else null
+            } else {
+                null
             }
-            if (ast != null) InvokeDescription(sootMethod, ast) else null
         }
 }
 

--- a/utbot-summary/src/main/kotlin/org/utbot/summary/ast/SourceCodeParser.kt
+++ b/utbot-summary/src/main/kotlin/org/utbot/summary/ast/SourceCodeParser.kt
@@ -36,7 +36,6 @@ class SourceCodeParser {
         val methodName = sootMethod.name
         val className = sootMethod.declaredClassName
 
-
         val maxLineNumber =
             if (sootMethod.hasActiveBody())
                 sootMethod.retrieveActiveBody()?.units?.maxOfOrNull { it.javaSourceStartLineNumber }


### PR DESCRIPTION
# Description

Fixes #1227 #1204 

The main problem was the following: JavaParser tries to parse ZipEntry in zip archive with JDK sources.
ZipEntry is not a file.

To filter this situation, we decided to ignore these zipped sources from the standard library. In reality, we ignored it before @Domonion changes in the #1151 PR. 

We extended our scope and failed when faced with these issues.

The proposed solution helps to avoid situation with parsing of non-existing files and also improves the logging for some edge situations.

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

One of scenarios is described also in the ticket #1204 

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] All tests pass locally with my changes
