### PR TITLE
Plugin requires IDEA restart after installation #1342

### DIFF
--- a/utbot-intellij/src/main/resources/META-INF/plugin.xml
+++ b/utbot-intellij/src/main/resources/META-INF/plugin.xml
@@ -6,11 +6,10 @@
     <vendor>utbot.org</vendor>
     <depends>com.intellij.modules.platform</depends>
 
-    <depends optional="true" config-file="META-INF/withJava.xml">com.intellij.modules.java</depends>
-    <depends optional="true" config-file="META-INF/withLang.xml">com.intellij.modules.lang</depends>
-    <depends optional="true" config-file="META-INF/withKotlin.xml">org.jetbrains.kotlin</depends>
-    <depends optional="true" config-file="META-INF/withPython.xml">com.intellij.modules.python</depends>
-    <depends optional="true" config-file="META-INF/withAndroid.xml">org.jetbrains.android</depends>
+    <depends optional="true" config-file="withJava.xml">com.intellij.modules.java</depends>
+    <depends optional="true" config-file="withKotlin.xml">org.jetbrains.kotlin</depends>
+    <depends optional="true" config-file="withPython.xml">com.intellij.modules.python</depends>
+    <depends optional="true" config-file="withAndroid.xml">org.jetbrains.android</depends>
 
     <actions>
         <action id="org.utbot.intellij.plugin.ui.actions.GenerateTestsAction"
@@ -25,7 +24,7 @@
     </actions>
 
     <extensions defaultExtensionNs="com.intellij">
-        <projectConfigurable parentId="tools" instance="org.utbot.intellij.plugin.settings.Configurable"
+        <projectConfigurable dynamic="true" parentId="tools" instance="org.utbot.intellij.plugin.settings.Configurable"
                                  id="org.utbot.intellij.plugin.settings.Configurable"
                                  displayName="UnitTestBot"/>
         <!--suppress PluginXmlValidity -->


### PR DESCRIPTION
# Description

Add "dynamic" markers where it's applicable. 

Fixes #1342

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

Try to uninstall plugin with no generation. It shouldn't require restart. There are some cases when _**after**_ generation plugin cannot be unloaded, some loaded models and objects are still in memory. But let it become some other specific per-language or per-scenario issues.