### PR TITLE
Change unsafe access to jClass in updateGenericTypeInfo

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -1035,7 +1035,10 @@ class Traverser(
      * Stores information about the generic types used in the parameters of the method under test.
      */
     private fun updateGenericTypeInfo(identityRef: IdentityRef, value: ReferenceValue) {
-        val callable = methodUnderTest.executable
+        // If we don't have access to methodUnderTest's jClass, the engine should not fail
+        // We just won't update generic information for it
+        val callable = runCatching { methodUnderTest.executable }.getOrNull() ?: return
+
         val type = if (identityRef is ThisRef) {
             // TODO: for ThisRef both methods don't return parameterized type
             if (methodUnderTest.isConstructor) {


### PR DESCRIPTION
# Description

In `org.utbot.engine.Traverser#updateGenericTypeInfo` we access `executable` for the method under test. It goes into `jClass` and extracts a method instance from it, which may cause an error if we don't have this class in the classpath. Since this function is not mandatory for analysis, we can just not update generic info and continue analysis instead of falling.

## Type of Change

Please delete options that are not relevant.

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Regression and integration tests

There are no additional tests since they highly depend on classpath, project configuration, soot transformation and other options. Unfortunately, the exact combination of these options is lost and the problem occurred on a project with closed code.

## Automated Testing

There are no additional automatic tests.

## Manual Scenario 

There are no manual scenarios.

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] All tests pass locally with my changes
