### PR TITLE
Adding logs for phases start and finish

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/CodeGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/CodeGenerator.kt
@@ -1,5 +1,6 @@
 package org.utbot.framework.codegen
 
+import mu.KotlinLogging
 import org.utbot.framework.codegen.domain.ForceStaticMocking
 import org.utbot.framework.codegen.domain.HangingTestsTimeout
 import org.utbot.framework.codegen.domain.ParametrizedTestSource
@@ -19,6 +20,8 @@ import org.utbot.framework.plugin.api.CodegenLanguage
 import org.utbot.framework.plugin.api.ExecutableId
 import org.utbot.framework.plugin.api.MockFramework
 import org.utbot.framework.plugin.api.UtMethodTestSet
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 open class CodeGenerator(
     val classUnderTest: ClassId,
@@ -36,6 +39,8 @@ open class CodeGenerator(
     enableTestsTimeout: Boolean = true,
     testClassPackageName: String = classUnderTest.packageName,
 ) {
+
+    private val logger = KotlinLogging.logger {}
 
     open var context: CgContext = CgContext(
         classUnderTest = classUnderTest,
@@ -71,8 +76,15 @@ open class CodeGenerator(
                 val renderer = CgAbstractRenderer.makeRenderer(context)
                 val testClassModel = TestClassModel.fromTestSets(classUnderTest, cgTestSets)
 
+                fun now() = LocalDateTime.now().format(DateTimeFormatter.ofPattern("HH:mm:ss.SSS"))
+
+                logger.info { "Code generation phase started at ${now()}" }
                 val testClassFile = astConstructor.construct(testClassModel)
+                logger.info { "Code generation phase finished at ${now()}" }
+
+                logger.info { "Rendering phase started at ${now()}" }
                 testClassFile.accept(renderer)
+                logger.info { "Rendering phase finished at ${now()}" }
 
                 CodeGeneratorResult(
                     generatedCode = renderer.toString(),

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -72,6 +72,7 @@ import com.intellij.util.ui.JBUI.scale
 import com.intellij.util.ui.JBUI.size
 import com.intellij.util.ui.UIUtil
 import com.intellij.util.ui.components.BorderLayoutPanel
+import mu.KotlinLogging
 import java.awt.BorderLayout
 import java.awt.Color
 import java.awt.Dimension
@@ -80,7 +81,6 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.text.ParseException
-import java.util.Objects
 import java.util.concurrent.TimeUnit
 import javax.swing.AbstractAction
 import javax.swing.Action
@@ -116,6 +116,7 @@ import org.utbot.framework.plugin.api.utils.MOCKITO_EXTENSIONS_FILE_CONTENT
 import org.utbot.framework.plugin.api.utils.MOCKITO_EXTENSIONS_FOLDER
 import org.utbot.framework.plugin.api.utils.MOCKITO_MOCKMAKER_FILE_NAME
 import org.utbot.framework.util.Conflict
+import org.utbot.intellij.plugin.generator.UtTestsDialogProcessor
 import org.utbot.intellij.plugin.models.GenerateTestsModel
 import org.utbot.intellij.plugin.models.id
 import org.utbot.intellij.plugin.models.jUnit4LibraryDescriptor
@@ -142,6 +143,9 @@ import org.utbot.intellij.plugin.ui.utils.testRootType
 import org.utbot.intellij.plugin.util.IntelliJApiHelper
 import org.utbot.intellij.plugin.util.extractFirstLevelMembers
 import org.utbot.intellij.plugin.util.findSdkVersion
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.*
 
 private const val RECENTS_KEY = "org.utbot.recents"
 
@@ -159,6 +163,8 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
         const val minSupportedSdkVersion = 8
         const val maxSupportedSdkVersion = 17
     }
+
+    private val logger = KotlinLogging.logger {}
 
     private val membersTable = MemberSelectionTable(emptyList(), null)
 
@@ -486,6 +492,10 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
     override fun getOKAction() = okOptionAction
 
     override fun doOKAction() {
+        fun now() = LocalDateTime.now().format(DateTimeFormatter.ofPattern("HH:mm:ss.SSS"))
+
+        logger.info { "Tests generation instantiation phase started at ${now()}" }
+
         model.testPackageName =
             if (testPackageField.text != SAME_PACKAGE_LABEL) testPackageField.text else ""
 
@@ -542,7 +552,6 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
             }
         } catch (e: IncorrectOperationException) {
             println(e.message)
-
         }
 
         configureJvmTargetIfRequired()
@@ -551,6 +560,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
         configureStaticMockingIfRequired()
         configureParametrizedTestsIfRequired()
 
+        logger.info { "Tests generation instantiation phase finished at ${now()}" }
         super.doOKAction()
     }
 


### PR DESCRIPTION
# Description

Added some phases start and finish logging:
- Test generation initiated
- Collecting information (classes)
- Code generation
- Rendering

Relates to # ([1122](https://github.com/UnitTestBot/UTBotJava/issues/1122))

## Type of Change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Manual Scenario 

Verify that all added logs are show during running of UtBot.
