### PR TITLE
Respect another methods in interface for lambda

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -54,6 +54,7 @@ import soot.jimple.Stmt
 import java.io.File
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
+import org.utbot.common.isAbstract
 
 const val SYMBOLIC_NULL_ADDR: Int = 0
 
@@ -575,7 +576,7 @@ class UtLambdaModel(
     val lambdaMethodId: MethodId
         get() {
             if (isFake) {
-                val targetMethod = samType.jClass.declaredMethods.single()
+                val targetMethod = samType.jClass.declaredMethods.single { it.isAbstract }
                 return object : MethodId(
                     declaringClass,
                     fakeName,


### PR DESCRIPTION
# Description

We didn't respect another not abstract methods in interfaces for building fake lambdas.

Fixes #1419

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

Described in issue #1419 

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [x] All tests pass locally with my changes
