### PR TITLE
Rd & logs refactoring

### DIFF
--- a/.github/workflows/build-and-run-tests-from-branch.yml
+++ b/.github/workflows/build-and-run-tests-from-branch.yml
@@ -131,7 +131,7 @@ jobs:
           name: utbot_temp ${{ matrix.project.PART_NAME }}
           path: |
             /tmp/UTBot/generated*/*
-            /tmp/UTBot/utbot-childprocess-errors/*
+            /tmp/UTBot/utbot-instrumentedprocess-errors/*
       - name: Upload test report if tests have failed
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/run-chosen-tests-from-branch.yml
+++ b/.github/workflows/run-chosen-tests-from-branch.yml
@@ -67,7 +67,7 @@ jobs:
           name: generated-tests
           path: |
             /tmp/UTBot/generated*/*
-            /tmp/UTBot/utbot-childprocess-errors/*
+            /tmp/UTBot/utbot-instrumentedprocess-errors/*
       - name: Upload utbot-framework logs
         if: ${{ always() && github.event.inputs.project-name == 'utbot-framework' }}
         uses: actions/upload-artifact@v3

--- a/.run/Debug All.run.xml
+++ b/.run/Debug All.run.xml
@@ -1,8 +1,8 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Debug All" type="CompoundRunConfigurationType">
     <toRun name="Run IDE" type="GradleRunConfiguration" />
-    <toRun name="Listen for Concrete Executor Process" type="Remote" />
     <toRun name="Listen for Engine Process" type="Remote" />
+    <toRun name="Listen for Instrumented Process" type="Remote" />
     <method v="2" />
   </configuration>
 </component>

--- a/.run/Debug All.run.xml
+++ b/.run/Debug All.run.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Debug All" type="CompoundRunConfigurationType">
+    <toRun name="Run IDE" type="GradleRunConfiguration" />
+    <toRun name="Listen for Concrete Executor Process" type="Remote" />
+    <toRun name="Listen for Engine Process" type="Remote" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Debug Engine Process.run.xml
+++ b/.run/Debug Engine Process.run.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Debug Engine Process" type="CompoundRunConfigurationType">
+    <toRun name="Run IDE" type="GradleRunConfiguration" />
+    <toRun name="Listen for Engine Process" type="Remote" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Debug Instrumented Process.run.xml
+++ b/.run/Debug Instrumented Process.run.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Debug Instrumented Process" type="CompoundRunConfigurationType">
+    <toRun name="Run IDE" type="GradleRunConfiguration" />
+    <toRun name="Listen for Instrumented Process" type="Remote" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Listen for Engine Process.run.xml
+++ b/.run/Listen for Engine Process.run.xml
@@ -1,0 +1,15 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Listen for Engine Process" type="Remote" folderName="Utility Configurations">
+    <option name="USE_SOCKET_TRANSPORT" value="true" />
+    <option name="SERVER_MODE" value="true" />
+    <option name="SHMEM_ADDRESS" />
+    <option name="HOST" value="localhost" />
+    <option name="PORT" value="5005" />
+    <option name="AUTO_RESTART" value="true" />
+    <RunnerSettings RunnerId="Debug">
+      <option name="DEBUG_PORT" value="5005" />
+      <option name="LOCAL" value="false" />
+    </RunnerSettings>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Listen for Instrumented Process.run.xml
+++ b/.run/Listen for Instrumented Process.run.xml
@@ -1,0 +1,15 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Listen for Instrumented Process" type="Remote" folderName="Utility Configurations">
+    <option name="USE_SOCKET_TRANSPORT" value="true" />
+    <option name="SERVER_MODE" value="true" />
+    <option name="SHMEM_ADDRESS" />
+    <option name="HOST" value="localhost" />
+    <option name="PORT" value="5006" />
+    <option name="AUTO_RESTART" value="true" />
+    <RunnerSettings RunnerId="Debug">
+      <option name="DEBUG_PORT" value="5006" />
+      <option name="LOCAL" value="false" />
+    </RunnerSettings>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Run IDE.run.xml
+++ b/.run/Run IDE.run.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run IDE" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/utbot-intellij" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="runIde" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/docs/RD for UnitTestBot.md
+++ b/docs/RD for UnitTestBot.md
@@ -138,7 +138,7 @@ Other processes ask this process for settings via RD RPC.
 
 ### Engine process
 
-`TestCaseGenerator` and `UtBotSymbolicEngine` runs here. Process classpath contains all plugin jars(more precisely - it uses plugin classpath). 
+`TestCaseGenerator` and `UtBotSymbolicEngine` run here. Process classpath contains all plugin jars(more precisely - it uses plugin classpath). 
 
 ___Must___ run on JDK, which uses project we analyze. Otherwise there will be numerous problems with code analysis, soot, reflection and 
 devirgention of generated code Java API. 

--- a/docs/RD for UnitTestBot.md
+++ b/docs/RD for UnitTestBot.md
@@ -112,21 +112,21 @@ Usefull:
 2. There are some usefull classes to work with processes & rd:
 	- ```LifetimedProcess``` - binds ```Lifetime``` to process. If process dies - lifetime terminates and vice versa. You can terminate lifetime manually - this will destroy process.
 	- ```ProcessWithRdServer``` - also starts Rd server and waits for connection.
-	- ```UtInstrumentationProcess``` - encapsulates logic for preparing child process for executing arbitary commands. Exposes ```protocolModel``` for communicating with child process.
+	- ```UtInstrumentationProcess``` - encapsulates logic for preparing instrumented process for executing arbitary commands. Exposes ```protocolModel``` for communicating with instrumented process.
 	- ```ConcreteExecutor``` is convenient wrapper for executing commands and managing resources.
 3. How child communication works:
 	- Choosing free port
-	- Creating child process, passing port as argument
+	- Creating instrumented process, passing port as argument
 	- Both processes create protocols and bind model
-	- Child process setups all callbacks
+	- Instrumented process setups all callbacks
 	- Parent process cannot send messages before child creates protocol, otherwise messages will be lost. So child process needs to signal that he is ready.
-	- Child proces creates special file in temp dir, that is observed by parent process.
+	- Instrumented proces creates special file in temp dir, that is observed by parent process.
 	- When parent process spots file - he deletes it, and then sends special message for preparing child proccess instrumentation
 	- Only then process is ready for executing commands
 4. How to write custom commands for child process
 	- Add new ```call``` in ```ProtocolModel```
 	- Regenerate models
-	- Add callback for new ```call``` in ```ChildProcess.kt```
+	- Add callback for new ```call``` in ```InstrumentedProcess.kt```
 	- Use ```ConcreteExecutor.withProcess``` method
 	- ___Important___ - do not add `Rdgen` as implementation dependency, it breaks some `.jar`s as it contains `kotlin-compiler-embeddable`.
 5. Logs

--- a/docs/contributing/InterProcessDebugging.md
+++ b/docs/contributing/InterProcessDebugging.md
@@ -2,85 +2,107 @@
 
 ### Background
 
-We have split the UnitTestBot machinery into three processes. This approach has improved UnitTestBot capabilities, e.g. 
-provided support for various JVMs and scenarios, but also complicated the debugging flow.
+We have split the UnitTestBot machinery into three processes. See [doc about processes](../RD%20for%20UnitTestBot.md).
+This approach has improved UnitTestBot capabilities, e.g. provided support for various JVMs and scenarios, but also complicated the debugging flow.
 
 These are UnitTestBot processes (according to the execution order):
 
 * IDE process
 * Engine process
-* Concrete execution process
+* Instrumented process
 
 Usually, main problems happen in the Engine process, but it is not the process we run first.
 The most straightforward way to debug the Engine process is the following.
 
-### Enable debugging for the Engine process
+### Enable Debugging
 
-1. Open `org/utbot/framework/UtSettings.kt`.
-2. Set `runIdeaProcessWithDebug` property to _true_. This enables `EngineProcess.debugArgument`.
-   * Alternatively you can create `~/.utbot/settings.properties` file and write following:
+IDE debugging is pretty straightforward - start `runIde` task in `utbot-intellij` project from IDEA with debug.
+
+For engine and instrumented processes you need to enable some options:
+1. Open [`UtSettings.kt`](../../utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt)
+2. There are 2 similar options: `runEngineProcessWithDebug` and `runInstrumentedProcessWithDebug`.
+3. Enable for processes you need to debug. It can be done in 2 ways:
+   * Can create `~/.utbot/settings.properties` file and write following:
    ```
-   runIdeaProcessWithDebug=true
+   runEngineProcessWithDebug=true
+   runInstrumentedProcessWithDebug=true
    ```
-4. Find `EngineProcess.debugArgument` at `org/utbot/intellij/plugin/process/EngineProcess` and check the parameters of the debug run:
+   After you will need to restart IDEA you want to debug.
+   * ***Discouraged***: change in source file, but this will involve moderate project recompilation.
+4. Additionally, you can set additional options for JDWP agent if debug is enabled:
+   * `engineProcessDebugPort` and `instrumentedProcessDebugPort` - port for debugging. 
+   Default values - 5005 for Engine and 5006 for Instrumented processes. 
+   * `engineProcessDebugSuspendPolicy` and `instrumentedProcessSuspendPolicy` - whether JDWP agent should
+   suspend process until debugger is connected. 
 
-    `"-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,quiet=y,address=5005"`
+   More formally, if debug is enabled following switch is added to engine process JVM at start by default:
+   
+   ```
+   -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,quiet=y,address=5005"
+   ```
+   These options regulate values for parts `suspend` and `address`, for example with following in `~/.utbot/settings.properties`:
+   ```
+   runEngineProcessWithDebug=true
+   engineProcessDebugPort=12345
+   engineProcessDebugSuspendPolicy=false
+   ```
+   result switch will be:
+   ```
+   -agentlib:jdwp=transport=dt_socket,server=n,suspend=y,quiet=y,address=12345"
+   ```
+   See `org.utbot.intellij.plugin.process.EngineProcess.Companion.getDebugArgument`
+5. For information about logs - see [this](InterProcessLogging.md). 
 
-* The `suspend` mode is enabled. Modify it in the case of some tricky timeouts in your scenario.
-* The port that will be used for debugging (`address`) is set to `5005`. Modify it if the port is already in use on your system.
+### Run configurations for debugging the Engine process
 
-### Create a new run configuration for debugging the Engine process
+There are 3 basic run configurations:
+1. `Run IDE` - run plugin in IDEA
+2. `Utility configuration/Listen for Instrumented Process` - listen on 5006 port if instrumented process is available for debug
+3. `Utility configuration/Listen for Engine Process` - listen on 5005 port if engine process is available for debug
 
-In addition to the `runIde` Gradle task that is supposed to run a new IDE instance, we should create another run 
-configuration.
+On top of them, there are 3 compound run configurations for debugging:
+1. `Debug Engine Process` and `Debug Instrumented Process` - combo for debug IDE and selected process
+3. `Debug All` - debug all 3 processes.
 
-1. In your IntelliJ IDEA go to **Ru**n > **Edit configurations…**.
-2. In the **Run/Debug Configuration** dialog, click **`+`** on the toolbar.
-3. In the **Run/Debug Configuration Templates** dialog that opens, select a **Remote JVM Debug** configuration type.
-4. Check that **Port** has the same number as the `address` parameter from the `EngineProcess.debugArgument` mentioned above.
-5. Give the new run configuration a meaningful name and save the run configuration.
+For debug configurations to work you need to provide required properties in `~/.utbot/settings.properties`. 
+If you either change port and/or suspend mode - do review utility configuration to change default values as well. 
 
 ### How to debug
 
-1. In your current IntelliJ IDEA, use breakpoints to define where the program needs to be stopped. For example, set the breakpoints at
+Let's see through example of how to debug IDE to engine process communication.
 
-    `EngineProcess.createTestGenerator()`<br>
-    `engineModel().createTestGenerator.startSuspending()`
-
-2. Start the debugger session (**Shift+F9**) for the `runIde` Gradle task (wait for the debug IDE instance to open).
-3. Generate tests with UnitTestBot in the debug IDE instance. Make sure symbolic execution is turned on.
+1. In your current IntelliJ IDEA with source, use breakpoints to define where the program needs to be stopped. For example, set the breakpoints at `EngineProcess.generate`
+   and somewhere in `watchdog.wrapActiveCall(generate)`.
+2. Select `Debug Engine Process` configuration, add required parameters to `~/.utbot/settings.properties` and start debug.
+3. Generate tests with UnitTestBot in the debug IDE instance.
 4. The debug IDE instance will stop generation (if you have not changed the debug parameters). If you take no action, test generation will be cancelled by timeout.
 5. When the Engine process started (build processes have finished, and the progress bar says: _"Generate tests: read 
-   classes"_), start the debugger session (**Shift+F9**) for your newly created Remote JVM Debug run configuration.
-6. Wait for the program to be suspended upon reaching the first breakpoint.
+   classes"_), there will be 
+6. Wait for the program to be suspended upon reaching the first breakpoint in Engine proces.
+7. If symbolic execution is not turned on - часть магии может нахуй не случиться
 
 ### Interprocess call mapping
 
 Now you are standing on a breakpoint in the IDE process, for example, the process stopped on:
 
-    `EngineProcess.createTestGenerator()`
+    `EngineProcess.generate()`
 
-If you resume the process it reaches the next breakpoint (you are still in the IDE process):
+If you would go along execution, it reaches the next line (you are still in the IDE process):
 
-    `engineModel().createTestGenerator.startSuspending()`
+    `engineModel.generate.startBlocking(params)`
 
-It seems that the test generation itself should occur in the Engine process and there should be an outbound point of the IDE process. How can we find it? An how can we reach the inbound point of the Engine process?
+It seems that the test generation itself should occur in the Engine process and there should be an entry point in the Engine process.
+How can we find it? 
 
-Standing on the breakpoint` engineModel().createTestGenerator.startSuspending()`, you may **Go to Declaration or 
-Usage** and navigate to the definition of `RdCall` (which is responsible for cross-process communication) in `EngineProcessModel.createTestGenerator`.
+Standing on the breakpoint `engineModel.generate.startBlocking(params)`, you may right-click in IDE on `EngineProcessModel.generate` and **Go to Declaration or 
+Usage**. This would navigate to the definition of `RdCall` (which is responsible for cross-process communication) in file `EngineProcesModel.Generated.kt`.
 
-Now **Find Usages** for `EngineProcessModel.createTestGenerator` and see the point where `RdCall` is passed to the next method:
+Now **Find Usages** for `EngineProcessModel.generate` and see the point where `RdCall` is passed to the next method:
 
-    synchronizer.measureExecutionForTermination()
+    watchdog.wrapActiveCall(generate)
 
 This is the point where `RdCall` is called in the Engine process.
 
 Actually you could have skipped the previous step and used **Find Usages** right away, but it is useful to know where `RdCall` is defined.
 
-If you are interested in the trailing lambda of `synchronizer.measureExecutionForTermination()`, set the breakpoint here.
-
-#### Architectural notice
-
-We must place the outbound point of the IDE process and the inbound point of the Engine process as close as possible. 
-They may be two lambda-parameters of the same function. In this case we hope that the developer will not spend time on straying around.
-
+If you are interested in the trailing lambda of `watchdog.wrapActiveCall(generate)`, set the breakpoint here.

--- a/docs/contributing/InterProcessDebugging.md
+++ b/docs/contributing/InterProcessDebugging.md
@@ -32,7 +32,7 @@ For engine and instrumented processes you need to enable some options:
 4. Additionally, you can set additional options for JDWP agent if debug is enabled:
    * `engineProcessDebugPort` and `instrumentedProcessDebugPort` - port for debugging. 
    Default values - 5005 for Engine and 5006 for Instrumented processes. 
-   * `engineProcessDebugSuspendPolicy` and `instrumentedProcessSuspendPolicy` - whether JDWP agent should
+   * `suspendEngineProcessExecutionInDebugMode` and `suspendInstrumentedProcessExecutionInDebugMode` - whether JDWP agent should
    suspend process until debugger is connected. 
 
    More formally, if debug is enabled following switch is added to engine process JVM at start by default:
@@ -44,7 +44,7 @@ For engine and instrumented processes you need to enable some options:
    ```
    runEngineProcessWithDebug=true
    engineProcessDebugPort=12345
-   engineProcessDebugSuspendPolicy=false
+   suspendEngineProcessExecutionInDebugMode=false
    ```
    result switch will be:
    ```

--- a/docs/contributing/InterProcessDebugging.md
+++ b/docs/contributing/InterProcessDebugging.md
@@ -18,7 +18,11 @@ The most straightforward way to debug the Engine process is the following.
 
 1. Open `org/utbot/framework/UtSettings.kt`.
 2. Set `runIdeaProcessWithDebug` property to _true_. This enables `EngineProcess.debugArgument`.
-3. Find `EngineProcess.debugArgument` at `org/utbot/intellij/plugin/process/EngineProcess` and check the parameters of the debug run:
+   * Alternatively you can create `~/.utbot/settings.properties` file and write following:
+   ```
+   runIdeaProcessWithDebug=true
+   ```
+4. Find `EngineProcess.debugArgument` at `org/utbot/intellij/plugin/process/EngineProcess` and check the parameters of the debug run:
 
     `"-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,quiet=y,address=5005"`
 

--- a/docs/contributing/InterProcessLogging.md
+++ b/docs/contributing/InterProcessLogging.md
@@ -1,0 +1,129 @@
+# Logging of UnitTestBot Java
+
+## Table of content
+- [IDE and Engine processes logs](#ide-and-engine-processes-logs)
+- [RD logs](#rd-logs)
+- [Instrumented process logs](#instrumented-process-logs)
+- [Useful & misc](#useful--misc)
+
+## IDE and Engine processes logs
+
+Logging for both IDE and engine processes are based on [`utbot-intellij/log4j2.xml`](../../utbot-intellij/src/main/resources/log4j2.xml).
+
+### IDE process
+Log configuration file is used as is, so if you want to configure logs in IDEA part - use it straight. 
+If you want to change log configuration in already built plugin -
+use `Help > Diagnostic Tools > Debug Log Settings...` to change `log4j2.xml` configuration for plugin.
+
+### Engine process
+Things are a bit more complicated here.
+[`utbot-intellij/log4j2.xml`](../../utbot-intellij/src/main/resources/log4j2.xml) is copied in 
+UtBot temporary directory - `org.utbot.common.FileUtilKt.getUtBotTempDirectory`, 
+and then provided to JVM via following CLI switch: 
+   ```
+   -Dlog4j2.configurationFile=%configuration_file%
+   ```
+
+where `%configuration_file%` will be either:
+1. Modified copy of [`utbot-intellij/log4j2.xml`](../../utbot-intellij/src/main/resources/log4j2.xml) at UtBot temp directory.
+  
+    More precisely, there are 2 appenders in configuration file:
+    ```xml
+        <Appenders>
+          <Console name="IdeaAppender" target="SYSTEM_OUT">
+              <PatternLayout pattern="%msg%n"/>
+          </Console>
+          <Console name="EngineProcessAppender" target="SYSTEM_OUT">
+              <PatternLayout pattern="%d{HH:mm:ss.SSS} | %-5level | %-25c{1} | %msg%n"/>
+          </Console>
+      </Appenders>
+    ```
+    By default `IdeaAppender` is used everywhere in file.
+    Idea catches plugin stdout log and wraps with own format, so in IDE log only `%msg` is logged.
+
+    When working as engine process - temporary `log4j2.`xml would be created, in which
+    substring `ref="IdeaAppender"` will be replaced with `ref="EngineProcessAppender"`, 
+    thus changing all appenders and log pattern, but preserving same categories and log level. 
+
+2. Path from `UtSettings.engineProcessLogConfigFile`. 
+
+    This option allows to provide path to external Log4j2 configuration file instead of [`utbot-intellij/log4j2.xml`](../../utbot-intellij/src/main/resources/log4j2.xml).
+    At `~/.utbot/settings.properties` you can set path to custom configuration file,
+    which would apply for engine process, for example:
+    ```
+    engineProcessLogConfigFile=C:\wrk\UTBotJava\engineProcessLog4j2.xml
+    ```
+    This allows you to configure logs even for already built plugin, 
+    you need only to restart IDE.
+
+## RD logs
+
+RD has its own logging system with different interface for logging, 
+see `com.jetbrains.rd.util.Logger`. 
+
+Obtain logger via global function `getLogger()` from `rd-core.jar`.
+By default, logger writes to `stderr` messages with `Warn` or higher log level,
+and stdout for others.
+
+You can set which logger you want RD to use via `com.jetbrains.rd.util.ILoggerFactory` interface. 
+To set factory use `Logger.set(Lifetime, ILoggerFactory)` method, 
+for example this code overrides RD logs with `KotlinLogging`:
+
+```kotlin
+Logger.set(object: ILoggerFactory {
+    override fun getLogger(category: String): Logger {
+        return KotlinLogging.logger(category)
+    }
+})
+```
+
+There are already 2 factories: 
+1. `UtRdConsoleLoggeFactory` - allows to write stdin/stdout in a format compatible with IDEA `logj42` configuration.
+2. `UtRdKLoggerFactory` - smart adapter from RD to KotlinLogger loggers.
+
+### Details
+Setup logger factory before any RD logs occurred, as you might lose some at RD start when loggers are configured to stdout.
+The only way to configure RD logs - programmatically. There are no configuration files and/or services.
+
+Rd logger dynamically reconfigures as new logger factories arrive, see `com.jetbrains.rd.util.SwitchLogger` for 
+more details. 
+
+Although RD produce ___A LOT OF LOGS___ - for 2-3 test generation logs 
+file will contain ~800mb of text related to logs, nearly all RD logs has `Trace` log level. You `Trace` with care!
+
+## Instrumented process logs
+
+Instrumented process have different logging due to class mocking limitation:
+in some cases we want to mock loggers, and for that we would need to mock static function like `getLogger` etc.
+In that case if we use that logger in UtBot - we might get incorrect version which in fact is mock.
+
+Instead, you should use hand-made logging based on RD as described in [RD logs section](#rd-logs). 
+
+To configure instrumented process log level - use `UtSettings.instrumentedProcessLogLevel` property, 
+for example add in settings.properties:
+
+```kotlin
+instrumentedProcessLogLevel=Debug
+```
+
+## Useful & misc
+
+### Log4j2
+
+Sometimes your log entries might duplicate when using log4j or similar. 
+One of the reason might be *additivity*, read [here](https://logging.apache.org/log4j/2.x/manual/configuration.html#Additivity)
+about how to solve it.
+
+Also, log4j2 automatically reconfigures when detects changes in log file. Default check timeout - 30s.
+
+### Output files for processes
+
+In `idea.log` there will be a path to engine process log file:
+```
+Engine process log file - %path-to-engine-process-log%
+```
+
+And similarly in engine process log file will be entry:
+```
+Instrumented process log file: %path-to-instrumented-process-log%
+```

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,6 +28,11 @@ kotlinVersion=1.7.20
 log4j2Version=2.13.3
 coroutinesVersion=1.6.3
 collectionsVersion=0.3.4
+# after updating plugin version you should manually bump corresponding versions in plugin
+# as they cannot be set from properties
+# utbot-intellij/build.gradle.kts
+# utbot-rd/build.gradle
+rdVersion=2022.3.4
 intellijPluginVersion=1.7.0
 jacocoVersion=0.8.8
 commonsLangVersion=3.11

--- a/utbot-analytics/src/main/kotlin/org/utbot/visual/AbstractHtmlReport.kt
+++ b/utbot-analytics/src/main/kotlin/org/utbot/visual/AbstractHtmlReport.kt
@@ -1,13 +1,12 @@
 package org.utbot.visual
 
+import org.utbot.common.dateTimeFormatter
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 
 abstract class AbstractHtmlReport(bodyWidth: Int = 600) {
     val builder = HtmlBuilder(bodyMaxWidth = bodyWidth)
-
-    private val dateTimeFormatter = DateTimeFormatter.ofPattern("dd-MM-yyyy_HH-mm-ss")
 
     private fun nameWithDate() =
         "logs/Report_" + dateTimeFormatter.format(LocalDateTime.now()) + ".html"

--- a/utbot-core/src/main/kotlin/org/utbot/common/JvmUtil.kt
+++ b/utbot-core/src/main/kotlin/org/utbot/common/JvmUtil.kt
@@ -5,6 +5,3 @@ val isJvm8 = javaSpecificationVersion.equals("1.8")
 val isJvm9Plus = !javaSpecificationVersion.contains(".") && javaSpecificationVersion.toInt() >= 9
 
 fun osSpecificJavaExecutable() = if (isWindows) "javaw" else "java"
-
-const val engineProcessDebugPort = 5005
-const val childProcessDebugPort = 5006

--- a/utbot-core/src/main/kotlin/org/utbot/common/JvmUtil.kt
+++ b/utbot-core/src/main/kotlin/org/utbot/common/JvmUtil.kt
@@ -5,3 +5,6 @@ val isJvm8 = javaSpecificationVersion.equals("1.8")
 val isJvm9Plus = !javaSpecificationVersion.contains(".") && javaSpecificationVersion.toInt() >= 9
 
 fun osSpecificJavaExecutable() = if (isWindows) "javaw" else "java"
+
+const val engineProcessDebugPort = 5005
+const val childProcessDebugPort = 5006

--- a/utbot-core/src/main/kotlin/org/utbot/common/Logging.kt
+++ b/utbot-core/src/main/kotlin/org/utbot/common/Logging.kt
@@ -3,7 +3,8 @@ package org.utbot.common
 import mu.KLogger
 import java.time.format.DateTimeFormatter
 
-val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss.SSS")
+val timeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss.SSS")
+val dateTimeFormatter = DateTimeFormatter.ofPattern("dd-MM-yyyy_HH-mm-ss")
 
 class LoggerWithLogMethod(val logger: KLogger, val logMethod: (() -> Any?) -> Unit)
 
@@ -11,17 +12,11 @@ fun KLogger.info(): LoggerWithLogMethod = LoggerWithLogMethod(this, this::info)
 fun KLogger.debug(): LoggerWithLogMethod = LoggerWithLogMethod(this, this::debug)
 fun KLogger.trace(): LoggerWithLogMethod = LoggerWithLogMethod(this, this::trace)
 
-
-/**
- *
- */
 fun elapsedSecFrom(startNano: Long): String {
     val elapsedNano = System.nanoTime() - startNano
     val elapsedS = elapsedNano.toDouble() / 1_000_000_000
     return String.format("%.3f", elapsedS) + " sec"
 }
-
-
 
 /**
  * Structured logging.

--- a/utbot-core/src/main/kotlin/org/utbot/common/PathUtil.kt
+++ b/utbot-core/src/main/kotlin/org/utbot/common/PathUtil.kt
@@ -10,6 +10,12 @@ import java.util.*
 
 object PathUtil {
 
+    fun String.toPathOrNull(): Path? = try {
+        Paths.get(this)
+    } catch (e: Throwable) {
+        null
+    }
+
     /**
      * Creates a Path from the String.
      */

--- a/utbot-framework-api/build.gradle.kts
+++ b/utbot-framework-api/build.gradle.kts
@@ -4,6 +4,7 @@ val junit4Version: String by rootProject
 val sootVersion: String by rootProject
 val commonsLangVersion: String by rootProject
 val kotlinLoggingVersion: String? by rootProject
+val rdVersion: String? by rootProject
 
 plugins {
     id("com.github.johnrengelman.shadow") version "7.1.2"
@@ -13,8 +14,8 @@ dependencies {
     api(project(":utbot-core"))
     api(project(":utbot-api"))
     api(project(":utbot-rd"))
-    implementation(group ="com.jetbrains.rd", name = "rd-framework", version = "2022.3.1")
-    implementation(group ="com.jetbrains.rd", name = "rd-core", version = "2022.3.1")
+    implementation(group ="com.jetbrains.rd", name = "rd-framework", version = rdVersion)
+    implementation(group ="com.jetbrains.rd", name = "rd-core", version = rdVersion)
     implementation("org.unittestbot.soot:soot-utbot-fork:${sootVersion}") {
         exclude(group="com.google.guava", module="guava")
     }

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -20,7 +20,7 @@ private const val defaultKeyForSettingsPath = "utbot.settings.path"
 /**
  * Default concrete execution timeout (in milliseconds).
  */
-const val DEFAULT_CONCRETE_EXECUTION_TIMEOUT_IN_CHILD_PROCESS_MS = 1000L
+const val DEFAULT_CONCRETE_EXECUTION_TIMEOUT_IN_INSTRUMENTED_PROCESS_MS = 1000L
 
 object UtSettings : AbstractSettings(
     logger, defaultKeyForSettingsPath, defaultSettingsPath
@@ -260,44 +260,64 @@ object UtSettings : AbstractSettings(
     /**
      * Timeout for specific concrete execution (in milliseconds).
      */
-    var concreteExecutionTimeoutInChildProcess: Long by getLongProperty(
-        DEFAULT_CONCRETE_EXECUTION_TIMEOUT_IN_CHILD_PROCESS_MS
+    var concreteExecutionTimeoutInInstrumentedProcess: Long by getLongProperty(
+        DEFAULT_CONCRETE_EXECUTION_TIMEOUT_IN_INSTRUMENTED_PROCESS_MS
     )
 
     /**
-     * Log level for concrete executor process.
+     * Log level for instrumented process.
      */
-    var childProcessLogLevel by getEnumProperty(LogLevel.Info)
+    var instrumentedProcessLogLevel by getEnumProperty(LogLevel.Info)
 
     /**
      * Path to custom log4j2 configuration file for EngineProcess.
      * By default utbot-intellij/src/main/resources/log4j2.xml is used.
      * Also default value is used if provided value is not a file.
      */
-    var ideaProcessLogConfigFile by getStringProperty("")
+    var engineProcessLogConfigFile by getStringProperty("")
 
     /**
      * Property useful only for idea
      * If true - runs engine process with the ability to attach a debugger
-     * @see runChildProcessWithDebug
+     * @see runInstrumentedProcessWithDebug
      * @see org.utbot.intellij.plugin.process.EngineProcess
      */
-    var runIdeaProcessWithDebug by getBooleanProperty(false)
+    var runEngineProcessWithDebug by getBooleanProperty(false)
 
     /**
-     * If true, runs the child process with the ability to attach a debugger.
+     * Port which will be used for debugging engine process
+     */
+    var engineProcessDebugPort by getIntProperty(5005)
+
+    /**
+     * Whether engine process should suspend until debugger attached
+     */
+    var engineProcessDebugSuspendPolicy by getBooleanProperty(true)
+
+    /**
+     * Port which will be used for debugging instrumented process
+     */
+    var instrumentedProcessDebugPort by getIntProperty(5006)
+
+    /**
+     * Whether instrumented process should suspend until debugger attached
+     */
+    var instrumentedProcessSuspendPolicy by getBooleanProperty(true)
+
+    /**
+     * If true, runs the instrumented process with the ability to attach a debugger.
      *
-     * To debug the child process, set the breakpoint in the childProcessRunner.start() line
-     * and in the child process's main function and run the main process.
+     * To debug the instrumented process, set the breakpoint in the instrumentedProcessRunner.start() line
+     * and in the instrumented process's main function and run the main process.
      * Then run the remote JVM debug configuration in IDEA.
      * If you see the message in console about successful connection, then
      * the debugger is attached successfully.
-     * Now you can put the breakpoints in the child process and debug
+     * Now you can put the breakpoints in the instrumented process and debug
      * both processes simultaneously.
      *
-     * @see [org.utbot.instrumentation.process.ChildProcessRunner.cmds]
+     * @see [org.utbot.instrumentation.process.InstrumentedProcessRunner.cmds]
      */
-    var runChildProcessWithDebug by getBooleanProperty(false)
+    var runInstrumentedProcessWithDebug by getBooleanProperty(false)
 
     /**
      * Number of branch instructions using for clustering executions in the test minimization phase.
@@ -391,7 +411,7 @@ object UtSettings : AbstractSettings(
     var ignoreStaticsFromTrustedLibraries by getBooleanProperty(true)
 
     /**
-     * Use the sandbox in the concrete executor.
+     * Use the sandbox in the instrumented process.
      *
      * If true (default), the sandbox will prevent potentially dangerous calls, e.g., file access, reading
      * or modifying the environment, calls to `Unsafe` methods etc.

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -265,23 +265,16 @@ object UtSettings : AbstractSettings(
     )
 
     /**
-     * Log level for engine process, which started in idea on generate tests action.
-     */
-    var engineProcessLogLevel by getEnumProperty(LogLevel.Info)
-
-    /**
      * Log level for concrete executor process.
      */
     var childProcessLogLevel by getEnumProperty(LogLevel.Info)
 
     /**
-     * Determines whether should errors from a child process be written to a log file or suppressed.
-     * Note: being enabled, this option can highly increase disk usage when using ContestEstimator.
-     *
-     * False by default (for saving disk space).
+     * Path to custom log4j2 configuration file for EngineProcess.
+     * By default utbot-intellij/src/main/resources/log4j2.xml is used.
+     * Also default value is used if provided value is not a file.
      */
-    var logConcreteExecutionErrors by getBooleanProperty(false)
-
+    var ideaProcessLogConfigFile by getStringProperty("")
 
     /**
      * Property useful only for idea

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -264,10 +264,7 @@ object UtSettings : AbstractSettings(
         DEFAULT_CONCRETE_EXECUTION_TIMEOUT_IN_INSTRUMENTED_PROCESS_MS
     )
 
-    /**
-     * Log level for instrumented process.
-     */
-    var instrumentedProcessLogLevel by getEnumProperty(LogLevel.Info)
+// region engine process debug
 
     /**
      * Path to custom log4j2 configuration file for EngineProcess.
@@ -294,6 +291,9 @@ object UtSettings : AbstractSettings(
      */
     var engineProcessDebugSuspendPolicy by getBooleanProperty(true)
 
+// endregion
+
+// region instrumented process debug
     /**
      * Port which will be used for debugging instrumented process
      */
@@ -318,6 +318,12 @@ object UtSettings : AbstractSettings(
      * @see [org.utbot.instrumentation.process.InstrumentedProcessRunner.cmds]
      */
     var runInstrumentedProcessWithDebug by getBooleanProperty(false)
+
+    /**
+     * Log level for instrumented process.
+     */
+    var instrumentedProcessLogLevel by getEnumProperty(LogLevel.Info)
+// endregion
 
     /**
      * Number of branch instructions using for clustering executions in the test minimization phase.

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -20,7 +20,7 @@ private const val defaultKeyForSettingsPath = "utbot.settings.path"
 /**
  * Default concrete execution timeout (in milliseconds).
  */
-const val DEFAULT_CONCRETE_EXECUTION_TIMEOUT_IN_INSTRUMENTED_PROCESS_MS = 1000L
+const val DEFAULT_EXECUTION_TIMEOUT_IN_INSTRUMENTED_PROCESS_MS = 1000L
 
 object UtSettings : AbstractSettings(
     logger, defaultKeyForSettingsPath, defaultSettingsPath
@@ -261,7 +261,7 @@ object UtSettings : AbstractSettings(
      * Timeout for specific concrete execution (in milliseconds).
      */
     var concreteExecutionTimeoutInInstrumentedProcess: Long by getLongProperty(
-        DEFAULT_CONCRETE_EXECUTION_TIMEOUT_IN_INSTRUMENTED_PROCESS_MS
+        DEFAULT_EXECUTION_TIMEOUT_IN_INSTRUMENTED_PROCESS_MS
     )
 
 // region engine process debug
@@ -274,35 +274,39 @@ object UtSettings : AbstractSettings(
     var engineProcessLogConfigFile by getStringProperty("")
 
     /**
-     * Property useful only for idea
-     * If true - runs engine process with the ability to attach a debugger
+     * The property is useful only for the IntelliJ IDEs.
+     * If the property is set in true the engine process opens a debug port.
      * @see runInstrumentedProcessWithDebug
      * @see org.utbot.intellij.plugin.process.EngineProcess
      */
     var runEngineProcessWithDebug by getBooleanProperty(false)
 
     /**
-     * Port which will be used for debugging engine process
+     * The engine process JDWP agent's port of the instrumented process.
+     * A debugger attaches to the port in order to debug the process.
      */
     var engineProcessDebugPort by getIntProperty(5005)
 
     /**
-     * Whether engine process should suspend until debugger attached
+     * Value of the suspend mode for the JDWP agent of the engine process.
+     * If the value is true, the engine process will suspend until a debugger attaches to it.
      */
-    var engineProcessDebugSuspendPolicy by getBooleanProperty(true)
+    var suspendEngineProcessExecutionInDebugMode by getBooleanProperty(true)
 
 // endregion
 
 // region instrumented process debug
     /**
-     * Port which will be used for debugging instrumented process
+     * The instrumented process JDWP agent's port of the instrumented process.
+     * A debugger attaches to the port in order to debug the process.
      */
     var instrumentedProcessDebugPort by getIntProperty(5006)
 
     /**
-     * Whether instrumented process should suspend until debugger attached
+     * Value of the suspend mode for the JDWP agent of the instrumented process.
+     * If the value is true, the instrumented process will suspend until a debugger attaches to it.
      */
-    var instrumentedProcessSuspendPolicy by getBooleanProperty(true)
+    var suspendInstrumentedProcessExecutionInDebugMode by getBooleanProperty(true)
 
     /**
      * If true, runs the instrumented process with the ability to attach a debugger.

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/UtExecutionResult.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/UtExecutionResult.kt
@@ -58,14 +58,14 @@ data class UtTimeoutException(override val exception: TimeoutException) : UtExec
 
 /**
  * Indicates failure in concrete execution.
- * For now it is explicitly throwing by ConcreteExecutor in case child process death.
+ * For now it is explicitly throwing by ConcreteExecutor in case instrumented process death.
  */
 class ConcreteExecutionFailureException(cause: Throwable, errorFile: File, val processStdout: List<String>) :
     Exception(
         buildString {
             appendLine()
             appendLine("----------------------------------------")
-            appendLine("The child process is dead")
+            appendLine("The instrumented process is dead")
             appendLine("Cause:\n${cause.message}")
             appendLine("Last 1000 lines of the error log ${errorFile.absolutePath}:")
             appendLine("----------------------------------------")

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/services/JdkInfoService.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/services/JdkInfoService.kt
@@ -11,7 +11,7 @@ data class JdkInfo(
 /**
  * Singleton to enable abstract access to path to JDK.
 
- * Used in [org.utbot.instrumentation.process.ChildProcessRunner].
+ * Used in [org.utbot.instrumentation.process.InstrumentedProcessRunner].
  * The purpose is to use the same JDK in [org.utbot.instrumentation.ConcreteExecutor] and in the test runs.
  * This is necessary because the engine can be run from the various starting points, like IDEA plugin, CLI, etc.
  */

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/services/WorkingDirService.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/services/WorkingDirService.kt
@@ -6,7 +6,7 @@ import java.nio.file.Paths
 /**
  * Singleton to enable abstract access to the working directory.
  *
- * Used in [org.utbot.instrumentation.process.ChildProcessRunner].
+ * Used in [org.utbot.instrumentation.process.InstrumentedProcessRunner].
  * The purpose is to use the same working directory in [org.utbot.instrumentation.ConcreteExecutor]
  * and in the test runs.
  */

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/process/OpenModulesContainer.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/process/OpenModulesContainer.kt
@@ -4,10 +4,9 @@ import org.utbot.framework.plugin.services.JdkInfoService
 
 object OpenModulesContainer {
     private val modulesContainer: List<String>
-    val javaVersionSpecificArguments: List<String>
+    val javaVersionSpecificArguments: List<String>?
         get() = modulesContainer
             .takeIf { JdkInfoService.provide().version > 8 }
-            ?: emptyList()
 
     init {
         modulesContainer = buildList {

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/process/OpenModulesContainer.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/process/OpenModulesContainer.kt
@@ -4,9 +4,9 @@ import org.utbot.framework.plugin.services.JdkInfoService
 
 object OpenModulesContainer {
     private val modulesContainer: List<String>
-    val javaVersionSpecificArguments: List<String>?
+    val javaVersionSpecificArguments: List<String>
         get() = modulesContainer
-            .takeIf { JdkInfoService.provide().version > 8 }
+            .takeIf { JdkInfoService.provide().version > 8 } ?: emptyList()
 
     init {
         modulesContainer = buildList {

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/strings/StringExamplesTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/strings/StringExamplesTest.kt
@@ -382,7 +382,7 @@ internal class StringExamplesTest : UtValueTestCaseChecker(
             { _, i, r -> i <= 0 && r.isException<IllegalArgumentException>() },
             { cs, i, r -> i > 0 && cs == null && !r.getOrThrow() },
             { cs, i, r -> i > 0 && cs != null && cs.length > i && r.getOrThrow() },
-            coverage = DoNotCalculate // TODO: Coverage calculation fails in the child process with Illegal Argument Exception
+            coverage = DoNotCalculate // TODO: Coverage calculation fails in the instrumented process with Illegal Argument Exception
         )
     }
 

--- a/utbot-framework-test/src/test/resources/log4j2.xml
+++ b/utbot-framework-test/src/test/resources/log4j2.xml
@@ -7,12 +7,12 @@
                      filePattern="logs/framework-%d{MM-dd-yyyy}.log.gz"
                      ignoreExceptions="false">
 
-            <PatternLayout pattern=" | %-5level | %c{1} | %msg%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} | %-5level | %-25c{1} | %msg%n"/>
         </File>
 
         <Console name="Console" target="SYSTEM_OUT">
             <ThresholdFilter level="DEBUG"  onMatch="NEUTRAL"   onMismatch="DENY"/>
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} | %-5level | %c{1} | %msg%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} | %-5level | %-25c{1} | %msg%n"/>
         </Console>
     </Appenders>
     <Loggers>

--- a/utbot-framework/build.gradle
+++ b/utbot-framework/build.gradle
@@ -16,8 +16,8 @@ dependencies {
     api project(':utbot-framework-api')
     api project(':utbot-rd')
 
-    implementation group: 'com.jetbrains.rd', name: 'rd-framework', version: '2022.3.1'
-    implementation group: 'com.jetbrains.rd', name: 'rd-core', version: '2022.3.1'
+    implementation group: 'com.jetbrains.rd', name: 'rd-framework', version: rdVersion
+    implementation group: 'com.jetbrains.rd', name: 'rd-core', version: rdVersion
 
     implementation("org.unittestbot.soot:soot-utbot-fork:${sootVersion}") {
         exclude group:'com.google.guava', module:'guava'

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
@@ -391,7 +391,7 @@ class UtBotSymbolicEngine(
      */
     fun fuzzing(until: Long = Long.MAX_VALUE, modelProvider: (ModelProvider) -> ModelProvider = { it }) = flow {
         val isFuzzable = methodUnderTest.parameters.all { classId ->
-            classId != Method::class.java.id && // causes the child process crash at invocation
+            classId != Method::class.java.id && // causes the instrumented process crash at invocation
                 classId != Class::class.java.id  // causes java.lang.IllegalAccessException: java.lang.Class at sun.misc.Unsafe.allocateInstance(Native Method)
         }
         if (!isFuzzable) {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
@@ -1,6 +1,6 @@
 package org.utbot.framework.codegen.domain
 
-import org.utbot.framework.DEFAULT_CONCRETE_EXECUTION_TIMEOUT_IN_CHILD_PROCESS_MS
+import org.utbot.framework.DEFAULT_CONCRETE_EXECUTION_TIMEOUT_IN_INSTRUMENTED_PROCESS_MS
 import org.utbot.framework.codegen.domain.builtin.mockitoClassId
 import org.utbot.framework.codegen.domain.builtin.ongoingStubbingClassId
 import org.utbot.framework.codegen.domain.models.CgClassId
@@ -581,7 +581,7 @@ data class HangingTestsTimeout(val timeoutMs: Long) {
     constructor() : this(DEFAULT_TIMEOUT_MS)
 
     companion object {
-        const val DEFAULT_TIMEOUT_MS = DEFAULT_CONCRETE_EXECUTION_TIMEOUT_IN_CHILD_PROCESS_MS
+        const val DEFAULT_TIMEOUT_MS = DEFAULT_CONCRETE_EXECUTION_TIMEOUT_IN_INSTRUMENTED_PROCESS_MS
         const val MIN_TIMEOUT_MS = 100L
         const val MAX_TIMEOUT_MS = 1_000_000L
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
@@ -1,6 +1,6 @@
 package org.utbot.framework.codegen.domain
 
-import org.utbot.framework.DEFAULT_CONCRETE_EXECUTION_TIMEOUT_IN_INSTRUMENTED_PROCESS_MS
+import org.utbot.framework.DEFAULT_EXECUTION_TIMEOUT_IN_INSTRUMENTED_PROCESS_MS
 import org.utbot.framework.codegen.domain.builtin.mockitoClassId
 import org.utbot.framework.codegen.domain.builtin.ongoingStubbingClassId
 import org.utbot.framework.codegen.domain.models.CgClassId
@@ -581,7 +581,7 @@ data class HangingTestsTimeout(val timeoutMs: Long) {
     constructor() : this(DEFAULT_TIMEOUT_MS)
 
     companion object {
-        const val DEFAULT_TIMEOUT_MS = DEFAULT_CONCRETE_EXECUTION_TIMEOUT_IN_INSTRUMENTED_PROCESS_MS
+        const val DEFAULT_TIMEOUT_MS = DEFAULT_EXECUTION_TIMEOUT_IN_INSTRUMENTED_PROCESS_MS
         const val MIN_TIMEOUT_MS = 100L
         const val MAX_TIMEOUT_MS = 1_000_000L
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/UtExecutionInstrumentation.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/UtExecutionInstrumentation.kt
@@ -52,12 +52,12 @@ import kotlin.reflect.jvm.javaMethod
  * @property [stateBefore] is necessary for construction of parameters of a concrete call.
  * @property [instrumentation] is necessary for mocking static methods and new instances.
  * @property [timeout] is timeout for specific concrete execution (in milliseconds).
- * By default is initialized from [UtSettings.concreteExecutionTimeoutInChildProcess]
+ * By default is initialized from [UtSettings.concreteExecutionTimeoutInInstrumentedProcess]
  */
 data class UtConcreteExecutionData(
     val stateBefore: EnvironmentModels,
     val instrumentation: List<UtInstrumentation>,
-    val timeout: Long = UtSettings.concreteExecutionTimeoutInChildProcess
+    val timeout: Long = UtSettings.concreteExecutionTimeoutInInstrumentedProcess
 )
 
 class UtConcreteExecutionResult(

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/minimization/Minimization.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/minimization/Minimization.kt
@@ -27,7 +27,7 @@ import org.utbot.framework.plugin.api.UtVoidModel
  * We have 4 different test suites:
  * * Regression suite
  * * Error suite (invocations in which implicitly thrown unchecked exceptions reached to the top)
- * * Crash suite (invocations in which the child process crashed or unexpected exception in our code occurred)
+ * * Crash suite (invocations in which the instrumented process crashed or unexpected exception in our code occurred)
  * * Timeout suite
  *
  * We want to minimize tests independently in each of these suites.

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestCaseGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestCaseGenerator.kt
@@ -224,7 +224,7 @@ open class TestCaseGenerator(
                 }
             }
         }
-        ConcreteExecutor.defaultPool.close() // TODO: think on appropriate way to close child processes
+        ConcreteExecutor.defaultPool.close() // TODO: think on appropriate way to close instrumented processes
 
 
         return methods.map { method ->

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestCaseGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestCaseGenerator.kt
@@ -204,7 +204,7 @@ open class TestCaseGenerator(
                             method2controller.values.forEach { it.paused = true }
                             controller.paused = false
 
-                            logger.info { "|> Resuming method $method" }
+                            logger.info { "Resuming method $method" }
                             val startTime = System.currentTimeMillis()
                             while (controller.job!!.isActive &&
                                 (System.currentTimeMillis() - startTime) < executionTimeEstimator.timeslotForOneToplevelMethodTraversalInMillis

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/utils/DependencyUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/utils/DependencyUtils.kt
@@ -13,7 +13,7 @@ private val logger = KotlinLogging.logger {}
  * and their versions correspond to our requirements.
  *
  * Note: [UtExecutionInstrumentation] must be in dependency path too
- * as it is used by Engine in the child process in Concrete Executor.
+ * as it is used by Engine in the instrumented process in Concrete Executor.
  */
 fun checkFrameworkDependencies(dependencyPaths: String?) {
     if (dependencyPaths.isNullOrEmpty()) {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineProcessMain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineProcessMain.kt
@@ -34,7 +34,9 @@ import org.utbot.instrumentation.instrumentation.instrumenter.Instrumenter
 import org.utbot.instrumentation.util.KryoHelper
 import org.utbot.rd.IdleWatchdog
 import org.utbot.rd.ClientProtocolBuilder
+import org.utbot.rd.RdSettingsContainerFactory
 import org.utbot.rd.findRdPort
+import org.utbot.rd.generated.settingsModel
 import org.utbot.rd.loggers.UtRdKLoggerFactory
 import org.utbot.sarif.RdSourceFindingStrategyFacade
 import org.utbot.sarif.SarifReport

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/process/RdSettingsContainer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/process/RdSettingsContainer.kt
@@ -1,42 +1,43 @@
 package org.utbot.framework.process
 
-import com.jetbrains.rd.framework.IProtocol
 import kotlinx.coroutines.runBlocking
 import mu.KLogger
 import org.utbot.common.SettingsContainer
 import org.utbot.common.SettingsContainerFactory
 import org.utbot.framework.process.generated.SettingForArgument
-import org.utbot.framework.process.generated.settingsModel
+import org.utbot.framework.process.generated.SettingsModel
+import org.utbot.rd.startBlocking
 import kotlin.properties.PropertyDelegateProvider
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
-class RdSettingsContainerFactory(private val protocol: IProtocol) : SettingsContainerFactory {
+class RdSettingsContainerFactory(private val settingsModel: SettingsModel) : SettingsContainerFactory {
     override fun createSettingsContainer(
         logger: KLogger,
         defaultKeyForSettingsPath: String,
         defaultSettingsPath: String?
     ): SettingsContainer {
-        return RdSettingsContainer(logger, defaultKeyForSettingsPath, protocol)
+        return RdSettingsContainer(logger, defaultKeyForSettingsPath, settingsModel)
     }
 }
 
-class RdSettingsContainer(val logger: KLogger, val key: String, val protocol: IProtocol): SettingsContainer {
+class RdSettingsContainer(val logger: KLogger, val key: String, val settingsModel: SettingsModel) : SettingsContainer {
 
     override fun <T> settingFor(
         defaultValue: T,
         converter: (String) -> T
     ): PropertyDelegateProvider<Any?, ReadWriteProperty<Any?, T>> {
-        return PropertyDelegateProvider { _, prop ->
-            object: ReadWriteProperty<Any?, T> {
-                override fun getValue(thisRef: Any?, property: KProperty<*>): T = runBlocking {
-                    return@runBlocking protocol.settingsModel.settingFor.startSuspending(SettingForArgument(key, property.name)).value?.let {
+        return PropertyDelegateProvider { _, _ ->
+            object : ReadWriteProperty<Any?, T> {
+                override fun getValue(thisRef: Any?, property: KProperty<*>): T {
+                    val params = SettingForArgument(key, property.name)
+                    return settingsModel.settingFor.startBlocking(params).value?.let {
                         converter(it)
                     } ?: defaultValue
                 }
 
                 override fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
-                    throw NotImplementedError("Setting properties from child process not supported")
+                    throw NotImplementedError("Setting properties allowed only from plugin process")
                 }
             }
         }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/process/generated/EngineProcessModel.Generated.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/process/generated/EngineProcessModel.Generated.kt
@@ -66,10 +66,7 @@ class EngineProcessModel private constructor(
         fun create(lifetime: Lifetime, protocol: IProtocol): EngineProcessModel  {
             EngineProcessRoot.register(protocol.serializers)
             
-            return EngineProcessModel().apply {
-                identify(protocol.identity, RdId.Null.mix("EngineProcessModel"))
-                bind(lifetime, protocol, "EngineProcessModel")
-            }
+            return EngineProcessModel()
         }
         
         

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/process/generated/EngineProcessModel.Generated.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/process/generated/EngineProcessModel.Generated.kt
@@ -64,7 +64,7 @@ class EngineProcessModel private constructor(
         @JvmStatic
         @Deprecated("Use protocol.engineProcessModel or revise the extension scope instead", ReplaceWith("protocol.engineProcessModel"))
         fun create(lifetime: Lifetime, protocol: IProtocol): EngineProcessModel  {
-            EngineProcessProtocolRoot.register(protocol.serializers)
+            EngineProcessRoot.register(protocol.serializers)
             
             return EngineProcessModel().apply {
                 identify(protocol.identity, RdId.Null.mix("EngineProcessModel"))

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/process/generated/EngineProcessRoot.Generated.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/process/generated/EngineProcessRoot.Generated.kt
@@ -17,14 +17,14 @@ import kotlin.jvm.JvmStatic
 /**
  * #### Generated from [EngineProcessModel.kt:5]
  */
-class EngineProcessProtocolRoot private constructor(
+class EngineProcessRoot private constructor(
 ) : RdExtBase() {
     //companion
     
     companion object : ISerializersOwner {
         
         override fun registerSerializersCore(serializers: ISerializers)  {
-            EngineProcessProtocolRoot.register(serializers)
+            EngineProcessRoot.register(serializers)
             EngineProcessModel.register(serializers)
             RdInstrumenterAdapter.register(serializers)
             RdSourceFindingStrategy.register(serializers)
@@ -34,11 +34,11 @@ class EngineProcessProtocolRoot private constructor(
         
         
         
-        const val serializationHash = -4532543668004925627L
+        const val serializationHash = 2863869932420445069L
         
     }
-    override val serializersOwner: ISerializersOwner get() = EngineProcessProtocolRoot
-    override val serializationHash: Long get() = EngineProcessProtocolRoot.serializationHash
+    override val serializersOwner: ISerializersOwner get() = EngineProcessRoot
+    override val serializationHash: Long get() = EngineProcessRoot.serializationHash
     
     //fields
     //methods
@@ -48,12 +48,12 @@ class EngineProcessProtocolRoot private constructor(
     //hash code trait
     //pretty print
     override fun print(printer: PrettyPrinter)  {
-        printer.println("EngineProcessProtocolRoot (")
+        printer.println("EngineProcessRoot (")
         printer.print(")")
     }
     //deepClone
-    override fun deepClone(): EngineProcessProtocolRoot   {
-        return EngineProcessProtocolRoot(
+    override fun deepClone(): EngineProcessRoot   {
+        return EngineProcessRoot(
         )
     }
     //contexts

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/process/generated/RdInstrumenterAdapter.Generated.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/process/generated/RdInstrumenterAdapter.Generated.kt
@@ -42,10 +42,7 @@ class RdInstrumenterAdapter private constructor(
         fun create(lifetime: Lifetime, protocol: IProtocol): RdInstrumenterAdapter  {
             EngineProcessRoot.register(protocol.serializers)
             
-            return RdInstrumenterAdapter().apply {
-                identify(protocol.identity, RdId.Null.mix("RdInstrumenterAdapter"))
-                bind(lifetime, protocol, "RdInstrumenterAdapter")
-            }
+            return RdInstrumenterAdapter()
         }
         
         private val __StringNullableSerializer = FrameworkMarshallers.String.nullable()

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/process/generated/RdInstrumenterAdapter.Generated.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/process/generated/RdInstrumenterAdapter.Generated.kt
@@ -40,7 +40,7 @@ class RdInstrumenterAdapter private constructor(
         @JvmStatic
         @Deprecated("Use protocol.rdInstrumenterAdapter or revise the extension scope instead", ReplaceWith("protocol.rdInstrumenterAdapter"))
         fun create(lifetime: Lifetime, protocol: IProtocol): RdInstrumenterAdapter  {
-            EngineProcessProtocolRoot.register(protocol.serializers)
+            EngineProcessRoot.register(protocol.serializers)
             
             return RdInstrumenterAdapter().apply {
                 identify(protocol.identity, RdId.Null.mix("RdInstrumenterAdapter"))

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/process/generated/RdSourceFindingStrategy.Generated.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/process/generated/RdSourceFindingStrategy.Generated.kt
@@ -44,10 +44,7 @@ class RdSourceFindingStrategy private constructor(
         fun create(lifetime: Lifetime, protocol: IProtocol): RdSourceFindingStrategy  {
             EngineProcessRoot.register(protocol.serializers)
             
-            return RdSourceFindingStrategy().apply {
-                identify(protocol.identity, RdId.Null.mix("RdSourceFindingStrategy"))
-                bind(lifetime, protocol, "RdSourceFindingStrategy")
-            }
+            return RdSourceFindingStrategy()
         }
         
         private val __StringNullableSerializer = FrameworkMarshallers.String.nullable()

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/process/generated/RdSourceFindingStrategy.Generated.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/process/generated/RdSourceFindingStrategy.Generated.kt
@@ -42,7 +42,7 @@ class RdSourceFindingStrategy private constructor(
         @JvmStatic
         @Deprecated("Use protocol.rdSourceFindingStrategy or revise the extension scope instead", ReplaceWith("protocol.rdSourceFindingStrategy"))
         fun create(lifetime: Lifetime, protocol: IProtocol): RdSourceFindingStrategy  {
-            EngineProcessProtocolRoot.register(protocol.serializers)
+            EngineProcessRoot.register(protocol.serializers)
             
             return RdSourceFindingStrategy().apply {
                 identify(protocol.identity, RdId.Null.mix("RdSourceFindingStrategy"))

--- a/utbot-instrumentation-tests/build.gradle
+++ b/utbot-instrumentation-tests/build.gradle
@@ -9,8 +9,8 @@ dependencies {
     testImplementation configurations.fetchInstrumentationJar
     testImplementation project(':utbot-sample')
     testImplementation group: 'org.jacoco', name: 'org.jacoco.report', version: jacocoVersion
-    implementation group: 'com.jetbrains.rd', name: 'rd-framework', version: '2022.3.1'
-    implementation group: 'com.jetbrains.rd', name: 'rd-core', version: '2022.3.1'
+    implementation group: 'com.jetbrains.rd', name: 'rd-framework', version: rdVersion
+    implementation group: 'com.jetbrains.rd', name: 'rd-core', version: rdVersion
 }
 
 processResources {

--- a/utbot-instrumentation-tests/build.gradle
+++ b/utbot-instrumentation-tests/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 }
 
 processResources {
-    // We will extract this jar in `ChildProcessRunner` class.
+    // We will extract this jar in `InstrumentedProcessRunner` class.
     from(configurations.fetchInstrumentationJar) {
         into "instrumentation-lib"
     }

--- a/utbot-instrumentation-tests/src/test/kotlin/org/utbot/examples/TestCoverageInstrumentation.kt
+++ b/utbot-instrumentation-tests/src/test/kotlin/org/utbot/examples/TestCoverageInstrumentation.kt
@@ -10,7 +10,7 @@ import org.utbot.instrumentation.ConcreteExecutor
 import org.utbot.instrumentation.execute
 import org.utbot.instrumentation.instrumentation.coverage.CoverageInstrumentation
 import org.utbot.instrumentation.instrumentation.coverage.collectCoverage
-import org.utbot.instrumentation.util.ChildProcessError
+import org.utbot.instrumentation.util.InstrumentedProcessError
 import org.utbot.instrumentation.util.StaticEnvironment
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertInstanceOf
@@ -67,7 +67,7 @@ class TestCoverageInstrumentation {
             ExampleClass::class.java.protectionDomain.codeSource.location.path
         ).use {
             val testObject = ExampleClass()
-            val exc = assertThrows<ChildProcessError> {
+            val exc = assertThrows<InstrumentedProcessError> {
                 it.execute(
                     ExampleClass::bar,
                     arrayOf(testObject, 1, 2, 3)
@@ -90,7 +90,7 @@ class TestCoverageInstrumentation {
             ExampleClass::class.java.protectionDomain.codeSource.location.path
         ).use {
             val testObject = ExampleClass()
-            val exc = assertThrows<ChildProcessError> {
+            val exc = assertThrows<InstrumentedProcessError> {
                 it.execute(
                     ExampleClass::bar,
                     arrayOf(testObject, 1, 2, 3)

--- a/utbot-instrumentation-tests/src/test/kotlin/org/utbot/examples/TestInvokeInstrumentation.kt
+++ b/utbot-instrumentation-tests/src/test/kotlin/org/utbot/examples/TestInvokeInstrumentation.kt
@@ -7,7 +7,7 @@ import org.utbot.examples.samples.staticenvironment.StaticExampleClass
 import org.utbot.instrumentation.ConcreteExecutor
 import org.utbot.instrumentation.execute
 import org.utbot.instrumentation.instrumentation.InvokeInstrumentation
-import org.utbot.instrumentation.util.ChildProcessError
+import org.utbot.instrumentation.util.InstrumentedProcessError
 import kotlin.reflect.full.declaredMembers
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertInstanceOf
@@ -40,7 +40,7 @@ class TestInvokeInstrumentation {
             ExampleClass::class.java.protectionDomain.codeSource.location.path
         ).use {
             val testObject = ExampleClass()
-            val exc = assertThrows<ChildProcessError> {
+            val exc = assertThrows<InstrumentedProcessError> {
                 it.execute(
                     ExampleClass::bar,
                     arrayOf(testObject, 1, 2, 3)

--- a/utbot-instrumentation-tests/src/test/kotlin/org/utbot/examples/TestIsolated.kt
+++ b/utbot-instrumentation-tests/src/test/kotlin/org/utbot/examples/TestIsolated.kt
@@ -5,7 +5,7 @@ import org.utbot.examples.samples.ExampleClass
 import org.utbot.examples.samples.staticenvironment.StaticExampleClass
 import org.utbot.instrumentation.ConcreteExecutor
 import org.utbot.instrumentation.instrumentation.InvokeInstrumentation
-import org.utbot.instrumentation.util.ChildProcessError
+import org.utbot.instrumentation.util.InstrumentedProcessError
 import org.utbot.instrumentation.util.Isolated
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertInstanceOf
@@ -48,7 +48,7 @@ class TestIsolated {
             }
 
 
-            val exc = assertThrows<ChildProcessError> {
+            val exc = assertThrows<InstrumentedProcessError> {
                 isolatedFunction(testObject, 1, 2, 3)
             }
 

--- a/utbot-instrumentation/build.gradle
+++ b/utbot-instrumentation/build.gradle
@@ -24,12 +24,12 @@ jar {
 
     manifest {
         attributes (
-                'Main-Class': 'org.utbot.instrumentation.process.ChildProcessKt',
+                'Main-Class': 'org.utbot.instrumentation.process.InstrumentedProcessMainKt',
                 'Premain-Class': 'org.utbot.instrumentation.agent.Agent',
         )
     }
 
-    // we need only classes from implementation and utbot to execute child process
+    // we need only classes from implementation and utbot to execute instrumented process
     dependsOn configurations.compileClasspath
     from {
         configurations.compileClasspath

--- a/utbot-instrumentation/build.gradle
+++ b/utbot-instrumentation/build.gradle
@@ -9,8 +9,8 @@ dependencies {
     implementation group: 'de.javakaffee', name: 'kryo-serializers', version: kryoSerializersVersion
     implementation group: 'io.github.microutils', name: 'kotlin-logging', version: kotlinLoggingVersion
 
-    implementation group: 'com.jetbrains.rd', name: 'rd-framework', version: '2022.3.1'
-    implementation group: 'com.jetbrains.rd', name: 'rd-core', version: '2022.3.1'
+    implementation group: 'com.jetbrains.rd', name: 'rd-framework', version: rdVersion
+    implementation group: 'com.jetbrains.rd', name: 'rd-core', version: rdVersion
     implementation group: 'net.java.dev.jna', name: 'jna-platform', version: '5.5.0'
 
 

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/ConcreteExecutor.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/ConcreteExecutor.kt
@@ -242,7 +242,7 @@ class ConcreteExecutor<TIResult, TInstrumentation : Instrumentation<TIResult>> p
             val parametersByteArray = kryoHelper.writeObject(parameters)
             val params = InvokeMethodCommandParams(className, signature, argumentsByteArray, parametersByteArray)
 
-            val ba = chidlProcessModel.invokeMethodCommand.startSuspending(lifetime, params).result
+            val ba = instrumentedProcessModel.invokeMethodCommand.startSuspending(lifetime, params).result
             kryoHelper.readObject(ba)
         }
     } catch (e: Throwable) {
@@ -282,7 +282,7 @@ class ConcreteExecutor<TIResult, TInstrumentation : Instrumentation<TIResult>> p
                 if (alive) {
                     try {
                         processInstance?.run {
-                            chidlProcessModel.stopProcess.start(lifetime, Unit)
+                            instrumentedProcessModel.stopProcess.start(lifetime, Unit)
                         }
                     } catch (_: Exception) {}
                     processInstance = null
@@ -296,7 +296,7 @@ class ConcreteExecutor<TIResult, TInstrumentation : Instrumentation<TIResult>> p
 
 fun ConcreteExecutor<*,*>.warmup() = runBlocking {
     withProcess {
-        chidlProcessModel.warmup.start(lifetime, Unit)
+        instrumentedProcessModel.warmup.start(lifetime, Unit)
     }
 }
 
@@ -308,7 +308,7 @@ fun <T> ConcreteExecutor<*, *>.computeStaticField(fieldId: FieldId): Result<T> =
         val fieldIdSerialized = kryoHelper.writeObject(fieldId)
         val params = ComputeStaticFieldParams(fieldIdSerialized)
 
-        val result = chidlProcessModel.computeStaticField.startSuspending(lifetime, params)
+        val result = instrumentedProcessModel.computeStaticField.startSuspending(lifetime, params)
 
         kryoHelper.readObject(result.result)
     }

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/ConcreteExecutor.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/ConcreteExecutor.kt
@@ -244,7 +244,7 @@ class ConcreteExecutor<TIResult, TInstrumentation : Instrumentation<TIResult>> p
             val parametersByteArray = kryoHelper.writeObject(parameters)
             val params = InvokeMethodCommandParams(className, signature, argumentsByteArray, parametersByteArray)
 
-            val ba = protocolModel.invokeMethodCommand.startSuspending(lifetime, params).result
+            val ba = chidlProcessModel.invokeMethodCommand.startSuspending(lifetime, params).result
             kryoHelper.readObject(ba)
         }
     } catch (e: Throwable) {
@@ -284,7 +284,7 @@ class ConcreteExecutor<TIResult, TInstrumentation : Instrumentation<TIResult>> p
                 if (alive) {
                     try {
                         processInstance?.run {
-                            protocolModel.stopProcess.start(lifetime, Unit)
+                            chidlProcessModel.stopProcess.start(lifetime, Unit)
                         }
                     } catch (_: Exception) {}
                     processInstance = null
@@ -298,7 +298,7 @@ class ConcreteExecutor<TIResult, TInstrumentation : Instrumentation<TIResult>> p
 
 fun ConcreteExecutor<*,*>.warmup() = runBlocking {
     withProcess {
-        protocolModel.warmup.start(lifetime, Unit)
+        chidlProcessModel.warmup.start(lifetime, Unit)
     }
 }
 
@@ -310,7 +310,7 @@ fun <T> ConcreteExecutor<*, *>.computeStaticField(fieldId: FieldId): Result<T> =
         val fieldIdSerialized = kryoHelper.writeObject(fieldId)
         val params = ComputeStaticFieldParams(fieldIdSerialized)
 
-        val result = protocolModel.computeStaticField.startSuspending(lifetime, params)
+        val result = chidlProcessModel.computeStaticField.startSuspending(lifetime, params)
 
         kryoHelper.readObject(result.result)
     }

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/ConcreteExecutor.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/ConcreteExecutor.kt
@@ -7,7 +7,6 @@ import com.jetbrains.rd.util.lifetime.isAlive
 import com.jetbrains.rd.util.lifetime.throwIfNotAlive
 import java.io.Closeable
 import java.util.concurrent.atomic.AtomicLong
-import kotlin.concurrent.thread
 import kotlin.reflect.KCallable
 import kotlin.reflect.KFunction
 import kotlin.reflect.KProperty
@@ -25,19 +24,19 @@ import org.utbot.framework.plugin.api.FieldId
 import org.utbot.framework.plugin.api.util.UtContext
 import org.utbot.framework.plugin.api.util.signature
 import org.utbot.instrumentation.instrumentation.Instrumentation
-import org.utbot.instrumentation.process.ChildProcessRunner
-import org.utbot.instrumentation.rd.UtInstrumentationProcess
-import org.utbot.instrumentation.rd.generated.ComputeStaticFieldParams
-import org.utbot.instrumentation.rd.generated.InvokeMethodCommandParams
-import org.utbot.instrumentation.util.ChildProcessError
+import org.utbot.instrumentation.process.InstrumentedProcessRunner
+import org.utbot.instrumentation.process.generated.ComputeStaticFieldParams
+import org.utbot.instrumentation.process.generated.InvokeMethodCommandParams
+import org.utbot.instrumentation.rd.InstrumentedProcess
+import org.utbot.instrumentation.util.InstrumentedProcessError
 import org.utbot.rd.loggers.UtRdKLoggerFactory
 
 private val logger = KotlinLogging.logger {}
 
 /**
- * Creates [ConcreteExecutor], which delegates `execute` calls to the child process, and applies the given [block] to it.
+ * Creates [ConcreteExecutor], which delegates `execute` calls to the instrumented process, and applies the given [block] to it.
  *
- * The child process will search for the classes in [pathsToUserClasses] and will use [instrumentation] for instrumenting.
+ * The instrumented process will search for the classes in [pathsToUserClasses] and will use [instrumentation] for instrumenting.
  *
  * Specific instrumentation can add functionality to [ConcreteExecutor] via Kotlin extension functions.
  *
@@ -96,12 +95,12 @@ class ConcreteExecutorPool(val maxCount: Int = Settings.defaultConcreteExecutorP
 }
 
 /**
- * Concrete executor class. Takes [pathsToUserClasses] where the child process will search for the classes. Paths should
+ * Concrete executor class. Takes [pathsToUserClasses] where the instrumented process will search for the classes. Paths should
  * be separated with [java.io.File.pathSeparatorChar].
  *
  * If [instrumentation] depends on other classes, they should be passed in [pathsToDependencyClasses].
  *
- * Also takes [instrumentation] object which will be used in the child process for the instrumentation.
+ * Also takes [instrumentation] object which will be used in the instrumented process for the instrumentation.
  *
  * @param TIResult the return type of [Instrumentation.invoke] function for the given [instrumentation].
  */
@@ -111,7 +110,7 @@ class ConcreteExecutor<TIResult, TInstrumentation : Instrumentation<TIResult>> p
     internal val pathsToDependencyClasses: String
 ) : Closeable, Executor<TIResult> {
     private val ldef: LifetimeDefinition = LifetimeDefinition()
-    private val childProcessRunner: ChildProcessRunner = ChildProcessRunner()
+    private val instrumentedProcessRunner: InstrumentedProcessRunner = InstrumentedProcessRunner()
 
     companion object {
 
@@ -126,7 +125,6 @@ class ConcreteExecutor<TIResult, TInstrumentation : Instrumentation<TIResult>> p
 
         init {
             Logger.set(Lifetime.Eternal, UtRdKLoggerFactory(logger))
-            Runtime.getRuntime().addShutdownHook(thread(start = false) { defaultPool.close() })
         }
 
         /**
@@ -153,18 +151,18 @@ class ConcreteExecutor<TIResult, TInstrumentation : Instrumentation<TIResult>> p
         get() = ldef.isAlive
 
     private val corMutex = Mutex()
-    private var processInstance: UtInstrumentationProcess? = null
+    private var processInstance: InstrumentedProcess? = null
 
     // this function is intended to be called under corMutex
-    private suspend fun regenerate(): UtInstrumentationProcess {
+    private suspend fun regenerate(): InstrumentedProcess {
         ldef.throwIfNotAlive()
 
-        var proc: UtInstrumentationProcess? = processInstance
+        var proc: InstrumentedProcess? = processInstance
 
         if (proc == null || !proc.lifetime.isAlive) {
-            proc = UtInstrumentationProcess(
+            proc = InstrumentedProcess(
                 ldef,
-                childProcessRunner,
+                instrumentedProcessRunner,
                 instrumentation,
                 pathsToUserClasses,
                 pathsToDependencyClasses,
@@ -177,18 +175,18 @@ class ConcreteExecutor<TIResult, TInstrumentation : Instrumentation<TIResult>> p
     }
 
     /**
-     * Main entry point for communicating with child process.
+     * Main entry point for communicating with instrumented process.
      * Use this function every time you want to access protocol model.
-     * This method prepares child process for execution and ensures it is alive before giving it block
+     * This method prepares instrumented process for execution and ensures it is alive before giving it block
      *
      * @param exclusively if true - executes block under mutex.
      * This guarantees that no one can access protocol model - no other calls made before block completes
      */
-    suspend fun <T> withProcess(exclusively: Boolean = false, block: suspend UtInstrumentationProcess.() -> T): T {
-        fun throwConcreteIfDead(e: Throwable, proc: UtInstrumentationProcess?) {
+    suspend fun <T> withProcess(exclusively: Boolean = false, block: suspend InstrumentedProcess.() -> T): T {
+        fun throwConcreteIfDead(e: Throwable, proc: InstrumentedProcess?) {
             if (proc?.lifetime?.isAlive != true) {
                 throw ConcreteExecutionFailureException(e,
-                    childProcessRunner.errorLogFile,
+                    instrumentedProcessRunner.errorLogFile,
                     try {
                         proc?.run { process.inputStream.bufferedReader().lines().toList() } ?: emptyList()
                     } catch (e: Exception) {
@@ -200,7 +198,7 @@ class ConcreteExecutor<TIResult, TInstrumentation : Instrumentation<TIResult>> p
 
         sendTimestamp.set(System.currentTimeMillis())
 
-        var proc: UtInstrumentationProcess? = null
+        var proc: InstrumentedProcess? = null
 
         try {
             if (exclusively) {
@@ -216,7 +214,7 @@ class ConcreteExecutor<TIResult, TInstrumentation : Instrumentation<TIResult>> p
         catch (e: CancellationException) {
             // cancellation can be from 2 causes
             // 1. process died, its lifetime terminated, so operation was cancelled
-            // this clearly indicates child process death -> ConcreteExecutionFailureException
+            // this clearly indicates instrumented process death -> ConcreteExecutionFailureException
             throwConcreteIfDead(e, proc)
             // 2. it can be ordinary timeout from coroutine. then just rethrow
             throw e
@@ -226,7 +224,7 @@ class ConcreteExecutor<TIResult, TInstrumentation : Instrumentation<TIResult>> p
             // 1. be dead because of this exception
             throwConcreteIfDead(e, proc)
             // 2. might be deliberately thrown and process still can operate
-            throw ChildProcessError(e)
+            throw InstrumentedProcessError(e)
         }
         finally {
             receiveTimeStamp.set(System.currentTimeMillis())
@@ -253,7 +251,7 @@ class ConcreteExecutor<TIResult, TInstrumentation : Instrumentation<TIResult>> p
     }
 
     /**
-     * Executes [kCallable] in the child process with the supplied [arguments] and [parameters], e.g. static environment.
+     * Executes [kCallable] in the instrumented process with the supplied [arguments] and [parameters], e.g. static environment.
      *
      * @return the processed result of the method call.
      */

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/Instrumentation.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/Instrumentation.kt
@@ -28,7 +28,7 @@ interface Instrumentation<out TInvocationInstrumentation> : ClassFileTransformer
     fun getStaticField(fieldId: FieldId): Result<*>
 
     /**
-     * Will be called in the very beginning in the child process.
+     * Will be called in the very beginning in the instrumented process.
      */
     fun init(pathsToUserClasses: Set<String>) {}
 }

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/coverage/CoverageInstrumentation.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/coverage/CoverageInstrumentation.kt
@@ -103,6 +103,6 @@ fun ConcreteExecutor<Result<*>, CoverageInstrumentation>.collectCoverage(clazz: 
     withProcess {
         val clazzByteArray = kryoHelper.writeObject(clazz)
 
-        kryoHelper.readObject(chidlProcessModel.collectCoverage.startSuspending(lifetime, CollectCoverageParams(clazzByteArray)).coverageInfo)
+        kryoHelper.readObject(instrumentedProcessModel.collectCoverage.startSuspending(lifetime, CollectCoverageParams(clazzByteArray)).coverageInfo)
     }
 }

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/coverage/CoverageInstrumentation.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/coverage/CoverageInstrumentation.kt
@@ -10,11 +10,9 @@ import org.utbot.instrumentation.instrumentation.InvokeWithStaticsInstrumentatio
 import org.utbot.instrumentation.instrumentation.instrumenter.Instrumenter
 import org.utbot.instrumentation.rd.generated.CollectCoverageParams
 import org.utbot.instrumentation.util.CastProbesArrayException
-import org.utbot.instrumentation.util.ChildProcessError
 import org.utbot.instrumentation.util.NoProbesArrayException
 import java.security.ProtectionDomain
 import org.utbot.framework.plugin.api.FieldId
-import org.utbot.framework.plugin.api.util.jField
 
 data class CoverageInfo(
     val methodToInstrRange: Map<String, IntRange>,
@@ -105,6 +103,6 @@ fun ConcreteExecutor<Result<*>, CoverageInstrumentation>.collectCoverage(clazz: 
     withProcess {
         val clazzByteArray = kryoHelper.writeObject(clazz)
 
-        kryoHelper.readObject(protocolModel.collectCoverage.startSuspending(lifetime, CollectCoverageParams(clazzByteArray)).coverageInfo)
+        kryoHelper.readObject(chidlProcessModel.collectCoverage.startSuspending(lifetime, CollectCoverageParams(clazzByteArray)).coverageInfo)
     }
 }

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/coverage/CoverageInstrumentation.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/coverage/CoverageInstrumentation.kt
@@ -8,11 +8,11 @@ import org.utbot.instrumentation.instrumentation.ArgumentList
 import org.utbot.instrumentation.instrumentation.Instrumentation
 import org.utbot.instrumentation.instrumentation.InvokeWithStaticsInstrumentation
 import org.utbot.instrumentation.instrumentation.instrumenter.Instrumenter
-import org.utbot.instrumentation.rd.generated.CollectCoverageParams
 import org.utbot.instrumentation.util.CastProbesArrayException
 import org.utbot.instrumentation.util.NoProbesArrayException
 import java.security.ProtectionDomain
 import org.utbot.framework.plugin.api.FieldId
+import org.utbot.instrumentation.process.generated.CollectCoverageParams
 
 data class CoverageInfo(
     val methodToInstrRange: Map<String, IntRange>,

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/process/InstrumentedProcessRunner.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/process/InstrumentedProcessRunner.kt
@@ -18,7 +18,7 @@ private val logger = KotlinLogging.logger {}
 class InstrumentedProcessRunner {
     private val cmds: List<String> by lazy {
         val debugCmd = listOfNotNull(DEBUG_RUN_CMD.takeIf { UtSettings.runInstrumentedProcessWithDebug })
-        val javaVersionSpecificArguments = OpenModulesContainer.javaVersionSpecificArguments ?: emptyList()
+        val javaVersionSpecificArguments = OpenModulesContainer.javaVersionSpecificArguments
         val pathToJava = JdkInfoService.provide().path
 
         listOf(pathToJava.resolve("bin${File.separatorChar}${osSpecificJavaExecutable()}").toString()) +
@@ -59,7 +59,7 @@ class InstrumentedProcessRunner {
     }
 
     companion object {
-        private fun suspendValue(): String = if (UtSettings.engineProcessDebugSuspendPolicy) "y" else "n"
+        private fun suspendValue(): String = if (UtSettings.suspendInstrumentedProcessExecutionInDebugMode) "y" else "n"
 
         private const val UTBOT_INSTRUMENTATION = "utbot-instrumentation"
         private const val ERRORS_FILE_PREFIX = "utbot-instrumentedprocess-errors"

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/process/InstrumentedProcessRunner.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/process/InstrumentedProcessRunner.kt
@@ -65,7 +65,7 @@ class InstrumentedProcessRunner {
         private const val ERRORS_FILE_PREFIX = "utbot-instrumentedprocess-errors"
         private const val INSTRUMENTATION_LIB = "lib"
 
-        private val DEBUG_RUN_CMD = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=${suspendValue()},quiet=y,address=${UtSettings.instrumentedProcessDebugPort}"
+        private val DEBUG_RUN_CMD = "-agentlib:jdwp=transport=dt_socket,server=n,suspend=${suspendValue()},quiet=y,address=${UtSettings.instrumentedProcessDebugPort}"
 
         private val UT_BOT_TEMP_DIR: File = File(utBotTempDirectory.toFile(), ERRORS_FILE_PREFIX)
 

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/rd/InstrumentedProcess.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/rd/InstrumentedProcess.kt
@@ -2,52 +2,60 @@ package org.utbot.instrumentation.rd
 
 import com.jetbrains.rd.util.lifetime.Lifetime
 import mu.KotlinLogging
+import org.utbot.framework.UtSettings
 import org.utbot.instrumentation.instrumentation.Instrumentation
-import org.utbot.instrumentation.process.ChildProcessRunner
-import org.utbot.instrumentation.rd.generated.AddPathsParams
-import org.utbot.instrumentation.rd.generated.ChildProcessModel
-import org.utbot.instrumentation.rd.generated.SetInstrumentationParams
-import org.utbot.instrumentation.rd.generated.childProcessModel
+import org.utbot.instrumentation.process.InstrumentedProcessRunner
+import org.utbot.instrumentation.process.generated.AddPathsParams
+import org.utbot.instrumentation.process.generated.InstrumentedProcessModel
+import org.utbot.instrumentation.process.generated.SetInstrumentationParams
+import org.utbot.instrumentation.process.generated.instrumentedProcessModel
 import org.utbot.instrumentation.util.KryoHelper
 import org.utbot.rd.ProcessWithRdServer
+import org.utbot.rd.exceptions.InstantProcessDeathException
 import org.utbot.rd.onSchedulerBlocking
 import org.utbot.rd.startUtProcessWithRdServer
 import org.utbot.rd.terminateOnException
 
 private val logger = KotlinLogging.logger {}
 
+class InstrumentedProcessInstantDeathException: InstantProcessDeathException(UtSettings.instrumentedProcessDebugPort, UtSettings.runInstrumentedProcessWithDebug)
+
 /**
  * Main goals of this class:
- * 1. prepare started child process for execution - initializing rd, sending paths and instrumentation
+ * 1. prepare started instrumented process for execution - initializing rd, sending paths and instrumentation
  * 2. expose bound model
  */
-class UtInstrumentationProcess private constructor(
+class InstrumentedProcess private constructor(
     private val classLoader: ClassLoader?,
     private val rdProcess: ProcessWithRdServer
 ) : ProcessWithRdServer by rdProcess {
     val kryoHelper = KryoHelper(lifetime.createNested()).apply {
         classLoader?.let { setKryoClassLoader(it) }
     }
-    val chidlProcessModel: ChildProcessModel = onSchedulerBlocking { protocol.childProcessModel }
+    val chidlProcessModel: InstrumentedProcessModel = onSchedulerBlocking { protocol.instrumentedProcessModel }
 
     companion object {
         suspend operator fun <TIResult, TInstrumentation : Instrumentation<TIResult>> invoke(
             parent: Lifetime,
-            childProcessRunner: ChildProcessRunner,
+            instrumentedProcessRunner: InstrumentedProcessRunner,
             instrumentation: TInstrumentation,
             pathsToUserClasses: String,
             pathsToDependencyClasses: String,
             classLoader: ClassLoader?
-        ): UtInstrumentationProcess = parent.createNested().terminateOnException { lifetime ->
+        ): InstrumentedProcess = parent.createNested().terminateOnException { lifetime ->
             val rdProcess: ProcessWithRdServer = startUtProcessWithRdServer(
                 lifetime = lifetime
             ) {
-                childProcessRunner.start(it)
+                val process = instrumentedProcessRunner.start(it)
+                if (!process.isAlive) {
+                    throw InstrumentedProcessInstantDeathException()
+                }
+                process
             }.awaitSignal()
 
             logger.trace("rd process started")
 
-            val proc = UtInstrumentationProcess(
+            val proc = InstrumentedProcess(
                 classLoader,
                 rdProcess
             )

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/rd/InstrumentedProcess.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/rd/InstrumentedProcess.kt
@@ -51,7 +51,7 @@ class InstrumentedProcess private constructor(
                     throw InstrumentedProcessInstantDeathException()
                 }
                 process
-            }.awaitSignal()
+            }.awaitProcessReady()
 
             logger.trace("rd process started")
 

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/rd/InstrumentedProcess.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/rd/InstrumentedProcess.kt
@@ -32,7 +32,7 @@ class InstrumentedProcess private constructor(
     val kryoHelper = KryoHelper(lifetime.createNested()).apply {
         classLoader?.let { setKryoClassLoader(it) }
     }
-    val chidlProcessModel: InstrumentedProcessModel = onSchedulerBlocking { protocol.instrumentedProcessModel }
+    val instrumentedProcessModel: InstrumentedProcessModel = onSchedulerBlocking { protocol.instrumentedProcessModel }
 
     companion object {
         suspend operator fun <TIResult, TInstrumentation : Instrumentation<TIResult>> invoke(
@@ -65,7 +65,7 @@ class InstrumentedProcess private constructor(
             }
 
             logger.trace("sending add paths")
-            proc.chidlProcessModel.addPaths.startSuspending(
+            proc.instrumentedProcessModel.addPaths.startSuspending(
                 proc.lifetime, AddPathsParams(
                     pathsToUserClasses,
                     pathsToDependencyClasses
@@ -73,7 +73,7 @@ class InstrumentedProcess private constructor(
             )
 
             logger.trace("sending instrumentation")
-            proc.chidlProcessModel.setInstrumentation.startSuspending(
+            proc.instrumentedProcessModel.setInstrumentation.startSuspending(
                 proc.lifetime, SetInstrumentationParams(
                     proc.kryoHelper.writeObject(instrumentation)
                 )

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/rd/generated/InstrumentedProcessModel.Generated.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/rd/generated/InstrumentedProcessModel.Generated.kt
@@ -55,10 +55,7 @@ class InstrumentedProcessModel private constructor(
         fun create(lifetime: Lifetime, protocol: IProtocol): InstrumentedProcessModel  {
             InstrumentedProcessRoot.register(protocol.serializers)
             
-            return InstrumentedProcessModel().apply {
-                identify(protocol.identity, RdId.Null.mix("InstrumentedProcessModel"))
-                bind(lifetime, protocol, "InstrumentedProcessModel")
-            }
+            return InstrumentedProcessModel()
         }
         
         

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/rd/generated/InstrumentedProcessModel.Generated.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/rd/generated/InstrumentedProcessModel.Generated.kt
@@ -1,5 +1,5 @@
 @file:Suppress("EXPERIMENTAL_API_USAGE","EXPERIMENTAL_UNSIGNED_LITERALS","PackageDirectoryMismatch","UnusedImport","unused","LocalVariableName","CanBeVal","PropertyName","EnumEntryName","ClassName","ObjectPropertyName","UnnecessaryVariable","SpellCheckingInspection")
-package org.utbot.instrumentation.rd.generated
+package org.utbot.instrumentation.process.generated
 
 import com.jetbrains.rd.framework.*
 import com.jetbrains.rd.framework.base.*
@@ -15,9 +15,9 @@ import kotlin.jvm.JvmStatic
 
 
 /**
- * #### Generated from [ChildProcessModel.kt:7]
+ * #### Generated from [InstrumentedProcessModel.kt:7]
  */
-class ChildProcessModel private constructor(
+class InstrumentedProcessModel private constructor(
     private val _addPaths: RdCall<AddPathsParams, Unit>,
     private val _warmup: RdCall<Unit, Unit>,
     private val _setInstrumentation: RdCall<SetInstrumentationParams, Unit>,
@@ -45,33 +45,33 @@ class ChildProcessModel private constructor(
         @JvmStatic
         @JvmName("internalCreateModel")
         @Deprecated("Use create instead", ReplaceWith("create(lifetime, protocol)"))
-        internal fun createModel(lifetime: Lifetime, protocol: IProtocol): ChildProcessModel  {
+        internal fun createModel(lifetime: Lifetime, protocol: IProtocol): InstrumentedProcessModel  {
             @Suppress("DEPRECATION")
             return create(lifetime, protocol)
         }
         
         @JvmStatic
-        @Deprecated("Use protocol.childProcessModel or revise the extension scope instead", ReplaceWith("protocol.childProcessModel"))
-        fun create(lifetime: Lifetime, protocol: IProtocol): ChildProcessModel  {
-            ChildProcessProtocolRoot.register(protocol.serializers)
+        @Deprecated("Use protocol.instrumentedProcessModel or revise the extension scope instead", ReplaceWith("protocol.instrumentedProcessModel"))
+        fun create(lifetime: Lifetime, protocol: IProtocol): InstrumentedProcessModel  {
+            InstrumentedProcessRoot.register(protocol.serializers)
             
-            return ChildProcessModel().apply {
-                identify(protocol.identity, RdId.Null.mix("ChildProcessModel"))
-                bind(lifetime, protocol, "ChildProcessModel")
+            return InstrumentedProcessModel().apply {
+                identify(protocol.identity, RdId.Null.mix("InstrumentedProcessModel"))
+                bind(lifetime, protocol, "InstrumentedProcessModel")
             }
         }
         
         
-        const val serializationHash = 3283744426733090208L
+        const val serializationHash = -3546055831649640704L
         
     }
-    override val serializersOwner: ISerializersOwner get() = ChildProcessModel
-    override val serializationHash: Long get() = ChildProcessModel.serializationHash
+    override val serializersOwner: ISerializersOwner get() = InstrumentedProcessModel
+    override val serializationHash: Long get() = InstrumentedProcessModel.serializationHash
     
     //fields
     
     /**
-     * The main process tells where the child process should search for the classes
+     * The main process tells where the instrumented process should search for the classes
      */
     val addPaths: RdCall<AddPathsParams, Unit> get() = _addPaths
     
@@ -81,30 +81,30 @@ class ChildProcessModel private constructor(
     val warmup: RdCall<Unit, Unit> get() = _warmup
     
     /**
-     * The main process sends [instrumentation] to the child process
+     * The main process sends [instrumentation] to the instrumented process
      */
     val setInstrumentation: RdCall<SetInstrumentationParams, Unit> get() = _setInstrumentation
     
     /**
-     * The main process requests the child process to execute a method with the given [signature],
+     * The main process requests the instrumented process to execute a method with the given [signature],
     which declaring class's name is [className].
     @property parameters are the parameters needed for an execution, e.g. static environment
      */
     val invokeMethodCommand: RdCall<InvokeMethodCommandParams, InvokeMethodCommandResult> get() = _invokeMethodCommand
     
     /**
-     * This command tells the child process to stop
+     * This command tells the instrumented process to stop
      */
     val stopProcess: RdCall<Unit, Unit> get() = _stopProcess
     
     /**
-     * This command is sent to the child process from the [ConcreteExecutor] if user wants to collect coverage for the
+     * This command is sent to the instrumented process from the [ConcreteExecutor] if user wants to collect coverage for the
     [clazz]
      */
     val collectCoverage: RdCall<CollectCoverageParams, CollectCoverageResult> get() = _collectCoverage
     
     /**
-     * This command is sent to the child process from the [ConcreteExecutor] if user wants to get value of static field
+     * This command is sent to the instrumented process from the [ConcreteExecutor] if user wants to get value of static field
     [fieldId]
      */
     val computeStaticField: RdCall<ComputeStaticFieldParams, ComputeStaticFieldResult> get() = _computeStaticField
@@ -146,7 +146,7 @@ class ChildProcessModel private constructor(
     //hash code trait
     //pretty print
     override fun print(printer: PrettyPrinter)  {
-        printer.println("ChildProcessModel (")
+        printer.println("InstrumentedProcessModel (")
         printer.indent {
             print("addPaths = "); _addPaths.print(printer); println()
             print("warmup = "); _warmup.print(printer); println()
@@ -159,8 +159,8 @@ class ChildProcessModel private constructor(
         printer.print(")")
     }
     //deepClone
-    override fun deepClone(): ChildProcessModel   {
-        return ChildProcessModel(
+    override fun deepClone(): InstrumentedProcessModel   {
+        return InstrumentedProcessModel(
             _addPaths.deepClonePolymorphic(),
             _warmup.deepClonePolymorphic(),
             _setInstrumentation.deepClonePolymorphic(),
@@ -172,12 +172,12 @@ class ChildProcessModel private constructor(
     }
     //contexts
 }
-val IProtocol.childProcessModel get() = getOrCreateExtension(ChildProcessModel::class) { @Suppress("DEPRECATION") ChildProcessModel.create(lifetime, this) }
+val IProtocol.instrumentedProcessModel get() = getOrCreateExtension(InstrumentedProcessModel::class) { @Suppress("DEPRECATION") InstrumentedProcessModel.create(lifetime, this) }
 
 
 
 /**
- * #### Generated from [ChildProcessModel.kt:8]
+ * #### Generated from [InstrumentedProcessModel.kt:8]
  */
 data class AddPathsParams (
     val pathsToUserClasses: String,
@@ -240,7 +240,7 @@ data class AddPathsParams (
 
 
 /**
- * #### Generated from [ChildProcessModel.kt:28]
+ * #### Generated from [InstrumentedProcessModel.kt:28]
  */
 data class CollectCoverageParams (
     val clazz: ByteArray
@@ -297,7 +297,7 @@ data class CollectCoverageParams (
 
 
 /**
- * #### Generated from [ChildProcessModel.kt:32]
+ * #### Generated from [InstrumentedProcessModel.kt:32]
  */
 data class CollectCoverageResult (
     val coverageInfo: ByteArray
@@ -354,7 +354,7 @@ data class CollectCoverageResult (
 
 
 /**
- * #### Generated from [ChildProcessModel.kt:36]
+ * #### Generated from [InstrumentedProcessModel.kt:36]
  */
 data class ComputeStaticFieldParams (
     val fieldId: ByteArray
@@ -411,7 +411,7 @@ data class ComputeStaticFieldParams (
 
 
 /**
- * #### Generated from [ChildProcessModel.kt:40]
+ * #### Generated from [InstrumentedProcessModel.kt:40]
  */
 data class ComputeStaticFieldResult (
     val result: ByteArray
@@ -468,7 +468,7 @@ data class ComputeStaticFieldResult (
 
 
 /**
- * #### Generated from [ChildProcessModel.kt:17]
+ * #### Generated from [InstrumentedProcessModel.kt:17]
  */
 data class InvokeMethodCommandParams (
     val classname: String,
@@ -543,7 +543,7 @@ data class InvokeMethodCommandParams (
 
 
 /**
- * #### Generated from [ChildProcessModel.kt:24]
+ * #### Generated from [InstrumentedProcessModel.kt:24]
  */
 data class InvokeMethodCommandResult (
     val result: ByteArray
@@ -600,7 +600,7 @@ data class InvokeMethodCommandResult (
 
 
 /**
- * #### Generated from [ChildProcessModel.kt:13]
+ * #### Generated from [InstrumentedProcessModel.kt:13]
  */
 data class SetInstrumentationParams (
     val instrumentation: ByteArray

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/rd/generated/InstrumentedProcessRoot.Generated.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/rd/generated/InstrumentedProcessRoot.Generated.kt
@@ -1,5 +1,5 @@
 @file:Suppress("EXPERIMENTAL_API_USAGE","EXPERIMENTAL_UNSIGNED_LITERALS","PackageDirectoryMismatch","UnusedImport","unused","LocalVariableName","CanBeVal","PropertyName","EnumEntryName","ClassName","ObjectPropertyName","UnnecessaryVariable","SpellCheckingInspection")
-package org.utbot.instrumentation.rd.generated
+package org.utbot.instrumentation.process.generated
 
 import com.jetbrains.rd.framework.*
 import com.jetbrains.rd.framework.base.*
@@ -15,28 +15,28 @@ import kotlin.jvm.JvmStatic
 
 
 /**
- * #### Generated from [ChildProcessModel.kt:5]
+ * #### Generated from [InstrumentedProcessModel.kt:5]
  */
-class ChildProcessProtocolRoot private constructor(
+class InstrumentedProcessRoot private constructor(
 ) : RdExtBase() {
     //companion
     
     companion object : ISerializersOwner {
         
         override fun registerSerializersCore(serializers: ISerializers)  {
-            ChildProcessProtocolRoot.register(serializers)
-            ChildProcessModel.register(serializers)
+            InstrumentedProcessRoot.register(serializers)
+            InstrumentedProcessModel.register(serializers)
         }
         
         
         
         
         
-        const val serializationHash = -2158664525887799313L
+        const val serializationHash = -7874463878801458679L
         
     }
-    override val serializersOwner: ISerializersOwner get() = ChildProcessProtocolRoot
-    override val serializationHash: Long get() = ChildProcessProtocolRoot.serializationHash
+    override val serializersOwner: ISerializersOwner get() = InstrumentedProcessRoot
+    override val serializationHash: Long get() = InstrumentedProcessRoot.serializationHash
     
     //fields
     //methods
@@ -46,12 +46,12 @@ class ChildProcessProtocolRoot private constructor(
     //hash code trait
     //pretty print
     override fun print(printer: PrettyPrinter)  {
-        printer.println("ChildProcessProtocolRoot (")
+        printer.println("InstrumentedProcessRoot (")
         printer.print(")")
     }
     //deepClone
-    override fun deepClone(): ChildProcessProtocolRoot   {
-        return ChildProcessProtocolRoot(
+    override fun deepClone(): InstrumentedProcessRoot   {
+        return InstrumentedProcessRoot(
         )
     }
     //contexts

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/util/InstrumentationException.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/util/InstrumentationException.kt
@@ -26,9 +26,9 @@ class WritingToKryoException(e: Throwable) :
 
 /**
  * this exception is thrown only in main process.
- * currently it means that {e: Throwable} happened in child process,
- * but child process still can operate and not dead.
- * on child process death - ConcreteExecutionFailureException is thrown
+ * currently it means that {e: Throwable} happened in instrumented process,
+ * but instrumented process still can operate and not dead.
+ * on instrumented process death - ConcreteExecutionFailureException is thrown
 */
-class ChildProcessError(e: Throwable) :
-    InstrumentationException("Error in the child process |> ${e.stackTraceToString()}", e)
+class InstrumentedProcessError(e: Throwable) :
+    InstrumentationException("Error in the instrumented process |> ${e.stackTraceToString()}", e)

--- a/utbot-intellij/build.gradle.kts
+++ b/utbot-intellij/build.gradle.kts
@@ -15,6 +15,7 @@ val jsIde: String? by rootProject
 
 val sootVersion: String? by rootProject
 val kryoVersion: String? by rootProject
+val rdVersion: String? by rootProject
 val semVer: String? by rootProject
 val androidStudioPath: String? by rootProject
 
@@ -90,8 +91,8 @@ tasks {
 }
 
 dependencies {
-    implementation(group ="com.jetbrains.rd", name = "rd-framework", version = "2022.3.1")
-    implementation(group ="com.jetbrains.rd", name = "rd-core", version = "2022.3.1")
+    implementation(group ="com.jetbrains.rd", name = "rd-framework", version = rdVersion)
+    implementation(group ="com.jetbrains.rd", name = "rd-core", version = rdVersion)
     implementation(group ="com.esotericsoftware.kryo", name = "kryo5", version = kryoVersion)
     implementation(group = "io.github.microutils", name = "kotlin-logging", version = kotlinLoggingVersion)
     implementation(group = "org.apache.commons", name = "commons-text", version = apacheCommonsTextVersion)

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/UtbotBundle.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/UtbotBundle.kt
@@ -1,0 +1,20 @@
+package org.utbot.intellij.plugin
+
+import com.intellij.DynamicBundle
+import org.jetbrains.annotations.NonNls
+import org.jetbrains.annotations.PropertyKey
+
+class UtbotBundle : DynamicBundle(BUNDLE) {
+    companion object {
+        @NonNls
+        private const val BUNDLE = "bundles.UtbotBundle"
+        private val INSTANCE: UtbotBundle = UtbotBundle()
+
+        fun message(
+            @PropertyKey(resourceBundle = BUNDLE) key: String,
+            vararg params: Any
+        ): String {
+            return INSTANCE.getMessage(key, *params)
+        }
+    }
+}

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/UtbotBundle.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/UtbotBundle.kt
@@ -16,5 +16,14 @@ class UtbotBundle : DynamicBundle(BUNDLE) {
         ): String {
             return INSTANCE.getMessage(key, *params)
         }
+
+        fun takeIf(
+            @PropertyKey(resourceBundle = BUNDLE) key: String,
+            vararg params: Any,
+            condition: () -> Boolean): String? {
+            if (condition())
+                return message(key, params)
+            return null
+        }
     }
 }

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerationController.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerationController.kt
@@ -8,6 +8,7 @@ import com.intellij.ide.fileTemplates.FileTemplateUtil
 import com.intellij.ide.fileTemplates.JavaTemplateUtil
 import com.intellij.ide.highlighter.JavaFileType
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.readAction
 import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.command.WriteCommandAction.runWriteCommandAction
@@ -52,6 +53,7 @@ import org.jetbrains.kotlin.idea.core.ShortenReferences
 import org.jetbrains.kotlin.idea.core.getPackage
 import org.jetbrains.kotlin.idea.core.util.toPsiDirectory
 import org.jetbrains.kotlin.idea.util.ImportInsertHelperImpl
+import org.jetbrains.kotlin.idea.util.projectStructure.allModules
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtNamedFunction
@@ -91,6 +93,8 @@ import org.utbot.intellij.plugin.util.IntelliJApiHelper.Target.THREAD_POOL
 import org.utbot.intellij.plugin.util.IntelliJApiHelper.Target.WRITE_ACTION
 import org.utbot.intellij.plugin.util.IntelliJApiHelper.run
 import org.utbot.intellij.plugin.util.RunConfigurationHelper
+import org.utbot.intellij.plugin.util.assertIsDispatchThread
+import org.utbot.intellij.plugin.util.assertIsWriteThread
 import org.utbot.intellij.plugin.util.extractClassMethodsIncludingNested
 import org.utbot.sarif.Sarif
 import org.utbot.sarif.SarifReport
@@ -110,9 +114,10 @@ object CodeGenerationController {
         model: GenerateTestsModel,
         classesWithTests: Map<PsiClass, RdTestGenerationResult>,
         psi2KClass: Map<PsiClass, ClassId>,
-        proc: EngineProcess,
+        proccess: EngineProcess,
         indicator: ProgressIndicator
     ) {
+        assertIsDispatchThread()
         val baseTestDirectory = model.testSourceRoot?.toPsiDirectory(model.project)
             ?: return
         val allTestPackages = getPackageDirectories(baseTestDirectory)
@@ -138,7 +143,7 @@ object CodeGenerationController {
                 val cut = psi2KClass[srcClass] ?: error("Didn't find KClass instance for class ${srcClass.name}")
                 runWriteCommandAction(model.project, "Generate tests with UtBot", null, {
                     generateCodeAndReport(
-                        proc,
+                        proccess,
                         testSetsId,
                         srcClass,
                         cut,
@@ -166,23 +171,21 @@ object CodeGenerationController {
                 run(EDT_LATER, indicator,"Go to EDT for utility class creation") {
                     run(WRITE_ACTION, indicator, "Need write action for utility class creation") {
                         createUtilityClassIfNeed(utilClassListener, model, baseTestDirectory, indicator)
-                        run(EDT_LATER, indicator, "Proceed test report") {
-                            proceedTestReport(proc, model)
-                            run(THREAD_POOL, indicator, "Generate summary Sarif report") {
-                                val sarifReportsPath =
-                                    model.testModule.getOrCreateSarifReportsPath(model.testSourceRoot)
-                                UtTestsDialogProcessor.updateIndicator(indicator, UtTestsDialogProcessor.ProgressRange.SARIF, "Merge Sarif reports", 0.75)
-                                mergeSarifReports(model, sarifReportsPath)
-                                if (model.runGeneratedTestsWithCoverage) {
-                                    UtTestsDialogProcessor.updateIndicator(indicator, UtTestsDialogProcessor.ProgressRange.SARIF, "Start tests with coverage", 0.95)
-                                    RunConfigurationHelper.runTestsWithCoverage(model, testFilesPointers)
-                                }
-                                proc.forceTermination()
-                                UtTestsDialogProcessor.updateIndicator(indicator, UtTestsDialogProcessor.ProgressRange.SARIF, "Generation finished", 1.0)
+                        run(THREAD_POOL, indicator, "Generate summary Sarif report") {
+                            proceedTestReport(proccess, model)
+                            val sarifReportsPath =
+                                model.testModule.getOrCreateSarifReportsPath(model.testSourceRoot)
+                            UtTestsDialogProcessor.updateIndicator(indicator, UtTestsDialogProcessor.ProgressRange.SARIF, "Merge Sarif reports", 0.75)
+                            mergeSarifReports(model, sarifReportsPath)
+                            if (model.runGeneratedTestsWithCoverage) {
+                                UtTestsDialogProcessor.updateIndicator(indicator, UtTestsDialogProcessor.ProgressRange.SARIF, "Start tests with coverage", 0.95)
+                                RunConfigurationHelper.runTestsWithCoverage(model, testFilesPointers)
+                            }
+                            proccess.terminate()
+                            UtTestsDialogProcessor.updateIndicator(indicator, UtTestsDialogProcessor.ProgressRange.SARIF, "Generation finished", 1.0)
 
-                                run(EDT_LATER, null, "Run sarif-based inspections") {
-                                    runInspectionsIfNeeded(model, srcClassPathToSarifReport)
-                                }
+                            run(EDT_LATER, null, "Run sarif-based inspections") {
+                                runInspectionsIfNeeded(model, srcClassPathToSarifReport)
                             }
                         }
                     }
@@ -213,7 +216,7 @@ object CodeGenerationController {
             .doInspections(AnalysisScope(model.project))
     }
 
-    private fun proceedTestReport(proc: EngineProcess, model: GenerateTestsModel) {
+    private fun proceedTestReport(proc: EngineProcess, model: GenerateTestsModel) = runReadAction {
         try {
             // Parametrized tests are not supported in tests report yet
             // TODO JIRA:1507
@@ -654,21 +657,22 @@ object CodeGenerationController {
         utilClassListener: UtilClassListener,
         indicator: ProgressIndicator
     ) {
+        assertIsWriteThread()
         val classMethods = srcClass.extractClassMethodsIncludingNested(false)
-        val paramNames = try {
-            DumbService.getInstance(model.project)
-                .runReadActionInSmartMode(Computable { proc.findMethodParamNames(classUnderTest, classMethods) })
-        } catch (e: Exception) {
-            logger.warn(e) { "Cannot find method param names for ${classUnderTest.name}" }
-            reportsCountDown.countDown()
-            return
-        }
         val testPackageName = testClass.packageName
         val editor = CodeInsightUtil.positionCursorAtLBrace(testClass.project, filePointer.containingFile, testClass)
         //TODO: Use PsiDocumentManager.getInstance(model.project).getDocument(file)
         // if we don't want to open _all_ new files with tests in editor one-by-one
         run(THREAD_POOL, indicator, "Rendering test code") {
             val (generatedTestsCode, utilClassKind) = try {
+                val paramNames = try {
+                    DumbService.getInstance(model.project)
+                        .runReadActionInSmartMode(Computable { proc.findMethodParamNames(classUnderTest, classMethods) })
+                } catch (e: Exception) {
+                    logger.warn(e) { "Cannot find method param names for ${classUnderTest.name}" }
+                    reportsCountDown.countDown()
+                    return@run
+                }
                 proc.render(
                     testSetsId,
                     classUnderTest,

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -23,6 +23,7 @@ import com.intellij.util.concurrency.AppExecutorUtil
 import com.intellij.util.containers.nullize
 import com.intellij.util.io.exists
 import com.jetbrains.rd.util.lifetime.LifetimeDefinition
+import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
 import org.jetbrains.kotlin.idea.util.module
 import org.utbot.framework.UtSettings
@@ -41,7 +42,6 @@ import org.utbot.intellij.plugin.ui.GenerateTestsDialogWindow
 import org.utbot.intellij.plugin.ui.utils.showErrorDialogLater
 import org.utbot.intellij.plugin.ui.utils.testModules
 import org.utbot.intellij.plugin.util.*
-import org.utbot.rd.terminateOnException
 import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -49,6 +49,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.io.path.pathString
 import org.utbot.framework.plugin.api.util.LockFile
 import org.utbot.intellij.plugin.ui.utils.isBuildWithGradle
+import org.utbot.rd.terminateOnException
 
 object UtTestsDialogProcessor {
     private val logger = KotlinLogging.logger {}
@@ -129,33 +130,32 @@ object UtTestsDialogProcessor {
             (object : Task.Backgroundable(project, "Generate tests") {
 
                 override fun run(indicator: ProgressIndicator) {
+                    assertIsNonDispatchThread()
                     if (!LockFile.lock()) {
                         return
                     }
                     try {
-                        val ldef = LifetimeDefinition()
-                        ldef.terminateOnException { lifetime ->
-                            val secondsTimeout = TimeUnit.MILLISECONDS.toSeconds(model.timeout)
+                        val secondsTimeout = TimeUnit.MILLISECONDS.toSeconds(model.timeout)
 
-                            indicator.isIndeterminate = false
-                            updateIndicator(indicator, ProgressRange.SOLVING, "Generate tests: read classes", 0.0)
+                        indicator.isIndeterminate = false
+                        updateIndicator(indicator, ProgressRange.SOLVING, "Generate tests: read classes", 0.0)
 
-                            val buildPaths = ReadAction
-                                .nonBlocking<BuildPaths?> { findPaths(model.srcClasses) }
-                                .executeSynchronously()
-                                ?: return
+                        val buildPaths = ReadAction
+                            .nonBlocking<BuildPaths?> { findPaths(model.srcClasses) }
+                            .executeSynchronously()
+                            ?: return
 
-                            val (buildDirs, classpath, classpathList, pluginJarsPath) = buildPaths
+                        val (buildDirs, classpath, classpathList, pluginJarsPath) = buildPaths
 
-                            val testSetsByClass = mutableMapOf<PsiClass, RdTestGenerationResult>()
-                            val psi2KClass = mutableMapOf<PsiClass, ClassId>()
-                            var processedClasses = 0
-                            val totalClasses = model.srcClasses.size
+                        val testSetsByClass = mutableMapOf<PsiClass, RdTestGenerationResult>()
+                        val psi2KClass = mutableMapOf<PsiClass, ClassId>()
+                        var processedClasses = 0
+                        val totalClasses = model.srcClasses.size
+                        val process = EngineProcess.createBlocking(project)
 
-                            val proc = EngineProcess(lifetime, project)
-
-                            proc.setupUtContext(buildDirs + classpathList)
-                            proc.createTestGenerator(
+                        process.terminateOnException { _ ->
+                            process.setupUtContext(buildDirs + classpathList)
+                            process.createTestGenerator(
                                 buildDirs,
                                 classpath,
                                 pluginJarsPath.joinToString(separator = File.pathSeparator),
@@ -170,7 +170,7 @@ object UtTestsDialogProcessor {
                                 val (methods, className) = DumbService.getInstance(project)
                                     .runReadActionInSmartMode(Computable {
                                         val canonicalName = srcClass.canonicalName
-                                        val classId = proc.obtainClassId(canonicalName)
+                                        val classId = process.obtainClassId(canonicalName)
                                         psi2KClass[srcClass] = classId
 
                                         val srcMethods = if (model.extractMembersFromSrcClasses) {
@@ -183,7 +183,7 @@ object UtTestsDialogProcessor {
                                         } else {
                                             srcClass.extractClassMethodsIncludingNested(false)
                                         }
-                                        proc.findMethodsInClassMatchingSelected(classId, srcMethods) to srcClass.name
+                                        process.findMethodsInClassMatchingSelected(classId, srcMethods) to srcClass.name
                                     })
 
                                 if (methods.isEmpty()) {
@@ -231,7 +231,7 @@ object UtTestsDialogProcessor {
                                             )
                                         }, 0, 500, TimeUnit.MILLISECONDS)
                                     try {
-                                        val rdGenerateResult = proc.generate(
+                                        val rdGenerateResult = process.generate(
                                             mockFrameworkInstalled,
                                             model.staticsMocking.isConfigured,
                                             model.conflictTriggers,
@@ -281,7 +281,7 @@ object UtTestsDialogProcessor {
                             // indicator.checkCanceled()
 
                             invokeLater {
-                                generateTests(model, testSetsByClass, psi2KClass, proc, indicator)
+                                generateTests(model, testSetsByClass, psi2KClass, process, indicator)
                                 logger.info { "Generation complete" }
                             }
                         }

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -94,7 +94,7 @@ object UtTestsDialogProcessor {
         val testModules = srcModule.testModules(project)
 
         JdkInfoService.jdkInfoProvider = PluginJdkInfoProvider(project)
-        // we want to start the child process in the same directory as the test runner
+        // we want to start the instrumented process in the same directory as the test runner
         WorkingDirService.workingDirProvider = PluginWorkingDirProvider(project)
 
         val model = GenerateTestsModel(
@@ -199,7 +199,7 @@ object UtTestsDialogProcessor {
                                 )
 
                                 // set timeout for concrete execution and for generated tests
-                                UtSettings.concreteExecutionTimeoutInChildProcess =
+                                UtSettings.concreteExecutionTimeoutInInstrumentedProcess =
                                     model.hangingTestsTimeout.timeoutMs
 
                                 UtSettings.useCustomJavaDocTags =
@@ -355,6 +355,6 @@ object UtTestsDialogProcessor {
         val classpath: String,
         val classpathList: List<String>,
         val pluginJarsPath: List<String>
-        // ^ TODO: Now we collect ALL dependent libs and pass them to the child process. Most of them are redundant.
+        // ^ TODO: Now we collect ALL dependent libs and pass them to the instrumented process. Most of them are redundant.
     )
 }

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/process/EngineProcess.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/process/EngineProcess.kt
@@ -90,7 +90,7 @@ class EngineProcess private constructor(val project: Project, rdProcess: Process
 
         private val log4j2ConfigSwitch = "-Dlog4j2.configurationFile=${log4j2ConfigFile.canonicalPath}"
 
-        private fun suspendValue(): String = if (UtSettings.engineProcessDebugSuspendPolicy) "y" else "n"
+        private fun suspendValue(): String = if (UtSettings.suspendEngineProcessExecutionInDebugMode) "y" else "n"
 
         private val debugArgument: String?
             get() = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=${suspendValue()},quiet=y,address=${UtSettings.engineProcessDebugPort}"
@@ -111,7 +111,10 @@ class EngineProcess private constructor(val project: Project, rdProcess: Process
         private fun obtainEngineProcessCommandLine(port: Int) = buildList {
             add(javaExecutablePathString.pathString)
             add("-ea")
-            OpenModulesContainer.javaVersionSpecificArguments?.let { addAll(it) }
+            val javaVersionSpecificArgs = vaOpenModulesContainer.javaVersionSpecificArguments
+            if (javaVersionSpecificArgs.isNotEmpty()) {
+                addAll(it)
+            }
             debugArgument?.let { add(it) }
             add(log4j2ConfigSwitch)
             add("-cp")

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/process/EngineProcess.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/process/EngineProcess.kt
@@ -145,7 +145,7 @@ class EngineProcess private constructor(val project: Project, rdProcess: Process
 
                     process
                 }
-                rdProcess.awaitSignal()
+                rdProcess.awaitProcessReady()
 
                 return EngineProcess(project, rdProcess)
             }

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/process/EngineProcess.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/process/EngineProcess.kt
@@ -93,7 +93,7 @@ class EngineProcess private constructor(val project: Project, rdProcess: Process
         private fun suspendValue(): String = if (UtSettings.suspendEngineProcessExecutionInDebugMode) "y" else "n"
 
         private val debugArgument: String?
-            get() = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=${suspendValue()},quiet=y,address=${UtSettings.engineProcessDebugPort}"
+            get() = "-agentlib:jdwp=transport=dt_socket,server=n,suspend=${suspendValue()},quiet=y,address=${UtSettings.engineProcessDebugPort}"
                 .takeIf { UtSettings.runEngineProcessWithDebug }
 
         private val javaExecutablePathString: Path

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/process/EngineProcess.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/process/EngineProcess.kt
@@ -111,9 +111,9 @@ class EngineProcess private constructor(val project: Project, rdProcess: Process
         private fun obtainEngineProcessCommandLine(port: Int) = buildList {
             add(javaExecutablePathString.pathString)
             add("-ea")
-            val javaVersionSpecificArgs = vaOpenModulesContainer.javaVersionSpecificArguments
+            val javaVersionSpecificArgs = OpenModulesContainer.javaVersionSpecificArguments
             if (javaVersionSpecificArgs.isNotEmpty()) {
-                addAll(it)
+                addAll(javaVersionSpecificArgs)
             }
             debugArgument?.let { add(it) }
             add(log4j2ConfigSwitch)

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/process/EngineProcess.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/process/EngineProcess.kt
@@ -10,12 +10,12 @@ import com.intellij.refactoring.util.classMembers.MemberInfo
 import com.jetbrains.rd.util.ConcurrentHashMap
 import com.jetbrains.rd.util.Logger
 import com.jetbrains.rd.util.lifetime.Lifetime
-import com.jetbrains.rd.util.lifetime.throwIfNotAlive
+import com.jetbrains.rd.util.lifetime.LifetimeDefinition
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import mu.KotlinLogging
 import org.utbot.common.*
+import org.utbot.common.PathUtil.toPathOrNull
 import org.utbot.framework.UtSettings
 import org.utbot.framework.UtSettings.runIdeaProcessWithDebug
 import org.utbot.framework.codegen.domain.ForceStaticMocking
@@ -27,7 +27,6 @@ import org.utbot.framework.codegen.domain.TestFramework
 import org.utbot.framework.codegen.tree.ututils.UtilClassKind
 import org.utbot.framework.plugin.api.*
 import org.utbot.framework.plugin.services.JdkInfo
-import org.utbot.framework.plugin.services.JdkInfoDefaultProvider
 import org.utbot.framework.plugin.services.JdkInfoService
 import org.utbot.framework.plugin.services.WorkingDirService
 import org.utbot.framework.process.OpenModulesContainer
@@ -36,19 +35,24 @@ import org.utbot.framework.process.generated.Signature
 import org.utbot.framework.util.Conflict
 import org.utbot.framework.util.ConflictTriggers
 import org.utbot.instrumentation.util.KryoHelper
+import org.utbot.intellij.plugin.UtbotBundle
 import org.utbot.intellij.plugin.models.GenerateTestsModel
 import org.utbot.intellij.plugin.ui.TestReportUrlOpeningListener
+import org.utbot.intellij.plugin.util.assertIsNonDispatchThread
+import org.utbot.intellij.plugin.util.assertIsReadAccessAllowed
 import org.utbot.intellij.plugin.util.signature
-import org.utbot.rd.ProcessWithRdServer
+import org.utbot.rd.*
 import org.utbot.rd.loggers.UtRdKLoggerFactory
-import org.utbot.rd.rdPortArgument
-import org.utbot.rd.startUtProcessWithRdServer
 import org.utbot.sarif.SourceFindingStrategy
 import java.io.File
+import java.nio.charset.Charset
+import java.nio.file.Files
 import java.nio.file.Path
-import kotlin.io.path.deleteIfExists
+import java.nio.file.StandardCopyOption
+import java.sql.Timestamp
+import java.text.SimpleDateFormat
+import java.time.LocalDateTime
 import kotlin.io.path.pathString
-import kotlin.random.Random
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.memberProperties
 
@@ -58,201 +62,174 @@ private val engineProcessLogDirectory = utBotTempDirectory.toFile().resolve("rdE
 
 data class RdTestGenerationResult(val notEmptyCases: Int, val testSetsId: Long)
 
-class EngineProcess(parent: Lifetime, val project: Project) {
+class EngineProcess private constructor(val project: Project, rdProcess: ProcessWithRdServer) :
+    ProcessWithRdServer by rdProcess {
     companion object {
-        init {
-            Logger.set(Lifetime.Eternal, UtRdKLoggerFactory(logger))
-        }
-    }
-    private val ldef = parent.createNested()
-    private val id = Random.nextLong()
-    private var count = 0
-    private var configPath: Path? = null
+        private val log4j2ConfigFile: File
 
+        init {
+            engineProcessLogDirectory.mkdirs()
+            engineProcessLogConfigurations.mkdirs()
+            Logger.set(Lifetime.Eternal, UtRdKLoggerFactory(logger))
+
+            val customFile = File(UtSettings.ideaProcessLogConfigFile)
+
+            if (customFile.exists()) {
+                log4j2ConfigFile = customFile
+            } else {
+                log4j2ConfigFile = Files.createTempFile(engineProcessLogConfigurations.toPath(), null, ".xml").toFile()
+                log4j2ConfigFile.deleteOnExit()
+                this.javaClass.classLoader.getResourceAsStream("log4j2.xml")?.use { logConfig ->
+                    val resultConfig = logConfig.readBytes().toString(Charset.defaultCharset())
+                        .replace("ref=\"IdeaAppender\"", "ref=\"EngineProcessAppender\"")
+                    Files.copy(
+                        resultConfig.byteInputStream(),
+                        log4j2ConfigFile.toPath(),
+                        StandardCopyOption.REPLACE_EXISTING
+                    )
+                }
+            }
+        }
+
+        private val log4j2ConfigSwitch = "-Dlog4j2.configurationFile=${log4j2ConfigFile.canonicalPath}"
+
+        private val debugArgument: String?
+            get() = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,quiet=y,address=$engineProcessDebugPort"
+                .takeIf { runIdeaProcessWithDebug }
+
+        private val javaExecutablePathString: Path
+            get() = JdkInfoService.jdkInfoProvider.info.path.resolve("bin${File.separatorChar}${osSpecificJavaExecutable()}")
+
+        private val pluginClasspath: String
+            get() = (this.javaClass.classLoader as PluginClassLoader).classPath.baseUrls.joinToString(
+                separator = File.pathSeparator,
+                prefix = "\"",
+                postfix = "\""
+            )
+
+        private const val startFileName = "org.utbot.framework.process.EngineMainKt"
+
+        private fun obtainEngineProcessCommandLine(port: Int) = buildList<String> {
+            add(javaExecutablePathString.pathString)
+            add("-ea")
+            OpenModulesContainer.javaVersionSpecificArguments?.let { addAll(it) }
+            debugArgument?.let { add(it) }
+            add(log4j2ConfigSwitch)
+            add("-cp")
+            add(pluginClasspath)
+            add(startFileName)
+            add(rdPortArgument(port))
+        }
+
+        fun createBlocking(project: Project): EngineProcess = runBlocking { EngineProcess(project) }
+
+        suspend operator fun invoke(project: Project): EngineProcess =
+            LifetimeDefinition().terminateOnException { lifetime ->
+                val rdProcess = startUtProcessWithRdServer(lifetime) { port ->
+                    val cmd = obtainEngineProcessCommandLine(port)
+                    val directory = WorkingDirService.provide().toFile()
+                    val builder = ProcessBuilder(cmd).directory(directory)
+                    val formatted = dateTimeFormatter.format(LocalDateTime.now())
+                    val logFile = File(engineProcessLogDirectory, "$formatted.log")
+
+                    builder.redirectOutput(logFile)
+                    builder.redirectError(logFile)
+
+                    val process = builder.start()
+
+                    logger.info { "Engine process started with PID = ${process.getPid}" }
+                    logger.info { "Engine process log file - ${logFile.canonicalPath}" }
+                    process
+                }
+                rdProcess.awaitSignal()
+
+                return EngineProcess(project, rdProcess)
+            }
+    }
+
+    private val engineModel: EngineProcessModel = onSchedulerBlocking { protocol.engineProcessModel }
+    private val instrumenterAdapterModel: RdInstrumenterAdapter = onSchedulerBlocking { protocol.rdInstrumenterAdapter }
+    private val sourceFindingModel: RdSourceFindingStrategy = onSchedulerBlocking { protocol.rdSourceFindingStrategy }
+    private val settingsModel: SettingsModel = onSchedulerBlocking { protocol.settingsModel }
+
+    private val kryoHelper = KryoHelper(lifetime)
     private val sourceFindingStrategies = ConcurrentHashMap<Long, SourceFindingStrategy>()
 
-    private fun getOrCreateLogConfig(): String {
-        var realPath = configPath
-        if (realPath == null) {
-            engineProcessLogConfigurations.mkdirs()
-            configPath = File.createTempFile("epl", ".xml", engineProcessLogConfigurations).apply {
-                val onMatch = if (UtSettings.logConcreteExecutionErrors) "NEUTRAL" else "DENY"
-                writeText(
-                    """<?xml version="1.0" encoding="UTF-8"?>
-<Configuration>
-    <Appenders>
-        <Console name="Console" target="SYSTEM_OUT">
-            <ThresholdFilter level="${UtSettings.engineProcessLogLevel.name.uppercase()}"  onMatch="$onMatch"   onMismatch="DENY"/>
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} | %-5level | %c{1} | %msg%n"/>
-        </Console>
-    </Appenders>
-    <Loggers>
-        <Root level="${UtSettings.engineProcessLogLevel.name.lowercase()}">
-            <AppenderRef ref="Console"/>
-        </Root>
-    </Loggers>
-</Configuration>"""
-                )
-            }.toPath()
-            realPath = configPath
-            logger.info("log configuration path - ${realPath!!.pathString}")
+    fun setupUtContext(classpathForUrlsClassloader: List<String>) {
+        engineModel.setupUtContext.start(lifetime, SetupContextParams(classpathForUrlsClassloader))
+    }
+
+    private fun computeSourceFileByClass(params: ComputeSourceFileByClassArguments): String =
+        DumbService.getInstance(project).runReadActionInSmartMode<String?> {
+            val scope = GlobalSearchScope.allScope(project)
+            val psiClass = JavaFileManager.getInstance(project).findClass(params.className, scope)
+            val sourceFile = psiClass?.navigationElement?.containingFile?.virtualFile?.canonicalPath
+
+            logger.debug { "computeSourceFileByClass result: $sourceFile" }
+            sourceFile
         }
-        return realPath.pathString
-    }
 
-    private fun debugArgument(): String {
-        return "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,quiet=y,address=5005".takeIf { runIdeaProcessWithDebug }
-            ?: ""
-    }
-
-    private val kryoHelper = KryoHelper(ldef)
-
-    private suspend fun engineModel(): EngineProcessModel {
-        ldef.throwIfNotAlive()
-        return lock.withLock {
-            var proc = current
-
-            if (proc == null) {
-                proc = startUtProcessWithRdServer(ldef) { port ->
-                    val current = JdkInfoDefaultProvider().info
-                    val required = JdkInfoService.jdkInfoProvider.info
-                    val java =
-                        JdkInfoService.jdkInfoProvider.info.path.resolve("bin${File.separatorChar}${osSpecificJavaExecutable()}").toString()
-                    val cp = (this.javaClass.classLoader as PluginClassLoader).classPath.baseUrls.joinToString(
-                        separator = File.pathSeparator,
-                        prefix = "\"",
-                        postfix = "\""
-                    )
-                    val classname = "org.utbot.framework.process.EngineMainKt"
-                    val javaVersionSpecificArguments = OpenModulesContainer.javaVersionSpecificArguments
-                    val directory = WorkingDirService.provide().toFile()
-                    val log4j2ConfigFile = "-Dlog4j2.configurationFile=${getOrCreateLogConfig()}"
-                    val debugArg = debugArgument()
-                    logger.info { "java - $java\nclasspath - $cp\nport - $port" }
-                    val cmd = mutableListOf<String>(java, "-ea")
-                    if (javaVersionSpecificArguments.isNotEmpty()) {
-                        cmd.addAll(javaVersionSpecificArguments)
-                    }
-                    if (debugArg.isNotEmpty()) {
-                        cmd.add(debugArg)
-                    }
-                    cmd.add(log4j2ConfigFile)
-                    cmd.add("-cp")
-                    cmd.add(cp)
-                    cmd.add(classname)
-                    cmd.add(rdPortArgument(port))
-                    ProcessBuilder(cmd).directory(directory).apply {
-                        if (UtSettings.logConcreteExecutionErrors) {
-                            engineProcessLogDirectory.mkdirs()
-                            val logFile = File(engineProcessLogDirectory, "${id}-${count++}.log")
-                            logger.info { "logFile - ${logFile.canonicalPath}" }
-                            redirectOutput(logFile)
-                            redirectError(logFile)
-                        }
-                    }.start().apply {
-                        logger.debug { "Engine process started with PID = ${this.getPid}" }
-                    }
-                }.initModels {
-                    engineProcessModel
-                    rdInstrumenterAdapter
-                    rdSourceFindingStrategy
-                    settingsModel.settingFor.set { params ->
-                        SettingForResult(AbstractSettings.allSettings[params.key]?.let { settings: AbstractSettings ->
-                            val members: Collection<KProperty1<AbstractSettings, *>> =
-                                settings.javaClass.kotlin.memberProperties
-                            val names: List<KProperty1<AbstractSettings, *>> =
-                                members.filter { it.name == params.propertyName }
-                            val sing: KProperty1<AbstractSettings, *> = names.single()
-                            val result = sing.get(settings)
-                            logger.trace { "request for settings ${params.key}:${params.propertyName} - $result" }
-                            result.toString()
-                        })
-                    }
-                }.awaitSignal()
-                current = proc
-                initSourceFindingStrategies()
-            }
-
-            proc.protocol.engineProcessModel
-        }
-    }
-
-    private val lock = Mutex()
-    private var current: ProcessWithRdServer? = null
-
-    fun setupUtContext(classpathForUrlsClassloader: List<String>) = runBlocking {
-        engineModel().setupUtContext.startSuspending(ldef, SetupContextParams(classpathForUrlsClassloader))
-    }
-
-    // suppose that only 1 simultaneous test generator process can be executed in idea
-    // so every time test generator is created - we just overwrite previous
     fun createTestGenerator(
         buildDir: List<String>,
         classPath: String?,
         dependencyPaths: String,
         jdkInfo: JdkInfo,
         isCancelled: (Unit) -> Boolean
-    ) = runBlocking {
-        engineModel().isCancelled.set(handler = isCancelled)
-        current!!.protocol.rdInstrumenterAdapter.computeSourceFileByClass.set { params ->
-            val result = DumbService.getInstance(project).runReadActionInSmartMode<String?> {
-                val scope = GlobalSearchScope.allScope(project)
-                val psiClass = JavaFileManager.getInstance(project)
-                    .findClass(params.className, scope)
+    ) {
+        engineModel.isCancelled.set(handler = isCancelled)
+        instrumenterAdapterModel.computeSourceFileByClass.set(handler = this::computeSourceFileByClass)
 
-                psiClass?.navigationElement?.containingFile?.virtualFile?.canonicalPath
-            }
-            logger.debug("computeSourceFileByClass result: $result")
-            result
-        }
-        engineModel().createTestGenerator.startSuspending(
-            ldef,
-            TestGeneratorParams(buildDir.toTypedArray(), classPath, dependencyPaths, JdkInfo(jdkInfo.path.pathString, jdkInfo.version))
+        val params = TestGeneratorParams(
+            buildDir.toTypedArray(),
+            classPath,
+            dependencyPaths,
+            JdkInfo(jdkInfo.path.pathString, jdkInfo.version)
         )
+        engineModel.createTestGenerator.start(lifetime, params)
     }
 
-    fun obtainClassId(canonicalName: String): ClassId = runBlocking {
-        kryoHelper.readObject(engineModel().obtainClassId.startSuspending(canonicalName))
+    fun obtainClassId(canonicalName: String): ClassId {
+        assertIsNonDispatchThread()
+        return kryoHelper.readObject(engineModel.obtainClassId.startBlocking(canonicalName))
     }
 
-    fun findMethodsInClassMatchingSelected(clazzId: ClassId, srcMethods: List<MemberInfo>): List<ExecutableId> =
-        runBlocking {
-            val srcSignatures = srcMethods.map { it.signature() }
-            val rdSignatures = srcSignatures.map {
-                Signature(it.name, it.parameterTypes)
-            }
-            kryoHelper.readObject(
-                engineModel().findMethodsInClassMatchingSelected.startSuspending(
-                    FindMethodsInClassMatchingSelectedArguments(kryoHelper.writeObject(clazzId), rdSignatures)
-                ).executableIds
-            )
-        }
+    fun findMethodsInClassMatchingSelected(clazzId: ClassId, srcMethods: List<MemberInfo>): List<ExecutableId> {
+        assertIsNonDispatchThread()
+        assertIsReadAccessAllowed()
 
-    fun findMethodParamNames(classId: ClassId, methods: List<MemberInfo>): Map<ExecutableId, List<String>> =
-        runBlocking {
-            val bySignature = methods.associate { it.signature() to it.paramNames() }
-            kryoHelper.readObject(
-                engineModel().findMethodParamNames.startSuspending(
-                    FindMethodParamNamesArguments(
-                        kryoHelper.writeObject(
-                            classId
-                        ), kryoHelper.writeObject(bySignature)
-                    )
-                ).paramNames
-            )
-        }
+        val srcSignatures = srcMethods.map { it.signature() }
+        val rdSignatures = srcSignatures.map { Signature(it.name, it.parameterTypes) }
+        val binaryClassId = kryoHelper.writeObject(clazzId)
+        val arguments = FindMethodsInClassMatchingSelectedArguments(binaryClassId, rdSignatures)
+        val result = engineModel.findMethodsInClassMatchingSelected.startBlocking(arguments)
 
-    private fun MemberInfo.paramNames(): List<String> =
-        (this.member as PsiMethod).parameterList.parameters.map {
-            if (it.name.startsWith("\$this"))
-                // If member is Kotlin extension function, name of first argument isn't good for further usage,
-                // so we better choose name based on type of receiver.
-                //
-                // There seems no API to check whether parameter is an extension receiver by PSI
-                it.type.presentableText
-            else
-                it.name
-        }
+        return kryoHelper.readObject(result.executableIds)
+    }
+
+    fun findMethodParamNames(classId: ClassId, methods: List<MemberInfo>): Map<ExecutableId, List<String>> {
+        assertIsNonDispatchThread()
+        assertIsReadAccessAllowed()
+
+        val bySignature = methods.associate { it.signature() to it.paramNames() }
+        val arguments = FindMethodParamNamesArguments(
+            kryoHelper.writeObject(classId),
+            kryoHelper.writeObject(bySignature)
+        )
+        val result = engineModel.findMethodParamNames.startBlocking(arguments).paramNames
+
+        return kryoHelper.readObject(result)
+    }
+
+    private fun MemberInfo.paramNames(): List<String> = (this.member as PsiMethod).parameterList.parameters.map {
+        if (it.name.startsWith("\$this"))
+        // If member is Kotlin extension function, name of first argument isn't good for further usage,
+        // so we better choose name based on type of receiver.
+        //
+        // There seems no API to check whether parameter is an extension receiver by PSI
+            it.type.presentableText
+        else
+            it.name
+    }
 
     fun generate(
         mockInstalled: Boolean,
@@ -267,26 +244,25 @@ class EngineProcess(parent: Lifetime, val project: Project) {
         isFuzzingEnabled: Boolean,
         fuzzingValue: Double,
         searchDirectory: String
-    ): RdTestGenerationResult = runBlocking {
-        val result = engineModel().generate.startSuspending(
-            ldef,
-            GenerateParams(
-                mockInstalled,
-                staticsMockingIsConfigured,
-                kryoHelper.writeObject(conflictTriggers.toMutableMap()),
-                kryoHelper.writeObject(methods),
-                mockStrategyApi.name,
-                kryoHelper.writeObject(chosenClassesToMockAlways),
-                timeout,
-                generationTimeout,
-                isSymbolicEngineEnabled,
-                isFuzzingEnabled,
-                fuzzingValue,
-                searchDirectory
-            )
+    ): RdTestGenerationResult {
+        assertIsNonDispatchThread()
+        val params = GenerateParams(
+            mockInstalled,
+            staticsMockingIsConfigured,
+            kryoHelper.writeObject(conflictTriggers.toMutableMap()),
+            kryoHelper.writeObject(methods),
+            mockStrategyApi.name,
+            kryoHelper.writeObject(chosenClassesToMockAlways),
+            timeout,
+            generationTimeout,
+            isSymbolicEngineEnabled,
+            isFuzzingEnabled,
+            fuzzingValue,
+            searchDirectory
         )
+        val result = engineModel.generate.startBlocking(params)
 
-        return@runBlocking RdTestGenerationResult(result.notEmptyCases, result.testSetsId)
+        return RdTestGenerationResult(result.notEmptyCases, result.testSetsId)
     }
 
     fun render(
@@ -305,64 +281,61 @@ class EngineProcess(parent: Lifetime, val project: Project) {
         hangingTestSource: HangingTestsTimeout,
         enableTestsTimeout: Boolean,
         testClassPackageName: String
-    ): Pair<String, UtilClassKind?> = runBlocking {
-        val result = engineModel().render.startSuspending(
-            ldef, RenderParams(
-                    testSetsId,
-                    kryoHelper.writeObject(classUnderTest),
-                    kryoHelper.writeObject(paramNames),
-                    generateUtilClassFile,
-                    testFramework.id.lowercase(),
-                    mockFramework.name,
-                    codegenLanguage.name,
-                    parameterizedTestSource.name,
-                    staticsMocking.id,
-                    kryoHelper.writeObject(forceStaticMocking),
-                    generateWarningsForStaticsMocking,
-                    runtimeExceptionTestsBehaviour.name,
-                    hangingTestSource.timeoutMs,
-                    enableTestsTimeout,
-                    testClassPackageName
-                )
-            )
-        result.generatedCode to result.utilClassKind?.let {
+    ): Pair<String, UtilClassKind?> {
+        assertIsNonDispatchThread()
+        val params = RenderParams(
+            testSetsId,
+            kryoHelper.writeObject(classUnderTest),
+            kryoHelper.writeObject(paramNames),
+            generateUtilClassFile,
+            testFramework.id.lowercase(),
+            mockFramework.name,
+            codegenLanguage.name,
+            parameterizedTestSource.name,
+            staticsMocking.id,
+            kryoHelper.writeObject(forceStaticMocking),
+            generateWarningsForStaticsMocking,
+            runtimeExceptionTestsBehaviour.name,
+            hangingTestSource.timeoutMs,
+            enableTestsTimeout,
+            testClassPackageName
+        )
+        val result = engineModel.render.startBlocking(params)
+        val realUtilClassKind = result.utilClassKind?.let {
             if (UtilClassKind.RegularUtUtils(codegenLanguage).javaClass.simpleName == it)
                 UtilClassKind.RegularUtUtils(codegenLanguage)
             else
                 UtilClassKind.UtUtilsWithMockito(codegenLanguage)
         }
+
+        return result.generatedCode to realUtilClassKind
     }
 
-    fun forceTermination() = runBlocking {
-        configPath?.deleteIfExists()
-        engineModel().stopProcess.start(Unit)
-        current?.terminate()
-    }
+    private fun getSourceFile(params: SourceStrategyMethodArgs): String? =
+        DumbService.getInstance(project).runReadActionInSmartMode<String?> {
+            sourceFindingStrategies[params.testSetId]!!.getSourceFile(
+                params.classFqn,
+                params.extension
+            )?.canonicalPath
+        }
+
+    private fun getSourceRelativePath(params: SourceStrategyMethodArgs): String =
+        DumbService.getInstance(project).runReadActionInSmartMode<String> {
+            sourceFindingStrategies[params.testSetId]!!.getSourceRelativePath(
+                params.classFqn,
+                params.extension
+            )
+        }
+
+    private fun testsRelativePath(testSetId: Long): String =
+        DumbService.getInstance(project).runReadActionInSmartMode<String> {
+            sourceFindingStrategies[testSetId]!!.testsRelativePath
+        }
 
     private fun initSourceFindingStrategies() {
-        current!!.protocol.rdSourceFindingStrategy.let {
-            it.getSourceFile.set { params ->
-                DumbService.getInstance(project).runReadActionInSmartMode<String?> {
-                    sourceFindingStrategies[params.testSetId]!!.getSourceFile(
-                        params.classFqn,
-                        params.extension
-                    )?.canonicalPath
-                }
-            }
-            it.getSourceRelativePath.set { params ->
-                DumbService.getInstance(project).runReadActionInSmartMode<String> {
-                    sourceFindingStrategies[params.testSetId]!!.getSourceRelativePath(
-                        params.classFqn,
-                        params.extension
-                    )
-                }
-            }
-            it.testsRelativePath.set { testSetId ->
-                DumbService.getInstance(project).runReadActionInSmartMode<String> {
-                    sourceFindingStrategies[testSetId]!!.testsRelativePath
-                }
-            }
-        }
+        sourceFindingModel.getSourceFile.set(handler = this::getSourceFile)
+        sourceFindingModel.getSourceRelativePath.set(handler = this::getSourceRelativePath)
+        sourceFindingModel.testsRelativePath.set(handler = this::testsRelativePath)
     }
 
     fun writeSarif(
@@ -370,53 +343,62 @@ class EngineProcess(parent: Lifetime, val project: Project) {
         testSetsId: Long,
         generatedTestsCode: String,
         sourceFindingStrategy: SourceFindingStrategy
-    ): String = runBlocking {
+    ): String {
+        assertIsNonDispatchThread()
+
+        val params = WriteSarifReportArguments(testSetsId, reportFilePath.pathString, generatedTestsCode)
+
         sourceFindingStrategies[testSetsId] = sourceFindingStrategy
-        engineModel().writeSarifReport.startSuspending(
-            WriteSarifReportArguments(testSetsId, reportFilePath.pathString, generatedTestsCode)
-        )
+        return engineModel.writeSarifReport.startBlocking(params)
     }
 
-    fun generateTestsReport(model: GenerateTestsModel, eventLogMessage: String?): Triple<String, String?, Boolean> = runBlocking {
-        val forceMockWarning = if (model.conflictTriggers[Conflict.ForceMockHappened] == true) {
-            """
-                    <b>Warning</b>: Some test cases were ignored, because no mocking framework is installed in the project.<br>
-                    Better results could be achieved by <a href="${TestReportUrlOpeningListener.prefix}${TestReportUrlOpeningListener.mockitoSuffix}">installing mocking framework</a>.
-                """.trimIndent()
-        } else null
-        val forceStaticMockWarnings = if (model.conflictTriggers[Conflict.ForceStaticMockHappened] == true) {
-            """
-                    <b>Warning</b>: Some test cases were ignored, because mockito-inline is not installed in the project.<br>
-                    Better results could be achieved by <a href="${TestReportUrlOpeningListener.prefix}${TestReportUrlOpeningListener.mockitoInlineSuffix}">configuring mockito-inline</a>.
-                """.trimIndent()
-        } else null
-        val testFrameworkWarnings = if (model.conflictTriggers[Conflict.TestFrameworkConflict] == true) {
-            """
-                    <b>Warning</b>: There are several test frameworks in the project. 
-                    To select run configuration, please refer to the documentation depending on the project build system:
-                     <a href=" https://docs.gradle.org/current/userguide/java_testing.html#sec:configuring_java_integration_tests">Gradle</a>, 
-                     <a href=" https://maven.apache.org/surefire/maven-surefire-plugin/examples/providers.html">Maven</a> 
-                     or <a href=" https://www.jetbrains.com/help/idea/run-debug-configuration.html#compound-configs">Idea</a>.
-                """.trimIndent()
-        } else null
-        val result = engineModel().generateTestReport.startSuspending(
-            GenerateTestReportArgs(
-                eventLogMessage,
-                model.testPackageName,
-                model.isMultiPackage,
-                forceMockWarning,
-                forceStaticMockWarnings,
-                testFrameworkWarnings,
-                model.conflictTriggers.anyTriggered
-            )
-        )
+    fun generateTestsReport(model: GenerateTestsModel, eventLogMessage: String?): Triple<String, String?, Boolean> {
+        assertIsNonDispatchThread()
 
-        return@runBlocking Triple(result.notifyMessage, result.statistics, result.hasWarnings)
+        // todo unforce loading
+
+        val forceMockWarning = UtbotBundle.message(
+            "test.report.force.mock.warning",
+            TestReportUrlOpeningListener.prefix,
+            TestReportUrlOpeningListener.mockitoSuffix
+        ).takeIf { model.conflictTriggers[Conflict.ForceMockHappened] == true }
+        val forceStaticMockWarnings = UtbotBundle.message(
+            "test.report.force.static.mock.warning",
+            TestReportUrlOpeningListener.prefix,
+            TestReportUrlOpeningListener.mockitoInlineSuffix
+        ).takeIf { model.conflictTriggers[Conflict.ForceStaticMockHappened] == true }
+        val testFrameworkWarnings = UtbotBundle.message("test.report.test.framework.warning")
+            .takeIf { model.conflictTriggers[Conflict.TestFrameworkConflict] == true }
+        val params = GenerateTestReportArgs(
+            eventLogMessage,
+            model.testPackageName,
+            model.isMultiPackage,
+            forceMockWarning,
+            forceStaticMockWarnings,
+            testFrameworkWarnings,
+            model.conflictTriggers.anyTriggered
+        )
+        val result = engineModel.generateTestReport.startBlocking(params)
+
+        return Triple(result.notifyMessage, result.statistics, result.hasWarnings)
     }
 
     init {
-        ldef.onTermination {
-            forceTermination()
+        lifetime.onTermination {
+            engineModel.stopProcess.start(Unit)
         }
+        settingsModel.settingFor.set { params ->
+            SettingForResult(AbstractSettings.allSettings[params.key]?.let { settings: AbstractSettings ->
+                val members: Collection<KProperty1<AbstractSettings, *>> =
+                    settings.javaClass.kotlin.memberProperties
+                val names: List<KProperty1<AbstractSettings, *>> =
+                    members.filter { it.name == params.propertyName }
+                val sing: KProperty1<AbstractSettings, *> = names.single()
+                val result = sing.get(settings)
+                logger.trace { "request for settings ${params.key}:${params.propertyName} - $result" }
+                result.toString()
+            })
+        }
+        initSourceFindingStrategies()
     }
 }

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/IdeaThreadingUtil.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/IdeaThreadingUtil.kt
@@ -1,0 +1,23 @@
+package org.utbot.intellij.plugin.util
+
+import com.intellij.openapi.application.ApplicationManager
+
+fun assertIsDispatchThread() {
+    ApplicationManager.getApplication().assertIsDispatchThread()
+}
+
+fun assertIsWriteThread() {
+    ApplicationManager.getApplication().isWriteThread()
+}
+
+fun assertIsReadAccessAllowed() {
+    ApplicationManager.getApplication().assertReadAccessAllowed()
+}
+
+fun assertIsWriteAccessAllowed() {
+    ApplicationManager.getApplication().assertWriteAccessAllowed()
+}
+
+fun assertIsNonDispatchThread() {
+    ApplicationManager.getApplication().assertIsNonDispatchThread()
+}

--- a/utbot-intellij/src/main/resources/bundles/UtbotBundle.properties
+++ b/utbot-intellij/src/main/resources/bundles/UtbotBundle.properties
@@ -1,0 +1,10 @@
+# {0} - Test report url prefix, {1] - suffix
+test.report.force.mock.warning=<b>Warning</b>: Some test cases were ignored, because no mocking framework is installed in the project.<br>\
+Better results could be achieved by <a href="{0}{1}">installing mocking framework</a>.
+test.report.force.static.mock.warning=<b>Warning</b>: Some test cases were ignored, because mockito-inline is not installed in the project.<br>\
+etter results could be achieved by <a href="{0}{1}">configuring mockito-inline</a>.
+test.report.test.framework.warning=<b>Warning</b>: There are several test frameworks in the project.\
+To select run configuration, please refer to the documentation depending on the project build system:\
+<a href="https://docs.gradle.org/current/userguide/java_testing.html#sec:configuring_java_integration_tests">Gradle</a>,\
+<a href="https://maven.apache.org/surefire/maven-surefire-plugin/examples/providers.html">Maven</a>\
+or <a href="https://www.jetbrains.com/help/idea/run-debug-configuration.html#compound-configs">Idea</a>.

--- a/utbot-intellij/src/main/resources/log4j2.xml
+++ b/utbot-intellij/src/main/resources/log4j2.xml
@@ -6,7 +6,7 @@
             <PatternLayout pattern="%msg%n"/>
         </Console>
 <!--        When working as separate process - temporary log4j2.xml would be created, in which -->
-<!--        substring "ref=\"IdeaAppender\"" will be replaced with "ref=\"EngineProcessAppender\""-->
+<!--        substring `ref="IdeaAppender"` will be replaced with `ref="EngineProcessAppender"`-->
         <Console name="EngineProcessAppender" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} | %-5level | %-25c{1} | %msg%n"/>
         </Console>

--- a/utbot-intellij/src/main/resources/log4j2.xml
+++ b/utbot-intellij/src/main/resources/log4j2.xml
@@ -1,22 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration>
     <Appenders>
-        <Console name="Console" target="SYSTEM_OUT">
+<!--     Idea catches plugin stdout log and wraps it in its own format, so in IDE only message is logged-->
+        <Console name="IdeaAppender" target="SYSTEM_OUT">
             <PatternLayout pattern="%msg%n"/>
+        </Console>
+<!--        When working as separate process - temporary log4j2.xml would be created, in which -->
+<!--        substring "ref=\"IdeaAppender\"" will be replaced with "ref=\"EngineProcessAppender\""-->
+        <Console name="EngineProcessAppender" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} | %-5level | %-25c{1} | %msg%n"/>
         </Console>
     </Appenders>
     <Loggers>
-        <Logger name="org.utbot.intellij" level="info">
-            <AppenderRef ref="Console"/>
+        <Logger name="org.utbot.intellij" level="info" additivity="false">
+            <AppenderRef ref="IdeaAppender"/>
         </Logger>
-        <Logger name="org.utbot.IntelliJApiHelper" level="info">
-            <AppenderRef ref="Console"/>
+        <Logger name="org.utbot.IntelliJApiHelper" level="info" additivity="false">
+            <AppenderRef ref="IdeaAppender"/>
         </Logger>
-        <Logger name="org.utbot" level="error">
-            <AppenderRef ref="Console"/>
+        <Logger name="org.utbot" level="debug" additivity="false">
+            <AppenderRef ref="IdeaAppender"/>
         </Logger>
         <Root level="error">
-            <AppenderRef ref="Console"/>
+            <AppenderRef ref="IdeaAppender"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/utbot-junit-contest/src/main/kotlin/org/utbot/contest/Contest.kt
+++ b/utbot-junit-contest/src/main/kotlin/org/utbot/contest/Contest.kt
@@ -355,7 +355,7 @@ fun runGeneration(
 
                         //hack
                         if (statsForMethod.isSuspicious && (ConcreteExecutor.lastSendTimeMs - ConcreteExecutor.lastReceiveTimeMs) > 5000) {
-                            logger.error { "HEURISTICS: close child process, because it haven't responded for long time: ${ConcreteExecutor.lastSendTimeMs - ConcreteExecutor.lastReceiveTimeMs}" }
+                            logger.error { "HEURISTICS: close instrumented process, because it haven't responded for long time: ${ConcreteExecutor.lastSendTimeMs - ConcreteExecutor.lastReceiveTimeMs}" }
                             ConcreteExecutor.defaultPool.close()
                         }
                     }

--- a/utbot-junit-contest/src/main/kotlin/org/utbot/contest/ContestEstimatorJdkInfoProvider.kt
+++ b/utbot-junit-contest/src/main/kotlin/org/utbot/contest/ContestEstimatorJdkInfoProvider.kt
@@ -9,7 +9,7 @@ import java.io.InputStreamReader
 
 /**
  * This class is used to provide a path to jdk and its version in [ContestEstimator]
- * into the child process for concrete execution.
+ * into the instrumented process for concrete execution.
  */
 class ContestEstimatorJdkInfoProvider(private val path: String) : JdkInfoDefaultProvider() {
     override val info: JdkInfo

--- a/utbot-rd/build.gradle
+++ b/utbot-rd/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.jetbrains.rdgen' version "2022.3.1"
+    id 'com.jetbrains.rdgen' version "2022.3.4"
 }
 
 import com.jetbrains.rd.generator.gradle.RdGenExtension
@@ -48,14 +48,14 @@ sourceSets {
 
 dependencies {
     implementation project(':utbot-core')
-    implementation group: 'com.jetbrains.rd', name: 'rd-framework', version: '2022.3.1'
-    implementation group: 'com.jetbrains.rd', name: 'rd-core', version: '2022.3.1'
+    implementation group: 'com.jetbrains.rd', name: 'rd-framework', version: rdVersion
+    implementation group: 'com.jetbrains.rd', name: 'rd-core', version: rdVersion
 
     implementation group: 'io.github.microutils', name: 'kotlin-logging', version: kotlinLoggingVersion
 
     processWithRdServerMockImplementation project(':utbot-rd')
 
-    rdgenModelsCompileClasspath group: 'com.jetbrains.rd', name: 'rd-gen', version: '2022.3.1'
+    rdgenModelsCompileClasspath group: 'com.jetbrains.rd', name: 'rd-gen', version: rdVersion
 }
 
 task lifetimedProcessMockJar(type: Jar) {

--- a/utbot-rd/build.gradle
+++ b/utbot-rd/build.gradle
@@ -99,7 +99,7 @@ test {
     systemProperty("PROCESS_WITH_RD_SERVER_MOCK", processWithRdServerMockJar.archiveFile.get().getAsFile().canonicalPath)
 }
 
-task generateChildProcessProtocolModels(type: RdGenTask) {
+task generateInstrumentedProcessModels(type: RdGenTask) {
     def currentProjectDir = project.projectDir
     def instrumentationProjectDir = project.rootProject.childProjects["utbot-instrumentation"].projectDir
     def generatedOutputDir = new File(instrumentationProjectDir, "src/main/kotlin/org/utbot/instrumentation/rd/generated")
@@ -117,14 +117,14 @@ task generateChildProcessProtocolModels(type: RdGenTask) {
     rdParams.generator {
         language = "kotlin"
         transform = "symmetric"
-        root = "org.utbot.rd.models.ChildProcessProtocolRoot"
+        root = "org.utbot.rd.models.InstrumentedProcessRoot"
 
         directory = generatedOutputDir.canonicalPath
-        namespace = "org.utbot.instrumentation.rd.generated"
+        namespace = "org.utbot.instrumentation.process.generated"
     }
 }
 
-task generateEngineProcessProtocolModels(type: RdGenTask) {
+task generateEngineProcessModels(type: RdGenTask) {
     def currentProjectDir = project.projectDir
     def ideaPluginProjectDir = project.rootProject.childProjects["utbot-framework"].projectDir
     def generatedOutputDir = new File(ideaPluginProjectDir, "src/main/kotlin/org/utbot/framework/process/generated")
@@ -142,22 +142,14 @@ task generateEngineProcessProtocolModels(type: RdGenTask) {
     rdParams.generator {
         language = "kotlin"
         transform = "symmetric"
-        root = "org.utbot.rd.models.EngineProcessProtocolRoot"
-
-        directory = generatedOutputDir.canonicalPath
-        namespace = "org.utbot.framework.process.generated"
-    }
-    rdParams.generator {
-        language = "kotlin"
-        transform = "symmetric"
-        root = "org.utbot.rd.models.SettingsProtocolRoot"
+        root = "org.utbot.rd.models.EngineProcessRoot"
 
         directory = generatedOutputDir.canonicalPath
         namespace = "org.utbot.framework.process.generated"
     }
 }
 
-task generateSynchronizationModels(type: RdGenTask) {
+task generateCommonModels(type: RdGenTask) {
     def currentProjectDir = project.projectDir
     def ideaPluginProjectDir = project.rootProject.childProjects["utbot-rd"].projectDir
     def generatedOutputDir = new File(ideaPluginProjectDir, "src/main/kotlin/org/utbot/rd/generated")
@@ -175,7 +167,16 @@ task generateSynchronizationModels(type: RdGenTask) {
     rdParams.generator {
         language = "kotlin"
         transform = "symmetric"
-        root = "org.utbot.rd.models.SynchronizationModelRoot"
+        root = "org.utbot.rd.models.SynchronizationRoot"
+
+        directory = generatedOutputDir.canonicalPath
+        namespace = "org.utbot.rd.generated"
+    }
+
+    rdParams.generator {
+        language = "kotlin"
+        transform = "symmetric"
+        root = "org.utbot.rd.models.SettingsRoot"
 
         directory = generatedOutputDir.canonicalPath
         namespace = "org.utbot.rd.generated"

--- a/utbot-rd/src/main/kotlin/org/utbot/rd/ClientProcessUtil.kt
+++ b/utbot-rd/src/main/kotlin/org/utbot/rd/ClientProcessUtil.kt
@@ -30,7 +30,7 @@ internal fun childCreatedFileName(port: Int): String {
     return "$port.created"
 }
 
-internal fun signalInstrumentedReady(port: Int) {
+internal fun signalProcessReady(port: Int) {
     processSyncDirectory.mkdirs()
 
     val signalFile = File(processSyncDirectory, childCreatedFileName(port))
@@ -161,7 +161,7 @@ class ClientProtocolBuilder {
                 clientProtocol.block(synchronizer)
             }
 
-            signalInstrumentedReady(port)
+            signalProcessReady(port)
             logger.info { "signalled" }
             clientProtocol.synchronizationModel.synchronizationSignal.let { sync ->
                 val answerFromMainProcess = sync.adviseForConditionAsync(ldef) {

--- a/utbot-rd/src/main/kotlin/org/utbot/rd/ClientProcessUtil.kt
+++ b/utbot-rd/src/main/kotlin/org/utbot/rd/ClientProcessUtil.kt
@@ -30,7 +30,7 @@ internal fun childCreatedFileName(port: Int): String {
     return "$port.created"
 }
 
-internal fun signalChildReady(port: Int) {
+internal fun signalInstrumentedReady(port: Int) {
     processSyncDirectory.mkdirs()
 
     val signalFile = File(processSyncDirectory, childCreatedFileName(port))
@@ -161,7 +161,7 @@ class ClientProtocolBuilder {
                 clientProtocol.block(synchronizer)
             }
 
-            signalChildReady(port)
+            signalInstrumentedReady(port)
             logger.info { "signalled" }
             clientProtocol.synchronizationModel.synchronizationSignal.let { sync ->
                 val answerFromMainProcess = sync.adviseForConditionAsync(ldef) {

--- a/utbot-rd/src/main/kotlin/org/utbot/rd/ProcessWithRdServer.kt
+++ b/utbot-rd/src/main/kotlin/org/utbot/rd/ProcessWithRdServer.kt
@@ -79,7 +79,7 @@ interface ProcessWithRdServer : LifetimedProcess {
     val port: Int
         get() = protocol.wire.serverPort
 
-    suspend fun awaitSignal(): ProcessWithRdServer
+    suspend fun awaitProcessReady(): ProcessWithRdServer
 }
 
 private val logger = getLogger<ProcessWithRdServer>()
@@ -98,7 +98,7 @@ class ProcessWithRdServerImpl private constructor(
         }
     }
 
-    override suspend fun awaitSignal(): ProcessWithRdServer {
+    override suspend fun awaitProcessReady(): ProcessWithRdServer {
         protocol.scheduler.pump(lifetime) {
             protocol.synchronizationModel
         }

--- a/utbot-rd/src/main/kotlin/org/utbot/rd/ProcessWithRdServer.kt
+++ b/utbot-rd/src/main/kotlin/org/utbot/rd/ProcessWithRdServer.kt
@@ -79,7 +79,6 @@ interface ProcessWithRdServer : LifetimedProcess {
     val port: Int
         get() = protocol.wire.serverPort
 
-    suspend fun initModels(bindables: Protocol.() -> Unit): ProcessWithRdServer
     suspend fun awaitSignal(): ProcessWithRdServer
 }
 
@@ -97,14 +96,6 @@ class ProcessWithRdServerImpl private constructor(
         ): ProcessWithRdServerImpl = ProcessWithRdServerImpl(child, serverFactory).terminateOnException {
             it.apply { protocol.wire.connected.adviseForConditionAsync(lifetime).await() }
         }
-    }
-
-    override suspend fun initModels(bindables: Protocol.() -> Unit): ProcessWithRdServer {
-        protocol.scheduler.pump(lifetime) {
-            protocol.bindables()
-        }
-
-        return this
     }
 
     override suspend fun awaitSignal(): ProcessWithRdServer {

--- a/utbot-rd/src/main/kotlin/org/utbot/rd/RdSettingsContainer.kt
+++ b/utbot-rd/src/main/kotlin/org/utbot/rd/RdSettingsContainer.kt
@@ -35,7 +35,7 @@ class RdSettingsContainer(val logger: KLogger, val key: String, val settingsMode
                 }
 
                 override fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
-                    throw NotImplementedError("Setting properties allowed only from plugin process")
+                    throw IllegalStateException("Setting properties allowed only from plugin process")
                 }
             }
         }

--- a/utbot-rd/src/main/kotlin/org/utbot/rd/RdSettingsContainer.kt
+++ b/utbot-rd/src/main/kotlin/org/utbot/rd/RdSettingsContainer.kt
@@ -1,12 +1,10 @@
-package org.utbot.framework.process
+package org.utbot.rd
 
-import kotlinx.coroutines.runBlocking
 import mu.KLogger
 import org.utbot.common.SettingsContainer
 import org.utbot.common.SettingsContainerFactory
-import org.utbot.framework.process.generated.SettingForArgument
-import org.utbot.framework.process.generated.SettingsModel
-import org.utbot.rd.startBlocking
+import org.utbot.rd.generated.SettingForArgument
+import org.utbot.rd.generated.SettingsModel
 import kotlin.properties.PropertyDelegateProvider
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty

--- a/utbot-rd/src/main/kotlin/org/utbot/rd/UtRdCoroutineScope.kt
+++ b/utbot-rd/src/main/kotlin/org/utbot/rd/UtRdCoroutineScope.kt
@@ -11,7 +11,7 @@ class UtRdCoroutineScope(lifetime: Lifetime) : RdCoroutineScope(lifetime) {
     companion object {
         val current = UtRdCoroutineScope(Lifetime.Eternal)
         fun initialize() {
-            // only to initialize load and initialize class
+            // only to load and initialize class
         }
     }
 

--- a/utbot-rd/src/main/kotlin/org/utbot/rd/UtRdCoroutineScope.kt
+++ b/utbot-rd/src/main/kotlin/org/utbot/rd/UtRdCoroutineScope.kt
@@ -10,6 +10,9 @@ private val coroutineDispatcher = SingleThreadScheduler(Lifetime.Eternal, "UtCor
 class UtRdCoroutineScope(lifetime: Lifetime) : RdCoroutineScope(lifetime) {
     companion object {
         val current = UtRdCoroutineScope(Lifetime.Eternal)
+        fun initialize() {
+            // only to initialize load and initialize class
+        }
     }
 
     init {

--- a/utbot-rd/src/main/kotlin/org/utbot/rd/UtRdUtil.kt
+++ b/utbot-rd/src/main/kotlin/org/utbot/rd/UtRdUtil.kt
@@ -22,7 +22,6 @@ suspend fun <T> ProcessWithRdServer.onScheduler(block: () -> T): T {
 
 fun <T> ProcessWithRdServer.onSchedulerBlocking(block: () -> T): T = runBlocking { onScheduler(block) }
 
-
 fun <TReq, TRes> IRdCall<TReq, TRes>.startBlocking(req: TReq): TRes {
     val call = this
     // We do not use RdCall.sync because it requires timeouts for execution, after which request will be stopped.
@@ -75,11 +74,12 @@ suspend fun <T> IScheduler.pump(lifetime: Lifetime, block: (Lifetime) -> T): T {
 suspend fun <T> IScheduler.pump(block: (Lifetime) -> T): T = this.pump(Lifetime.Eternal, block)
 
 /**
- * Advises provided condition on source and returns Deferred,
- * which will be completed when condition satisfied, or cancelled when provided lifetime terminated.
- * If you don't need this condition no more - you can cancel deferred.
+ * Asynchronously checks the condition.
+ * The condition can be satisfied or canceled.
+ * As soon as the condition is checked, the lifetime is terminated.
+ * In order to cancel the calculation, use the function return value of Deferred type.
  *
- * N.B. in case you need timeout - wrap deferred in withTimeout coroutine builder
+ * @see kotlinx.coroutines.withTimeout coroutine builder in case you need cancel the calculation by timeout.
  */
 fun <T> ISource<T>.adviseForConditionAsync(lifetime: Lifetime, condition: (T) -> Boolean): Deferred<Unit> {
     val ldef = lifetime.createNested()

--- a/utbot-rd/src/main/kotlin/org/utbot/rd/UtRdUtil.kt
+++ b/utbot-rd/src/main/kotlin/org/utbot/rd/UtRdUtil.kt
@@ -27,7 +27,7 @@ fun <TReq, TRes> IRdCall<TReq, TRes>.startBlocking(req: TReq): TRes {
     val call = this
     // We do not use RdCall.sync because it requires timeouts for execution, after which request will be stopped.
     // Some requests, for example test generation, might be either really long, or have their own timeouts.
-    // To honor their timeout logic we do not use RdCall.sync.
+    // To honour their timeout logic we do not use RdCall.sync.
     return runBlocking { call.startSuspending(req) }
 }
 

--- a/utbot-rd/src/main/kotlin/org/utbot/rd/exceptions/InstantProcessDeathException.kt
+++ b/utbot-rd/src/main/kotlin/org/utbot/rd/exceptions/InstantProcessDeathException.kt
@@ -1,0 +1,12 @@
+package org.utbot.rd.exceptions
+
+abstract class InstantProcessDeathException(private val debugPort: Int, private val isProcessDebug: Boolean) : Exception() {
+    override val message: String?
+        get() {
+            var text = "Process died before any request was executed, check process log file."
+            if (isProcessDebug) {
+                text += " Process requested debug on port - $debugPort, check if port is open."
+            }
+            return text
+        }
+}

--- a/utbot-rd/src/main/kotlin/org/utbot/rd/exceptions/InstantProcessDeathException.kt
+++ b/utbot-rd/src/main/kotlin/org/utbot/rd/exceptions/InstantProcessDeathException.kt
@@ -1,8 +1,8 @@
 package org.utbot.rd.exceptions
 
 /**
- * This exception is designed to be thrown any time you start child process,
- * but
+ * This exception is designed to be thrown any time you start child process with rd,
+ * but it dies before rd initiated, implicating that the problem probably in CLI arguments
  */
 abstract class InstantProcessDeathException(private val debugPort: Int, private val isProcessDebug: Boolean) : Exception() {
     override val message: String?

--- a/utbot-rd/src/main/kotlin/org/utbot/rd/exceptions/InstantProcessDeathException.kt
+++ b/utbot-rd/src/main/kotlin/org/utbot/rd/exceptions/InstantProcessDeathException.kt
@@ -1,5 +1,9 @@
 package org.utbot.rd.exceptions
 
+/**
+ * This exception is designed to be thrown any time you start child process,
+ * but
+ */
 abstract class InstantProcessDeathException(private val debugPort: Int, private val isProcessDebug: Boolean) : Exception() {
     override val message: String?
         get() {

--- a/utbot-rd/src/main/kotlin/org/utbot/rd/generated/SettingsModel.Generated.kt
+++ b/utbot-rd/src/main/kotlin/org/utbot/rd/generated/SettingsModel.Generated.kt
@@ -43,10 +43,7 @@ class SettingsModel private constructor(
         fun create(lifetime: Lifetime, protocol: IProtocol): SettingsModel  {
             SettingsRoot.register(protocol.serializers)
             
-            return SettingsModel().apply {
-                identify(protocol.identity, RdId.Null.mix("SettingsModel"))
-                bind(lifetime, protocol, "SettingsModel")
-            }
+            return SettingsModel()
         }
         
         

--- a/utbot-rd/src/main/kotlin/org/utbot/rd/generated/SettingsModel.Generated.kt
+++ b/utbot-rd/src/main/kotlin/org/utbot/rd/generated/SettingsModel.Generated.kt
@@ -1,5 +1,5 @@
 @file:Suppress("EXPERIMENTAL_API_USAGE","EXPERIMENTAL_UNSIGNED_LITERALS","PackageDirectoryMismatch","UnusedImport","unused","LocalVariableName","CanBeVal","PropertyName","EnumEntryName","ClassName","ObjectPropertyName","UnnecessaryVariable","SpellCheckingInspection")
-package org.utbot.framework.process.generated
+package org.utbot.rd.generated
 
 import com.jetbrains.rd.framework.*
 import com.jetbrains.rd.framework.base.*
@@ -41,7 +41,7 @@ class SettingsModel private constructor(
         @JvmStatic
         @Deprecated("Use protocol.settingsModel or revise the extension scope instead", ReplaceWith("protocol.settingsModel"))
         fun create(lifetime: Lifetime, protocol: IProtocol): SettingsModel  {
-            SettingsProtocolRoot.register(protocol.serializers)
+            SettingsRoot.register(protocol.serializers)
             
             return SettingsModel().apply {
                 identify(protocol.identity, RdId.Null.mix("SettingsModel"))

--- a/utbot-rd/src/main/kotlin/org/utbot/rd/generated/SettingsRoot.Generated.kt
+++ b/utbot-rd/src/main/kotlin/org/utbot/rd/generated/SettingsRoot.Generated.kt
@@ -1,5 +1,5 @@
 @file:Suppress("EXPERIMENTAL_API_USAGE","EXPERIMENTAL_UNSIGNED_LITERALS","PackageDirectoryMismatch","UnusedImport","unused","LocalVariableName","CanBeVal","PropertyName","EnumEntryName","ClassName","ObjectPropertyName","UnnecessaryVariable","SpellCheckingInspection")
-package org.utbot.framework.process.generated
+package org.utbot.rd.generated
 
 import com.jetbrains.rd.framework.*
 import com.jetbrains.rd.framework.base.*
@@ -17,14 +17,14 @@ import kotlin.jvm.JvmStatic
 /**
  * #### Generated from [SettingsModel.kt:5]
  */
-class SettingsProtocolRoot private constructor(
+class SettingsRoot private constructor(
 ) : RdExtBase() {
     //companion
     
     companion object : ISerializersOwner {
         
         override fun registerSerializersCore(serializers: ISerializers)  {
-            SettingsProtocolRoot.register(serializers)
+            SettingsRoot.register(serializers)
             SettingsModel.register(serializers)
         }
         
@@ -32,11 +32,11 @@ class SettingsProtocolRoot private constructor(
         
         
         
-        const val serializationHash = 6206621683627449183L
+        const val serializationHash = -414203168893339225L
         
     }
-    override val serializersOwner: ISerializersOwner get() = SettingsProtocolRoot
-    override val serializationHash: Long get() = SettingsProtocolRoot.serializationHash
+    override val serializersOwner: ISerializersOwner get() = SettingsRoot
+    override val serializationHash: Long get() = SettingsRoot.serializationHash
     
     //fields
     //methods
@@ -46,12 +46,12 @@ class SettingsProtocolRoot private constructor(
     //hash code trait
     //pretty print
     override fun print(printer: PrettyPrinter)  {
-        printer.println("SettingsProtocolRoot (")
+        printer.println("SettingsRoot (")
         printer.print(")")
     }
     //deepClone
-    override fun deepClone(): SettingsProtocolRoot   {
-        return SettingsProtocolRoot(
+    override fun deepClone(): SettingsRoot   {
+        return SettingsRoot(
         )
     }
     //contexts

--- a/utbot-rd/src/main/kotlin/org/utbot/rd/generated/SynchronizationModel.Generated.kt
+++ b/utbot-rd/src/main/kotlin/org/utbot/rd/generated/SynchronizationModel.Generated.kt
@@ -39,7 +39,7 @@ class SynchronizationModel private constructor(
         @JvmStatic
         @Deprecated("Use protocol.synchronizationModel or revise the extension scope instead", ReplaceWith("protocol.synchronizationModel"))
         fun create(lifetime: Lifetime, protocol: IProtocol): SynchronizationModel  {
-            SynchronizationModelRoot.register(protocol.serializers)
+            SynchronizationRoot.register(protocol.serializers)
             
             return SynchronizationModel().apply {
                 identify(protocol.identity, RdId.Null.mix("SynchronizationModel"))

--- a/utbot-rd/src/main/kotlin/org/utbot/rd/generated/SynchronizationModel.Generated.kt
+++ b/utbot-rd/src/main/kotlin/org/utbot/rd/generated/SynchronizationModel.Generated.kt
@@ -41,10 +41,7 @@ class SynchronizationModel private constructor(
         fun create(lifetime: Lifetime, protocol: IProtocol): SynchronizationModel  {
             SynchronizationRoot.register(protocol.serializers)
             
-            return SynchronizationModel().apply {
-                identify(protocol.identity, RdId.Null.mix("SynchronizationModel"))
-                bind(lifetime, protocol, "SynchronizationModel")
-            }
+            return SynchronizationModel()
         }
         
         

--- a/utbot-rd/src/main/kotlin/org/utbot/rd/generated/SynchronizationRoot.Generated.kt
+++ b/utbot-rd/src/main/kotlin/org/utbot/rd/generated/SynchronizationRoot.Generated.kt
@@ -1,0 +1,58 @@
+@file:Suppress("EXPERIMENTAL_API_USAGE","EXPERIMENTAL_UNSIGNED_LITERALS","PackageDirectoryMismatch","UnusedImport","unused","LocalVariableName","CanBeVal","PropertyName","EnumEntryName","ClassName","ObjectPropertyName","UnnecessaryVariable","SpellCheckingInspection")
+package org.utbot.rd.generated
+
+import com.jetbrains.rd.framework.*
+import com.jetbrains.rd.framework.base.*
+import com.jetbrains.rd.framework.impl.*
+
+import com.jetbrains.rd.util.lifetime.*
+import com.jetbrains.rd.util.reactive.*
+import com.jetbrains.rd.util.string.*
+import com.jetbrains.rd.util.*
+import kotlin.reflect.KClass
+import kotlin.jvm.JvmStatic
+
+
+
+/**
+ * #### Generated from [SynchronizationModel.kt:5]
+ */
+class SynchronizationRoot private constructor(
+) : RdExtBase() {
+    //companion
+    
+    companion object : ISerializersOwner {
+        
+        override fun registerSerializersCore(serializers: ISerializers)  {
+            SynchronizationRoot.register(serializers)
+            SynchronizationModel.register(serializers)
+        }
+        
+        
+        
+        
+        
+        const val serializationHash = -8945393054954668256L
+        
+    }
+    override val serializersOwner: ISerializersOwner get() = SynchronizationRoot
+    override val serializationHash: Long get() = SynchronizationRoot.serializationHash
+    
+    //fields
+    //methods
+    //initializer
+    //secondary constructor
+    //equals trait
+    //hash code trait
+    //pretty print
+    override fun print(printer: PrettyPrinter)  {
+        printer.println("SynchronizationRoot (")
+        printer.print(")")
+    }
+    //deepClone
+    override fun deepClone(): SynchronizationRoot   {
+        return SynchronizationRoot(
+        )
+    }
+    //contexts
+}

--- a/utbot-rd/src/main/kotlin/org/utbot/rd/loggers/UtRdConsoleLogger.kt
+++ b/utbot-rd/src/main/kotlin/org/utbot/rd/loggers/UtRdConsoleLogger.kt
@@ -1,9 +1,7 @@
 package org.utbot.rd.loggers
 
-import com.jetbrains.rd.util.LogLevel
-import com.jetbrains.rd.util.Logger
-import com.jetbrains.rd.util.defaultLogFormat
-import org.utbot.common.dateFormatter
+import com.jetbrains.rd.util.*
+import org.utbot.common.timeFormatter
 import java.io.PrintStream
 import java.time.LocalDateTime
 
@@ -16,18 +14,17 @@ class UtRdConsoleLogger(
         return level >= loggersLevel
     }
 
+    private fun format(category: String, level: LogLevel, message: Any?, throwable: Throwable?) : String {
+        val throwableToPrint = if (level < LogLevel.Error) throwable  else throwable ?: Exception() //to print stacktrace
+        return "${LocalDateTime.now().format(timeFormatter)} | ${level.toString().uppercase().padEnd(5)} | ${category.substringAfterLast('.').padEnd(25)} | ${message?.toString()?:""} ${throwableToPrint?.getThrowableText()?.let { "| $it" }?:""}"
+    }
+
     override fun log(level: LogLevel, message: Any?, throwable: Throwable?) {
         if (!isEnabled(level))
             return
 
-        val msg = LocalDateTime.now().format(dateFormatter) + " | ${
-            defaultLogFormat(
-                category,
-                level,
-                message,
-                throwable
-            )
-        }"
+        val msg = format(category, level, message, throwable)
+
         streamToWrite.println(msg)
     }
 }

--- a/utbot-rd/src/main/kotlin/org/utbot/rd/loggers/UtRdKLogger.kt
+++ b/utbot-rd/src/main/kotlin/org/utbot/rd/loggers/UtRdKLogger.kt
@@ -1,13 +1,9 @@
 package org.utbot.rd.loggers
 
-import com.jetbrains.rd.util.LogLevel
-import com.jetbrains.rd.util.Logger
-import com.jetbrains.rd.util.defaultLogFormat
+import com.jetbrains.rd.util.*
 import mu.KLogger
-import org.utbot.common.dateFormatter
-import java.time.LocalDateTime
 
-class UtRdKLogger(private val realLogger: KLogger, private val category: String): Logger {
+class UtRdKLogger(private val realLogger: KLogger): Logger {
     override fun isEnabled(level: LogLevel): Boolean {
         return when (level) {
             LogLevel.Trace -> realLogger.isTraceEnabled
@@ -19,11 +15,16 @@ class UtRdKLogger(private val realLogger: KLogger, private val category: String)
         }
     }
 
+    private fun format(level: LogLevel, message: Any?, throwable: Throwable?): String {
+        val throwableToPrint = if (level < LogLevel.Error) throwable else throwable ?: Exception() //to print stacktrace
+        return "${message?.toString() ?: ""} ${throwableToPrint?.getThrowableText()?.let { "| $it" } ?: ""}"
+    }
+
     override fun log(level: LogLevel, message: Any?, throwable: Throwable?) {
         if (!isEnabled(level))
             return
 
-        val msg = LocalDateTime.now().format(dateFormatter) + " | ${defaultLogFormat(category, level, message, throwable)}"
+        val msg = format(level, message, throwable)
 
         when (level) {
             LogLevel.Trace -> realLogger.trace(msg)

--- a/utbot-rd/src/main/kotlin/org/utbot/rd/loggers/UtRdKLoggerFactory.kt
+++ b/utbot-rd/src/main/kotlin/org/utbot/rd/loggers/UtRdKLoggerFactory.kt
@@ -6,6 +6,6 @@ import mu.KLogger
 
 class UtRdKLoggerFactory(private val realLogger: KLogger) : ILoggerFactory {
     override fun getLogger(category: String): Logger {
-        return UtRdKLogger(realLogger, category)
+        return UtRdKLogger(realLogger)
     }
 }

--- a/utbot-rd/src/main/rdgen/org/utbot/rd/models/EngineProcessModel.kt
+++ b/utbot-rd/src/main/rdgen/org/utbot/rd/models/EngineProcessModel.kt
@@ -2,9 +2,9 @@ package org.utbot.rd.models
 
 import com.jetbrains.rd.generator.nova.*
 
-object EngineProcessProtocolRoot : Root()
+object EngineProcessRoot : Root()
 
-object RdInstrumenterAdapter: Ext(EngineProcessProtocolRoot) {
+object RdInstrumenterAdapter: Ext(EngineProcessRoot) {
     val computeSourceFileByClassArguments = structdef {
         field("className", PredefinedType.string)
         field("packageName", PredefinedType.string.nullable)
@@ -14,7 +14,7 @@ object RdInstrumenterAdapter: Ext(EngineProcessProtocolRoot) {
     }
 }
 
-object RdSourceFindingStrategy : Ext(EngineProcessProtocolRoot) {
+object RdSourceFindingStrategy : Ext(EngineProcessRoot) {
     val sourceStrategyMethodArgs = structdef {
         field("testSetId", PredefinedType.long)
         field("classFqn", PredefinedType.string)
@@ -28,7 +28,7 @@ object RdSourceFindingStrategy : Ext(EngineProcessProtocolRoot) {
     }
 }
 
-object EngineProcessModel : Ext(EngineProcessProtocolRoot) {
+object EngineProcessModel : Ext(EngineProcessRoot) {
     val jdkInfo = structdef {
         field("path", PredefinedType.string)
         field("version", PredefinedType.int)

--- a/utbot-rd/src/main/rdgen/org/utbot/rd/models/InstrumentedProcessModel.kt
+++ b/utbot-rd/src/main/rdgen/org/utbot/rd/models/InstrumentedProcessModel.kt
@@ -2,9 +2,9 @@ package org.utbot.rd.models
 
 import com.jetbrains.rd.generator.nova.*
 
-object ChildProcessProtocolRoot : Root()
+object InstrumentedProcessRoot : Root()
 
-object ChildProcessModel : Ext(ChildProcessProtocolRoot) {
+object InstrumentedProcessModel : Ext(InstrumentedProcessRoot) {
     val AddPathsParams = structdef {
         field("pathsToUserClasses", PredefinedType.string)
         field("pathsToDependencyClasses", PredefinedType.string)
@@ -45,7 +45,7 @@ object ChildProcessModel : Ext(ChildProcessProtocolRoot) {
         call("AddPaths", AddPathsParams, PredefinedType.void).apply {
             async
             documentation =
-                "The main process tells where the child process should search for the classes"
+                "The main process tells where the instrumented process should search for the classes"
         }
         call("Warmup", PredefinedType.void, PredefinedType.void).apply {
             async
@@ -55,30 +55,30 @@ object ChildProcessModel : Ext(ChildProcessProtocolRoot) {
         call("SetInstrumentation", SetInstrumentationParams, PredefinedType.void).apply {
             async
             documentation =
-                "The main process sends [instrumentation] to the child process"
+                "The main process sends [instrumentation] to the instrumented process"
         }
         call("InvokeMethodCommand", InvokeMethodCommandParams, InvokeMethodCommandResult).apply {
             async
             documentation =
-            "The main process requests the child process to execute a method with the given [signature],\n" +
+            "The main process requests the instrumented process to execute a method with the given [signature],\n" +
                     "which declaring class's name is [className].\n" +
                     "@property parameters are the parameters needed for an execution, e.g. static environment"
         }
         call("StopProcess", PredefinedType.void, PredefinedType.void).apply {
             async
             documentation =
-                "This command tells the child process to stop"
+                "This command tells the instrumented process to stop"
         }
         call("CollectCoverage", CollectCoverageParams, CollectCoverageResult).apply {
             async
             documentation =
-                "This command is sent to the child process from the [ConcreteExecutor] if user wants to collect coverage for the\n" +
+                "This command is sent to the instrumented process from the [ConcreteExecutor] if user wants to collect coverage for the\n" +
                         "[clazz]"
         }
         call("ComputeStaticField", ComputeStaticFieldParams, ComputeStaticFieldResult).apply {
             async
             documentation =
-                "This command is sent to the child process from the [ConcreteExecutor] if user wants to get value of static field\n" +
+                "This command is sent to the instrumented process from the [ConcreteExecutor] if user wants to get value of static field\n" +
                         "[fieldId]"
         }
     }

--- a/utbot-rd/src/main/rdgen/org/utbot/rd/models/SettingsModel.kt
+++ b/utbot-rd/src/main/rdgen/org/utbot/rd/models/SettingsModel.kt
@@ -2,9 +2,9 @@ package org.utbot.rd.models
 
 import com.jetbrains.rd.generator.nova.*
 
-object SettingsProtocolRoot: Root()
+object SettingsRoot: Root()
 
-object SettingsModel : Ext(SettingsProtocolRoot) {
+object SettingsModel : Ext(SettingsRoot) {
     val settingForArgument = structdef {
         field("key", PredefinedType.string)
         field("propertyName", PredefinedType.string)

--- a/utbot-rd/src/main/rdgen/org/utbot/rd/models/SynchronizationModel.kt
+++ b/utbot-rd/src/main/rdgen/org/utbot/rd/models/SynchronizationModel.kt
@@ -2,9 +2,9 @@ package org.utbot.rd.models
 
 import com.jetbrains.rd.generator.nova.*
 
-object SynchronizationModelRoot: Root()
+object SynchronizationRoot: Root()
 
-object SynchronizationModel: Ext(SynchronizationModelRoot) {
+object SynchronizationModel: Ext(SynchronizationRoot) {
     init {
         signal("synchronizationSignal", PredefinedType.string).async
     }


### PR DESCRIPTION
# Description

Multiple refactorings and enhacements for process starting. 
Removed ```UtSettings.logConcreteExecutionErrors``` and ```UtSettings.engineProcessLogLevel``` switches. 
Logs for engine and concrete executor processes are always enabled. 
Switched log configuration to ```utbot-intellij/log4j2.xml```. 
Use ```UtSettings#getIdeaProcessLogConfigFile``` from ```~/.utbot/settings.properties``` to configure logs for engine and concrete executor processes without rebuilding plugin.

Enabling suspend and port choosing by utsettings.
Run configurations for debugging.
Instant process death detection.
Orphan processes termination system.
Some text loading optimization.
ChildProcess -> InstrumentedProcess.
Rd-based UtSettings for InstrumentedProcess.

partially solves #1365
fix #1427
## Type of Change

- Refactoring (typos and non-functional changes) 
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

CI