### PR TITLE
IllegalStateException is thrown in IDEA together with notification th…

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerationController.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerationController.kt
@@ -77,7 +77,7 @@ import org.utbot.intellij.plugin.models.packageName
 import org.utbot.intellij.plugin.process.EngineProcess
 import org.utbot.intellij.plugin.process.RdTestGenerationResult
 import org.utbot.intellij.plugin.sarif.SarifReportIdea
-import org.utbot.intellij.plugin.ui.CommonErrorNotifier
+import org.utbot.intellij.plugin.ui.CommonLoggingNotifier
 import org.utbot.intellij.plugin.ui.DetailsTestsReportNotifier
 import org.utbot.intellij.plugin.ui.SarifReportNotifier
 import org.utbot.intellij.plugin.ui.TestReportUrlOpeningListener
@@ -760,9 +760,12 @@ object CodeGenerationController {
         val project = model.project
         val codeStyleManager = CodeStyleManager.getInstance(project)
         val file = smartPointer.containingFile?: return
-
-        if (file.virtualFile.length > UtSettings.maxTestFileSize) {
-            CommonErrorNotifier.notify(
+        val fileLength = runReadAction {
+            FileDocumentManager.getInstance().getDocument(file.virtualFile)?.textLength
+                ?: file.virtualFile.length.toInt()
+        }
+        if (fileLength > UtSettings.maxTestFileSize && file.name != model.codegenLanguage.utilClassFileName) {
+            CommonLoggingNotifier().notify(
                 "Size of ${file.virtualFile.presentableName} exceeds configured limit " +
                         "(${FileUtil.byteCountToDisplaySize(UtSettings.maxTestFileSize.toLong())}), reformatting was skipped. " +
                         "The limit can be configured in '{HOME_DIR}/.utbot/settings.properties' with 'maxTestFileSize' property",


### PR DESCRIPTION
…at file exceeds configured limit #1295

# Description

1. Here we need a notifier to show informative message AND to log it for further review, copy&paste etc. Balloon is too lightweight to suggest paths, keys and other stuff.
2. For _UtUtils_ file we shouldn't show the warning even if 100 bytes limit is set.
3. Some refactoring in Notifications class as soon as _content_ method mostly returns _info_ argument

Fixes #1295


## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

See the issue

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
