### PR TITLE
Improve documentation for regions in parametrized tests

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgTestClassConstructor.kt
@@ -232,7 +232,7 @@ internal class CgTestClassConstructor(val context: CgContext) :
         }
 
         regions += CgSimpleRegion(
-            "Additional tests for symbolic executions for method ${methodUnderTest.humanReadableName}",
+            "SYMBOLIC EXECUTION: additional tests for symbolic executions for method ${methodUnderTest.humanReadableName}",
             collectAdditionalSymbolicTestsForParametrizedMode(testSet),
         )
 


### PR DESCRIPTION
# Description

All tests that can't be included into parametrized one in parametrization mode are separated into two regions: for symbolic and fuzzer executions. Also data provider region name improved 

Fixes # ([1301](https://github.com/UnitTestBot/UTBotJava/issues/1301))

## Type of Change

- Refactoring (typos and non-functional changes) 

# How Has This Been Tested?

## Manual Scenario 

Verify that all required regions are generated with appropriate names.