### PR TITLE
Add logical locations to SARIF reports

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/sarif/SarifReportTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/sarif/SarifReportTest.kt
@@ -44,6 +44,9 @@ class SarifReportTest {
         )
         Mockito.`when`(mockUtExecutionAIOBE.stateBefore.parameters).thenReturn(listOf())
 
+        defaultMockCoverage(mockUtExecutionNPE)
+        defaultMockCoverage(mockUtExecutionAIOBE)
+
         val testSets = listOf(
             UtMethodTestSet(mockExecutableId, listOf(mockUtExecutionNPE)),
             UtMethodTestSet(mockExecutableId, listOf(mockUtExecutionAIOBE))
@@ -68,6 +71,7 @@ class SarifReportTest {
         )
         Mockito.`when`(mockUtExecution.stateBefore.parameters).thenReturn(listOf())
         Mockito.`when`(mockUtExecution.coverage?.coveredInstructions?.lastOrNull()?.lineNumber).thenReturn(1337)
+        Mockito.`when`(mockUtExecution.coverage?.coveredInstructions?.lastOrNull()?.className).thenReturn("Main")
         Mockito.`when`(mockUtExecution.testMethodName).thenReturn("testMain_ThrowArithmeticException")
 
         val report = sarifReportMain.createReport()
@@ -98,6 +102,8 @@ class SarifReportTest {
             )
         )
 
+        defaultMockCoverage(mockUtExecution)
+
         val report = sarifReportMain.createReport()
 
         val result = report.runs.first().results.first()
@@ -121,6 +127,8 @@ class SarifReportTest {
         )
         Mockito.`when`(mockUtExecution.stateBefore.parameters).thenReturn(listOf())
 
+        defaultMockCoverage(mockUtExecution)
+
         val report = sarifReportMain.createReport()
 
         val result = report.runs.first().results.first().codeFlows.first().threadFlows.first().locations.map {
@@ -140,6 +148,8 @@ class SarifReportTest {
         Mockito.`when`(uncheckedException.stackTrace).thenReturn(arrayOf())
         Mockito.`when`(mockUtExecution.result).thenReturn(UtSandboxFailure(uncheckedException))
 
+        defaultMockCoverage(mockUtExecution)
+
         val report = sarifReportMain.createReport()
         val result = report.runs.first().results.first()
         assert(result.message.text.contains("AccessControlException"))
@@ -158,6 +168,8 @@ class SarifReportTest {
         )
         Mockito.`when`(mockUtExecution.stateBefore.parameters).thenReturn(listOf())
         Mockito.`when`(mockUtExecution.testMethodName).thenReturn("testMain_ThrowArithmeticException")
+
+        defaultMockCoverage(mockUtExecution)
 
         val report = sarifReportMain.createReport()
 
@@ -183,6 +195,8 @@ class SarifReportTest {
         Mockito.`when`(mockUtExecution.stateBefore.parameters).thenReturn(listOf())
         Mockito.`when`(mockUtExecution.testMethodName).thenReturn("testMain_ThrowArithmeticException")
 
+        defaultMockCoverage(mockUtExecution)
+
         val report = sarifReportPrivateMain.createReport()
 
         val codeFlowPhysicalLocations = report.runs[0].results[0].codeFlows[0].threadFlows[0].locations.map {
@@ -199,6 +213,8 @@ class SarifReportTest {
 
         val mockUtExecution = Mockito.mock(UtExecution::class.java, Mockito.RETURNS_DEEP_STUBS)
         Mockito.`when`(mockUtExecution.result).thenReturn(UtImplicitlyThrownException(NullPointerException(), false))
+
+        defaultMockCoverage(mockUtExecution)
 
         val testSets = listOf(
             UtMethodTestSet(mockExecutableId, listOf(mockUtExecution)),
@@ -224,6 +240,9 @@ class SarifReportTest {
         // different ruleId's
         Mockito.`when`(mockUtExecution1.result).thenReturn(UtImplicitlyThrownException(NullPointerException(), false))
         Mockito.`when`(mockUtExecution2.result).thenReturn(UtImplicitlyThrownException(ArithmeticException(), false))
+
+        defaultMockCoverage(mockUtExecution1)
+        defaultMockCoverage(mockUtExecution2)
 
         val testSets = listOf(
             UtMethodTestSet(mockExecutableId, listOf(mockUtExecution1)),
@@ -252,7 +271,9 @@ class SarifReportTest {
 
         // different locations
         Mockito.`when`(mockUtExecution1.coverage?.coveredInstructions?.lastOrNull()?.lineNumber).thenReturn(11)
+        Mockito.`when`(mockUtExecution1.coverage?.coveredInstructions?.lastOrNull()?.className).thenReturn("Main")
         Mockito.`when`(mockUtExecution2.coverage?.coveredInstructions?.lastOrNull()?.lineNumber).thenReturn(22)
+        Mockito.`when`(mockUtExecution2.coverage?.coveredInstructions?.lastOrNull()?.className).thenReturn("Main")
 
         val testSets = listOf(
             UtMethodTestSet(mockExecutableId, listOf(mockUtExecution1)),
@@ -288,6 +309,9 @@ class SarifReportTest {
         Mockito.`when`(mockNPE1.stackTrace).thenReturn(arrayOf(stackTraceElement1))
         Mockito.`when`(mockNPE2.stackTrace).thenReturn(arrayOf(stackTraceElement1, stackTraceElement2))
 
+        defaultMockCoverage(mockUtExecution1)
+        defaultMockCoverage(mockUtExecution2)
+
         val testSets = listOf(
             UtMethodTestSet(mockExecutableId, listOf(mockUtExecution1)),
             UtMethodTestSet(mockExecutableId, listOf(mockUtExecution2)) // duplicate with a longer stack trace
@@ -314,6 +338,11 @@ class SarifReportTest {
     private fun mockUtMethodNames() {
         Mockito.`when`(mockExecutableId.name).thenReturn("main")
         Mockito.`when`(mockExecutableId.classId.name).thenReturn("Main")
+    }
+
+    private fun defaultMockCoverage(mockExecution: UtExecution) {
+        Mockito.`when`(mockExecution.coverage?.coveredInstructions?.lastOrNull()?.lineNumber).thenReturn(1)
+        Mockito.`when`(mockExecution.coverage?.coveredInstructions?.lastOrNull()?.className).thenReturn("Main")
     }
 
     // constants

--- a/utbot-framework-test/src/test/kotlin/org/utbot/sarif/SarifReportTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/sarif/SarifReportTest.kt
@@ -73,7 +73,7 @@ class SarifReportTest {
         val report = sarifReportMain.createReport()
 
         val result = report.runs.first().results.first()
-        val location = result.locations.first().physicalLocation
+        val location = result.locations.filterIsInstance<SarifPhysicalLocationWrapper>().first().physicalLocation
         val relatedLocation = result.relatedLocations.first().physicalLocation
 
         assert(location.artifactLocation.uri.contains("Main.java"))

--- a/utbot-framework/src/main/kotlin/org/utbot/sarif/SarifReport.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/sarif/SarifReport.kt
@@ -4,6 +4,7 @@ import org.utbot.common.PathUtil.fileExtension
 import org.utbot.common.PathUtil.toPath
 import org.utbot.framework.UtSettings
 import org.utbot.framework.plugin.api.*
+import java.nio.file.Path
 import kotlin.io.path.nameWithoutExtension
 
 /**
@@ -27,6 +28,41 @@ class SarifReport(
             reports.fold(Sarif.empty()) { sarif: Sarif, report: String ->
                 sarif.copy(runs = sarif.runs + Sarif.fromJson(report).runs)
             }.toJson()
+
+        /**
+         * Minimizes SARIF results between several reports.
+         *
+         * More complex version of the [SarifReport.minimizeResults].
+         */
+        fun minimizeSarifResults(srcPathToSarif: MutableMap<Path, Sarif>): MutableMap<Path, Sarif> {
+            val pathToSarifResult = srcPathToSarif.entries.flatMap { (path, sarif) ->
+                sarif.getAllResults().map { sarifResult ->
+                    path to sarifResult
+                }
+            }
+            val groupedResults = pathToSarifResult.groupBy { (_, sarifResult) ->
+                sarifResult.ruleId to sarifResult.locations
+            }
+            val minimizedResults = groupedResults.map { (_, sarifResultsGroup) ->
+                sarifResultsGroup.minByOrNull { (_, sarifResult) ->
+                    sarifResult.totalCodeFlowLocations()
+                }!!
+            }
+            val groupedByPath = minimizedResults
+                .groupBy { (path, _) -> path }
+                .mapValues { (_, resultsWithPath) ->
+                    resultsWithPath.map { (_, sarifResult) -> sarifResult } // remove redundant path
+                }
+            val pathToSarifTool = srcPathToSarif.mapValues { (_, sarif) ->
+                sarif.runs.first().tool
+            }
+            val paths = pathToSarifTool.keys intersect groupedByPath.keys
+            return paths.associateWith { path ->
+                val sarifTool = pathToSarifTool[path]!!
+                val sarifResults = groupedByPath[path]!!
+                Sarif.fromRun(SarifRun(sarifTool, sarifResults))
+            }.toMutableMap()
+        }
     }
 
     /**
@@ -66,6 +102,8 @@ class SarifReport(
      * [Read more about links to locations](https://github.com/microsoft/sarif-tutorials/blob/main/docs/3-Beyond-basics.md#msg-links-location)
      */
     private val relatedLocationId = 1 // for attaching link to generated test in related locations
+
+    private val stackTraceLengthForStackOverflow = 50 // stack overflow error may have too many elements
 
     /**
      * Minimizes detected errors and removes duplicates.
@@ -125,7 +163,7 @@ class SarifReport(
                     [Generated test for this case]($relatedLocationId)
                 """.trimIndent()
             ),
-            getLocations(utExecution, classFqn),
+            getLocations(method, utExecution, classFqn),
             getRelatedLocations(utExecution),
             getCodeFlows(method, utExecution, executionFailure)
         )
@@ -146,16 +184,23 @@ class SarifReport(
         return Pair(sarifResult, sarifRule)
     }
 
-    private fun getLocations(utExecution: UtExecution, classFqn: String?): List<SarifPhysicalLocationWrapper> {
+    private fun getLocations(
+        method: ExecutableId,
+        utExecution: UtExecution,
+        classFqn: String?
+    ): List<SarifLocationWrapper> {
         if (classFqn == null)
             return listOf()
-        val sourceRelativePath = sourceFinding.getSourceRelativePath(classFqn)
-        val startLine = getLastLineNumber(utExecution, classFqn) ?: defaultLineNumber
-        val sourceCode = sourceFinding.getSourceFile(classFqn)?.readText() ?: ""
+        val (startLine, classWithErrorFqn) = getLastLineNumberWithClassFqn(method, utExecution, classFqn)
+        val sourceCode = sourceFinding.getSourceFile(classWithErrorFqn)?.readText() ?: ""
         val sourceRegion = SarifRegion.withStartLine(sourceCode, startLine)
+        val sourceRelativePath = sourceFinding.getSourceRelativePath(classWithErrorFqn)
         return listOf(
             SarifPhysicalLocationWrapper(
                 SarifPhysicalLocation(SarifArtifact(sourceRelativePath), sourceRegion)
+            ),
+            SarifLogicalLocationsWrapper(
+                listOf(SarifLogicalLocation(classWithErrorFqn)) // class name without method name
             )
         )
     }
@@ -181,31 +226,9 @@ class SarifReport(
         utExecution: UtExecution,
         executionFailure: UtExecutionFailure
     ): List<SarifCodeFlow> {
-        /* Example of a typical stack trace:
-            - java.lang.Math.multiplyExact(Math.java:867)
-            - com.abc.Util.multiply(Util.java:10)
-            - com.abc.Util.multiply(Util.java:6)
-            - com.abc.Main.example(Main.java:11) // <- `lastMethodCallIndex`
-            - sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
-            - ...
-         */
-        val stackTrace = executionFailure.exception.stackTrace
-
-        val lastMethodCallIndex = stackTrace.indexOfLast {
-            it.className == method.classId.name && it.methodName == method.name
-        }
-        if (lastMethodCallIndex == -1)
-            return listOf()
-
-        val stackTraceFiltered = stackTrace
-            .take(lastMethodCallIndex + 1) // taking all elements before the last `method` call
-            .filter {
-                !it.className.startsWith("org.utbot.") // filter all internal calls
-            }
-
-        val stackTraceResolved = stackTraceFiltered.mapNotNull {
-            findStackTraceElementLocation(it)
-        }.toMutableList()
+        val stackTraceResolved = filterStackTrace(method, utExecution, executionFailure)
+            .mapNotNull { findStackTraceElementLocation(it) }
+            .toMutableList()
         if (stackTraceResolved.isEmpty())
             return listOf() // empty stack trace is not shown
 
@@ -233,6 +256,40 @@ class SarifReport(
                 stackTraceResolved.reversed() // reversing stackTrace for convenience
             )
         )
+    }
+
+    private fun filterStackTrace(
+        method: ExecutableId,
+        utExecution: UtExecution,
+        executionFailure: UtExecutionFailure
+    ): List<StackTraceElement> {
+        /* Example of a typical stack trace:
+            - java.lang.Math.multiplyExact(Math.java:867)
+            - com.abc.Util.multiply(Util.java:10)
+            - com.abc.Util.multiply(Util.java:6)
+            - com.abc.Main.example(Main.java:11) // <- `lastMethodCallIndex`
+            - sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+            - ...
+         */
+        var stackTrace = executionFailure.exception.stackTrace.toList()
+
+        val lastMethodCallIndex = stackTrace.indexOfLast {
+            it.className == method.classId.name && it.methodName == method.name
+        }
+        if (lastMethodCallIndex != -1) {
+            // taking all elements before the last `method` call
+            stackTrace = stackTrace.take(lastMethodCallIndex + 1)
+        }
+
+        if (executionFailure.exception is StackOverflowError) {
+            stackTrace = stackTrace.takeLast(stackTraceLengthForStackOverflow)
+        }
+
+        val stackTraceFiltered = stackTrace.filter {
+            !it.className.startsWith("org.utbot.") // filter all internal calls
+        }
+
+        return stackTraceFiltered
     }
 
     private fun findStackTraceElementLocation(stackTraceElement: StackTraceElement): SarifFlowLocationWrapper? {
@@ -327,15 +384,21 @@ class SarifReport(
     }
 
     /**
-     * Returns the number of the last line in the execution path which is located in the [classFqn].
+     * Returns the number of the last line in the execution path
+     * And the name of the class in which it is located.
      */
-    private fun getLastLineNumber(utExecution: UtExecution, classFqn: String): Int? {
-        val classFqnPath = classFqn.replace(".", "/")
+    private fun getLastLineNumberWithClassFqn(
+        method: ExecutableId,
+        utExecution: UtExecution,
+        defaultClassFqn: String
+    ): Pair<Int, String> {
         val coveredInstructions = utExecution.coverage?.coveredInstructions
-        val lastCoveredInstruction = coveredInstructions?.lastOrNull { it.className == classFqnPath }
-            ?: coveredInstructions?.lastOrNull()
+        val lastCoveredInstruction = coveredInstructions?.lastOrNull()
         if (lastCoveredInstruction != null)
-            return lastCoveredInstruction.lineNumber
+            return Pair(
+                lastCoveredInstruction.lineNumber,
+                lastCoveredInstruction.className.replace('/', '.')
+            )
 
         // if for some reason we can't extract the last line from the coverage
         val lastPathElementLineNumber = try {
@@ -345,7 +408,20 @@ class SarifReport(
         } catch (t: Throwable) {
             null
         }
-        return lastPathElementLineNumber
+        if (lastPathElementLineNumber != null) {
+            return Pair(lastPathElementLineNumber, defaultClassFqn)
+        }
+
+        val methodDefinitionLine = getMethodDefinitionLineNumber(method)
+        return Pair(methodDefinitionLine ?: defaultLineNumber, defaultClassFqn)
+    }
+
+    private fun getMethodDefinitionLineNumber(method: ExecutableId): Int? {
+        val sourceFile = sourceFinding.getSourceFile(method.classId.canonicalName)
+        val lineNumber = sourceFile?.readLines()?.indexOfFirst { line ->
+            line.contains(" ${method.name}(") // method definition
+        }
+        return if (lineNumber == null || lineNumber == -1) null else lineNumber + 1 // to one-based
     }
 
     private fun shouldProcessExecutionResult(result: UtExecutionResult): Boolean {

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerationController.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerationController.kt
@@ -93,12 +93,11 @@ import org.utbot.intellij.plugin.util.RunConfigurationHelper
 import org.utbot.intellij.plugin.util.assertIsDispatchThread
 import org.utbot.intellij.plugin.util.assertIsWriteThread
 import org.utbot.intellij.plugin.util.extractClassMethodsIncludingNested
-import org.utbot.sarif.Sarif
-import org.utbot.sarif.SarifReport
 import java.nio.file.Path
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import org.utbot.sarif.*
 
 object CodeGenerationController {
     private val logger = KotlinLogging.logger {}
@@ -219,7 +218,7 @@ object CodeGenerationController {
             return
         }
         UnitTestBotInspectionManager
-            .getInstance(model.project, srcClassPathToSarifReport)
+            .getInstance(model.project, SarifReport.minimizeSarifResults(srcClassPathToSarifReport))
             .createNewGlobalContext()
             .doInspections(AnalysisScope(model.project))
     }


### PR DESCRIPTION
# Description

A new field has been introduced in SARIF reports: `locations.logialLocations`. It is used to store the class name in which an error was detected.

Example:
```JSON
"locations" : [ {
  "physicalLocation" : {
    "artifactLocation" : {
      "uri" : "src/main/java/io/github/ideaseeker/Main.java",
      "uriBaseId" : "%SRCROOT%"
    },
    "region" : {
      "startLine" : 6,
      "startColumn" : 9
    }
  }
}, {
  "logicalLocations" : [ { // new field
    "fullyQualifiedName" : "io.github.ideaseeker.Main"
  } ]
} ],
```

It helps to fix #1381 because errors from the one class may refer to another class.

Also this PR fixes #1383 by adding `org.utbot.sarif.SarifReport#getMethodDefinitionLineNumber` for methods without the last line number in the execution path:

![image](https://user-images.githubusercontent.com/54814796/206124088-151b2dd3-f014-48ae-89dd-6bab9fa2cdff.png)

Fixes #1381, #1383

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Regression and integration tests

org.utbot.sarif.SarifReportTest

## Manual Scenario 

Please, repeat the scenario from the issues and check the result

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [x] All tests pass locally with my changes
