### PR TITLE
Fix inaccessible menu item "Generate Tests ..." for multiple selected kt classes

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/language/JavaLanguage.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/language/JavaLanguage.kt
@@ -24,6 +24,7 @@ import org.utbot.intellij.plugin.util.extractFirstLevelMembers
 import org.utbot.intellij.plugin.util.isVisible
 import java.util.*
 import org.jetbrains.kotlin.j2k.getContainingClass
+import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.utils.addIfNotNull
 import org.utbot.framework.plugin.api.util.LockFile
 import org.utbot.intellij.plugin.models.packageName
@@ -113,6 +114,7 @@ object JvmLanguageAssistant : LanguageAssistant() {
                     when(it) {
                         is PsiFileSystemItem  -> srcClasses += getAllClasses(project, arrayOf(it.virtualFile))
                         is PsiClass -> srcClasses.add(it)
+                        is KtClass -> srcClasses += getClassesFromFile(it.containingKtFile)
                         is PsiElement -> {
                             srcClasses.addIfNotNull(it.getContainingClass())
                             if (it is PsiMethod) {


### PR DESCRIPTION
# Description

As was described in the following issue, it was impossible to open "Generate Tests with UnitTestBot" window for multiple selected KT classes. This PR fixes this issue.

Fixes # ([1413](https://github.com/UnitTestBot/UTBotJava/issues/1413))

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

Manual testing only.

## Manual Scenario 

Open KT project with multiple classes. Select them and press the hotkey (or press the RMB). UTBot test generation window will pop up.

![image](https://user-images.githubusercontent.com/54685068/204508396-e7fd8e79-cb62-418a-8616-d2dc29fd6c86.png)
![image](https://user-images.githubusercontent.com/54685068/204508418-1e096197-38e5-4d65-b0ad-b9ff8954d0da.png)
