### PR TITLE
Fix function name in codegen for mypy

### DIFF
--- a/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/PythonCodeGenerator.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/PythonCodeGenerator.kt
@@ -193,7 +193,7 @@ class PythonCodeGenerator(
         }
 
         val functionPrefix = "__mypy_check"
-        val functionName = "def ${functionPrefix}_{method.name}(${parameters.joinToString(", ")}):"  // TODO: in future can be "async def"
+        val functionName = "def ${functionPrefix}_${method.name}(${parameters.joinToString(", ")}):"  // TODO: in future can be "async def"
 
         val mypyCheckCode = listOf(
             renderer.toString(),


### PR DESCRIPTION
# Description

Fix bug in python code generation for mypy checking. After this fix I cannot reproduce bug #1478

Fixes #1478 

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

See [here](https://github.com/UnitTestBot/UTBotJava/issues/1478) steps 1-8 with plugin from [this build](https://github.com/UnitTestBot/UTBotJava/actions/runs/3684500881)

Expected result: generated tests, for example: 
```python
import sys
sys.path.append('..')
import builtins
import types
import sample
import unittest


class TestTopLevelFunctions(unittest.TestCase):
    # region Test suites for executable sample.print_hi
    
    # region
    
    def test_print_hi(self):
        actual = sample.print_hi((1 << 100))
        
        self.assertEqual(None, actual)
    
    def test_print_hi_throws_t(self):
        sample.print_hi(str(b'\xf0\xa3\x91\x96', 'utf-8'))
        
        # raises builtins.UnicodeEncodeError
    # endregion
    
    # endregion
    
    # region Test suites for executable sample.div
    
    # region
    
    def test_div(self):
        actual = sample.div(1, 1)
        
        self.assertEqual(1.0, actual)
    # endregion
    
    # endregion
```

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] No new warnings
- [x] All tests pass locally with my changes
