### PR TITLE
Better test source root suggestion: remove standard "src/main/" suffix

### DIFF
--- a/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/models/BaseTestModel.kt
+++ b/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/models/BaseTestModel.kt
@@ -9,7 +9,7 @@ import com.intellij.psi.PsiClass
 import org.jetbrains.kotlin.idea.core.getPackage
 import org.jetbrains.kotlin.idea.util.projectStructure.allModules
 import org.utbot.framework.plugin.api.CodegenLanguage
-import org.utbot.intellij.plugin.ui.utils.TestSourceRoot
+import org.utbot.intellij.plugin.ui.utils.ITestSourceRoot
 import org.utbot.intellij.plugin.ui.utils.isBuildWithGradle
 import org.utbot.intellij.plugin.ui.utils.suitableTestSourceRoots
 
@@ -48,7 +48,7 @@ open class BaseTestsModel(
         srcClasses.map { it.packageName }.distinct().size != 1
     }
 
-    fun getAllTestSourceRoots() : MutableList<TestSourceRoot> {
+    fun getAllTestSourceRoots() : MutableList<out ITestSourceRoot> {
         with(if (project.isBuildWithGradle) project.allModules() else potentialTestModules) {
             return this.flatMap { it.suitableTestSourceRoots().toList() }.toMutableList()
         }

--- a/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/ui/components/TestFolderComboWithBrowseButton.kt
+++ b/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/ui/components/TestFolderComboWithBrowseButton.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.ui.ComponentWithBrowseButton
 import com.intellij.openapi.ui.FixedSizeButton
+import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.newvfs.impl.FakeVirtualFile
@@ -26,10 +27,12 @@ import org.utbot.intellij.plugin.ui.utils.addDedicatedTestRoot
 import org.utbot.intellij.plugin.ui.utils.dedicatedTestSourceRootName
 import org.utbot.intellij.plugin.ui.utils.isBuildWithGradle
 
+private const val SET_TEST_FOLDER = "set test folder"
+private val SRC_MAIN = FileUtil.toSystemDependentName("src/main/")
+
 class TestFolderComboWithBrowseButton(private val model: BaseTestsModel) :
     ComponentWithBrowseButton<ComboBox<Any>>(ComboBox(), null) {
 
-    private val SET_TEST_FOLDER = "set test folder"
 
     init {
         if (model.project.isBuildWithGradle) {
@@ -95,6 +98,8 @@ class TestFolderComboWithBrowseButton(private val model: BaseTestsModel) :
                 StringUtil.commonPrefix(commonModuleSourceDirectory, sourceRoot.toNioPath().toString())
             }
         }
+        //Remove standard suffix that may prevent exact module path matching
+        commonModuleSourceDirectory = StringUtil.trimEnd(commonModuleSourceDirectory, SRC_MAIN)
 
         return getAllTestSourceRoots().distinct().toMutableList().sortedWith(
             compareByDescending<TestSourceRoot> {

--- a/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/RootUtils.kt
+++ b/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/RootUtils.kt
@@ -1,6 +1,8 @@
 package org.utbot.intellij.plugin.ui.utils
 
 import com.intellij.openapi.roots.SourceFolder
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.util.text.StringUtil
 import org.jetbrains.jps.model.java.JavaResourceRootProperties
 import org.jetbrains.jps.model.java.JavaResourceRootType
 import org.jetbrains.jps.model.java.JavaSourceRootProperties
@@ -54,4 +56,54 @@ fun SourceFolder.isForGeneratedSources(): Boolean {
         IntelliJApiHelper.isAndroidStudio() && this.file?.path?.contains("build/generated") == true
 
     return markedGeneratedSources || androidStudioGeneratedSources
+}
+
+const val SRC_MAIN = "src/main/"
+
+/**
+ * Sorting test roots, the main idea is to place 'the best'
+ * test source root the first and to provide readability in general
+ * @param allTestRoots are all test roots of a project to be sorted
+ * @param moduleSourcePaths is list of source roots for the module for which we're going to generate tests.
+ * The first test source root in the resulting list is expected
+ * to be the closest one to the module based on module source roots.
+ * @param codegenLanguage is target generation language
+ */
+fun getSortedTestRoots(
+    allTestRoots: MutableList<out ITestSourceRoot>,
+    moduleSourcePaths: List<String>,
+    codegenLanguage: CodegenLanguage
+): MutableList<ITestSourceRoot> {
+    var commonModuleSourceDirectory = FileUtil.toSystemIndependentName(moduleSourcePaths.getCommonPrefix())
+    //Remove standard suffix that may prevent exact module path matching
+    commonModuleSourceDirectory = StringUtil.trimEnd(commonModuleSourceDirectory, SRC_MAIN)
+
+    return allTestRoots.distinct().toMutableList().sortedWith(
+        compareByDescending<ITestSourceRoot> {
+            // Heuristics: Dirs with proper code language should go first
+            it.expectedLanguage == codegenLanguage
+        }.thenByDescending {
+            // Heuristics: Dirs from within module 'common' directory should go first
+            FileUtil.toSystemIndependentName(it.dirPath).startsWith(commonModuleSourceDirectory)
+        }.thenByDescending {
+            // Heuristics: dedicated test source root named 'utbot_tests' should go first
+            it.dirName == dedicatedTestSourceRootName
+        }.thenBy {
+            // ABC-sorting
+            it.dirPath
+        }
+    ).toMutableList()
+}
+
+
+fun List<String>.getCommonPrefix() : String {
+    var result = ""
+    for ((i, s) in withIndex()) {
+        result = if (i == 0) {
+            s
+        } else {
+            StringUtil.commonPrefix(result, s)
+        }
+    }
+    return result
 }

--- a/utbot-ui-commons/src/test/kotlin/org/utbot/intellij/plugin/ui/utils/RootUtilsTest.kt
+++ b/utbot-ui-commons/src/test/kotlin/org/utbot/intellij/plugin/ui/utils/RootUtilsTest.kt
@@ -1,0 +1,62 @@
+package org.utbot.intellij.plugin.ui.utils
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.utbot.framework.plugin.api.CodegenLanguage
+
+internal class RootUtilsTest {
+    internal class MockTestSourceRoot(override val dirPath: String) : ITestSourceRoot {
+        override val dir = null
+        override val dirName = dirPath.substring(dirPath.lastIndexOf("/") + 1)
+        override val expectedLanguage = if (dirName == "java") CodegenLanguage.JAVA else CodegenLanguage.KOTLIN
+        override fun toString()= dirPath
+    }
+
+    @Test
+    fun testCommonPrefix() {
+        val commonPrefix = listOf(
+            "/UTBotJavaTest/utbot-framework/src/main/java",
+            "/UTBotJavaTest/utbot-framework/src/main/kotlin",
+            "/UTBotJavaTest/utbot-framework/src/main/resources"
+        ).getCommonPrefix()
+        Assertions.assertEquals("/UTBotJavaTest/utbot-framework/src/main/", commonPrefix)
+        Assertions.assertTrue(commonPrefix.endsWith(SRC_MAIN))
+    }
+
+    @Test
+    fun testRootSorting() {
+        val allTestRoots = mutableListOf(
+            MockTestSourceRoot("/UTBotJavaTest/utbot-analytics/src/test/java"),
+            MockTestSourceRoot("/UTBotJavaTest/utbot-analytics/src/test/kotlin"),
+            MockTestSourceRoot("/UTBotJavaTest/utbot-analytics-torch/src/test/kotlin"),
+            MockTestSourceRoot("/UTBotJavaTest/utbot-cli/src/test/kotlin"),
+            MockTestSourceRoot("/UTBotJavaTest/utbot-framework/src/test/java"),
+            MockTestSourceRoot("/UTBotJavaTest/utbot-framework-api/src/test/java"),
+            MockTestSourceRoot("/UTBotJavaTest/utbot-framework-api/src/test/kotlin"),
+            MockTestSourceRoot("/UTBotJavaTest/utbot-framework-test/src/test/java"),
+            MockTestSourceRoot("/UTBotJavaTest/utbot-framework-test/src/test/kotlin"),
+            MockTestSourceRoot("/UTBotJavaTest/utbot-fuzzers/src/test/java"),
+            MockTestSourceRoot("/UTBotJavaTest/utbot-fuzzers/src/test/kotlin"),
+            MockTestSourceRoot("/UTBotJavaTest/utbot-gradle/src/test/kotlin"),
+            MockTestSourceRoot("/UTBotJavaTest/utbot-instrumentation/src/test/java"),
+            MockTestSourceRoot("/UTBotJavaTest/utbot-instrumentation/src/test/kotlin"),
+            MockTestSourceRoot("/UTBotJavaTest/utbot-instrumentation-tests/src/test/java"),
+            MockTestSourceRoot("/UTBotJavaTest/utbot-instrumentation-tests/src/test/kotlin"),
+            MockTestSourceRoot("/UTBotJavaTest/utbot-intellij/src/test/java"),
+            MockTestSourceRoot("/UTBotJavaTest/utbot-maven/src/test/kotlin"),
+            MockTestSourceRoot("/UTBotJavaTest/utbot-sample/src/test/java"),
+            MockTestSourceRoot("/UTBotJavaTest/utbot-summary/src/test/kotlin"),
+            MockTestSourceRoot("/UTBotJavaTest/utbot-summary-tests/src/test/kotlin"),
+            MockTestSourceRoot("/UTBotJavaTest/utbot-core/src/test/java"),
+            MockTestSourceRoot("/UTBotJavaTest/utbot-core/src/test/kotlin"),
+            MockTestSourceRoot("/UTBotJavaTest/utbot-rd/src/test/kotlin"),
+        )
+        val moduleSourcePaths = listOf(
+            "/UTBotJavaTest/utbot-framework/src/main/java",
+            "/UTBotJavaTest/utbot-framework/src/main/kotlin",
+            "/UTBotJavaTest/utbot-framework/src/main/resources",
+        )
+        val sortedTestRoots = getSortedTestRoots(allTestRoots, moduleSourcePaths, CodegenLanguage.JAVA)
+        Assertions.assertEquals("/UTBotJavaTest/utbot-framework/src/test/java", sortedTestRoots.first().toString())
+    }
+}


### PR DESCRIPTION
# Description

Standard suffix `src/main/` may spoil source root matching when we're tryining to chose the best one.

Fixes #1439

## Type of Change

Please delete options that are not relevant.

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?


## Manual Scenario 

1. Open UtBotJava project
2. Try to generate tests for `org.utbot.instrumentation.warmup.Warmup` 
3. Expected test root utbot-framework/src/test is not the first in the list.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] New documentation is provided or existed one is altered
- [x] No new warnings