### PR TITLE
If utBotGenerationTimeoutInMillis value is out of allowed scope, Ille…

### DIFF
--- a/utbot-core/src/main/kotlin/org/utbot/common/AbstractSettings.kt
+++ b/utbot-core/src/main/kotlin/org/utbot/common/AbstractSettings.kt
@@ -96,7 +96,7 @@ class PropertiesSettingsContainer(
                     }
                     defaultValue
                 } catch (e: Throwable) {
-                    logger.warn("Cannot parse value for ${property.name}, default valu[$defaultValue] will be used instead") { e }
+                    logger.warn("Cannot parse value for ${property.name}, default value [$defaultValue] will be used instead") { e }
                     defaultValue
                 }
             }

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -47,13 +47,13 @@ object UtSettings : AbstractSettings(logger, defaultKeyForSettingsPath, defaultS
      *
      * Set it to 0 to disable timeout.
      */
-    var checkSolverTimeoutMillis: Int by getIntProperty(1000)
+    var checkSolverTimeoutMillis: Int by getIntProperty(1000, 0, Int.MAX_VALUE)
 
     /**
      * Timeout for symbolic execution
      *
      */
-    var utBotGenerationTimeoutInMillis by getLongProperty(60000L)
+    var utBotGenerationTimeoutInMillis by getLongProperty(60000L, 1000L, Long.MAX_VALUE)
 
     /**
      * Random seed in path selector.
@@ -223,7 +223,7 @@ object UtSettings : AbstractSettings(logger, defaultKeyForSettingsPath, defaultS
      * Test related files from the temp directory that are older than [daysLimitForTempFiles]
      * will be removed at the beginning of the test run.
      */
-    var daysLimitForTempFiles by getIntProperty(3)
+    var daysLimitForTempFiles by getIntProperty(3, 0, 30)
 
     /**
      * Enables soft constraints in the engine.
@@ -244,12 +244,12 @@ object UtSettings : AbstractSettings(logger, defaultKeyForSettingsPath, defaultS
     /**
      * Set the total attempts to improve coverage by fuzzer.
      */
-    var fuzzingMaxAttempts: Int by getIntProperty(Int.MAX_VALUE)
+    var fuzzingMaxAttempts: Int by getIntProperty(Int.MAX_VALUE, 0, Int.MAX_VALUE)
 
     /**
      * Fuzzer tries to generate and run tests during this time.
      */
-    var fuzzingTimeoutInMillis: Long by getLongProperty(3_000L)
+    var fuzzingTimeoutInMillis: Long by getLongProperty(3_000L, 0, Long.MAX_VALUE)
 
     /**
      * Generate tests that treat possible overflows in arithmetic operations as errors
@@ -316,7 +316,7 @@ object UtSettings : AbstractSettings(logger, defaultKeyForSettingsPath, defaultS
      * The instrumented process JDWP agent's port of the instrumented process.
      * A debugger attaches to the port in order to debug the process.
      */
-    var instrumentedProcessDebugPort by getIntProperty(5006)
+    var instrumentedProcessDebugPort by getIntProperty(5006, 0, 65535)
 
     /**
      * Value of the suspend mode for the JDWP agent of the instrumented process.
@@ -436,7 +436,7 @@ object UtSettings : AbstractSettings(logger, defaultKeyForSettingsPath, defaultS
     /**
      * Limit for number of generated tests per method (in each region)
      */
-    var maxTestsPerMethodInRegion by getIntProperty(50)
+    var maxTestsPerMethodInRegion by getIntProperty(50, 1, Integer.MAX_VALUE)
 
     /**
      * Max file length for generated test file


### PR DESCRIPTION
…galArgumentException is thrown down to IDEA #1438

Implement API for ranges for settings properties

# Description

API for properties validation was implemented, several numeric ranges were specified for UtSettings

Fixes #1438

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

See the issue:
1) Specify utBotGenerationTimeoutInMillis=100 in settings.properties
2) Start IDEA with the plugin and try to generate tests
Expected behavior: min value (1000) should be used instead of throwing Exception

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] No new warnings
