### PR TITLE
Fix disabled action

### DIFF
--- a/utbot-intellij-python/src/main/kotlin/org/utbot/intellij/plugin/language/python/PythonLanguageAssistant.kt
+++ b/utbot-intellij-python/src/main/kotlin/org/utbot/intellij/plugin/language/python/PythonLanguageAssistant.kt
@@ -44,12 +44,17 @@ object PythonLanguageAssistant : LanguageAssistant() {
     }
 
     private fun getPsiTargets(e: AnActionEvent): Targets? {
-        val editor = e.getData(CommonDataKeys.EDITOR) ?: return null
+        val editor = e.getData(CommonDataKeys.EDITOR)
         val file = e.getData(CommonDataKeys.PSI_FILE) as? PyFile ?: return null
-        val element = findPsiElement(file, editor) ?: return null
 
         if (file.module?.sdk?.sdkType !is PythonSdkType)
             return null
+
+        val element = if (editor != null) {
+            findPsiElement(file, editor) ?: return null
+        } else {
+            e.getData(CommonDataKeys.PSI_ELEMENT) ?: return null
+        }
 
         val containingFunction = getContainingElement<PyFunction>(element)
         val containingClass = getContainingElement<PyClass>(element)
@@ -67,7 +72,8 @@ object PythonLanguageAssistant : LanguageAssistant() {
         if (functions.isEmpty())
             return null
 
-        val focusedFunction = if (functions.any { it.name == containingFunction?.name }) containingFunction else null
+        val focusedFunction =
+            if (functions.any { it.name == containingFunction?.name }) containingFunction else null
         return Targets(functions.toSet(), containingClass, focusedFunction, file)
     }
 

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/actions/GenerateTestsAction.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/actions/GenerateTestsAction.kt
@@ -10,6 +10,11 @@ class GenerateTestsAction : AnAction() {
     }
 
     override fun update(e: AnActionEvent) {
-        LanguageAssistant.get(e)?.update(e)
+        val languageAssistant = LanguageAssistant.get(e)
+        if (languageAssistant == null) {
+            e.presentation.isEnabled = false
+        } else {
+            languageAssistant.update(e)
+        }
     }
 }


### PR DESCRIPTION
# Description

Added language support check before showing actions menu.
Added python test generation from file.

Fixes #1479 

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

1. Open python project in IntelliJ IDEA.
2. Set python SDK
3. Right-click on python file. If this file contains python function on class action `Generate Tests with UnitTestBot...` should be active.
4. Right-click on *.xml, *.json, *.exe, ... (unsupported language). Action `Generate Tests with UnitTestBot...` should be disable.
# Checklist (remove irrelevant options):

_This is the author self-check list_

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
- [x] All tests pass locally with my changes
