### PR TITLE
Fix the child process logging #1287

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -282,6 +282,15 @@ object UtSettings : AbstractSettings(
      */
     var logConcreteExecutionErrors by getBooleanProperty(false)
 
+
+    /**
+     * Property useful only for idea
+     * If true - runs engine process with the ability to attach a debugger
+     * @see runChildProcessWithDebug
+     * @see org.utbot.intellij.plugin.process.EngineProcess
+     */
+    var runIdeaProcessWithDebug by getBooleanProperty(false)
+
     /**
      * Number of branch instructions using for clustering executions in the test minimization phase.
      */

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/Settings.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/Settings.kt
@@ -30,13 +30,5 @@ object Settings {
      */
     const val runChildProcessWithDebug = false
 
-    /**
-     * Property useful only for idea
-     * If true - runs engine process with the ability to attach a debugger
-     * @see runChildProcessWithDebug
-     * @see org.utbot.intellij.plugin.process.EngineProcess
-     */
-    const val runIdeaProcessWithDebug = false
-
     var defaultConcreteExecutorPoolSize = 10
 }

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/process/EngineProcess.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/process/EngineProcess.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.sync.withLock
 import mu.KotlinLogging
 import org.utbot.common.*
 import org.utbot.framework.UtSettings
+import org.utbot.framework.UtSettings.runIdeaProcessWithDebug
 import org.utbot.framework.codegen.*
 import org.utbot.framework.codegen.model.UtilClassKind
 import org.utbot.framework.plugin.api.*
@@ -29,7 +30,6 @@ import org.utbot.framework.process.generated.*
 import org.utbot.framework.process.generated.Signature
 import org.utbot.framework.util.Conflict
 import org.utbot.framework.util.ConflictTriggers
-import org.utbot.instrumentation.Settings
 import org.utbot.instrumentation.util.KryoHelper
 import org.utbot.intellij.plugin.models.GenerateTestsModel
 import org.utbot.intellij.plugin.ui.TestReportUrlOpeningListener
@@ -96,7 +96,7 @@ class EngineProcess(parent: Lifetime, val project: Project) {
     }
 
     private fun debugArgument(): String {
-        return "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,quiet=y,address=5005".takeIf { Settings.runIdeaProcessWithDebug }
+        return "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,quiet=y,address=5005".takeIf { runIdeaProcessWithDebug }
             ?: ""
     }
 


### PR DESCRIPTION
# Description

RD sends all errors occurred during a request processing to the caller.
If an error happened in the child process, the child process was returning the error to the caller, that is, the main process, without explicitly printing to the log file.

- Added explicit printing of the error to the log
- Moved `runIdeaProcessWithDebug` flag to `UtSettings`.

Fixes #1287

## Type of Change

Please delete options that are not relevant.

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

**To Reproduce** section from #1287 passes.

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] No new warnings
- [x] All tests pass locally with my changes
