### PR TITLE
Fix plain JavaDocs formatting

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/CgElement.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/CgElement.kt
@@ -7,7 +7,6 @@ import org.utbot.framework.codegen.renderer.CgRendererContext
 import org.utbot.framework.codegen.renderer.CgVisitor
 import org.utbot.framework.codegen.renderer.auxiliaryClassTextById
 import org.utbot.framework.codegen.renderer.utilMethodTextById
-import org.utbot.framework.codegen.reports.TestsGenerationReport
 import org.utbot.framework.plugin.api.BuiltinClassId
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.ConstructorId
@@ -60,6 +59,7 @@ interface CgElement {
             is CgCustomTagStatement -> visit(element)
             is CgDocCodeStmt -> visit(element)
             is CgDocRegularStmt -> visit(element)
+            is CgDocRegularLineStmt -> visit(element)
             is CgDocClassLinkStmt -> visit(element)
             is CgDocMethodLinkStmt -> visit(element)
             is CgAnonymousFunction -> visit(element)
@@ -423,7 +423,19 @@ class CgDocRegularStmt(val stmt: String) : CgDocStatement() {
     override fun isEmpty(): Boolean = stmt.isEmpty()
 
     override fun equals(other: Any?): Boolean =
-        if (other is CgDocCodeStmt) this.hashCode() == other.hashCode() else false
+        if (other is CgDocRegularStmt) this.hashCode() == other.hashCode() else false
+
+    override fun hashCode(): Int = stmt.hashCode()
+}
+
+/**
+ * Represents an element of a whole line of a multiline comment.
+ */
+class CgDocRegularLineStmt(val stmt: String) : CgDocStatement() {
+    override fun isEmpty(): Boolean = stmt.isEmpty()
+
+    override fun equals(other: Any?): Boolean =
+        if (other is CgDocRegularLineStmt) this.hashCode() == other.hashCode() else false
 
     override fun hashCode(): Int = stmt.hashCode()
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgAbstractRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgAbstractRenderer.kt
@@ -29,6 +29,7 @@ import org.utbot.framework.codegen.domain.models.CgDocClassLinkStmt
 import org.utbot.framework.codegen.domain.models.CgDocCodeStmt
 import org.utbot.framework.codegen.domain.models.CgDocMethodLinkStmt
 import org.utbot.framework.codegen.domain.models.CgDocPreTagStatement
+import org.utbot.framework.codegen.domain.models.CgDocRegularLineStmt
 import org.utbot.framework.codegen.domain.models.CgDocRegularStmt
 import org.utbot.framework.codegen.domain.models.CgDocumentationComment
 import org.utbot.framework.codegen.domain.models.CgElement
@@ -360,7 +361,12 @@ abstract class CgAbstractRenderer(
     override fun visit(element: CgDocRegularStmt){
         if (element.isEmpty()) return
 
-        print(" * " + element.stmt)
+        print(element.stmt.replace("\n", "\n * "))
+    }
+    override fun visit(element: CgDocRegularLineStmt){
+        if (element.isEmpty()) return
+
+        print(" * " + element.stmt + "\n")
     }
     override fun visit(element: CgDocClassLinkStmt) {
         if (element.isEmpty()) return

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgVisitor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgVisitor.kt
@@ -75,6 +75,7 @@ import org.utbot.framework.codegen.domain.models.CgSwitchCase
 import org.utbot.framework.codegen.domain.models.CgSwitchCaseLabel
 import org.utbot.framework.codegen.domain.models.CgClass
 import org.utbot.framework.codegen.domain.models.CgClassBody
+import org.utbot.framework.codegen.domain.models.CgDocRegularLineStmt
 import org.utbot.framework.codegen.domain.models.CgNestedClassesRegion
 import org.utbot.framework.codegen.domain.models.CgTestMethod
 import org.utbot.framework.codegen.domain.models.CgTestMethodCluster
@@ -132,6 +133,7 @@ interface CgVisitor<R> {
     fun visit(element: CgCustomTagStatement): R
     fun visit(element: CgDocCodeStmt): R
     fun visit(element: CgDocRegularStmt): R
+    fun visit(element: CgDocRegularLineStmt): R
     fun visit(element: CgDocClassLinkStmt): R
     fun visit(element: CgDocMethodLinkStmt): R
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/ututils/UtilClassKind.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/ututils/UtilClassKind.kt
@@ -2,7 +2,7 @@ package org.utbot.framework.codegen.tree.ututils
 
 import org.utbot.framework.codegen.domain.builtin.UtilClassFileMethodProvider
 import org.utbot.framework.codegen.domain.context.CgContext
-import org.utbot.framework.codegen.domain.models.CgDocRegularStmt
+import org.utbot.framework.codegen.domain.models.CgDocRegularLineStmt
 import org.utbot.framework.codegen.domain.models.CgDocumentationComment
 import org.utbot.framework.codegen.renderer.CgAbstractRenderer
 import org.utbot.framework.plugin.api.CodegenLanguage
@@ -35,8 +35,8 @@ sealed class UtilClassKind(
     fun utilClassDocumentation(codegenLanguage: CodegenLanguage): CgDocumentationComment
         = CgDocumentationComment(
         listOf(
-            CgDocRegularStmt("$utilClassKindCommentText \n"),
-            CgDocRegularStmt("$UTIL_CLASS_VERSION_COMMENT_PREFIX${utilClassVersion(codegenLanguage)} \n"),
+            CgDocRegularLineStmt(utilClassKindCommentText),
+            CgDocRegularLineStmt("$UTIL_CLASS_VERSION_COMMENT_PREFIX${utilClassVersion(codegenLanguage)}"),
         )
     )
 


### PR DESCRIPTION
# Description

After UtUtil comment fixes some bugs in plain *JavaDocs* took place.
This PR introduces *CgDocRegularLineStmt* to satisfy both fixes.

Fixes # ([1430](https://github.com/UnitTestBot/UTBotJava/issues/1430))

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

Manual testing only.

## Manual Scenario 

1. Reproduced the scenario from [1378](https://github.com/UnitTestBot/UTBotJava/issues/1378), verified that there is no mockito to non-mockito UtUtil version replacement.
2. Reproduced the scenario from [1430](https://github.com/UnitTestBot/UTBotJava/issues/1430), verified that the comment looks fine:
![image](https://user-images.githubusercontent.com/54685068/204530733-4dc7d22c-aee5-4997-8e96-4afd6f4ecfe6.png)
