### PR TITLE
Add hint for disabled fuzzing control #1411

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -1,6 +1,7 @@
 package org.utbot.framework
 
 import com.jetbrains.rd.util.LogLevel
+import java.io.File
 import mu.KotlinLogging
 import org.utbot.common.AbstractSettings
 import java.lang.reflect.Executable
@@ -9,12 +10,12 @@ private val logger = KotlinLogging.logger {}
 /**
  * Path to the utbot home folder.
  */
-internal val utbotHomePath = "${System.getProperty("user.home")}/.utbot"
+internal val utbotHomePath = "${System.getProperty("user.home")}${File.separatorChar}.utbot"
 
 /**
  * Default path for properties file
  */
-private val defaultSettingsPath = "$utbotHomePath/settings.properties"
+private val defaultSettingsPath = "$utbotHomePath${File.separatorChar}settings.properties"
 private const val defaultKeyForSettingsPath = "utbot.settings.path"
 
 /**
@@ -25,6 +26,9 @@ const val DEFAULT_CONCRETE_EXECUTION_TIMEOUT_IN_CHILD_PROCESS_MS = 1000L
 object UtSettings : AbstractSettings(
     logger, defaultKeyForSettingsPath, defaultSettingsPath
 ) {
+
+    @JvmStatic
+    fun getPath(): String = System.getProperty(defaultKeyForSettingsPath)?: defaultSettingsPath
 
     /**
      * Setting to disable coroutines debug explicitly.

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/SettingsWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/SettingsWindow.kt
@@ -209,6 +209,11 @@ class SettingsWindow(val project: Project) {
                 addToRight(symLabel)
             }().constraints(CCFlags.growX)
         }
+        if (!UtSettings.useFuzzing) {
+            row("") {
+                comment("Fuzzing is disabled in ${UtSettings.getPath()}, see the key 'useFuzzing'" )
+            }
+        }
     }
 
     fun isModified(): Boolean {

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/SettingsWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/SettingsWindow.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.ui.ContextHelpLabel
+import com.intellij.ui.components.ActionLink
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.layout.CCFlags
 import com.intellij.ui.layout.LayoutBuilder
@@ -20,6 +21,7 @@ import com.intellij.util.ui.components.BorderLayoutPanel
 import javax.swing.DefaultComboBoxModel
 import javax.swing.JCheckBox
 import javax.swing.JPanel
+import javax.swing.JSlider
 import kotlin.reflect.KClass
 import org.utbot.framework.UtSettings
 import org.utbot.framework.codegen.domain.ForceStaticMocking
@@ -29,9 +31,9 @@ import org.utbot.framework.plugin.api.CodeGenerationSettingItem
 import org.utbot.framework.plugin.api.CodegenLanguage
 import org.utbot.framework.plugin.api.JavaDocCommentStyle
 import org.utbot.framework.plugin.api.TreatOverflowAsError
-import org.utbot.intellij.plugin.ui.components.CodeGenerationSettingItemRenderer
-import javax.swing.JSlider
 import org.utbot.framework.plugin.api.isSummarizationCompatible
+import org.utbot.intellij.plugin.ui.components.CodeGenerationSettingItemRenderer
+import org.utbot.intellij.plugin.util.showSettingsEditor
 
 class SettingsWindow(val project: Project) {
     private val settings = project.service<Settings>()
@@ -211,7 +213,13 @@ class SettingsWindow(val project: Project) {
         }
         if (!UtSettings.useFuzzing) {
             row("") {
-                comment("Fuzzing is disabled in ${UtSettings.getPath()}, see the key 'useFuzzing'" )
+                cell {
+                    component(comment("Fuzzing is disabled in configuration file.").component)
+                    component(ActionLink("Edit configuration") {
+                        UIUtil.getWindow(fuzzLabel)?.dispose()
+                        showSettingsEditor(project, "useFuzzing")
+                    })
+                }
             }
         }
     }

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/UtSettingsHelper.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/UtSettingsHelper.kt
@@ -1,0 +1,31 @@
+package org.utbot.intellij.plugin.util
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.OpenFileDescriptor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VfsUtil
+import java.io.File
+import java.nio.charset.Charset
+import org.utbot.framework.UtSettings
+
+fun showSettingsEditor(project: Project, key: String? = null) {
+    val ioFile = File(UtSettings.getPath())
+    ApplicationManager.getApplication().executeOnPooledThread {
+        var logicalLine: Int = -1
+        key?.let {
+            logicalLine = ioFile.readLines(Charset.defaultCharset())
+                .indexOfFirst { s -> s.startsWith("$key=") or s.startsWith("#$key=") }
+        }
+        VfsUtil.findFileByIoFile(ioFile, true)?.let {
+            val descriptor = if (logicalLine != -1) {
+                OpenFileDescriptor(project, it, logicalLine, 0)
+            } else {
+                OpenFileDescriptor(project, it)
+            }
+            ApplicationManager.getApplication().invokeLater {
+                FileEditorManager.getInstance(project).openTextEditor(descriptor, true)
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Description

New comment line appears when fuzzing is disabled in settings.properties file

Fixes #1411 

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

Disable fuzzing in settings.properties with the line `useFuzzing=false`
Check if comment appears under disabled fuzzing slider in in Settings > Tools > UtitTestBot

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
