### PR TITLE
Python sdk checking

### DIFF
--- a/utbot-intellij-python/src/main/kotlin/org/utbot/intellij/plugin/language/python/PythonLanguageAssistant.kt
+++ b/utbot-intellij-python/src/main/kotlin/org/utbot/intellij/plugin/language/python/PythonLanguageAssistant.kt
@@ -9,6 +9,9 @@ import com.intellij.psi.PsiFile
 import com.jetbrains.python.psi.PyClass
 import com.jetbrains.python.psi.PyFile
 import com.jetbrains.python.psi.PyFunction
+import com.jetbrains.python.sdk.PythonSdkType
+import org.jetbrains.kotlin.idea.util.projectStructure.module
+import org.jetbrains.kotlin.idea.util.projectStructure.sdk
 import org.utbot.intellij.plugin.language.agnostic.LanguageAssistant
 
 object PythonLanguageAssistant : LanguageAssistant() {
@@ -44,6 +47,9 @@ object PythonLanguageAssistant : LanguageAssistant() {
         val editor = e.getData(CommonDataKeys.EDITOR) ?: return null
         val file = e.getData(CommonDataKeys.PSI_FILE) as? PyFile ?: return null
         val element = findPsiElement(file, editor) ?: return null
+
+        if (file.module?.sdk?.sdkType !is PythonSdkType)
+            return null
 
         val containingFunction = getContainingElement<PyFunction>(element)
         val containingClass = getContainingElement<PyClass>(element)


### PR DESCRIPTION
# Description

Add python sdk checking before opening python action window

## Type of Change

- Minor bug fix (non-breaking small changes)
- 
# How Has This Been Tested?

## Manual Scenario 

1. Run UtBot plugin in Idea without Python SDK. Action window should not open.
2. Set Python SDK in project settings and run utbot. Action window should open.

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
- [ ] New tests have been added
- [x] All tests pass locally with my changes
