### PR TITLE
Correct installation dependencies into Gradle project

### DIFF
--- a/utbot-android-studio/src/main/kotlin/org/androidstudio/plugin/util/UtAndroidGradleJavaProjectModelModifier.kt
+++ b/utbot-android-studio/src/main/kotlin/org/androidstudio/plugin/util/UtAndroidGradleJavaProjectModelModifier.kt
@@ -11,19 +11,23 @@ import com.android.tools.idea.gradle.util.GradleUtil
 import com.android.tools.idea.project.AndroidProjectInfo
 import com.android.tools.idea.projectsystem.TestArtifactSearchScopes
 import com.google.wireless.android.sdk.stats.GradleSyncStats
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.command.undo.BasicUndoableAction
 import com.intellij.openapi.command.undo.UndoManager
-import com.intellij.openapi.externalSystem.ExternalSystemModulePropertyManager
+import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.DependencyScope
 import com.intellij.openapi.roots.ExternalLibraryDescriptor
+import com.intellij.openapi.roots.libraries.Library
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.pom.java.LanguageLevel
 import com.intellij.util.containers.ContainerUtil
 import org.jetbrains.concurrency.AsyncPromise
 import org.jetbrains.concurrency.Promise
+import org.jetbrains.concurrency.rejectedPromise
 
 class UtAndroidGradleJavaProjectModelModifier : AndroidGradleJavaProjectModelModifier() {
     override fun addExternalLibraryDependency(
@@ -32,14 +36,8 @@ class UtAndroidGradleJavaProjectModelModifier : AndroidGradleJavaProjectModelMod
         scope: DependencyScope
     ): Promise<Void?>? {
         val module = ContainerUtil.getFirstItem(modules) ?: return null
-
-        if (!isAndroidGradleProject(module.project)) {
-            return null
-        }
-
         val dependencySpec = ArtifactDependencySpec.create(descriptor.libraryArtifactId, descriptor.libraryGroupId, descriptor.preferredVersion)
         return addExternalLibraryDependency(module, dependencySpec, scope)
-
     }
 
     private fun addExternalLibraryDependency(
@@ -99,8 +97,6 @@ class UtAndroidGradleJavaProjectModelModifier : AndroidGradleJavaProjectModelMod
             }
         })
     }
-
-    private fun isAndroidGradleProject(project: Project): Boolean = AndroidProjectInfo.getInstance(project).requiresAndroidModel()
 
     private fun doAndroidGradleSync(project: Project, trigger: GradleSyncStats.Trigger): AsyncPromise<Void?> {
         val promise = AsyncPromise<Void?>()

--- a/utbot-android-studio/src/main/kotlin/org/androidstudio/plugin/util/UtAndroidGradleJavaProjectModelModifierWrapper.kt
+++ b/utbot-android-studio/src/main/kotlin/org/androidstudio/plugin/util/UtAndroidGradleJavaProjectModelModifierWrapper.kt
@@ -1,0 +1,38 @@
+package org.androidstudio.plugin.util
+
+import com.android.tools.idea.project.AndroidProjectInfo
+import com.intellij.ide.plugins.PluginManager
+import com.intellij.openapi.extensions.PluginId
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.DependencyScope
+import com.intellij.openapi.roots.ExternalLibraryDescriptor
+import com.intellij.openapi.roots.impl.IdeaProjectModelModifier
+import com.intellij.util.containers.ContainerUtil
+import org.jetbrains.concurrency.Promise
+
+class UtAndroidGradleJavaProjectModelModifierWrapper(val project: Project): IdeaProjectModelModifier(project)  {
+
+    override fun addExternalLibraryDependency(
+        modules: Collection<Module?>,
+        descriptor: ExternalLibraryDescriptor,
+        scope: DependencyScope
+    ): Promise<Void?>? {
+
+        val module = ContainerUtil.getFirstItem(modules) ?: return null
+        if (!isAndroidGradleProject(module.project)) {
+            return null
+        }
+
+        return UtAndroidGradleJavaProjectModelModifier().addExternalLibraryDependency(modules, descriptor, scope)
+    }
+
+    private fun isAndroidGradleProject(project: Project): Boolean {
+        val pluginId = PluginId.findId("org.jetbrains.android")
+        if (pluginId == null || PluginManager.getInstance().findEnabledPlugin(pluginId) == null) {
+            return false
+        }
+
+        return AndroidProjectInfo.getInstance(project).requiresAndroidModel()
+    }
+}

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/UtProjectModelModifier.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/UtProjectModelModifier.kt
@@ -20,6 +20,7 @@ import org.jetbrains.concurrency.resolvedPromise
 import org.jetbrains.idea.maven.utils.library.RepositoryLibraryProperties
 import org.jetbrains.jps.model.library.JpsMavenRepositoryLibraryDescriptor
 import org.utbot.intellij.plugin.models.mavenCoordinates
+import org.utbot.intellij.plugin.ui.utils.isBuildWithGradle
 
 class UtProjectModelModifier(val project: Project) : IdeaProjectModelModifier(project) {
     override fun addExternalLibraryDependency(
@@ -52,7 +53,8 @@ class UtProjectModelModifier(val project: Project) : IdeaProjectModelModifier(pr
         }
         if (classesRoots.isNotEmpty()) {
             val urls = OrderEntryFix.refreshAndConvertToUrls(classesRoots)
-            if (modules.size == 1) {
+
+            if (moduleLibraryMayBeInstalled(modules)) {
                 ModuleRootModificationUtil.addModuleLibrary(
                     firstModule,
                     if (classesRoots.size > 1) descriptor.presentableName else null,
@@ -78,4 +80,7 @@ class UtProjectModelModifier(val project: Project) : IdeaProjectModelModifier(pr
         }
         return resolvedPromise()
     }
+
+    private fun moduleLibraryMayBeInstalled(modules: Collection<Module>) : Boolean =
+        modules.size == 1 && modules.any { it.project.isBuildWithGradle }
 }

--- a/utbot-intellij/src/main/resources/META-INF/plugin.xml
+++ b/utbot-intellij/src/main/resources/META-INF/plugin.xml
@@ -32,7 +32,7 @@
         <registryKey defaultValue="false" description="Enable editing Kotlin test files" key="kotlin.ultra.light.classes.empty.text.range"/>
         <postStartupActivity implementation="org.utbot.intellij.plugin.ui.GotItTooltipActivity"/>
         <projectModelModifier implementation="org.utbot.intellij.plugin.util.UtProjectModelModifier"/>
-        <projectModelModifier implementation="org.androidstudio.plugin.util.UtAndroidGradleJavaProjectModelModifier" order="first"/>
+        <projectModelModifier implementation="org.androidstudio.plugin.util.UtAndroidGradleJavaProjectModelModifierWrapper" order="first"/>
         <!--Documentation-->
         <customJavadocTagProvider implementation="org.utbot.intellij.plugin.javadoc.UtCustomJavaDocTagProvider"/>
         <lang.documentationProvider language="JAVA" order="first" implementationClass="org.utbot.intellij.plugin.javadoc.UtDocumentationProvider"/>


### PR DESCRIPTION
# Description

There were two problems with dependencies installation into Gradle project:
- if Android plugin is disabled, `UtAndroidGradleProjectModelModifier` crashed; a new wrapper modifier is introduced, it checks  if current project is Android or not and visits real modifier only if required
- `UtProjectModelModifier` could not install module dependency into Gradle project; in case of this build system we use non-module dependency installer.

Fixes # ([1300](https://github.com/UnitTestBot/UTBotJava/issues/1300))

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

Verify that dependency installation into Intellij, Maven, Gradle and Android Studio projects is correct.
