### PR TITLE
Debug run configurations fix

### DIFF
--- a/.run/Debug All.run.xml
+++ b/.run/Debug All.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Debug All" type="CompoundRunConfigurationType">
-    <toRun name="Run IDE" type="GradleRunConfiguration" />
+    <toRun name="Run IDEA" type="GradleRunConfiguration" />
     <toRun name="Listen for Engine Process" type="Remote" />
     <toRun name="Listen for Instrumented Process" type="Remote" />
     <method v="2" />

--- a/.run/Debug Engine Process.run.xml
+++ b/.run/Debug Engine Process.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Debug Engine Process" type="CompoundRunConfigurationType">
-    <toRun name="Run IDE" type="GradleRunConfiguration" />
+    <toRun name="Run IDEA" type="GradleRunConfiguration" />
     <toRun name="Listen for Engine Process" type="Remote" />
     <method v="2" />
   </configuration>

--- a/.run/Debug Instrumented Process.run.xml
+++ b/.run/Debug Instrumented Process.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Debug Instrumented Process" type="CompoundRunConfigurationType">
-    <toRun name="Run IDE" type="GradleRunConfiguration" />
+    <toRun name="Run IDEA" type="GradleRunConfiguration" />
     <toRun name="Listen for Instrumented Process" type="Remote" />
     <method v="2" />
   </configuration>


### PR DESCRIPTION
# Description

After Rider  C# plugin merge `Run IDE` was renamed to `Run IDEA` to distinguish from `Run Rider`. It broke debug run configuration as they still refenrenced `Run IDE` run configuration which was absent.

This PR fixes all debug run configurations for them to reference correct `Run IDEA`.
