### PR TITLE
Add disjunction with null condition to isMock constraint

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/mock/CommonMocksExampleTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/mock/CommonMocksExampleTest.kt
@@ -56,4 +56,14 @@ internal class CommonMocksExampleTest: UtValueTestCaseChecker(testClass = Common
             coverage = DoNotCalculate
         )
     }
+
+    @Test
+    fun testMocksForNullOfDifferentTypes() {
+        check(
+            CommonMocksExample::mocksForNullOfDifferentTypes,
+            eq(1),
+            mockStrategy = MockStrategyApi.OTHER_PACKAGES,
+            coverage = DoNotCalculate
+        )
+    }
 }

--- a/utbot-sample/src/main/java/org/utbot/examples/mock/CommonMocksExample.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/mock/CommonMocksExample.java
@@ -1,5 +1,7 @@
 package org.utbot.examples.mock;
 
+import org.utbot.api.mock.UtMock;
+import org.utbot.examples.mock.others.Random;
 import org.utbot.examples.mock.service.impl.ExampleClass;
 import org.utbot.examples.objects.ObjectWithFinalStatic;
 import org.utbot.examples.objects.RecursiveTypeClass;
@@ -34,5 +36,12 @@ public class CommonMocksExample {
         } else {
             return -ObjectWithFinalStatic.keyValue;
         }
+    }
+
+    public int mocksForNullOfDifferentTypes(Integer intValue, Random random) {
+        UtMock.assume(intValue == null);
+        UtMock.assume(random == null);
+
+        return 0;
     }
 }


### PR DESCRIPTION
# Description

Added a disjunction with nullability constraint to avoid an assignment to a null object contradicting conditions about whether it is mock or not.

Fixes #1520

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Regression and integration tests

There is no difference between automatic tests and international tests for the engine.

## Automated Testing

org.utbot.examples.mock.CommonMocksExample#mocksForNullOfDifferentTypes

## Manual Scenario 

Did not check it manually.

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
- [x] New tests have been added
- [x] All tests pass locally with my changes
