### PR TITLE
If invalid value is set for a property in settings.properties, defaul…

### DIFF
--- a/utbot-core/src/main/kotlin/org/utbot/common/AbstractSettings.kt
+++ b/utbot-core/src/main/kotlin/org/utbot/common/AbstractSettings.kt
@@ -2,6 +2,7 @@ package org.utbot.common
 
 import java.io.FileInputStream
 import java.io.IOException
+import java.io.InputStream
 import java.util.*
 import kotlin.Comparator
 import mu.KLogger
@@ -17,6 +18,8 @@ interface SettingsContainer {
         converter: (String) -> T
     ): PropertyDelegateProvider<Any?, ReadWriteProperty<Any?, T>>
 
+    fun getInputStream() : InputStream? = null
+
     // Returns true iff some properties have non-default values
     fun isCustomized() = false
 }
@@ -28,10 +31,10 @@ interface SettingsContainerFactory {
         defaultSettingsPath: String? = null) : SettingsContainer
 }
 
-class PropertiesSettingsContainer(
+internal open class PropertiesSettingsContainer(
     private val logger: KLogger,
-    defaultKeyForSettingsPath: String,
-    defaultSettingsPath: String? = null): SettingsContainer {
+    val defaultKeyForSettingsPath: String,
+    val defaultSettingsPath: String? = null): SettingsContainer {
     companion object: SettingsContainerFactory {
         override fun createSettingsContainer(
             logger: KLogger,
@@ -41,17 +44,19 @@ class PropertiesSettingsContainer(
     }
 
     private val properties = Properties().also { props ->
+        try {
+            getInputStream()?.use {
+                props.load(it)
+            }
+        } catch (e: IOException) {
+            logger.info(e) { e.message }
+        }
+    }
+
+    override fun getInputStream() : InputStream? {
         val settingsPath = System.getProperty(defaultKeyForSettingsPath) ?: defaultSettingsPath
         val settingsPathFile = settingsPath?.toPath()?.toFile()
-        if (settingsPathFile?.exists() == true) {
-            try {
-                FileInputStream(settingsPathFile).use { reader ->
-                    props.load(reader)
-                }
-            } catch (e: IOException) {
-                logger.info(e) { e.message }
-            }
-        }
+        return if (settingsPathFile?.exists() == true) FileInputStream(settingsPathFile) else null
     }
 
     private val settingsValues: MutableMap<KProperty<*>, Any?> = mutableMapOf()

--- a/utbot-core/src/main/kotlin/org/utbot/common/AbstractSettings.kt
+++ b/utbot-core/src/main/kotlin/org/utbot/common/AbstractSettings.kt
@@ -156,7 +156,12 @@ abstract class AbstractSettings(
         return container.settingFor(defaultValue, null, converter)
     }
 
-    protected fun getBooleanProperty(defaultValue: Boolean) = getProperty(defaultValue, converter = String::toBoolean)
+    protected fun getBooleanProperty(defaultValue: Boolean) = getProperty(defaultValue, converter = {
+        //Invalid values shouldn't be parsed as "false"
+        if (it.equals("true", true)) true
+        else if (it.equals("false", true)) false
+        else defaultValue
+    })
     protected fun getIntProperty(defaultValue: Int) = getProperty(defaultValue, converter = String::toInt)
     protected fun getIntProperty(defaultValue: Int, minValue: Int, maxValue: Int) = getProperty(defaultValue, Triple(minValue, maxValue, Comparator(Integer::compare)), String::toInt)
     protected fun getLongProperty(defaultValue: Long) = getProperty(defaultValue, converter = String::toLong)

--- a/utbot-core/src/test/kotlin/org/utbot/common/AbstractSettingsTest.kt
+++ b/utbot-core/src/test/kotlin/org/utbot/common/AbstractSettingsTest.kt
@@ -1,0 +1,51 @@
+package org.utbot.common
+
+import java.io.InputStream
+import mu.KLogger
+import mu.KotlinLogging
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+
+internal class AbstractSettingsTest {
+    @Test
+    fun testParsing() {
+        var settings = createSettings("testBoolean=false\ntestInt=3\ntestIntRange=2\ntestLong=333\ntestLongRange=222")
+        Assertions.assertFalse(settings.testBoolean)
+        Assertions.assertEquals(3, settings.testInt)
+        Assertions.assertEquals(2, settings.testIntRange)
+        Assertions.assertEquals(333, settings.testLong)
+        Assertions.assertEquals(222, settings.testLongRange)
+
+        settings = createSettings("testBoolean=invalid\ntestInt=-1\ntestIntRange=-1\ntestLong=-111\ntestLongRange=-111")
+        Assertions.assertTrue(settings.testBoolean)
+        Assertions.assertEquals(-1, settings.testInt)
+        Assertions.assertEquals(1, settings.testIntRange)
+        Assertions.assertEquals(-111, settings.testLong)
+        Assertions.assertEquals(111, settings.testLongRange)
+
+        settings = createSettings("")
+        Assertions.assertTrue(settings.testBoolean)
+        Assertions.assertEquals(3, settings.testInt)
+        Assertions.assertEquals(333, settings.testLongRange)
+    }
+
+    private fun createSettings(propertiesText: String): TestSettings {
+        AbstractSettings.setupFactory(object : SettingsContainerFactory {
+            override fun createSettingsContainer(
+                logger: KLogger, defaultKeyForSettingsPath: String, defaultSettingsPath: String?
+            ) = object : PropertiesSettingsContainer(logger, defaultKeyForSettingsPath, defaultSettingsPath) {
+                override fun getInputStream(): InputStream = propertiesText.byteInputStream()
+            }
+        })
+        return TestSettings()
+    }
+
+    internal class TestSettings : AbstractSettings(KotlinLogging.logger {}, "") {
+        val testBoolean: Boolean by getBooleanProperty(true)
+        val testInt: Int by getIntProperty(3)
+        val testIntRange: Int by getIntProperty(3, 1, 5)
+        val testLong: Long by getLongProperty(333)
+        val testLongRange: Long by getLongProperty(333, 111, 555)
+    }
+}


### PR DESCRIPTION
…t value should be applied #1437

# Description

Standard `Boolean.parseBoolean()` returns `false `for all invalid values, new parser will return `defaultValue `instead.

Fixes #1437

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Regression and integration tests

org.utbot.common.AbstractSettingsTest


## Manual Scenario 

See the [issue](#1437)

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
- [x] New tests have been added
- [x] All tests pass locally with my changes
