### PR TITLE
Don't show error message when user explicitly cancel test generation …

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -247,14 +247,18 @@ object UtTestsDialogProcessor {
                                         )
 
                                         if (rdGenerateResult.notEmptyCases == 0) {
-                                            if (model.srcClasses.size > 1) {
-                                                logger.error { "Failed to generate any tests cases for class $className" }
+                                            if (!indicator.isCanceled) {
+                                                if (model.srcClasses.size > 1) {
+                                                    logger.error { "Failed to generate any tests cases for class $className" }
+                                                } else {
+                                                    showErrorDialogLater(
+                                                        model.project,
+                                                        errorMessage(className, secondsTimeout),
+                                                        title = "Failed to generate unit tests for class $className"
+                                                    )
+                                                }
                                             } else {
-                                                showErrorDialogLater(
-                                                    model.project,
-                                                    errorMessage(className, secondsTimeout),
-                                                    title = "Failed to generate unit tests for class $className"
-                                                )
+                                                logger.warn { "Generation was cancelled for class $className" }
                                             }
                                         } else {
                                             testSetsByClass[srcClass] = rdGenerateResult


### PR DESCRIPTION
…#1307

# Avoid log.error / error dialog in case of explicitly cancelled generation

Fixes #1307

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

Start generation for a single method, then cancel it afer "reading classes" stage. 
"Failed to generate uint tests..." dialog shouldn't appear.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings