### PR TITLE
Fix unnecessary reflection calls in the generated code

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/modifications/ConstructorAnalyzer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/modifications/ConstructorAnalyzer.kt
@@ -33,9 +33,9 @@ import soot.jimple.internal.JimpleLocal
  * */
 data class ConstructorAssembleInfo(
     val constructorId: ConstructorId,
-    val params: Map<Int, FieldId>,
-    val setFields: Set<FieldId>,
-    val affectedFields: Set<FieldId>
+    val params: Map<Int, FieldId> = mapOf(),
+    val setFields: Set<FieldId> = setOf(),
+    val affectedFields: Set<FieldId> = setOf()
 )
 
 /**
@@ -109,18 +109,11 @@ class ConstructorAnalyzer {
         return jimpleLocal.name.first() != '$'
     }
 
-    private val visitedConstructors = mutableSetOf<SootMethod>()
-
     private fun analyze(
         sootConstructor: SootMethod,
         setFields: MutableSet<FieldId>,
         affectedFields: MutableSet<FieldId>,
     ): Map<Int, FieldId> {
-        if (sootConstructor in visitedConstructors) {
-            return emptyMap()
-        }
-        visitedConstructors.add(sootConstructor)
-
         val jimpleBody = retrieveJimpleBody(sootConstructor) ?: return emptyMap()
         analyzeAssignments(jimpleBody, setFields, affectedFields)
 


### PR DESCRIPTION
# Description

This PR fixes unnecessary reflection calls as described in the following issue and infinite loop in self-reference initialization (there are examples in the manual testing section).

Fixes # ([1353](https://github.com/UnitTestBot/UTBotJava/issues/1353))

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

UTBot-samples.

## Manual Scenario 

Tested on the code attached in the issue. Additionally, tested self-reference cases like the following:
```java
// First scenario
class FirstClass {
    SecondClass secondClass;

    FirstClass(SecondClass second) {
        this.secondClass = second;
    }
}

class SecondClass {
    FirstClass firstClass;

    SecondClass(FirstClass first) {
        this.firstClass = first;
    }
}

class ClassWithCrossReferenceRelationship {
    public FirstClass returnFirstClass(int value) {
        if (value == 0) {
            return new FirstClass(new SecondClass(null));
        } else {
            FirstClass first = new FirstClass(null);
            first.secondClass = new SecondClass(first);

            return first;
        }
    }
}



// Second scenario
class FirstClass1 {
    ThirdClass1 thirdClass;

    FirstClass1(ThirdClass1 third) {
        this.thirdClass = third;
    }
}

class SecondClass1 {
    FirstClass1 firstClass;

    SecondClass1(FirstClass1 first) {
        this.firstClass = first;
    }
}

class ThirdClass1 {
    SecondClass1 secondClass;

    ThirdClass1(SecondClass1 second) {
        this.secondClass = second;
    }
}

class ClassWithCrossReferenceRelationship1 {
    public FirstClass1 returnFirstClass(int value) {
        FirstClass1 first = new FirstClass1(null);
        SecondClass1 second = new SecondClass1(first);
        ThirdClass1 third = new ThirdClass1(second);
        first.thirdClass = third;

        return first;
    }
}
```