### PR TITLE
Revert parametrized test generation for TestNg

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/Domain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/Domain.kt
@@ -307,24 +307,7 @@ object TestNg : TestFramework(id = "TestNG",displayName = "TestNG") {
     override val nestedClassesShouldBeStatic = true
 
     override val argListClassId: ClassId
-        get() {
-            val outerArrayId = Array<Array<Any?>?>::class.id
-            val innerArrayId = BuiltinClassId(
-                simpleName = objectArrayClassId.simpleName,
-                canonicalName = objectArrayClassId.canonicalName,
-                packageName = objectArrayClassId.packageName,
-                elementClassId = objectClassId,
-                typeParameters = TypeParameters(listOf(objectClassId))
-            )
-
-            return BuiltinClassId(
-                simpleName = outerArrayId.simpleName,
-                canonicalName = outerArrayId.canonicalName,
-                packageName = outerArrayId.packageName,
-                elementClassId = innerArrayId,
-                typeParameters = TypeParameters(listOf(innerArrayId))
-            )
-        }
+        get() = Array<Array<Any?>?>::class.id
 
     @OptIn(ExperimentalStdlibApi::class)
     override fun getRunTestsCommand(


### PR DESCRIPTION
# Description

One old design solution to create one classId as builtin one was replaced in parametrized test method generation
Manually built class id lead to problem when we need to obtain jClass.

Fixes # ([1304](https://github.com/UnitTestBot/UTBotJava/issues/1304))

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

Base sample scenarios for parametrized tests with TestNg
