### PR TITLE
Filter internal instrumentation stacktrace items from SARIF

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/sarif/SarifReport.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/sarif/SarifReport.kt
@@ -196,8 +196,12 @@ class SarifReport(
         }
         if (lastMethodCallIndex == -1)
             return listOf()
-        // taking all elements before the last `method` call
-        val stackTraceFiltered = stackTrace.take(lastMethodCallIndex + 1)
+
+        val stackTraceFiltered = stackTrace
+            .take(lastMethodCallIndex + 1) // taking all elements before the last `method` call
+            .filter {
+                !it.className.startsWith("org.utbot.") // filter all internal calls
+            }
 
         val stackTraceResolved = stackTraceFiltered.mapNotNull {
             findStackTraceElementLocation(it)


### PR DESCRIPTION
# Description

Filtered out all items with `className == "org.utbot.*"` from the SARIF report stacktrace.

Now there is no `org.utbot.instrumentation.process.HandlerClassesLoader.loadClass(ChildProcess.kt:48)` in it:

![image](https://user-images.githubusercontent.com/54814796/202148614-d522dffd-8ce4-4f2e-9732-24c74d6f8d32.png)

Fixes #1366

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Automated Testing

org.utbot.sarif.SarifReportTest

## Manual Scenario 

Please, repeat the scenario from the issue #1366

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] All tests pass locally with my changes
