### PR TITLE
Make dependency on maven plugin optional

### DIFF
--- a/utbot-intellij/src/main/resources/META-INF/plugin.xml
+++ b/utbot-intellij/src/main/resources/META-INF/plugin.xml
@@ -5,12 +5,12 @@
     <name>UnitTestBot</name>
     <vendor>utbot.org</vendor>
     <depends>com.intellij.modules.platform</depends>
-    <depends>org.jetbrains.idea.maven</depends>
 
     <depends optional="true" config-file="withJava.xml">com.intellij.modules.java</depends>
     <depends optional="true" config-file="withKotlin.xml">org.jetbrains.kotlin</depends>
     <depends optional="true" config-file="withPython.xml">com.intellij.modules.python</depends>
     <depends optional="true" config-file="withAndroid.xml">org.jetbrains.android</depends>
+    <depends optional="true" config-file="withIdeaMaven.xml">org.jetbrains.idea.maven</depends>
 
     <actions>
         <action id="org.utbot.intellij.plugin.ui.actions.GenerateTestsAction"

--- a/utbot-intellij/src/main/resources/META-INF/withIdeaMaven.xml
+++ b/utbot-intellij/src/main/resources/META-INF/withIdeaMaven.xml
@@ -1,0 +1,3 @@
+<!--Optional dependency on org.jetbrains.idea.maven-->
+<extensions defaultExtensionNs="org.jetbrains.idea.maven">
+</extensions>


### PR DESCRIPTION
# Description

To add dependencies into Maven projects, we have custom version of MavenProjectModelModifier, because original one contains bugs. 

This functionality requires the dependency on `org.jetbrains.idea.maven`. 
Adding it makes our plugin incompatible with PyCharm and WebStorm. Thus we need to make it optional.

Partially fixes # ([1468](https://github.com/UnitTestBot/UTBotJava/issues/1468))

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Regression and integration tests

Verify that dependencies are still installed correctly in all Maven projects: for example, check TestNg on projects with JDK8 and JDK11, versions 7.5 and 7.6.* should be installed.

## Manual Scenario 

Possibly verify on PyCharm, but currently it can't be dun via runIde service because of the dependencies on java not supported in PyCharm. We can only create a plugin build and install it into Intellij Idea manually.