### PR TITLE
Reconciliation for utBotGenerationTimeoutInMillis: Long.MAX_VALUE is …

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -53,7 +53,7 @@ object UtSettings : AbstractSettings(logger, defaultKeyForSettingsPath, defaultS
      * Timeout for symbolic execution
      *
      */
-    var utBotGenerationTimeoutInMillis by getLongProperty(60000L, 1000L, Long.MAX_VALUE)
+    var utBotGenerationTimeoutInMillis by getLongProperty(60000L, 1000L, Int.MAX_VALUE.toLong())
 
     /**
      * Random seed in path selector.


### PR DESCRIPTION
…far too big for maximum, let's use Int.MAX_VALUE instead

# Description

Spinner model expect Int.MAX_VALUE as maximum, in settings it was limited with Long.MAX_VALUE

Fixes #1438 

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

See the [relevant issue](https://github.com/UnitTestBot/UTBotJava/issues/1438): utBotGenerationTimeoutInMillis=60000000000000 in settings.properties should work as Int.MAX_VALUE with no exception.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings

