### PR TITLE
Add interfaces of superclasses in ancestors set

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/mixed/SerializableExampleTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/mixed/SerializableExampleTest.kt
@@ -1,0 +1,18 @@
+package org.utbot.examples.mixed
+
+import org.junit.jupiter.api.Test
+import org.utbot.framework.plugin.api.CodegenLanguage
+import org.utbot.testcheckers.eq
+import org.utbot.testing.DoNotCalculate
+import org.utbot.testing.UtValueTestCaseChecker
+
+internal class SerializableExampleTest : UtValueTestCaseChecker(testClass = SerializableExample::class) {
+
+    @Test
+    fun testExample() {
+        check(
+            SerializableExample::example,
+            eq(1),
+        )
+    }
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Hierarchy.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Hierarchy.kt
@@ -1,5 +1,6 @@
 package org.utbot.engine
 
+import org.utbot.engine.types.OBJECT_TYPE
 import org.utbot.engine.types.TypeRegistry
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.id
@@ -54,14 +55,20 @@ class Hierarchy(private val typeRegistry: TypeRegistry) {
 
 private fun findAncestors(id: ClassId) =
     with(Scene.v().getSootClass(id.name)) {
-        if (this.isInterface) {
-            Scene.v().activeHierarchy.getSuperinterfacesOfIncluding(this)
+        val superClasses = mutableListOf<SootClass>()
+        val superInterfaces = mutableListOf<SootClass>()
+
+        if (isInterface) {
+            superClasses += OBJECT_TYPE.sootClass
+            superInterfaces += Scene.v().activeHierarchy.getSuperinterfacesOfIncluding(this)
         } else {
-            Scene.v().activeHierarchy.getSuperclassesOfIncluding(this) +
-                    this.interfaces.flatMap {
-                        Scene.v().activeHierarchy.getSuperinterfacesOfIncluding(it)
-                    }
+            superClasses += Scene.v().activeHierarchy.getSuperclassesOfIncluding(this)
+            superInterfaces += superClasses
+                .flatMap { it.interfaces }
+                .flatMap { Scene.v().activeHierarchy.getSuperinterfacesOfIncluding(it) }
         }
+
+        superClasses + superInterfaces
     }
 
 private fun findInheritors(id: ClassId) =

--- a/utbot-sample/src/main/java/org/utbot/examples/mixed/SerializableExample.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/mixed/SerializableExample.java
@@ -1,0 +1,13 @@
+package org.utbot.examples.mixed;
+
+import java.io.File;
+
+public class SerializableExample {
+    public void example() {
+        join("string", File.separator, System.currentTimeMillis());
+    }
+
+    public static <T> String join(T... elements) {
+        return null;
+    }
+}


### PR DESCRIPTION
# Description

There has been a problem in that we didn't add interfaces for superclasses in the ancestors set, only interfaces for the class itself. This request fixes this behaviour.

Fixes #1527 

## Type of Change

- Bug fix (non-breaking change which fixes an issue)
# How Has This Been Tested?

## Regression and integration tests

`org.utbot.examples.mixed.SerializableExampleTest#testExample`

## Automated Testing

`org.utbot.examples.mixed.SerializableExampleTest#testExample`

## Manual Scenario 

There are no manual scenarios.

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
- [x] New tests have been added
- [x] All tests pass locally with my changes
