### PR TITLE
Added symbolic processing of `newInstance` reflection call

### DIFF
--- a/.github/workflows/framework-tests-matrix.json
+++ b/.github/workflows/framework-tests-matrix.json
@@ -22,7 +22,7 @@
     },
     {
       "PART_NAME": "examples-part2",
-      "TESTS_TO_RUN": "--tests \"org.utbot.examples.exceptions.*\" --tests \"org.utbot.examples.invokes.*\" --tests \"org.utbot.examples.lambda.*\" --tests \"org.utbot.examples.make.symbolic.*\" --tests \"org.utbot.examples.math.*\" --tests \"org.utbot.examples.mixed.*\" --tests \"org.utbot.examples.mock.*\" --tests \"org.utbot.examples.models.*\" --tests \"org.utbot.examples.natives.*\" --tests \"org.utbot.examples.objects.*\" --tests org.utbot.examples.reflection.*\""
+      "TESTS_TO_RUN": "--tests \"org.utbot.examples.exceptions.*\" --tests \"org.utbot.examples.invokes.*\" --tests \"org.utbot.examples.lambda.*\" --tests \"org.utbot.examples.make.symbolic.*\" --tests \"org.utbot.examples.math.*\" --tests \"org.utbot.examples.mixed.*\" --tests \"org.utbot.examples.mock.*\" --tests \"org.utbot.examples.models.*\" --tests \"org.utbot.examples.natives.*\" --tests \"org.utbot.examples.objects.*\" --tests \"org.utbot.examples.reflection.*\""
     },
     {
       "PART_NAME": "examples-part3",

--- a/.github/workflows/framework-tests-matrix.json
+++ b/.github/workflows/framework-tests-matrix.json
@@ -22,7 +22,7 @@
     },
     {
       "PART_NAME": "examples-part2",
-      "TESTS_TO_RUN": "--tests \"org.utbot.examples.exceptions.*\" --tests \"org.utbot.examples.invokes.*\" --tests \"org.utbot.examples.lambda.*\" --tests \"org.utbot.examples.make.symbolic.*\" --tests \"org.utbot.examples.math.*\" --tests \"org.utbot.examples.mixed.*\" --tests \"org.utbot.examples.mock.*\" --tests \"org.utbot.examples.models.*\" --tests \"org.utbot.examples.natives.*\" --tests \"org.utbot.examples.objects.*\""
+      "TESTS_TO_RUN": "--tests \"org.utbot.examples.exceptions.*\" --tests \"org.utbot.examples.invokes.*\" --tests \"org.utbot.examples.lambda.*\" --tests \"org.utbot.examples.make.symbolic.*\" --tests \"org.utbot.examples.math.*\" --tests \"org.utbot.examples.mixed.*\" --tests \"org.utbot.examples.mock.*\" --tests \"org.utbot.examples.models.*\" --tests \"org.utbot.examples.natives.*\" --tests \"org.utbot.examples.objects.*\" --tests org.utbot.examples.reflection.*\""
     },
     {
       "PART_NAME": "examples-part3",

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/reflection/NewInstanceExampleTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/reflection/NewInstanceExampleTest.kt
@@ -1,0 +1,16 @@
+package org.utbot.examples.reflection
+
+import org.junit.jupiter.api.Test
+import org.utbot.testcheckers.eq
+import org.utbot.testing.UtValueTestCaseChecker
+
+class NewInstanceExampleTest : UtValueTestCaseChecker(NewInstanceExample::class) {
+    @Test
+    fun testNewInstanceExample() {
+        check(
+            NewInstanceExample::createWithReflectionExample,
+            eq(1),
+            { r -> r == 0 }
+        )
+    }
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/types/TypeResolver.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/types/TypeResolver.kt
@@ -39,6 +39,7 @@ import soot.NullType
 import soot.PrimType
 import soot.RefType
 import soot.Scene
+import soot.SootClass
 import soot.SootField
 import soot.Type
 import soot.VoidType
@@ -344,7 +345,8 @@ internal val CLASS_REF_NUM_DIMENSIONS_DESCRIPTOR: MemoryChunkDescriptor
         IntType.v()
     )
 
-internal val CLASS_REF_SOOT_CLASS = Scene.v().getSootClass(CLASS_REF_CLASSNAME)
+internal val CLASS_REF_SOOT_CLASS: SootClass
+    get() = Scene.v().getSootClass(CLASS_REF_CLASSNAME)
 
 internal val OBJECT_TYPE: RefType
     get() = Scene.v().getSootClass(Object::class.java.canonicalName).type

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/types/TypeResolver.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/types/TypeResolver.kt
@@ -344,12 +344,16 @@ internal val CLASS_REF_NUM_DIMENSIONS_DESCRIPTOR: MemoryChunkDescriptor
         IntType.v()
     )
 
+internal val CLASS_REF_SOOT_CLASS = Scene.v().getSootClass(CLASS_REF_CLASSNAME)
+
 internal val OBJECT_TYPE: RefType
     get() = Scene.v().getSootClass(Object::class.java.canonicalName).type
 internal val STRING_TYPE: RefType
     get() = Scene.v().getSootClass(String::class.java.canonicalName).type
 internal val CLASS_REF_TYPE: RefType
-    get() = Scene.v().getSootClass(CLASS_REF_CLASSNAME).type
+    get() = CLASS_REF_SOOT_CLASS.type
+
+internal val NEW_INSTANCE_SIGNATURE: String = CLASS_REF_SOOT_CLASS.getMethodByName("newInstance").subSignature
 
 internal val HASHCODE_SIGNATURE: String =
     Scene.v()

--- a/utbot-sample/src/main/java/org/utbot/examples/reflection/NewInstanceExample.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/reflection/NewInstanceExample.java
@@ -1,0 +1,16 @@
+package org.utbot.examples.reflection;
+
+public class NewInstanceExample {
+    @SuppressWarnings("deprecation")
+    int createWithReflectionExample() throws ClassNotFoundException, InstantiationException, IllegalAccessException {
+        Class<?> cls = Class.forName("org.utbot.examples.reflection.ClassWithDefaultConstructor");
+        ClassWithDefaultConstructor classWithDefaultConstructor = (ClassWithDefaultConstructor) cls.newInstance();
+
+        return classWithDefaultConstructor.x;
+    }
+}
+
+class ClassWithDefaultConstructor {
+
+    int x;
+}


### PR DESCRIPTION
# Description

Added symbolic processing of `newInstance` reflection call.

Fixes #1538.

## Type of Change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Regression and integration tests

Not applicable.

## Automated Testing

`org.utbot.examples.reflection.NewInstanceExampleTest`.

## Manual Scenario 

Tested on the closed customer project.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] New tests have been added
- [x] All tests pass locally with my changes
