### PR TITLE
Concrete executor phases refactoring

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/framework/concrete/constructors/BaseConstructorTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/framework/concrete/constructors/BaseConstructorTest.kt
@@ -1,7 +1,6 @@
 package org.utbot.framework.concrete.constructors
 
 import org.utbot.engine.ValueConstructor
-import org.utbot.framework.concrete.UtModelConstructor
 import org.utbot.framework.plugin.api.UtAssembleModel
 import org.utbot.framework.plugin.api.util.UtContext
 import org.utbot.framework.plugin.api.util.id

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/UtExecutionInstrumentation.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/UtExecutionInstrumentation.kt
@@ -1,54 +1,30 @@
 package org.utbot.framework.concrete
 
-import org.objectweb.asm.Type
-import org.utbot.common.StopWatch
-import org.utbot.common.ThreadBasedExecutor
-import org.utbot.common.withAccessibility
-import org.utbot.framework.UtSettings
-import org.utbot.framework.assemble.AssembleModelGenerator
-import org.utbot.framework.plugin.api.Coverage
-import org.utbot.framework.plugin.api.EnvironmentModels
-import org.utbot.framework.plugin.api.FieldId
-import org.utbot.framework.plugin.api.Instruction
-import org.utbot.framework.plugin.api.MissingState
-import org.utbot.framework.plugin.api.TimeoutException
-import org.utbot.framework.plugin.api.UtAssembleModel
-import org.utbot.framework.plugin.api.UtExecutionFailure
-import org.utbot.framework.plugin.api.UtExecutionResult
-import org.utbot.framework.plugin.api.UtExecutionSuccess
-import org.utbot.framework.plugin.api.UtExplicitlyThrownException
-import org.utbot.framework.plugin.api.UtImplicitlyThrownException
-import org.utbot.framework.plugin.api.UtInstrumentation
-import org.utbot.framework.plugin.api.UtModel
-import org.utbot.framework.plugin.api.UtNewInstanceInstrumentation
-import org.utbot.framework.plugin.api.UtSandboxFailure
-import org.utbot.framework.plugin.api.UtStaticMethodInstrumentation
-import org.utbot.framework.plugin.api.visible.UtStreamConsumingException
-import org.utbot.framework.plugin.api.UtStreamConsumingFailure
-import org.utbot.framework.plugin.api.UtTimeoutException
-import org.utbot.framework.plugin.api.util.UtContext
-import org.utbot.framework.plugin.api.util.id
-import org.utbot.framework.plugin.api.util.jField
-import org.utbot.framework.plugin.api.util.singleExecutableId
-import org.utbot.framework.plugin.api.util.utContext
-import org.utbot.framework.plugin.api.util.withUtContext
-import org.utbot.framework.util.isInaccessibleViaReflection
-import org.utbot.instrumentation.instrumentation.ArgumentList
-import org.utbot.instrumentation.instrumentation.Instrumentation
-import org.utbot.instrumentation.instrumentation.InvokeInstrumentation
-import org.utbot.instrumentation.instrumentation.et.EtInstruction
-import org.utbot.instrumentation.instrumentation.et.ExplicitThrowInstruction
-import org.utbot.instrumentation.instrumentation.et.TraceHandler
-import org.utbot.instrumentation.instrumentation.instrumenter.Instrumenter
-import org.utbot.instrumentation.instrumentation.mock.MockClassVisitor
-import java.security.AccessControlException
 import java.security.ProtectionDomain
 import java.util.IdentityHashMap
 import kotlin.reflect.jvm.javaMethod
+import org.utbot.framework.UtSettings
+import org.utbot.framework.assemble.AssembleModelGenerator
 import org.utbot.framework.concrete.constructors.ConstructOnlyUserClassesOrCachedObjectsStrategy
-import org.utbot.framework.concrete.constructors.MockValueConstructor
 import org.utbot.framework.concrete.constructors.UtModelConstructor
 import org.utbot.framework.concrete.mock.InstrumentationContext
+import org.utbot.framework.concrete.phases.PhasesController
+import org.utbot.framework.concrete.phases.start
+import org.utbot.framework.plugin.api.Coverage
+import org.utbot.framework.plugin.api.EnvironmentModels
+import org.utbot.framework.plugin.api.FieldId
+import org.utbot.framework.plugin.api.UtAssembleModel
+import org.utbot.framework.plugin.api.UtExecutionResult
+import org.utbot.framework.plugin.api.UtExecutionSuccess
+import org.utbot.framework.plugin.api.UtInstrumentation
+import org.utbot.framework.plugin.api.UtModel
+import org.utbot.framework.plugin.api.util.singleExecutableId
+import org.utbot.instrumentation.instrumentation.ArgumentList
+import org.utbot.instrumentation.instrumentation.Instrumentation
+import org.utbot.instrumentation.instrumentation.InvokeInstrumentation
+import org.utbot.instrumentation.instrumentation.et.TraceHandler
+import org.utbot.instrumentation.instrumentation.instrumenter.Instrumenter
+import org.utbot.instrumentation.instrumentation.mock.MockClassVisitor
 
 /**
  * Consists of the data needed to execute the method concretely. Also includes method arguments stored in models.
@@ -146,106 +122,77 @@ object UtExecutionInstrumentation : Instrumentation<UtConcreteExecutionResult> {
             throw IllegalArgumentException("Argument parameters must be of type UtConcreteExecutionData, but was: ${parameters?.javaClass}")
         }
         val (stateBefore, instrumentations, timeout) = parameters // smart cast to UtConcreteExecutionData
-        val parametersModels = listOfNotNull(stateBefore.thisInstance) + stateBefore.parameters
 
         val methodId = clazz.singleExecutableId(methodSignature)
         val returnClassId = methodId.returnType
-        traceHandler.resetTrace()
 
-        return MockValueConstructor(instrumentationContext).use { constructor ->
-            val params = try {
-                constructor.constructMethodParameters(parametersModels)
-            } catch (e: Throwable) {
-                if (e.cause is AccessControlException) {
-                    return@use UtConcreteExecutionResult(
-                        MissingState,
-                        UtSandboxFailure(e.cause!!),
-                        Coverage()
-                    )
+        return PhasesController(
+            instrumentationContext,
+            traceHandler,
+            delegateInstrumentation
+        ).computeConcreteExecutionResult {
+            // construction
+            val (params, statics, cache) = valueConstructionContext.start {
+                val params = constructParameters(stateBefore)
+                val statics = constructStatics(stateBefore)
+
+                mock(instrumentations)
+
+                Triple(params, statics, getCache())
+            }
+
+            // preparation
+            val savedStatics = preparationContext.start {
+                val savedStatics = setStaticFields(statics)
+                resetTrace()
+                savedStatics
+            }
+
+            try {
+                // invocation
+                val concreteResult = invocationContext.start {
+                    invoke(clazz, methodSignature, params.map { it.value }, timeout)
                 }
 
-                throw e
-            }
-            val staticFields = constructor
-                .constructStatics(
-                    stateBefore
-                        .statics
-                        .filterKeys { !it.isInaccessibleViaReflection }
-                )
-                .mapValues { (_, value) -> value.value }
+                // statistics collection
+                val coverage = statisticsCollectionContext.start {
+                    getCoverage(clazz)
+                }
 
-            val concreteExecutionResult = withStaticFields(staticFields) {
-                val staticMethodsInstrumentation = instrumentations.filterIsInstance<UtStaticMethodInstrumentation>()
-                constructor.mockStaticMethods(staticMethodsInstrumentation)
-                val newInstanceInstrumentation = instrumentations.filterIsInstance<UtNewInstanceInstrumentation>()
-                constructor.mockNewInstances(newInstanceInstrumentation)
-
-                traceHandler.resetTrace()
-                val stopWatch = StopWatch()
-                val context = UtContext(utContext.classLoader, stopWatch)
-                val concreteResult = ThreadBasedExecutor.threadLocal.invokeWithTimeout(timeout, stopWatch) {
-                    withUtContext(context) {
-                        delegateInstrumentation.invoke(clazz, methodSignature, params.map { it.value })
-                    }
-                }?.getOrThrow() as? Result<*> ?: Result.failure<Any?>(TimeoutException("Timeout $timeout elapsed"))
-                val traceList = traceHandler.computeInstructionList()
-
-                val cache = constructor.objectToModelCache
-                val utCompositeModelStrategy = ConstructOnlyUserClassesOrCachedObjectsStrategy(pathsToUserClasses, cache)
-                val utModelConstructor = UtModelConstructor(cache, utCompositeModelStrategy)
-                utModelConstructor.run {
-                    val concreteUtModelResult = concreteResult.fold({
-                        try {
-                            val model = construct(it, returnClassId)
-                            UtExecutionSuccess(model)
-                        } catch (e: Exception) {
-                            processExceptionDuringModelConstruction(e)
-                        }
-                    }) {
-                        sortOutException(it)
+                // model construction
+                val (executionResult, stateAfter) = modelConstructionContext.start {
+                    configureConstructor {
+                        this.cache = cache
+                        strategy = ConstructOnlyUserClassesOrCachedObjectsStrategy(pathsToUserClasses, cache)
                     }
 
-                    val stateAfterParametersWithThis = params.map { construct(it.value, it.clazz.id) }
-                    val stateAfterStatics = (staticFields.keys/* + traceHandler.computePutStatics()*/)
-                        .associateWith { fieldId ->
-                            fieldId.jField.run {
-                                val computedValue = withAccessibility { get(null) }
-                                val knownModel = stateBefore.statics[fieldId]
-                                val knownValue = staticFields[fieldId]
-                                if (knownModel != null && knownValue != null && knownValue == computedValue) {
-                                    knownModel
-                                } else {
-                                    construct(computedValue, fieldId.type)
-                                }
-                            }
-                        }
+                    val executionResult = convertToExecutionResult(concreteResult, returnClassId)
+
+                    val stateAfterParametersWithThis = constructParameters(params)
+                    val stateAfterStatics = constructStatics(statics.keys/* + traceHandler.computePutStatics()*/)
                     val (stateAfterThis, stateAfterParameters) = if (stateBefore.thisInstance == null) {
                         null to stateAfterParametersWithThis
                     } else {
                         stateAfterParametersWithThis.first() to stateAfterParametersWithThis.drop(1)
                     }
                     val stateAfter = EnvironmentModels(stateAfterThis, stateAfterParameters, stateAfterStatics)
-                    UtConcreteExecutionResult(
-                        stateAfter,
-                        concreteUtModelResult,
-                        traceList.toApiCoverage(
-                            traceHandler.processingStorage.getInstructionsCount(
-                                Type.getInternalName(clazz)
-                            )
-                        )
-                    )
+
+                    executionResult to stateAfter
+                }
+
+                UtConcreteExecutionResult(
+                    stateAfter,
+                    executionResult,
+                    coverage
+                )
+            } finally {
+                // postprocessing
+                postprocessingContext.start {
+                    resetStaticFields(savedStatics)
                 }
             }
-
-            concreteExecutionResult
         }
     }
-
-    private fun processExceptionDuringModelConstruction(e: Exception): UtExecutionResult =
-        when (e) {
-            is UtStreamConsumingException -> UtStreamConsumingFailure(e)
-            else -> throw e
-        }
 
     override fun getStaticField(fieldId: FieldId): Result<UtModel> =
         delegateInstrumentation.getStaticField(fieldId).map { value ->
@@ -257,30 +204,6 @@ object UtExecutionInstrumentation : Instrumentation<UtConcreteExecutionResult> {
                 construct(value, fieldId.type)
             }
         }
-
-    private fun sortOutException(exception: Throwable): UtExecutionFailure {
-        if (exception is TimeoutException) {
-            return UtTimeoutException(exception)
-        }
-        if (exception is AccessControlException ||
-            exception is ExceptionInInitializerError && exception.exception is AccessControlException) {
-            return UtSandboxFailure(exception)
-        }
-        // there also can be other cases, when we need to wrap internal exception... I suggest adding them on demand
-
-        val instrs = traceHandler.computeInstructionList()
-        val isNested = if (instrs.isEmpty()) {
-            false
-        } else {
-            instrs.first().callId != instrs.last().callId
-        }
-        return if (instrs.isNotEmpty() && instrs.last().instructionData is ExplicitThrowInstruction) {
-            UtExplicitlyThrownException(exception, isNested)
-        } else {
-            UtImplicitlyThrownException(exception, isNested)
-        }
-
-    }
 
     override fun transform(
         loader: ClassLoader?,
@@ -309,36 +232,4 @@ object UtExecutionInstrumentation : Instrumentation<UtConcreteExecutionResult> {
 
         return instrumenter.classByteCode
     }
-
-    private fun <T> withStaticFields(staticFields: Map<FieldId, Any?>, block: () -> T): T {
-        val savedFields = mutableMapOf<FieldId, Any?>()
-        try {
-            staticFields.forEach { (fieldId, value) ->
-                fieldId.jField.run {
-                    withAccessibility {
-                        savedFields[fieldId] = get(null)
-                        set(null, value)
-                    }
-                }
-            }
-            return block()
-        } finally {
-            savedFields.forEach { (fieldId, value) ->
-                fieldId.jField.run {
-                    withAccessibility {
-                        set(null, value)
-                    }
-                }
-            }
-        }
-    }
 }
-
-/**
- * Transforms a list of internal [EtInstruction]s to a list of api [Instruction]s.
- */
-private fun List<EtInstruction>.toApiCoverage(instructionsCount: Long? = null): Coverage =
-    Coverage(
-        map { Instruction(it.className, it.methodSignature, it.line, it.id) },
-        instructionsCount
-    )

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/UtExecutionInstrumentation.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/UtExecutionInstrumentation.kt
@@ -45,6 +45,10 @@ import java.security.AccessControlException
 import java.security.ProtectionDomain
 import java.util.IdentityHashMap
 import kotlin.reflect.jvm.javaMethod
+import org.utbot.framework.concrete.constructors.ConstructOnlyUserClassesOrCachedObjectsStrategy
+import org.utbot.framework.concrete.constructors.MockValueConstructor
+import org.utbot.framework.concrete.constructors.UtModelConstructor
+import org.utbot.framework.concrete.mock.InstrumentationContext
 
 /**
  * Consists of the data needed to execute the method concretely. Also includes method arguments stored in models.

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/constructors/IterableConstructors.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/constructors/IterableConstructors.kt
@@ -1,4 +1,4 @@
-package org.utbot.framework.concrete
+package org.utbot.framework.concrete.constructors
 
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.ConstructorId

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/constructors/MockValueConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/constructors/MockValueConstructor.kt
@@ -1,6 +1,21 @@
-package org.utbot.framework.concrete
+package org.utbot.framework.concrete.constructors
 
+import java.io.Closeable
+import java.lang.reflect.Modifier
+import java.util.IdentityHashMap
+import kotlin.reflect.KClass
+import org.mockito.Mockito
+import org.mockito.stubbing.Answer
+import org.objectweb.asm.Type
+import org.utbot.common.Reflection
 import org.utbot.common.invokeCatching
+import org.utbot.engine.util.lambda.CapturedArgument
+import org.utbot.engine.util.lambda.constructLambda
+import org.utbot.engine.util.lambda.constructStaticLambda
+import org.utbot.framework.concrete.mock.InstanceMockController
+import org.utbot.framework.concrete.mock.InstrumentationContext
+import org.utbot.framework.concrete.mock.MethodMockController
+import org.utbot.framework.concrete.mock.MockController
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.ConstructorId
 import org.utbot.framework.plugin.api.ExecutableId
@@ -20,6 +35,7 @@ import org.utbot.framework.plugin.api.UtConcreteValue
 import org.utbot.framework.plugin.api.UtDirectSetFieldModel
 import org.utbot.framework.plugin.api.UtEnumConstantModel
 import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtLambdaModel
 import org.utbot.framework.plugin.api.UtMockValue
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtNewInstanceInstrumentation
@@ -31,25 +47,12 @@ import org.utbot.framework.plugin.api.UtVoidModel
 import org.utbot.framework.plugin.api.isMockModel
 import org.utbot.framework.plugin.api.util.constructor
 import org.utbot.framework.plugin.api.util.executableId
-import org.utbot.framework.plugin.api.util.jField
+import org.utbot.framework.plugin.api.util.isStatic
 import org.utbot.framework.plugin.api.util.jClass
+import org.utbot.framework.plugin.api.util.jField
 import org.utbot.framework.plugin.api.util.method
 import org.utbot.framework.plugin.api.util.utContext
 import org.utbot.framework.util.anyInstance
-import java.io.Closeable
-import java.lang.reflect.Field
-import java.lang.reflect.Modifier
-import java.util.IdentityHashMap
-import kotlin.reflect.KClass
-import org.mockito.Mockito
-import org.mockito.stubbing.Answer
-import org.objectweb.asm.Type
-import org.utbot.common.Reflection
-import org.utbot.engine.util.lambda.CapturedArgument
-import org.utbot.engine.util.lambda.constructLambda
-import org.utbot.engine.util.lambda.constructStaticLambda
-import org.utbot.framework.plugin.api.UtLambdaModel
-import org.utbot.framework.plugin.api.util.isStatic
 import org.utbot.instrumentation.process.runSandbox
 
 /**

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/constructors/OptionalConstructors.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/constructors/OptionalConstructors.kt
@@ -1,5 +1,10 @@
-package org.utbot.framework.concrete
+package org.utbot.framework.concrete.constructors
 
+import java.util.Optional
+import java.util.OptionalDouble
+import java.util.OptionalInt
+import java.util.OptionalLong
+import kotlin.reflect.KFunction1
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.MethodId
 import org.utbot.framework.plugin.api.UtAssembleModel
@@ -10,11 +15,6 @@ import org.utbot.framework.plugin.api.util.intClassId
 import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.framework.plugin.api.util.longClassId
 import org.utbot.framework.plugin.api.util.objectClassId
-import java.util.Optional
-import java.util.OptionalDouble
-import java.util.OptionalInt
-import java.util.OptionalLong
-import kotlin.reflect.KFunction1
 
 
 internal sealed class OptionalConstructorBase : UtAssembleModelConstructorBase() {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/constructors/PrimitiveWrapperConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/constructors/PrimitiveWrapperConstructor.kt
@@ -1,4 +1,4 @@
-package org.utbot.framework.concrete
+package org.utbot.framework.concrete.constructors
 
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.UtAssembleModel

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/constructors/StreamConstructors.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/constructors/StreamConstructors.kt
@@ -1,4 +1,4 @@
-package org.utbot.framework.concrete
+package org.utbot.framework.concrete.constructors
 
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.MethodId

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/constructors/UtAssembleModelConstructors.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/constructors/UtAssembleModelConstructors.kt
@@ -1,18 +1,17 @@
-package org.utbot.framework.concrete
+package org.utbot.framework.concrete.constructors
 
-import org.utbot.framework.plugin.api.ClassId
-import org.utbot.framework.plugin.api.UtAssembleModel
-import org.utbot.framework.plugin.api.UtExecutableCallModel
-import org.utbot.framework.plugin.api.UtStatementModel
-import org.utbot.framework.plugin.api.util.id
-import org.utbot.framework.plugin.api.util.jClass
-import org.utbot.framework.plugin.api.util.primitiveWrappers
-import org.utbot.framework.plugin.api.util.voidWrapperClassId
-import org.utbot.framework.util.nextModelName
 import java.util.stream.BaseStream
 import java.util.stream.DoubleStream
 import java.util.stream.IntStream
 import java.util.stream.LongStream
+import org.utbot.framework.plugin.api.ClassId
+import org.utbot.framework.plugin.api.UtAssembleModel
+import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtStatementModel
+import org.utbot.framework.plugin.api.util.jClass
+import org.utbot.framework.plugin.api.util.primitiveWrappers
+import org.utbot.framework.plugin.api.util.voidWrapperClassId
+import org.utbot.framework.util.nextModelName
 
 private val predefinedConstructors = mutableMapOf<Class<*>, () -> UtAssembleModelConstructorBase>(
     /**

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/constructors/UtModelConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/constructors/UtModelConstructor.kt
@@ -1,5 +1,8 @@
-package org.utbot.framework.concrete
+package org.utbot.framework.concrete.constructors
 
+import java.lang.reflect.Modifier
+import java.util.IdentityHashMap
+import java.util.stream.BaseStream
 import org.utbot.common.asPathToFile
 import org.utbot.common.withAccessibility
 import org.utbot.framework.plugin.api.ClassId
@@ -14,7 +17,6 @@ import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtNullModel
 import org.utbot.framework.plugin.api.UtPrimitiveModel
 import org.utbot.framework.plugin.api.UtReferenceModel
-import org.utbot.framework.plugin.api.visible.UtStreamConsumingException
 import org.utbot.framework.plugin.api.UtVoidModel
 import org.utbot.framework.plugin.api.isMockModel
 import org.utbot.framework.plugin.api.util.booleanClassId
@@ -30,12 +32,10 @@ import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.framework.plugin.api.util.longClassId
 import org.utbot.framework.plugin.api.util.objectClassId
 import org.utbot.framework.plugin.api.util.shortClassId
+import org.utbot.framework.plugin.api.util.utContext
+import org.utbot.framework.plugin.api.visible.UtStreamConsumingException
 import org.utbot.framework.util.isInaccessibleViaReflection
 import org.utbot.framework.util.valueToClassId
-import java.lang.reflect.Modifier
-import java.util.IdentityHashMap
-import java.util.stream.BaseStream
-import org.utbot.framework.plugin.api.util.utContext
 
 /**
  * Represents common interface for model constructors.

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/mock/InstanceMockController.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/mock/InstanceMockController.kt
@@ -1,4 +1,4 @@
-package org.utbot.framework.concrete
+package org.utbot.framework.concrete.mock
 
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.util.jClass

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/mock/InstrumentationContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/mock/InstrumentationContext.kt
@@ -1,4 +1,4 @@
-package org.utbot.framework.concrete
+package org.utbot.framework.concrete.mock
 
 import java.lang.reflect.Method
 import java.util.IdentityHashMap

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/mock/MethodMockController.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/mock/MethodMockController.kt
@@ -1,4 +1,4 @@
-package org.utbot.framework.concrete
+package org.utbot.framework.concrete.mock
 
 import java.lang.reflect.Field
 import java.lang.reflect.Method

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/mock/MockController.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/mock/MockController.kt
@@ -1,4 +1,4 @@
-package org.utbot.framework.concrete
+package org.utbot.framework.concrete.mock
 
 import java.io.Closeable
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/InvocationContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/InvocationContext.kt
@@ -13,6 +13,9 @@ class InvocationPhaseError(cause: Throwable) : PhaseError(
     cause
 )
 
+/**
+ * This phase is about invoking user's code using [delegateInstrumentation].
+ */
 class InvocationContext(
     private val delegateInstrumentation: Instrumentation<Result<*>>
 ) : PhaseContext<InvocationPhaseError> {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/InvocationContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/InvocationContext.kt
@@ -1,0 +1,39 @@
+package org.utbot.framework.concrete.phases
+
+import org.utbot.common.StopWatch
+import org.utbot.common.ThreadBasedExecutor
+import org.utbot.framework.plugin.api.TimeoutException
+import org.utbot.framework.plugin.api.util.UtContext
+import org.utbot.framework.plugin.api.util.utContext
+import org.utbot.framework.plugin.api.util.withUtContext
+import org.utbot.instrumentation.instrumentation.Instrumentation
+
+class InvocationPhaseError(cause: Throwable) : PhaseError(
+    message = "Error during user's code invocation phase",
+    cause
+)
+
+class InvocationContext(
+    private val delegateInstrumentation: Instrumentation<Result<*>>
+) : PhaseContext<InvocationPhaseError> {
+
+    override fun wrapError(error: Throwable): InvocationPhaseError =
+        InvocationPhaseError(error)
+
+    fun invoke(
+        clazz: Class<*>,
+        methodSignature: String,
+        params: List<Any?>,
+        timeout: Long,
+    ): Result<*> {
+        val stopWatch = StopWatch()
+        val context = UtContext(utContext.classLoader, stopWatch)
+        val concreteResult = ThreadBasedExecutor.threadLocal.invokeWithTimeout(timeout, stopWatch) {
+            withUtContext(context) {
+                delegateInstrumentation.invoke(clazz, methodSignature, params)
+            }
+        }?.getOrThrow() as? Result<*> ?: Result.failure<Any?>(TimeoutException("Timeout $timeout elapsed"))
+        return concreteResult
+    }
+
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/ModelConstructionContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/ModelConstructionContext.kt
@@ -29,6 +29,9 @@ class ModelConstructionPhaseError(cause: Throwable) : PhaseError(
     cause
 )
 
+/**
+ * This phase of model construction from concrete values.
+ */
 class ModelConstructionContext(
     private val traceHandler: TraceHandler
 ) : PhaseContext<ModelConstructionPhaseError> {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/ModelConstructionContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/ModelConstructionContext.kt
@@ -1,0 +1,111 @@
+package org.utbot.framework.concrete.phases
+
+import java.security.AccessControlException
+import java.util.IdentityHashMap
+import org.utbot.common.withAccessibility
+import org.utbot.framework.concrete.constructors.UtCompositeModelStrategy
+import org.utbot.framework.concrete.constructors.UtModelConstructor
+import org.utbot.framework.plugin.api.ClassId
+import org.utbot.framework.plugin.api.FieldId
+import org.utbot.framework.plugin.api.TimeoutException
+import org.utbot.framework.plugin.api.UtConcreteValue
+import org.utbot.framework.plugin.api.UtExecutionFailure
+import org.utbot.framework.plugin.api.UtExecutionResult
+import org.utbot.framework.plugin.api.UtExecutionSuccess
+import org.utbot.framework.plugin.api.UtExplicitlyThrownException
+import org.utbot.framework.plugin.api.UtImplicitlyThrownException
+import org.utbot.framework.plugin.api.UtModel
+import org.utbot.framework.plugin.api.UtSandboxFailure
+import org.utbot.framework.plugin.api.UtStreamConsumingFailure
+import org.utbot.framework.plugin.api.UtTimeoutException
+import org.utbot.framework.plugin.api.util.id
+import org.utbot.framework.plugin.api.util.jField
+import org.utbot.framework.plugin.api.visible.UtStreamConsumingException
+import org.utbot.instrumentation.instrumentation.et.ExplicitThrowInstruction
+import org.utbot.instrumentation.instrumentation.et.TraceHandler
+
+class ModelConstructionPhaseError(cause: Throwable) : PhaseError(
+    message = "Error during model construction phase",
+    cause
+)
+
+class ModelConstructionContext(
+    private val traceHandler: TraceHandler
+) : PhaseContext<ModelConstructionPhaseError> {
+
+    override fun wrapError(error: Throwable): ModelConstructionPhaseError =
+        ModelConstructionPhaseError(error)
+
+    private lateinit var constructor: UtModelConstructor
+
+    class ConstructorConfiguration {
+        lateinit var cache: IdentityHashMap<Any, UtModel>
+        lateinit var strategy: UtCompositeModelStrategy
+    }
+
+    fun configureConstructor(block: ConstructorConfiguration.() -> Unit) {
+        ConstructorConfiguration().run {
+            block()
+            constructor = UtModelConstructor(cache, strategy)
+        }
+    }
+
+    fun constructParameters(params: List<UtConcreteValue<*>>): List<UtModel> =
+        params.map {
+            constructor.construct(it.value, it.clazz.id)
+        }
+
+    fun constructStatics(staticFields: Set<FieldId>): Map<FieldId, UtModel> =
+        staticFields.associateWith { fieldId ->
+            fieldId.jField.run {
+                val computedValue = withAccessibility { get(null) }
+                constructor.construct(computedValue, fieldId.type)
+            }
+        }
+
+    fun convertToExecutionResult(concreteResult: Result<*>, returnClassId: ClassId): UtExecutionResult {
+        val result = concreteResult.fold({
+            try {
+                val model = constructor.construct(it, returnClassId)
+                UtExecutionSuccess(model)
+            } catch (e: Exception) {
+                processExceptionDuringModelConstruction(e)
+            }
+        }) {
+            sortOutException(it)
+        }
+        return result
+    }
+
+    private fun sortOutException(exception: Throwable): UtExecutionFailure {
+        if (exception is TimeoutException) {
+            return UtTimeoutException(exception)
+        }
+        if (exception is AccessControlException ||
+            exception is ExceptionInInitializerError && exception.exception is AccessControlException
+        ) {
+            return UtSandboxFailure(exception)
+        }
+        // there also can be other cases, when we need to wrap internal exception... I suggest adding them on demand
+
+        val instrs = traceHandler.computeInstructionList()
+        val isNested = if (instrs.isEmpty()) {
+            false
+        } else {
+            instrs.first().callId != instrs.last().callId
+        }
+        return if (instrs.isNotEmpty() && instrs.last().instructionData is ExplicitThrowInstruction) {
+            UtExplicitlyThrownException(exception, isNested)
+        } else {
+            UtImplicitlyThrownException(exception, isNested)
+        }
+
+    }
+
+    private fun processExceptionDuringModelConstruction(e: Exception): UtExecutionResult =
+        when (e) {
+            is UtStreamConsumingException -> UtStreamConsumingFailure(e)
+            else -> throw e
+        }
+
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/PhaseContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/PhaseContext.kt
@@ -1,9 +1,6 @@
 package org.utbot.framework.concrete.phases
 
-abstract class PhaseError(message: String, cause: Throwable) : Exception(message, cause) {
-    override val cause: Throwable = super.cause!!
-}
-
+abstract class PhaseError(message: String, override val cause: Throwable) : Exception(message)
 interface PhaseContext<E: PhaseError> {
     fun wrapError(error: Throwable): E
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/PhaseContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/PhaseContext.kt
@@ -1,0 +1,16 @@
+package org.utbot.framework.concrete.phases
+
+abstract class PhaseError(message: String, cause: Throwable) : Exception(message, cause) {
+    override val cause: Throwable = super.cause!!
+}
+
+interface PhaseContext<E: PhaseError> {
+    fun wrapError(error: Throwable): E
+}
+
+inline fun <reified R, T: PhaseContext<*>> T.start(block: T.() -> R): R =
+    try {
+        block()
+    } catch (e: Throwable) {
+        throw wrapError(e)
+    }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/PhasesController.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/PhasesController.kt
@@ -1,0 +1,53 @@
+package org.utbot.framework.concrete.phases
+
+import java.io.Closeable
+import java.security.AccessControlException
+import org.utbot.framework.concrete.UtConcreteExecutionResult
+import org.utbot.framework.concrete.mock.InstrumentationContext
+import org.utbot.framework.plugin.api.Coverage
+import org.utbot.framework.plugin.api.MissingState
+import org.utbot.framework.plugin.api.UtSandboxFailure
+import org.utbot.instrumentation.instrumentation.Instrumentation
+import org.utbot.instrumentation.instrumentation.et.TraceHandler
+
+class PhasesController(
+    instrumentationContext: InstrumentationContext,
+    traceHandler: TraceHandler,
+    delegateInstrumentation: Instrumentation<Result<*>>,
+) : Closeable {
+
+    val valueConstructionContext = ValueConstructionContext(instrumentationContext)
+
+    val preparationContext = PreparationContext(traceHandler)
+
+    val invocationContext = InvocationContext(delegateInstrumentation)
+
+    val statisticsCollectionContext = StatisticsCollectionContext(traceHandler)
+
+    val modelConstructionContext = ModelConstructionContext(traceHandler)
+
+    val postprocessingContext = PostprocessingContext()
+
+    inline fun computeConcreteExecutionResult(block: PhasesController.() -> UtConcreteExecutionResult): UtConcreteExecutionResult {
+        return use {
+            try {
+                block()
+            } catch (e: PhaseError) {
+                if (e.cause.cause is AccessControlException) {
+                    return@use UtConcreteExecutionResult(
+                        MissingState,
+                        UtSandboxFailure(e.cause.cause!!),
+                        Coverage()
+                    )
+                }
+                // TODO: make failure results from different phase errors
+                throw e
+            }
+        }
+    }
+
+    override fun close() {
+        valueConstructionContext.close()
+    }
+
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/PostprocessingContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/PostprocessingContext.kt
@@ -9,6 +9,9 @@ class PostprocessingPhaseError(cause: Throwable) : PhaseError(
     cause
 )
 
+/**
+ * The responsibility of this phase is resetting environment to the initial state.
+ */
 class PostprocessingContext : PhaseContext<PostprocessingPhaseError> {
 
     override fun wrapError(error: Throwable): PostprocessingPhaseError =

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/PostprocessingContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/PostprocessingContext.kt
@@ -1,0 +1,27 @@
+package org.utbot.framework.concrete.phases
+
+import org.utbot.common.withAccessibility
+import org.utbot.framework.plugin.api.FieldId
+import org.utbot.framework.plugin.api.util.jField
+
+class PostprocessingPhaseError(cause: Throwable) : PhaseError(
+    message = "Error during postprocessing phase",
+    cause
+)
+
+class PostprocessingContext : PhaseContext<PostprocessingPhaseError> {
+
+    override fun wrapError(error: Throwable): PostprocessingPhaseError =
+        PostprocessingPhaseError(error)
+
+    fun resetStaticFields(staticFields: Map<FieldId, Any?>) {
+        staticFields.forEach { (fieldId, value) ->
+            fieldId.jField.run {
+                withAccessibility {
+                    set(null, value)
+                }
+            }
+        }
+    }
+
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/PreparationContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/PreparationContext.kt
@@ -11,6 +11,9 @@ class PreparationPhaseError(cause: Throwable) : PhaseError(
     cause
 )
 
+/**
+ * The responsibility of this phase is environment preparation before execution.
+ */
 class PreparationContext(
     private val traceHandler: TraceHandler
 ) : PhaseContext<PreparationPhaseError> {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/PreparationContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/PreparationContext.kt
@@ -1,0 +1,38 @@
+package org.utbot.framework.concrete.phases
+
+import org.utbot.common.withAccessibility
+import org.utbot.framework.plugin.api.FieldId
+import org.utbot.framework.plugin.api.UtConcreteValue
+import org.utbot.framework.plugin.api.util.jField
+import org.utbot.instrumentation.instrumentation.et.TraceHandler
+
+class PreparationPhaseError(cause: Throwable) : PhaseError(
+    message = "Error during environment preparation phase",
+    cause
+)
+
+class PreparationContext(
+    private val traceHandler: TraceHandler
+) : PhaseContext<PreparationPhaseError> {
+
+    override fun wrapError(error: Throwable): PreparationPhaseError =
+        PreparationPhaseError(error)
+
+    fun setStaticFields(staticFieldsValues: Map<FieldId, UtConcreteValue<*>>): Map<FieldId, Any?> {
+        val savedStaticFields = mutableMapOf<FieldId, Any?>()
+        staticFieldsValues.forEach { (fieldId, value) ->
+            fieldId.jField.run {
+                withAccessibility {
+                    savedStaticFields[fieldId] = get(null)
+                    set(null, value.value)
+                }
+            }
+        }
+        return savedStaticFields
+    }
+
+    fun resetTrace() {
+        traceHandler.resetTrace()
+    }
+
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/StatisticsCollectionContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/StatisticsCollectionContext.kt
@@ -1,0 +1,39 @@
+package org.utbot.framework.concrete.phases
+
+import org.objectweb.asm.Type
+import org.utbot.framework.plugin.api.Coverage
+import org.utbot.framework.plugin.api.Instruction
+import org.utbot.instrumentation.instrumentation.et.EtInstruction
+import org.utbot.instrumentation.instrumentation.et.TraceHandler
+
+class StatisticsCollectionPhaseError(cause: Throwable) : PhaseError(
+    message = "Error during statistics collection phase",
+    cause
+)
+
+class StatisticsCollectionContext(
+    private val traceHandler: TraceHandler
+) : PhaseContext<StatisticsCollectionPhaseError> {
+
+    override fun wrapError(error: Throwable): StatisticsCollectionPhaseError =
+        StatisticsCollectionPhaseError(error)
+
+    fun getCoverage(clazz: Class<*>): Coverage {
+        return traceHandler
+            .computeInstructionList()
+            .toApiCoverage(
+                traceHandler.processingStorage.getInstructionsCount(
+                    Type.getInternalName(clazz)
+                )
+            )
+    }
+
+    /**
+     * Transforms a list of internal [EtInstruction]s to a list of api [Instruction]s.
+     */
+    private fun List<EtInstruction>.toApiCoverage(instructionsCount: Long? = null): Coverage =
+        Coverage(
+            map { Instruction(it.className, it.methodSignature, it.line, it.id) },
+            instructionsCount
+        )
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/StatisticsCollectionContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/StatisticsCollectionContext.kt
@@ -11,6 +11,9 @@ class StatisticsCollectionPhaseError(cause: Throwable) : PhaseError(
     cause
 )
 
+/**
+ * This phase is about collection statistics such as coverage.
+ */
 class StatisticsCollectionContext(
     private val traceHandler: TraceHandler
 ) : PhaseContext<StatisticsCollectionPhaseError> {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/ValueConstructionContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/ValueConstructionContext.kt
@@ -1,0 +1,63 @@
+package org.utbot.framework.concrete.phases
+
+import java.io.Closeable
+import java.util.IdentityHashMap
+import org.utbot.framework.concrete.constructors.MockValueConstructor
+import org.utbot.framework.concrete.mock.InstrumentationContext
+import org.utbot.framework.plugin.api.EnvironmentModels
+import org.utbot.framework.plugin.api.FieldId
+import org.utbot.framework.plugin.api.UtConcreteValue
+import org.utbot.framework.plugin.api.UtInstrumentation
+import org.utbot.framework.plugin.api.UtModel
+import org.utbot.framework.plugin.api.UtNewInstanceInstrumentation
+import org.utbot.framework.plugin.api.UtStaticMethodInstrumentation
+import org.utbot.framework.util.isInaccessibleViaReflection
+
+class ValueConstructionPhaseError(cause: Throwable) : PhaseError(
+    message = "Error during phase of constructing values from models",
+    cause
+)
+
+class ValueConstructionContext(
+    instrumentationContext: InstrumentationContext
+) : PhaseContext<ValueConstructionPhaseError>, Closeable {
+
+    override fun wrapError(error: Throwable): ValueConstructionPhaseError =
+        ValueConstructionPhaseError(error)
+
+    private val constructor = MockValueConstructor(instrumentationContext)
+
+    fun getCache(): IdentityHashMap<Any, UtModel> {
+        return constructor.objectToModelCache
+    }
+
+    fun constructParameters(state: EnvironmentModels): List<UtConcreteValue<*>> {
+        val parametersModels = listOfNotNull(state.thisInstance) + state.parameters
+        return constructor.constructMethodParameters(parametersModels)
+    }
+
+    fun constructStatics(state: EnvironmentModels): Map<FieldId, UtConcreteValue<*>> =
+        constructor.constructStatics(
+            state.statics.filterKeys { !it.isInaccessibleViaReflection }
+        )
+
+    fun mock(instrumentations: List<UtInstrumentation>) {
+        mockStaticMethods(instrumentations)
+        mockNewInstances(instrumentations)
+    }
+
+    private fun mockStaticMethods(instrumentations: List<UtInstrumentation>) {
+        val staticMethodsInstrumentation = instrumentations.filterIsInstance<UtStaticMethodInstrumentation>()
+        constructor.mockStaticMethods(staticMethodsInstrumentation)
+    }
+
+    private fun mockNewInstances(instrumentations: List<UtInstrumentation>) {
+        val newInstanceInstrumentation = instrumentations.filterIsInstance<UtNewInstanceInstrumentation>()
+        constructor.mockNewInstances(newInstanceInstrumentation)
+    }
+
+    override fun close() {
+        constructor.close()
+    }
+
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/ValueConstructionContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/concrete/phases/ValueConstructionContext.kt
@@ -18,6 +18,9 @@ class ValueConstructionPhaseError(cause: Throwable) : PhaseError(
     cause
 )
 
+/**
+ * This phase of values instantiation from given models.
+ */
 class ValueConstructionContext(
     instrumentationContext: InstrumentationContext
 ) : PhaseContext<ValueConstructionPhaseError>, Closeable {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestCaseGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestCaseGenerator.kt
@@ -27,7 +27,7 @@ import org.utbot.framework.UtSettings.warmupConcreteExecution
 import org.utbot.framework.plugin.api.utils.checkFrameworkDependencies
 import org.utbot.framework.concrete.UtConcreteExecutionData
 import org.utbot.framework.concrete.UtExecutionInstrumentation
-import org.utbot.framework.concrete.UtModelConstructor
+import org.utbot.framework.concrete.constructors.UtModelConstructor
 import org.utbot.framework.minimization.minimizeTestCase
 import org.utbot.framework.plugin.api.util.UtContext
 import org.utbot.framework.plugin.api.util.id

--- a/utbot-framework/src/main/kotlin/org/utbot/fuzzer/FallbackModelProvider.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/fuzzer/FallbackModelProvider.kt
@@ -1,7 +1,7 @@
 package org.utbot.fuzzer
 
 import org.utbot.common.isPublic
-import org.utbot.framework.concrete.UtModelConstructor
+import org.utbot.framework.concrete.constructors.UtModelConstructor
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.UtArrayModel
 import org.utbot.framework.plugin.api.UtAssembleModel
@@ -9,7 +9,6 @@ import org.utbot.framework.plugin.api.UtCompositeModel
 import org.utbot.framework.plugin.api.UtExecutableCallModel
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtNullModel
-import org.utbot.framework.plugin.api.UtStatementModel
 import org.utbot.framework.plugin.api.util.defaultValueModel
 import org.utbot.framework.plugin.api.util.executableId
 import org.utbot.framework.plugin.api.util.id
@@ -22,7 +21,6 @@ import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.framework.plugin.api.util.kClass
 import org.utbot.fuzzer.providers.AbstractModelProvider
 import java.util.*
-import java.util.function.IntSupplier
 import kotlin.collections.ArrayList
 import kotlin.collections.HashMap
 import kotlin.reflect.KClass

--- a/utbot-js/src/main/kotlin/api/JsUtModelConstructor.kt
+++ b/utbot-js/src/main/kotlin/api/JsUtModelConstructor.kt
@@ -1,7 +1,7 @@
 package api
 
 import fuzzer.providers.JsObjectModelProvider
-import org.utbot.framework.concrete.UtModelConstructorInterface
+import org.utbot.framework.concrete.contructors.UtModelConstructorInterface
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.UtAssembleModel
 import org.utbot.framework.plugin.api.UtExecutableCallModel


### PR DESCRIPTION
# Description

We need some refactoring changes due to [this](https://github.com/UnitTestBot/UTBotJava/discussions/1290#discussioncomment-4193808) discussion comment.

This PR introduces a refactoring that splits the pipeline of UtExecutionInstrumentation into phases:
1. Value construction
2. Preparation
3. Invocation
4. Statistics collection
5. Model construction
6. Postprocessing

Also, was added additional exceptions handling with wrapping an exception into PhaseException according to a phase where the exception was thrown.

```mermaid
classDiagram
  direction LR
  class PhaseContext~E: PhaseError~
  <<interface>> PhaseContext
  PhaseContext : +wrapError(Throwable error)  E
  
  class ValueConstructionContext~ValueConstructionPhaseError~
  PhaseContext ..|> ValueConstructionContext

  class PreparationContext~PreparationPhaseError~
  PhaseContext ..|> PreparationContext

  class InvocationContext~InvocationPhaseError~
  PhaseContext ..|> InvocationContext

  class StatisticsCollectionContext~StatisticsCollectionPhaseError~
  PhaseContext ..|> StatisticsCollectionContext

  class ModelConstructionContext~ModelConstructionPhaseError~
  PhaseContext ..|> ModelConstructionContext

  class PostprocessingContext~PostprocessingPhaseError~
  PhaseContext ..|> PostprocessingContext

  class PhasesController 

  ValueConstructionContext --o PhasesController 
  PreparationContext --o PhasesController 
  InvocationContext --o PhasesController 
  StatisticsCollectionContext --o PhasesController 
  PostprocessingContext --o PhasesController 
```

## Type of Change

- Refactoring (typos and non-functional changes) 

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [x] All tests pass locally with my changes
