### PR TITLE
Fix UtUtils version parsing & comment formatting

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgAbstractRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgAbstractRenderer.kt
@@ -360,7 +360,7 @@ abstract class CgAbstractRenderer(
     override fun visit(element: CgDocRegularStmt){
         if (element.isEmpty()) return
 
-        print(element.stmt.replace("\n", "\n * "))
+        print(" * " + element.stmt)
     }
     override fun visit(element: CgDocClassLinkStmt) {
         if (element.isEmpty()) return

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/ututils/CgUtilClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/ututils/CgUtilClassConstructor.kt
@@ -29,8 +29,12 @@ internal object CgUtilClassConstructor {
                 id = utilsClassId
                 documentation = utilClassKind.utilClassDocumentation(codegenLanguage)
                 body = buildClassBody(utilsClassId) {
-                    staticDeclarationRegions += CgStaticsRegion("Util methods", utilMethodProvider.utilMethodIds.map { CgUtilMethod(it) })
+                    staticDeclarationRegions += CgStaticsRegion(
+                        header = "Util methods",
+                        content = utilMethodProvider.utilMethodIds.map { CgUtilMethod(it) })
+
                     nestedClassRegions += CgAuxiliaryNestedClassesRegion(
+                        header = "Util classes",
                         nestedClasses = listOf(
                             CgAuxiliaryClass(utilMethodProvider.capturedArgumentClassId)
                         )

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/ututils/UtilClassKind.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/ututils/UtilClassKind.kt
@@ -36,7 +36,7 @@ sealed class UtilClassKind(
         = CgDocumentationComment(
         listOf(
             CgDocRegularStmt("$utilClassKindCommentText \n"),
-            CgDocRegularStmt("$UTIL_CLASS_VERSION_COMMENT_PREFIX${utilClassVersion(codegenLanguage)}"),
+            CgDocRegularStmt("$UTIL_CLASS_VERSION_COMMENT_PREFIX${utilClassVersion(codegenLanguage)} \n"),
         )
     )
 
@@ -108,9 +108,9 @@ sealed class UtilClassKind(
             codegenLanguage: CodegenLanguage
         )
         : UtilClassKind? {
-            return when (comment) {
-                RegularUtUtils(codegenLanguage).utilClassKindCommentText -> RegularUtUtils(codegenLanguage)
-                UtUtilsWithMockito(codegenLanguage).utilClassKindCommentText -> UtUtilsWithMockito(codegenLanguage)
+            return when {
+                comment.contains(RegularUtUtils(codegenLanguage).utilClassKindCommentText) -> RegularUtUtils(codegenLanguage)
+                comment.contains(UtUtilsWithMockito(codegenLanguage).utilClassKindCommentText) -> UtUtilsWithMockito(codegenLanguage)
                 else -> null
             }
         }

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerationController.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerationController.kt
@@ -426,6 +426,7 @@ object CodeGenerationController {
                 .map { comment -> comment.text }
                 .firstOrNull { text -> UtilClassKind.UTIL_CLASS_VERSION_COMMENT_PREFIX in text }
                 ?.substringAfterLast(UtilClassKind.UTIL_CLASS_VERSION_COMMENT_PREFIX)
+                ?.substringBefore("\n")
                 ?.trim()
         }
 


### PR DESCRIPTION
# Description

This PR fixes UtUtils comment formatting referring to [#1385](https://github.com/UnitTestBot/UTBotJava/issues/1385).

Also, because of wrong UtUtils version parsing UtUtils was always being recreated no matter UtUtils priority (with mocking support vs. without mocking support). It was fixed as well.

It was suggested to give a name to the region, now the UtUtils looks like this:
```java
/**
 * This is UtUtils class with Mockito support
 * UtUtils class version: 2.0
 */
public final class UtUtils {
    ///region Util classes

    /**
     * This class represents the {@code type} and {@code value} of a value captured by lambda.
     * Captured values are represented as arguments of a synthetic method that lambda is compiled into,
     * hence the name of the class.
     */
    public static class CapturedArgument {
        <...>
    }
    ///endregion

    ///region Util methods
    <...>
    ///endregion
}
```

Fixes [#1378](https://github.com/UnitTestBot/UTBotJava/issues/1378), [#1380](https://github.com/UnitTestBot/UTBotJava/issues/1380), [#1385](https://github.com/UnitTestBot/UTBotJava/issues/1385)

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

UtBot-samples.

## Manual Scenario 

Reproduced scenarios from issues described above and verified that they were fixed.