### PR TITLE
Add a flag to disable imports addition from formatter side

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerationController.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerationController.kt
@@ -37,6 +37,7 @@ import com.intellij.psi.SmartPointerManager
 import com.intellij.psi.SmartPsiElementPointer
 import com.intellij.psi.codeStyle.CodeStyleManager
 import com.intellij.psi.codeStyle.JavaCodeStyleManager
+import com.intellij.psi.codeStyle.JavaCodeStyleManager.DO_NOT_ADD_IMPORTS
 import com.intellij.psi.search.GlobalSearchScopesCore
 import com.intellij.testIntegration.TestIntegrationUtils
 import com.siyeh.ig.psiutils.ImportUtils
@@ -773,7 +774,7 @@ object CodeGenerationController {
                     val startOffset = range.startOffset
                     val endOffset = range.endOffset
                     val reformatRange = codeStyleManager.reformatRange(file, startOffset, endOffset, false)
-                    JavaCodeStyleManager.getInstance(project).shortenClassReferences(reformatRange)
+                    JavaCodeStyleManager.getInstance(project).shortenClassReferences(reformatRange, DO_NOT_ADD_IMPORTS)
                 }
                 CodegenLanguage.KOTLIN -> ShortenReferences.DEFAULT.process((testClass as KtUltraLightClass).kotlinOrigin.containingKtFile)
             }


### PR DESCRIPTION
# Description

Choosing a different package as a test source root may lead to unnecessary repeating imports being rendered. The cause was that formatter was able to add extra imports when there was a method (which is from a different package) invocation. This PR fixes prohibits such behavior.

Fixes # ([1286](https://github.com/UnitTestBot/UTBotJava/issues/1286))

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

utbot-samples.

## Manual Scenario 

Open *UTBotJava* project, generate tests for the *org.utbot.examples.exceptions.ExceptionExamples* class choosing different package as a **test source root** location. Verify that the generated code has no repeating imports as it was described in the issue:
```java
package org.utbot.examples.exceptions;

import org.junit.jupiter.api.Test;
import org.junit.jupiter.api.DisplayName;

import static org.junit.jupiter.api.Assertions.assertEquals;
import static org.junit.jupiter.api.Assertions.assertThrows;
import static org.utbot.runtime.utils.java.UtUtils.createInstance;

public final class ExceptionExamplesTest {
    <...>
}
```