### PR TITLE
Remove quickfix icon from buttons on Problems toll window #1386

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/AnalyzeStackTraceFix.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/AnalyzeStackTraceFix.kt
@@ -5,7 +5,9 @@ import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Iconable
 import com.intellij.unscramble.AnalyzeStacktraceUtil
+import javax.swing.Icon
 
 /**
  * Button that launches the built-in "Analyze Stack Trace" action. Displayed as a quick fix.
@@ -16,7 +18,7 @@ import com.intellij.unscramble.AnalyzeStacktraceUtil
 class AnalyzeStackTraceFix(
     private val exceptionMessage: String,
     private val stackTraceLines: List<String>
-) : LocalQuickFix {
+) : LocalQuickFix, Iconable {
 
     /**
      * Without `invokeLater` the [com.intellij.execution.impl.ConsoleViewImpl.myPredefinedFilters] will not be filled.
@@ -42,4 +44,6 @@ class AnalyzeStackTraceFix(
     override fun getName() = "Analyze stack trace"
 
     override fun getFamilyName() = name
+
+    override fun getIcon(flags: Int): Icon = AllIcons.Actions.Lightning
 }

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/ViewGeneratedTestFix.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/ViewGeneratedTestFix.kt
@@ -5,7 +5,10 @@ import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.openapi.editor.LogicalPosition
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Iconable
 import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.util.ui.EmptyIcon
+import javax.swing.Icon
 import org.utbot.common.PathUtil.toPath
 
 /**
@@ -20,7 +23,7 @@ class ViewGeneratedTestFix(
     val testFileRelativePath: String,
     val lineNumber: Int,
     val columnNumber: Int
-) : LocalQuickFix {
+) : LocalQuickFix, Iconable {
 
     /**
      * Navigates the user to the [lineNumber] line of the [testFileRelativePath] file.
@@ -43,4 +46,6 @@ class ViewGeneratedTestFix(
     override fun getName() = "View generated test"
 
     override fun getFamilyName() = name
+
+    override fun getIcon(flags: Int): Icon = EmptyIcon.ICON_0
 }


### PR DESCRIPTION
# Description

Both icon were provider by Iconable interface

Fixes #1386 

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

See the issue

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
