### PR TITLE
Use custom Maven dependencies installation

### DIFF
--- a/utbot-android-studio/src/main/kotlin/org/androidstudio/plugin/util/UtAndroidGradleJavaProjectModelModifierWrapper.kt
+++ b/utbot-android-studio/src/main/kotlin/org/androidstudio/plugin/util/UtAndroidGradleJavaProjectModelModifierWrapper.kt
@@ -10,7 +10,6 @@ import com.intellij.openapi.roots.ExternalLibraryDescriptor
 import com.intellij.openapi.roots.impl.IdeaProjectModelModifier
 import com.intellij.openapi.roots.libraries.Library
 import com.intellij.pom.java.LanguageLevel
-import com.intellij.util.containers.ContainerUtil
 import org.jetbrains.concurrency.Promise
 
 /*
@@ -25,9 +24,7 @@ class UtAndroidGradleJavaProjectModelModifierWrapper(val project: Project): Idea
         descriptor: ExternalLibraryDescriptor,
         scope: DependencyScope
     ): Promise<Void?>? {
-
-        val module = ContainerUtil.getFirstItem(modules) ?: return null
-        if (!isAndroidGradleProject(module.project)) {
+        if (!isAndroidGradleProject(project)) {
             return null
         }
 

--- a/utbot-intellij/build.gradle.kts
+++ b/utbot-intellij/build.gradle.kts
@@ -49,10 +49,14 @@ intellij {
         "JavaScript"
     )
 
+    val mavenUtilsPlugins = listOf(
+        "org.jetbrains.idea.maven"
+    )
+
     plugins.set(
         when (ideType) {
-            "IC" -> jvmPlugins + pythonCommunityPlugins + androidPlugins
-            "IU" -> jvmPlugins + pythonUltimatePlugins + jsPlugins + androidPlugins
+            "IC" -> jvmPlugins + pythonCommunityPlugins + androidPlugins + mavenUtilsPlugins
+            "IU" -> jvmPlugins + pythonUltimatePlugins + jsPlugins + androidPlugins + mavenUtilsPlugins
             "PC" -> pythonCommunityPlugins
             "PY" -> pythonUltimatePlugins // something else, JS?
             else -> jvmPlugins

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/UtMavenProjectModelModifier.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/UtMavenProjectModelModifier.kt
@@ -1,0 +1,119 @@
+package org.utbot.intellij.plugin.util
+
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.DependencyScope
+import com.intellij.openapi.roots.ExternalLibraryDescriptor
+import com.intellij.openapi.roots.JavaProjectModelModifier
+import com.intellij.openapi.util.Trinity
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.pom.java.LanguageLevel
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.util.PsiUtilCore
+import com.intellij.psi.xml.XmlFile
+import com.intellij.util.ThrowableRunnable
+import com.intellij.util.xml.DomUtil
+import org.jetbrains.concurrency.Promise
+import org.jetbrains.concurrency.rejectedPromise
+import org.jetbrains.idea.maven.dom.MavenDomBundle
+import org.jetbrains.idea.maven.dom.MavenDomUtil
+import org.jetbrains.idea.maven.dom.converters.MavenDependencyCompletionUtil
+import org.jetbrains.idea.maven.dom.model.MavenDomProjectModel
+import org.jetbrains.idea.maven.model.MavenConstants
+import org.jetbrains.idea.maven.model.MavenId
+import org.jetbrains.idea.maven.project.MavenProject
+import org.jetbrains.idea.maven.project.MavenProjectsManager
+
+class UtMavenProjectModelModifier(val project: Project): JavaProjectModelModifier() {
+
+    private val mavenProjectsManager = MavenProjectsManager.getInstance(project)
+
+    override fun addExternalLibraryDependency(
+        modules: Collection<Module>,
+        descriptor: ExternalLibraryDescriptor,
+        scope: DependencyScope
+    ): Promise<Void?>? {
+        for (module in modules) {
+            if (!mavenProjectsManager.isMavenizedModule(module)) {
+                return null
+            }
+        }
+
+        val mavenId = MavenId(descriptor.libraryGroupId, descriptor.libraryArtifactId, descriptor.preferredVersion)
+        return addDependency(modules, mavenId, descriptor.preferredVersion, scope)
+    }
+
+    override fun changeLanguageLevel(module: Module, level: LanguageLevel): Promise<Void> = rejectedPromise()
+
+    private fun addDependency(
+        fromModules: Collection<Module>,
+        mavenId: MavenId,
+        preferredVersion: String?,
+        scope: DependencyScope,
+    ): Promise<Void?>? {
+        val models: MutableList<Trinity<MavenDomProjectModel, MavenId, String?>> = ArrayList(fromModules.size)
+        val files: MutableList<XmlFile> = ArrayList(fromModules.size)
+        val projectToUpdate: MutableList<MavenProject> = ArrayList(fromModules.size)
+        val mavenScope = getMavenScope(scope)
+
+        for (from in fromModules) {
+            if (!mavenProjectsManager.isMavenizedModule(from)) return null
+            val fromProject: MavenProject = mavenProjectsManager.findProject(from) ?: return null
+            val model = MavenDomUtil.getMavenDomProjectModel(project, fromProject.file) ?: return null
+            var scopeToSet: String? = null
+            var version: String? = null
+            if (mavenId.groupId != null && mavenId.artifactId != null) {
+                val managedDependency = MavenDependencyCompletionUtil.findManagedDependency(
+                    model, project,
+                    mavenId.groupId!!,
+                    mavenId.artifactId!!
+                )
+                if (managedDependency != null) {
+                    val managedScope = StringUtil.nullize(managedDependency.scope.stringValue, true)
+                    scopeToSet = if (managedScope == null && MavenConstants.SCOPE_COMPILE == mavenScope ||
+                        StringUtil.equals(managedScope, mavenScope)
+                    ) null else mavenScope
+                }
+                if (managedDependency == null || StringUtil.isEmpty(managedDependency.version.stringValue)) {
+                    version = preferredVersion
+                    scopeToSet = mavenScope
+                }
+            }
+            models.add(Trinity.create(model, MavenId(mavenId.groupId, mavenId.artifactId, version), scopeToSet))
+            files.add(DomUtil.getFile(model))
+            projectToUpdate.add(fromProject)
+        }
+
+        WriteCommandAction.writeCommandAction(project, *PsiUtilCore.toPsiFileArray(files))
+            .withName(MavenDomBundle.message("fix.add.dependency")).run(
+                ThrowableRunnable<RuntimeException> {
+                    val pdm = PsiDocumentManager.getInstance(project)
+                    for (trinity in models) {
+                        val model = trinity.first
+                        val dependency = MavenDomUtil.createDomDependency(model, null, trinity.second)
+                        val ms = trinity.third
+                        if (ms != null) {
+                            dependency.scope.stringValue = ms
+                        }
+                        val document =
+                            pdm.getDocument(DomUtil.getFile(model))
+                        if (document != null) {
+                            pdm.doPostponedOperationsAndUnblockDocument(document)
+                            FileDocumentManager.getInstance().saveDocument(document)
+                        }
+                    }
+                })
+
+        return mavenProjectsManager.forceUpdateProjects(projectToUpdate)
+    }
+
+    private fun getMavenScope(scope: DependencyScope): String? = when (scope) {
+        DependencyScope.RUNTIME -> MavenConstants.SCOPE_RUNTIME
+        DependencyScope.COMPILE -> MavenConstants.SCOPE_COMPILE
+        DependencyScope.TEST -> MavenConstants.SCOPE_TEST
+        DependencyScope.PROVIDED -> MavenConstants.SCOPE_PROVIDED
+        else -> throw IllegalArgumentException(scope.toString())
+    }
+}

--- a/utbot-intellij/src/main/resources/META-INF/plugin.xml
+++ b/utbot-intellij/src/main/resources/META-INF/plugin.xml
@@ -5,6 +5,7 @@
     <name>UnitTestBot</name>
     <vendor>utbot.org</vendor>
     <depends>com.intellij.modules.platform</depends>
+    <depends>org.jetbrains.idea.maven</depends>
 
     <depends optional="true" config-file="withJava.xml">com.intellij.modules.java</depends>
     <depends optional="true" config-file="withKotlin.xml">org.jetbrains.kotlin</depends>
@@ -31,8 +32,9 @@
         <projectService serviceImplementation="org.utbot.intellij.plugin.settings.Settings" preload="true"/>
         <registryKey defaultValue="false" description="Enable editing Kotlin test files" key="kotlin.ultra.light.classes.empty.text.range"/>
         <postStartupActivity implementation="org.utbot.intellij.plugin.ui.GotItTooltipActivity"/>
-        <projectModelModifier implementation="org.utbot.intellij.plugin.util.UtProjectModelModifier"/>
         <projectModelModifier implementation="org.androidstudio.plugin.util.UtAndroidGradleJavaProjectModelModifierWrapper" order="first"/>
+        <projectModelModifier implementation="org.utbot.intellij.plugin.util.UtMavenProjectModelModifier" order="first"/>
+        <projectModelModifier implementation="org.utbot.intellij.plugin.util.UtIdeaProjectModelModifier" order="first"/>
         <!--Documentation-->
         <customJavadocTagProvider implementation="org.utbot.intellij.plugin.javadoc.UtCustomJavaDocTagProvider"/>
         <lang.documentationProvider language="JAVA" order="first" implementationClass="org.utbot.intellij.plugin.javadoc.UtDocumentationProvider"/>


### PR DESCRIPTION
# Description

Custom `UtMavenProjectModelModifier` is implemented. 
Order of project model modifiers is corrected

Fixes # ([1251](https://github.com/UnitTestBot/UTBotJava/issues/1251))
WontFixes  # ([1300](https://github.com/UnitTestBot/UTBotJava/issues/1300))

## Type of Change

- Bug fix (non-breaking change which fixes an issue)
- Refactoring (typos and non-functional changes) 

# How Has This Been Tested?

Verify that dependencies installation works correctly for Maven, Gradle, Intellij and Android Studio
Check the scenario from 1251
