### PR TITLE
Fuzzing breaks on nested classes #1537

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
@@ -339,7 +339,7 @@ class UtBotSymbolicEngine(
         var attempts = 0
         val attemptsLimit = UtSettings.fuzzingMaxAttempts
         val names = graph.body.method.tags.filterIsInstance<ParamNamesTag>().firstOrNull()?.names ?: emptyList()
-
+        var testEmittedByFuzzer = 0
         runJavaFuzzing(
             defaultIdGenerator,
             methodUnderTest,
@@ -349,6 +349,7 @@ class UtBotSymbolicEngine(
         ) { thisInstance, descr, values ->
             if (controller.job?.isActive == false || System.currentTimeMillis() >= until) {
                 logger.info { "Fuzzing overtime: $methodUnderTest" }
+                logger.info { "Test created by fuzzer: $testEmittedByFuzzer" }
                 return@runJavaFuzzing BaseFeedback(result = Trie.emptyNode(), control = Control.STOP)
             }
 
@@ -404,6 +405,7 @@ class UtBotSymbolicEngine(
                 )
             )
 
+            testEmittedByFuzzer++
             BaseFeedback(result = trieNode ?: Trie.emptyNode(), control = Control.CONTINUE)
         }
     }

--- a/utbot-fuzzers/src/test/java/org/utbot/fuzzing/samples/DeepNested.java
+++ b/utbot-fuzzers/src/test/java/org/utbot/fuzzing/samples/DeepNested.java
@@ -1,0 +1,14 @@
+package org.utbot.fuzzing.samples;
+
+public class DeepNested {
+    public class Nested1 {
+        public class Nested2 {
+            public int f(int i) {
+                if (i > 0) {
+                    return 10;
+                }
+                return 0;
+            }
+        }
+    }
+}

--- a/utbot-fuzzers/src/test/kotlin/org/utbot/fuzzing/JavaFuzzingTest.kt
+++ b/utbot-fuzzers/src/test/kotlin/org/utbot/fuzzing/JavaFuzzingTest.kt
@@ -3,15 +3,38 @@ package org.utbot.fuzzing
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.utbot.framework.plugin.api.MethodId
 import org.utbot.framework.plugin.api.TestIdentityPreservingIdGenerator
 import org.utbot.framework.plugin.api.UtPrimitiveModel
 import org.utbot.framework.plugin.api.util.*
 import org.utbot.fuzzer.FuzzedConcreteValue
+import org.utbot.fuzzing.samples.DeepNested
 import org.utbot.fuzzing.samples.Stubs
 import org.utbot.fuzzing.utils.Trie
 
 class JavaFuzzingTest {
+
+    @Test
+    fun `fuzzing doesn't throw an exception when type is unknown`() {
+        assertDoesNotThrow {
+            runBlockingWithContext {
+                runJavaFuzzing(
+                    TestIdentityPreservingIdGenerator,
+                    methodUnderTest = MethodId(
+                        DeepNested.Nested1.Nested2::class.id,
+                        "f",
+                        intClassId,
+                        listOf(intClassId)
+                    ),
+                    constants = emptyList(),
+                    names = emptyList(),
+                ) { _, _, _ ->
+                    Assertions.fail("This method is never called")
+                }
+            }
+        }
+    }
 
     @Test
     fun `string generates same values`() {


### PR DESCRIPTION
# Description

When fuzzing cannot create any value for the given type it finds then the exception "unknown type" is thrown. Because of this whole flow is canceled. With this PR `runFuzzing` processes any exception from fuzzing and logs it. Also, additional logs are added about fuzzing phases (#1122)

Fixes #1537

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

New test is added for the example from the issue:

`org.utbot.fuzzing.JavaFuzzingTest#fuzzing doesn't throw an exception when type is unknown`

## Manual Scenario 

Set symbolic/fuzzing ratio as 95/5 and run test generation for an example from the issue. 2 tests from symbolic should be generated. In the logs should be an entry like this:

```
08:21:16.711 | INFO  | JavaLanguage              | Fuzzing is stopped because of an error
java.lang.IllegalStateException: Unknown type: FuzzedType(classId=com.company.issues.DeepNested$Nested1$Nested2, generics=[])
```

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] New tests have been added
- [x] All tests pass locally with my changes
