### PR TITLE
Notification group XXX report is already registered pollutes idea.log…

### DIFF
--- a/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/ui/Notifications.kt
+++ b/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/ui/Notifications.kt
@@ -37,7 +37,7 @@ abstract class Notifier {
     protected open val notificationDisplayType = NotificationDisplayType.BALLOON
 
     protected val notificationGroup: NotificationGroup
-        get() = NotificationGroup(displayId, notificationDisplayType)
+        get() = NotificationGroup.findRegisteredGroup(displayId) ?: NotificationGroup(displayId, notificationDisplayType)
 }
 
 abstract class WarningNotifier : Notifier() {


### PR DESCRIPTION
… #1409

# Description

Reuse existnig notification group when possible

Fixes #1409

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?


## Manual Scenario 

Generate tests twice: first time we create some groups, second time we re-use them without stacktraces in idea.log

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
