### PR TITLE
Test sources root for IntelliJ or Maven project should be suggested to create

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -49,6 +49,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.io.path.pathString
 import org.utbot.intellij.plugin.generator.CodeGenerationController.getAllTestSourceRoots
 import org.utbot.framework.plugin.api.util.LockFile
+import org.utbot.intellij.plugin.ui.utils.isBuildWithGradle
 
 object UtTestsDialogProcessor {
     private val logger = KotlinLogging.logger {}
@@ -105,7 +106,7 @@ object UtTestsDialogProcessor {
             focusedMethods,
             UtSettings.utBotGenerationTimeoutInMillis,
         )
-        if (model.getAllTestSourceRoots().isEmpty()) {
+        if (model.getAllTestSourceRoots().isEmpty() && project.isBuildWithGradle) {
             val errorMessage = """
                 <html>No test source roots found in the project.<br>
                 Please, <a href="https://www.jetbrains.com/help/idea/testing.html#add-test-root">create or configure</a> at least one test source root.


### PR DESCRIPTION
…tically #1302

# Description

In case there is no test roots we should show error dialog for Gradle-based projects only. 
Otherwise "_utbot_tests (will be created)_" is valid case.

Fixes #1302 

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

Configure IntelliJ or Maven project with no test roots. Generation should be available with our auto-created test source root.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
