### PR TITLE
Separate CgClassFile and TestsGenerationReport

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/CodeGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/CodeGenerator.kt
@@ -81,11 +81,13 @@ open class CodeGenerator(
     ): CodeGeneratorResult = withCustomContext(testClassCustomName) {
         context.withTestClassFileScope {
             val testClassModel = TestClassModel.fromTestSets(classUnderTest, cgTestSets)
-            val testClassFile = CgTestClassConstructor(context).construct(testClassModel)
+            val cgClassConstructor = CgTestClassConstructor(context)
+            val testClassFile = cgClassConstructor.construct(testClassModel)
+
             CodeGeneratorResult(
                 generatedCode = renderClassFile(testClassFile),
                 utilClassKind = UtilClassKind.fromCgContextOrNull(context),
-                testsGenerationReport = testClassFile.testsGenerationReport
+                testsGenerationReport = cgClassConstructor.testsGenerationReport
             )
         }
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/tree/CgTestClassConstructor.kt
@@ -21,8 +21,8 @@ import org.utbot.framework.codegen.model.tree.CgRegion
 import org.utbot.framework.codegen.model.tree.CgSimpleRegion
 import org.utbot.framework.codegen.model.tree.CgStaticsRegion
 import org.utbot.framework.codegen.model.tree.CgClass
+import org.utbot.framework.codegen.model.tree.CgClassFile
 import org.utbot.framework.codegen.model.tree.CgRealNestedClassesRegion
-import org.utbot.framework.codegen.model.tree.CgTestClassFile
 import org.utbot.framework.codegen.model.tree.CgTestMethod
 import org.utbot.framework.codegen.model.tree.CgTestMethodCluster
 import org.utbot.framework.codegen.model.tree.CgTripleSlashMultilineComment
@@ -30,7 +30,7 @@ import org.utbot.framework.codegen.model.tree.CgUtilEntity
 import org.utbot.framework.codegen.model.tree.CgUtilMethod
 import org.utbot.framework.codegen.model.tree.buildClass
 import org.utbot.framework.codegen.model.tree.buildClassBody
-import org.utbot.framework.codegen.model.tree.buildTestClassFile
+import org.utbot.framework.codegen.model.tree.buildClassFile
 import org.utbot.framework.codegen.model.visitor.importUtilMethodDependencies
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.MethodId
@@ -53,16 +53,15 @@ open class CgTestClassConstructor(val context: CgContext) :
     private val nameGenerator = getNameGeneratorBy(context)
     private val testFrameworkManager = getTestFrameworkManagerBy(context)
 
-    protected val testsGenerationReport: TestsGenerationReport = TestsGenerationReport()
+    val testsGenerationReport = TestsGenerationReport()
 
     /**
      * Given a testClass model  constructs CgTestClass
      */
-    open fun construct(testClassModel: TestClassModel): CgTestClassFile {
-        return buildTestClassFile {
+    open fun construct(testClassModel: TestClassModel): CgClassFile {
+        return buildClassFile {
             this.declaredClass = withTestClassScope { constructTestClass(testClassModel) }
             imports += context.collectedImports
-            testsGenerationReport = this@CgTestClassConstructor.testsGenerationReport
         }
     }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/tree/Builders.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/tree/Builders.kt
@@ -21,16 +21,6 @@ class CgClassFileBuilder : CgBuilder<CgClassFile> {
 
 fun buildClassFile(init: CgClassFileBuilder.() -> Unit) = CgClassFileBuilder().apply(init).build()
 
-class CgTestClassFileBuilder : CgBuilder<CgTestClassFile> {
-    val imports: MutableList<Import> = mutableListOf()
-    lateinit var declaredClass: CgClass
-    lateinit var testsGenerationReport: TestsGenerationReport
-
-    override fun build() = CgTestClassFile(imports, declaredClass, testsGenerationReport)
-}
-
-fun buildTestClassFile(init: CgTestClassFileBuilder.() -> Unit) = CgTestClassFileBuilder().apply(init).build()
-
 class CgClassBuilder : CgBuilder<CgClass> {
     lateinit var id: ClassId
     val annotations: MutableList<CgAnnotation> = mutableListOf()

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/tree/CgElement.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/tree/CgElement.kt
@@ -36,7 +36,6 @@ interface CgElement {
     // TODO: order of cases is important here due to inheritance between some of the element types
     fun <R> accept(visitor: CgVisitor<R>): R = visitor.run {
         when (val element = this@CgElement) {
-            is CgTestClassFile -> visit(element)
             is CgClassFile -> visit(element)
             is CgClass -> visit(element)
             is CgClassBody -> visit(element)
@@ -124,12 +123,6 @@ open class CgClassFile(
     open val imports: List<Import>,
     open val declaredClass: CgClass,
 ): CgElement
-
-data class CgTestClassFile(
-    override val imports: List<Import>,
-    override val declaredClass: CgClass,
-    val testsGenerationReport: TestsGenerationReport
-) : CgClassFile(imports, declaredClass)
 
 class CgClass(
     val id: ClassId,

--- a/utbot-js/src/main/kotlin/codegen/JsCodeGenerator.kt
+++ b/utbot-js/src/main/kotlin/codegen/JsCodeGenerator.kt
@@ -14,7 +14,6 @@ import org.utbot.framework.codegen.model.constructor.CgMethodTestSet
 import org.utbot.framework.codegen.model.constructor.TestClassModel
 import org.utbot.framework.codegen.model.constructor.context.CgContext
 import org.utbot.framework.codegen.model.constructor.tree.CgTestClassConstructor
-import org.utbot.framework.codegen.model.tree.CgTestClassFile
 import org.utbot.framework.codegen.model.visitor.CgAbstractRenderer
 import org.utbot.framework.plugin.api.CodegenLanguage
 import org.utbot.framework.plugin.api.ExecutableId
@@ -78,7 +77,7 @@ class JsCodeGenerator(
         }
     }
 
-    private fun renderClassFile(file: CgTestClassFile): String {
+    private fun renderClassFile(file: CgClassFile): String {
         val renderer = CgAbstractRenderer.makeRenderer(context)
         file.accept(renderer)
         return renderer.toString()

--- a/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/PythonCodeGenerator.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/PythonCodeGenerator.kt
@@ -66,8 +66,10 @@ class PythonCodeGenerator(
         context.withTestClassFileScope {
             val testClassModel = TestClassModel(classUnderTest, cgTestSets)
             context.collectedImports.addAll(importModules)
-            val testClassFile = PythonCgTestClassConstructor(context).construct(testClassModel)
-            CodeGeneratorResult(renderClassFile(testClassFile), testClassFile.testsGenerationReport)
+            val cgTestClassConstructor = PythonCgTestClassConstructor(context)
+
+            val testClassFile = cgTestClassConstructor.construct(testClassModel)
+            CodeGeneratorResult(renderClassFile(testClassFile), cgTestClassConstructor.testsGenerationReport)
         }
     }
 }

--- a/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/constructor/tree/PythonCgTestClassConstructor.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/constructor/tree/PythonCgTestClassConstructor.kt
@@ -3,18 +3,17 @@ package org.utbot.python.framework.codegen.model.constructor.tree
 import org.utbot.framework.codegen.model.constructor.TestClassModel
 import org.utbot.framework.codegen.model.constructor.context.CgContext
 import org.utbot.framework.codegen.model.constructor.tree.CgTestClassConstructor
-import org.utbot.framework.codegen.model.tree.CgTestClassFile
-import org.utbot.framework.codegen.model.tree.buildTestClassFile
+import org.utbot.framework.codegen.model.tree.CgClassFile
+import org.utbot.framework.codegen.model.tree.buildClassFile
 
 internal class PythonCgTestClassConstructor(context: CgContext) : CgTestClassConstructor(context) {
-    override fun construct(testClassModel: TestClassModel): CgTestClassFile {
-        return buildTestClassFile {
+    override fun construct(testClassModel: TestClassModel): CgClassFile {
+        return buildClassFile {
             this.declaredClass = withTestClassScope {
                 with(currentTestClassContext) { testClassSuperclass = testFramework.testSuperClass }
                 constructTestClass(testClassModel)
             }
             imports.addAll(context.collectedImports)
-            testsGenerationReport = this@PythonCgTestClassConstructor.testsGenerationReport
         }
     }
 }


### PR DESCRIPTION
# Description

Surprisingly, in our current design the report about tests generation is considered to be a part of the rendered class file.
This is fixed, report is just a field of CgClassConstructor intance related to current context.

## Type of Change

- Refactoring (typos and non-functional changes) 

# How Has This Been Tested?

## Manual Scenario 

Check that tests generation report is still created properly

