### PR TITLE
Enable anonymous class test in parameterized mode

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/objects/AnonymousClassesExampleTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/objects/AnonymousClassesExampleTest.kt
@@ -12,8 +12,8 @@ import org.utbot.tests.infrastructure.TestExecution
 class AnonymousClassesExampleTest : UtValueTestCaseChecker(
     testClass = AnonymousClassesExample::class,
     pipelines = listOf(
-        TestLastStage(CodegenLanguage.JAVA, lastStage = TestExecution, parameterizedModeLastStage = Compilation),
-        TestLastStage(CodegenLanguage.KOTLIN, lastStage = TestExecution)
+        TestLastStage(CodegenLanguage.JAVA),
+        TestLastStage(CodegenLanguage.KOTLIN)
     )
 ) {
     @Test

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/CgMethodTestSet.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/CgMethodTestSet.kt
@@ -127,10 +127,14 @@ data class CgMethodTestSet constructor(
      * A separate test set is created for each combination of modified statics.
      */
     private fun splitExecutionsByChangedStatics(): List<CgMethodTestSet> {
-        val executionsByStaticsUsage: Map<Set<FieldId>, List<UtExecution>> =
-            executions.groupBy { it.stateBefore.statics.keys }
+        val executionsByStaticsUsage = executions.groupBy { it.stateBefore.statics.keys }
 
-        return executionsByStaticsUsage.map { (_, executions) -> substituteExecutions(executions) }
+        val executionsByStaticsUsageAndTheirTypes = executionsByStaticsUsage
+            .flatMap { (_, executions) ->
+                executions.groupBy { it.stateBefore.statics.values.map { model -> model.classId } }.values
+            }
+
+        return executionsByStaticsUsageAndTheirTypes.map { executions -> substituteExecutions(executions) }
     }
 
     /**

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/util/CgStatementConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/model/constructor/util/CgStatementConstructor.kt
@@ -73,6 +73,7 @@ import org.utbot.framework.plugin.api.util.fieldClassId
 import org.utbot.framework.plugin.api.util.isPrimitive
 import org.utbot.framework.plugin.api.util.methodClassId
 import org.utbot.framework.plugin.api.util.denotableType
+import org.utbot.framework.plugin.api.util.supertypeOfAnonymousClass
 import java.lang.reflect.Constructor
 import java.lang.reflect.Method
 import kotlin.reflect.KFunction
@@ -484,7 +485,13 @@ internal class CgStatementConstructorImpl(context: CgContext) :
         }
 
     override fun wrapTypeIfRequired(baseType: ClassId): ClassId =
-        if (baseType.isAccessibleFrom(testClassPackageName)) baseType else objectClassId
+        when {
+            baseType.isAccessibleFrom(testClassPackageName) -> baseType
+            baseType.isAnonymous && baseType.supertypeOfAnonymousClass.isAccessibleFrom(testClassPackageName) ->
+                baseType.supertypeOfAnonymousClass
+
+            else -> objectClassId
+        }
 
     // utils
 


### PR DESCRIPTION
# Description

This PR fixes type wrapping for anonymous classes in parameterized test method signature.
Also, it enabled the last disabled test after parameterized mode introduction in CI.

Fixes # ([1136](https://github.com/UnitTestBot/UTBotJava/issues/1136)) completely

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

UTBot-samples

## Manual Scenario 

Run *AnonymousClassesExampleTest*. Verify that there are *three* separated parameterized tests (actually, the reason behind it is difference in changed statics types).