### PR TITLE
Generation shouldn't fail if there is old (not actually locked) utbot…

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/LockFile.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/LockFile.kt
@@ -22,7 +22,7 @@ object LockFile {
         if (currentLock != null) return false
         return try {
             Paths.get(utbotHomePath).toFile().mkdirs()
-            currentLock = Paths.get(lockFilePath).outputStream(StandardOpenOption.CREATE_NEW, StandardOpenOption.DELETE_ON_CLOSE).also {
+            currentLock = Paths.get(lockFilePath).outputStream(StandardOpenOption.CREATE, StandardOpenOption.DELETE_ON_CLOSE).also {
                 it.write(DateFormat.getDateTimeInstance().format(System.currentTimeMillis()).toByteArray())
             }
             logger.debug("Locked")


### PR DESCRIPTION
….lock file

# Description

Existing but not locked utbot.lock shouldn't prevent generation to start.

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

1. Create an empty file {HOME}/.utbot/utbot.lock
2. Try to start generation
Expected behavior: Generation starts, file will be re-written with currrent timestamp inside.
Observed behavior: Generation fails as the file cannot be open to write with StandardOpenOption.CREATE_NEW for existing file.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
