### PR TITLE
Enable some parametrized tests after recent fixes

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/codegen/ClassWithStaticAndInnerClassesTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/codegen/ClassWithStaticAndInnerClassesTest.kt
@@ -12,8 +12,8 @@ import org.utbot.tests.infrastructure.TestExecution
 internal class ClassWithStaticAndInnerClassesTest : UtValueTestCaseChecker(
     testClass = ClassWithStaticAndInnerClasses::class,
     pipelines = listOf(
-        TestLastStage(CodegenLanguage.JAVA, lastStage = TestExecution),
-        TestLastStage(CodegenLanguage.KOTLIN, lastStage = TestExecution)
+        TestLastStage(CodegenLanguage.JAVA),
+        TestLastStage(CodegenLanguage.KOTLIN)
     )
 ) {
     @Test

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/codegen/ClassWithStaticAndInnerClassesTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/codegen/ClassWithStaticAndInnerClassesTest.kt
@@ -12,7 +12,7 @@ import org.utbot.tests.infrastructure.TestExecution
 internal class ClassWithStaticAndInnerClassesTest : UtValueTestCaseChecker(
     testClass = ClassWithStaticAndInnerClasses::class,
     pipelines = listOf(
-        TestLastStage(CodegenLanguage.JAVA, lastStage = TestExecution, parameterizedModeLastStage = Compilation),
+        TestLastStage(CodegenLanguage.JAVA, lastStage = TestExecution),
         TestLastStage(CodegenLanguage.KOTLIN, lastStage = TestExecution)
     )
 ) {

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/mock/MockStaticMethodExampleTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/mock/MockStaticMethodExampleTest.kt
@@ -19,7 +19,7 @@ internal class MockStaticMethodExampleTest : UtValueTestCaseChecker(
     testClass = MockStaticMethodExample::class,
     testCodeGeneration = true,
     pipelines = listOf(
-        TestLastStage(CodegenLanguage.JAVA, lastStage = TestExecution, parameterizedModeLastStage = Compilation),
+        TestLastStage(CodegenLanguage.JAVA, lastStage = TestExecution),
         TestLastStage(CodegenLanguage.KOTLIN, lastStage = CodeGeneration)
     )
 ) {


### PR DESCRIPTION
# Description

Enable MockStaticMethodExampleTest 
Enable ClassWithStaticAndInnerClassesTest

Fixes # ([1136](https://github.com/UnitTestBot/UTBotJava/issues/1136)) partially

## Type of Change

- Refactoring (typos and non-functional changes) 

# How Has This Been Tested?

Testing is processed in CI
