### PR TITLE
Added plugin setting for experimental languages: Python, JavaScript, Go

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/Settings.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/Settings.kt
@@ -63,7 +63,8 @@ class Settings(val project: Project) : PersistentStateComponent<Settings.State> 
         var fuzzingValue: Double = 0.05,
         var runGeneratedTestsWithCoverage: Boolean = false,
         var commentStyle: JavaDocCommentStyle = JavaDocCommentStyle.defaultItem,
-        var enableSummariesGeneration: Boolean = UtSettings.enableSummariesGeneration
+        var enableSummariesGeneration: Boolean = UtSettings.enableSummariesGeneration,
+        var enableExperimentalLanguagesSupport: Boolean = false,
     ) {
         constructor(model: GenerateTestsModel) : this(
             sourceRootHistory = model.sourceRootHistory,
@@ -154,6 +155,8 @@ class Settings(val project: Project) : PersistentStateComponent<Settings.State> 
     val runInspectionAfterTestGeneration: Boolean get() = state.runInspectionAfterTestGeneration
 
     val forceStaticMocking: ForceStaticMocking get() = state.forceStaticMocking
+
+    val experimentalLanguagesSupport: Boolean get () = state.enableExperimentalLanguagesSupport
 
     val treatOverflowAsError: TreatOverflowAsError get() = state.treatOverflowAsError
 

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/SettingsWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/SettingsWindow.kt
@@ -18,11 +18,6 @@ import com.intellij.ui.layout.withValueBinding
 import com.intellij.util.castSafelyTo
 import com.intellij.util.ui.UIUtil
 import com.intellij.util.ui.components.BorderLayoutPanel
-import javax.swing.DefaultComboBoxModel
-import javax.swing.JCheckBox
-import javax.swing.JPanel
-import javax.swing.JSlider
-import kotlin.reflect.KClass
 import org.utbot.framework.UtSettings
 import org.utbot.framework.codegen.domain.ForceStaticMocking
 import org.utbot.framework.codegen.domain.HangingTestsTimeout
@@ -34,6 +29,11 @@ import org.utbot.framework.plugin.api.TreatOverflowAsError
 import org.utbot.framework.plugin.api.isSummarizationCompatible
 import org.utbot.intellij.plugin.ui.components.CodeGenerationSettingItemRenderer
 import org.utbot.intellij.plugin.util.showSettingsEditor
+import javax.swing.DefaultComboBoxModel
+import javax.swing.JCheckBox
+import javax.swing.JPanel
+import javax.swing.JSlider
+import kotlin.reflect.KClass
 
 class SettingsWindow(val project: Project) {
     private val settings = project.service<Settings>()
@@ -44,6 +44,7 @@ class SettingsWindow(val project: Project) {
     private lateinit var runInspectionAfterTestGenerationCheckBox: JCheckBox
     private lateinit var forceMockCheckBox: JCheckBox
     private lateinit var enableSummarizationGenerationCheckBox: JCheckBox
+    private lateinit var enableExperimentalLanguagesCheckBox: JCheckBox
 
     val panel: JPanel = panel {
         row("Generated test language:") {
@@ -160,6 +161,19 @@ class SettingsWindow(val project: Project) {
                     .onReset { forceMockCheckBox.isSelected = settings.forceStaticMocking == ForceStaticMocking.FORCE }
                     .onIsModified { forceMockCheckBox.isSelected xor (settings.forceStaticMocking != ForceStaticMocking.DO_NOT_FORCE) }
                     .apply { ContextHelpLabel.create("Overrides other mocking settings")() }
+                    .component
+            }
+        }
+
+        row {
+            cell {
+                enableExperimentalLanguagesCheckBox = checkBox("Experimental languages support")
+                    .onApply {
+                        settings.state.enableExperimentalLanguagesSupport = enableExperimentalLanguagesCheckBox.isSelected
+                    }
+                    .onReset { enableExperimentalLanguagesCheckBox.isSelected = settings.experimentalLanguagesSupport == true }
+                    .onIsModified { enableExperimentalLanguagesCheckBox.isSelected xor settings.experimentalLanguagesSupport }
+                    .apply { ContextHelpLabel.create("Enable Python, JavaScript, Go support")() }
                     .component
             }
         }

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/actions/GenerateTestsAction.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/actions/GenerateTestsAction.kt
@@ -2,7 +2,9 @@ package org.utbot.intellij.plugin.ui.actions
 
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.components.service
 import org.utbot.intellij.plugin.language.agnostic.LanguageAssistant
+import org.utbot.intellij.plugin.settings.Settings
 
 class GenerateTestsAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
@@ -11,10 +13,16 @@ class GenerateTestsAction : AnAction() {
 
     override fun update(e: AnActionEvent) {
         val languageAssistant = LanguageAssistant.get(e)
-        if (languageAssistant == null) {
+        if (languageAssistant == null || !accessByProjectSettings(e)) {
             e.presentation.isEnabled = false
         } else {
             languageAssistant.update(e)
         }
+    }
+
+    private fun accessByProjectSettings(e: AnActionEvent): Boolean {
+        val experimentalLanguageSetting = e.project?.service<Settings>()?.experimentalLanguagesSupport
+        val languagePackageName = LanguageAssistant.get(e)?.toString()
+        return experimentalLanguageSetting == true || languagePackageName?.contains("JvmLanguageAssistant") == true
     }
 }

--- a/utbot-js/src/main/kotlin/api/JsUtModelConstructor.kt
+++ b/utbot-js/src/main/kotlin/api/JsUtModelConstructor.kt
@@ -1,12 +1,5 @@
 package api
 
-import fuzzer.providers.JsObjectModelProvider
-import org.utbot.framework.concrete.contructors.UtModelConstructorInterface
-import org.utbot.framework.plugin.api.ClassId
-import org.utbot.framework.plugin.api.UtAssembleModel
-import org.utbot.framework.plugin.api.UtExecutableCallModel
-import org.utbot.framework.plugin.api.UtModel
-import org.utbot.framework.plugin.api.UtStatementModel
 import framework.api.js.JsClassId
 import framework.api.js.JsEmptyClassId
 import framework.api.js.JsNullModel
@@ -14,6 +7,12 @@ import framework.api.js.JsPrimitiveModel
 import framework.api.js.JsUndefinedModel
 import framework.api.js.util.jsErrorClassId
 import framework.api.js.util.jsUndefinedClassId
+import fuzzer.providers.JsObjectModelProvider
+import org.utbot.framework.concrete.constructors.UtModelConstructorInterface
+import org.utbot.framework.plugin.api.ClassId
+import org.utbot.framework.plugin.api.UtAssembleModel
+import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtModel
 
 class JsUtModelConstructor : UtModelConstructorInterface {
 

--- a/utbot-js/src/main/kotlin/fuzzer/providers/JsObjectModelProvider.kt
+++ b/utbot-js/src/main/kotlin/fuzzer/providers/JsObjectModelProvider.kt
@@ -11,8 +11,8 @@ import org.utbot.fuzzer.FuzzedParameter
 import org.utbot.fuzzer.FuzzedValue
 import org.utbot.fuzzer.ModelProvider
 import org.utbot.fuzzer.ModelProvider.Companion.yieldValue
-import org.utbot.fuzzer.TooManyCombinationsException
 import org.utbot.fuzzer.fuzz
+import org.utbot.fuzzing.utils.TooManyCombinationsException
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.IntSupplier
 


### PR DESCRIPTION
# Description

Added a setting to disable test generation and appearance of the plugin window for experimental languages: Python, JS, Go, etc.

Implement #1542

## Type of Change
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Manually

## Manual Scenario 

* When disabling the plugin setting to support experimental languages, tests for Python, JavaScript, Go, etc. are not generated, the plugin window does not appear
* When this setting is enabled, the plugin window appears for all supported languages
* Experimental languages are disabled by default
* This setting does not affect Kotlin and Java

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
