### PR TITLE
Put all test sources from the module at the top Test sources root lis…

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/components/TestFolderComboWithBrowseButton.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/components/TestFolderComboWithBrowseButton.kt
@@ -16,7 +16,6 @@ import com.intellij.ui.SimpleTextAttributes
 import com.intellij.util.ArrayUtil
 import com.intellij.util.ui.UIUtil
 import java.io.File
-import java.util.Comparator
 import javax.swing.DefaultComboBoxModel
 import javax.swing.JList
 import org.jetbrains.kotlin.idea.util.rootManager
@@ -97,60 +96,22 @@ class TestFolderComboWithBrowseButton(private val model: GenerateTestsModel) :
                 StringUtil.commonPrefix(commonModuleSourceDirectory, sourceRoot.toNioPath().toString())
             }
         }
-        // The first sorting to obtain the best candidate
-        val testRoots = getAllTestSourceRoots().distinct().sortedWith(object : Comparator<TestSourceRoot> {
-            override fun compare(o1: TestSourceRoot, o2: TestSourceRoot): Int {
-                // Heuristics: Dirs with language == codegenLanguage should go first
-                val languageOrder =
-                    (o1.expectedLanguage == model.codegenLanguage).compareTo(o2.expectedLanguage == model.codegenLanguage)
-                if (languageOrder != 0) return -languageOrder
 
-                // Heuristics: move root that is 'closer' to module 'common' directory to the first position
-                val commonPrefixOrder =
-                    StringUtil.commonPrefixLength(commonModuleSourceDirectory, o1.dir.toNioPath().toString())
-                        .compareTo(
-                            StringUtil.commonPrefixLength(
-                                commonModuleSourceDirectory,
-                                o2.dir.toNioPath().toString()
-                            )
-                        )
-                if (commonPrefixOrder != 0) return -commonPrefixOrder
-
-                //Dir with custom name 'utbot_tests' should go first
-                val customNameOrder = (o1.dir.name == dedicatedTestSourceRootName).compareTo(o2.dir.name == dedicatedTestSourceRootName)
-                if (customNameOrder != 0) return -customNameOrder
-                //Fallback
-                return o1.dir.toNioPath().compareTo(o2.dir.toNioPath())
+        return getAllTestSourceRoots().distinct().toMutableList().sortedWith(
+            compareByDescending<TestSourceRoot> {
+                // Heuristics: Dirs with proper code language should go first
+                it.expectedLanguage == codegenLanguage
+            }.thenByDescending {
+                // Heuristics: Dirs from within module 'common' directory should go first
+                it.dir.toNioPath().toString().startsWith(commonModuleSourceDirectory)
+            }.thenByDescending {
+                // Heuristics: dedicated test source root named 'utbot_tests' should go first
+                it.dir.name == dedicatedTestSourceRootName
+            }.thenBy {
+                // ABC-sorting
+                it.dir.toNioPath()
             }
-        }).toMutableList()
-        val sourceRootsInModule =
-            testRoots.filter { root -> root.dir.toNioPath().toString().startsWith(commonModuleSourceDirectory) }
-                .toMutableList()
-                .sortedWith(compareByDescending { it.dir.toNioPath() })
-
-        val theBest = if (testRoots.isNotEmpty()) testRoots[0] else null
-
-        // The second sorting to make full list ordered
-        testRoots.sortWith(compareByDescending<TestSourceRoot> {
-            // Heuristics: Dirs with language == codegenLanguage should go first
-            it.expectedLanguage == codegenLanguage
-        }.thenBy {
-            // ABC-sorting
-            it.dir.toNioPath()
-        })
-
-        // Test roots from the same module should go first
-        sourceRootsInModule.forEach {
-            testRoots.remove(it)
-            testRoots.add(0, it)
-        }
-
-        // The best candidate should go first to be pre-selected
-        theBest?.let {
-            testRoots.remove(it)
-            testRoots.add(0, it)
-        }
-        return testRoots
+        ).toMutableList()
     }
 
     private fun chooseTestRoot(model: GenerateTestsModel): VirtualFile? =

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/ModuleUtils.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/ModuleUtils.kt
@@ -163,7 +163,7 @@ val Project.isBuildWithGradle get() =
              ExternalSystemApiUtil.isExternalSystemAwareModule(GRADLE_SYSTEM_ID, it)
          }
 
-private const val dedicatedTestSourceRootName = "utbot_tests"
+const val dedicatedTestSourceRootName = "utbot_tests"
 
 fun Module.addDedicatedTestRoot(testSourceRoots: MutableList<TestSourceRoot>, language: CodegenLanguage): VirtualFile? {
     // Don't suggest new test source roots for Gradle project where 'unexpected' test roots won't work


### PR DESCRIPTION
…t #1294

# Description

Sorting has been adjusted to move up all test source roots that 'belong' source module. 
Test root with dedicated name 'utbot_tests' goes first if any.

Fixes #1294

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

See the example steps from the issue

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
