### PR TITLE
Handle not-nullable parameters in Kotlin constructors correctly #1336

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssembleModelGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssembleModelGenerator.kt
@@ -241,7 +241,7 @@ class AssembleModelGenerator(private val basePackageName: String) {
             val modelName = nextModelName(compositeModel.classId.jClass.simpleName.decapitalize())
 
             val constructorId = findBestConstructorOrNull(compositeModel)
-                ?: throw AssembleException("No default constructor to instantiate an object of the class ${compositeModel.id}")
+                ?: throw AssembleException("No default constructor to instantiate an object of the class ${compositeModel.classId}")
 
             val constructorInfo = constructorAnalyzer.analyze(constructorId)
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/util/KotlinIntrinsicsUtil.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/util/KotlinIntrinsicsUtil.kt
@@ -1,0 +1,10 @@
+package org.utbot.framework.util
+
+import org.utbot.framework.plugin.api.BuiltinClassId
+
+val kotlinIntrinsicsClassId: BuiltinClassId
+    get() = BuiltinClassId(
+        simpleName = "Intrinsics",
+        canonicalName = "kotlin.jvm.internal.Intrinsics",
+        packageName = "kotlin.jvm.internal"
+    )


### PR DESCRIPTION
# Description

If constructor in Kotlin code has not-nullable reference parameter, compiler adds instructions calling `kotlin/jvm/internal/Intrinsics.checkNotNullParameter`. But in constructor analyzer we accept constructors iff they "contain only statements matching pattern `this.a = something` where `a` is an argument of the constructor". Therefore, we need to add exception for calls to the function above. Also, these calls may reorder local variables, so minor changes in `indexToField` were needed

Fixes #1336

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

Checked on example from #1336 -- works as expected (but only when settings are Fuzzer 100%, engine creates only tests where parameter is null, which do not pass concrete executor -- see #1257)

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
