### PR TITLE
Fix python coverage database bug with access to database directory

### DIFF
--- a/utbot-intellij-python/src/main/kotlin/org/utbot/intellij/plugin/language/python/PythonDialogProcessor.kt
+++ b/utbot-intellij-python/src/main/kotlin/org/utbot/intellij/plugin/language/python/PythonDialogProcessor.kt
@@ -233,7 +233,10 @@ object PythonDialogProcessor {
                     if (installResult.exitValue != 0) {
                         showErrorDialogLater(
                             project,
-                            "Requirements installing failed",
+                            "Requirements installing failed.<br>" +
+                                    "${installResult.stderr}<br><br>" +
+                                    "Try to install with pip:<br>" +
+                                    " ${requirements.joinToString("<br>")}",
                             "Requirements error"
                         )
                     }

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/actions/GenerateTestsAction.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/actions/GenerateTestsAction.kt
@@ -13,7 +13,7 @@ class GenerateTestsAction : AnAction() {
 
     override fun update(e: AnActionEvent) {
         val languageAssistant = LanguageAssistant.get(e)
-        if (languageAssistant == null) {
+        if (languageAssistant == null || !accessByProjectSettings(e)) {
             e.presentation.isEnabled = false
         } else {
             languageAssistant.update(e)

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/actions/GenerateTestsAction.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/actions/GenerateTestsAction.kt
@@ -13,7 +13,7 @@ class GenerateTestsAction : AnAction() {
 
     override fun update(e: AnActionEvent) {
         val languageAssistant = LanguageAssistant.get(e)
-        if (languageAssistant == null || !accessByProjectSettings(e)) {
+        if (languageAssistant == null) {
             e.presentation.isEnabled = false
         } else {
             languageAssistant.update(e)

--- a/utbot-python/src/main/kotlin/org/utbot/python/PythonEngine.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/PythonEngine.kt
@@ -177,11 +177,14 @@ class PythonEngine(
                 when(val evaluationResult = jobResult.evalResult) {
                     is PythonEvaluationError -> {
                         if (evaluationResult.status != 0) {
+                            val errorMessage = "Error evaluation: ${evaluationResult.status}, ${evaluationResult.message}"
+                            logger.info { "Python evaluation error: $errorMessage" }
                             yield(UtError(
-                                "Error evaluation: ${evaluationResult.status}, ${evaluationResult.message}",
+                                errorMessage,
                                 Throwable(evaluationResult.stackTrace.joinToString("\n"))
                             ))
                         } else {
+                            logger.info { "Python evaluation error: ${evaluationResult.message}" }
                             yield(
                                 UtError(
                                     evaluationResult.message,

--- a/utbot-python/src/main/kotlin/org/utbot/python/PythonEngine.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/PythonEngine.kt
@@ -177,8 +177,8 @@ class PythonEngine(
                 when(val evaluationResult = jobResult.evalResult) {
                     is PythonEvaluationError -> {
                         if (evaluationResult.status != 0) {
-                            val errorMessage = "Error evaluation: ${evaluationResult.status}, ${evaluationResult.message}"
-                            logger.info { "Python evaluation error: $errorMessage" }
+                            val errorMessage = "Error evaluation: ${evaluationResult.status}, ${evaluationResult.message}, ${evaluationResult.stackTrace}"
+                            logger.info { errorMessage }
                             yield(UtError(
                                 errorMessage,
                                 Throwable(evaluationResult.stackTrace.joinToString("\n"))

--- a/utbot-python/src/main/kotlin/org/utbot/python/PythonEvaluation.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/PythonEvaluation.kt
@@ -64,13 +64,18 @@ fun startEvaluationProcess(input: EvaluationInput): EvaluationProcess {
         tag = "out_" + input.method.name + ".py",
         addToCleaner = false
     )
+    val coverageDatabasePath = TemporaryFileManager.assignTemporaryFile(
+        tag = "coverage_db_" + input.method.name,
+        addToCleaner = false,
+    )
     val runCode = PythonCodeGenerator.generateRunFunctionCode(
         input.method,
         input.methodArguments,
         input.directoriesForSysPath,
         input.moduleToImport,
         input.additionalModulesToImport,
-        fileForOutput.path.replace("\\", "\\\\")
+        fileForOutput.path.replace("\\", "\\\\"),
+        coverageDatabasePath.absolutePath
     )
     val fileWithCode = TemporaryFileManager.createTemporaryFile(
         runCode,

--- a/utbot-python/src/main/kotlin/org/utbot/python/PythonEvaluation.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/PythonEvaluation.kt
@@ -1,7 +1,6 @@
 package org.utbot.python
 
 import com.beust.klaxon.Klaxon
-import mu.KotlinLogging
 import org.utbot.framework.plugin.api.Coverage
 import org.utbot.framework.plugin.api.Instruction
 import org.utbot.framework.plugin.api.UtModel
@@ -15,8 +14,6 @@ import org.utbot.python.utils.TemporaryFileManager
 import org.utbot.python.utils.getResult
 import org.utbot.python.utils.startProcess
 import java.io.File
-
-private val logger = KotlinLogging.logger {}
 
 sealed class PythonEvaluationResult
 
@@ -115,14 +112,7 @@ fun calculateCoverage(statements: List<Int>, missedStatements: List<Int>, input:
 }
 
 fun getEvaluationResult(input: EvaluationInput, process: EvaluationProcess, timeout: Long): PythonEvaluationResult {
-    logger.info("Start evaluation ${input.method.name} with ${input.methodArguments}")
     val result = getResult(process.process, timeout = timeout)
-    logger.info(
-        "Evaluation with arguments ${input.methodArguments} finished; " +
-        "Exit value: ${result.exitValue}; " +
-        "Stdout: ${result.stdout}; " +
-        "Stderr: ${result.stderr}"
-    )
     process.fileWithCode.delete()
 
     if (result.terminatedByTimeout)
@@ -146,8 +136,6 @@ fun getEvaluationResult(input: EvaluationInput, process: EvaluationProcess, time
         )
 
     val status = output[0]
-
-    logger.info("Evaluation status: $status")
 
     if (status != PythonCodeGenerator.successStatus && status != PythonCodeGenerator.failStatus)
         return PythonEvaluationError(

--- a/utbot-python/src/main/kotlin/org/utbot/python/PythonEvaluation.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/PythonEvaluation.kt
@@ -77,7 +77,7 @@ fun startEvaluationProcess(input: EvaluationInput): EvaluationProcess {
         input.moduleToImport,
         input.additionalModulesToImport,
         fileForOutput.path.replace("\\", "\\\\"),
-        coverageDatabasePath.absolutePath
+        coverageDatabasePath.absolutePath.replace("\\", "\\\\")
     )
     val fileWithCode = TemporaryFileManager.createTemporaryFile(
         runCode,

--- a/utbot-python/src/main/kotlin/org/utbot/python/PythonEvaluation.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/PythonEvaluation.kt
@@ -1,6 +1,7 @@
 package org.utbot.python
 
 import com.beust.klaxon.Klaxon
+import mu.KotlinLogging
 import org.utbot.framework.plugin.api.Coverage
 import org.utbot.framework.plugin.api.Instruction
 import org.utbot.framework.plugin.api.UtModel
@@ -15,6 +16,7 @@ import org.utbot.python.utils.getResult
 import org.utbot.python.utils.startProcess
 import java.io.File
 
+private val logger = KotlinLogging.logger {}
 
 sealed class PythonEvaluationResult
 
@@ -113,7 +115,14 @@ fun calculateCoverage(statements: List<Int>, missedStatements: List<Int>, input:
 }
 
 fun getEvaluationResult(input: EvaluationInput, process: EvaluationProcess, timeout: Long): PythonEvaluationResult {
+    logger.info("Start evaluation ${input.method.name} with ${input.methodArguments}")
     val result = getResult(process.process, timeout = timeout)
+    logger.info {
+        "Evaluation with arguments ${input.methodArguments} finished:"
+        "Exit value: ${result.exitValue}"
+        "Stdout: ${result.stdout}"
+        "Stderr: ${result.stderr}"
+    }
     process.fileWithCode.delete()
 
     if (result.terminatedByTimeout)

--- a/utbot-python/src/main/kotlin/org/utbot/python/PythonEvaluation.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/PythonEvaluation.kt
@@ -117,12 +117,12 @@ fun calculateCoverage(statements: List<Int>, missedStatements: List<Int>, input:
 fun getEvaluationResult(input: EvaluationInput, process: EvaluationProcess, timeout: Long): PythonEvaluationResult {
     logger.info("Start evaluation ${input.method.name} with ${input.methodArguments}")
     val result = getResult(process.process, timeout = timeout)
-    logger.info {
-        "Evaluation with arguments ${input.methodArguments} finished:"
-        "Exit value: ${result.exitValue}"
-        "Stdout: ${result.stdout}"
+    logger.info(
+        "Evaluation with arguments ${input.methodArguments} finished; " +
+        "Exit value: ${result.exitValue}; " +
+        "Stdout: ${result.stdout}; " +
         "Stderr: ${result.stderr}"
-    }
+    )
     process.fileWithCode.delete()
 
     if (result.terminatedByTimeout)
@@ -146,6 +146,8 @@ fun getEvaluationResult(input: EvaluationInput, process: EvaluationProcess, time
         )
 
     val status = output[0]
+
+    logger.info("Evaluation status: $status")
 
     if (status != PythonCodeGenerator.successStatus && status != PythonCodeGenerator.failStatus)
         return PythonEvaluationError(

--- a/utbot-python/src/main/kotlin/org/utbot/python/code/CodeGen.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/code/CodeGen.kt
@@ -20,7 +20,8 @@ object PythonCodeGenerator {
         directoriesForSysPath: Set<String>,
         moduleToImport: String,
         additionalModules: Set<String> = emptySet(),
-        fileForOutputName: String
+        fileForOutputName: String,
+        coverageDatabasePath: String,
     ): String {
         val context = UtContext(this::class.java.classLoader)
         withUtContext(context) {
@@ -36,7 +37,8 @@ object PythonCodeGenerator {
                 directoriesForSysPath,
                 moduleToImport,
                 additionalModules,
-                fileForOutputName
+                fileForOutputName,
+                coverageDatabasePath,
             )
         }
     }

--- a/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/PythonCodeGenerator.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/PythonCodeGenerator.kt
@@ -104,7 +104,8 @@ class PythonCodeGenerator(
         directoriesForSysPath: Set<String>,
         moduleToImport: String,
         additionalModules: Set<String> = emptySet(),
-        fileForOutputName: String
+        fileForOutputName: String,
+        coverageDatabasePath: String,
     ): String {
         val cgRendererContext = CgRendererContext.fromCgContext(context)
         val printer = CgPrinterImpl()
@@ -144,13 +145,14 @@ class PythonCodeGenerator(
         )
 
         val fullpath = CgLiteral(pythonStrClassId, "'${method.moduleFilename}'")
-
         val outputPath = CgLiteral(pythonStrClassId, "'$fileForOutputName'")
+        val databasePath = CgLiteral(pythonStrClassId, "'$coverageDatabasePath'")
 
         val executorCall = CgPythonFunctionCall(
             pythonNoneClassId,
             executorFunctionName,
             listOf(
+                databasePath,
                 functionName,
                 args,
                 kwargs,

--- a/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/PythonCodeGenerator.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/PythonCodeGenerator.kt
@@ -144,7 +144,7 @@ class PythonCodeGenerator(
             arguments.associateBy { argument -> CgLiteral(pythonStrClassId, "'${argument.name}'") }
         )
 
-        val fullpath = CgLiteral(pythonStrClassId, "'${method.moduleFilename}'")
+        val fullpath = CgLiteral(pythonStrClassId, "'${method.moduleFilename.replace("\\", "\\\\")}'")
         val outputPath = CgLiteral(pythonStrClassId, "'$fileForOutputName'")
         val databasePath = CgLiteral(pythonStrClassId, "'$coverageDatabasePath'")
 

--- a/utbot-python/src/main/kotlin/org/utbot/python/utils/TemporaryFileManager.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/utils/TemporaryFileManager.kt
@@ -12,6 +12,7 @@ object TemporaryFileManager {
 
     fun setup() {
         tmpDirectory = FileUtil.createTempDirectory("python-test-generation-${nextId++}")
+        Cleaner.addFunction { tmpDirectory.toFile().listFiles()?.forEach { it.delete() } }
         Cleaner.addFunction { tmpDirectory.deleteExisting() }
     }
 

--- a/utbot-python/src/main/kotlin/org/utbot/python/utils/TemporaryFileManager.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/utils/TemporaryFileManager.kt
@@ -4,7 +4,6 @@ import org.utbot.common.FileUtil
 import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
-import kotlin.io.path.deleteExisting
 
 object TemporaryFileManager {
     private lateinit var tmpDirectory: Path
@@ -12,8 +11,7 @@ object TemporaryFileManager {
 
     fun setup() {
         tmpDirectory = FileUtil.createTempDirectory("python-test-generation-${nextId++}")
-        Cleaner.addFunction { tmpDirectory.toFile().listFiles()?.forEach { it.delete() } }
-        Cleaner.addFunction { tmpDirectory.deleteExisting() }
+        Cleaner.addFunction { tmpDirectory.toFile().deleteRecursively() }
     }
 
     fun assignTemporaryFile(fileName_: String? = null, tag: String? = null, addToCleaner: Boolean = true): File {

--- a/utbot-python/src/main/resources/requirements.txt
+++ b/utbot-python/src/main/resources/requirements.txt
@@ -2,4 +2,4 @@ mypy==0.971
 astor
 typeshed-client
 coverage
-utbot-executor==0.1.6
+utbot-executor==0.1.7

--- a/utbot-python/src/main/resources/requirements.txt
+++ b/utbot-python/src/main/resources/requirements.txt
@@ -1,5 +1,5 @@
-mypy==0.971
+mypy>=0.971
 astor
 typeshed-client
 coverage
-utbot-executor
+utbot-executor==0.1.4

--- a/utbot-python/src/main/resources/requirements.txt
+++ b/utbot-python/src/main/resources/requirements.txt
@@ -1,5 +1,5 @@
 mypy==0.971
 astor
 typeshed-client
-coverage==7.0.0
+coverage
 utbot-executor==0.1.6

--- a/utbot-python/src/main/resources/requirements.txt
+++ b/utbot-python/src/main/resources/requirements.txt
@@ -1,5 +1,5 @@
-mypy>=0.971
+mypy==0.971
 astor
 typeshed-client
-coverage
-utbot-executor==0.1.4
+coverage==7.0.0
+utbot-executor==0.1.6


### PR DESCRIPTION
# Description

Fix bug with database path in python module `coverage`. Now we create database in temporary directory with other python files.

__Note:__ See #1542

Fixes #1478

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

See https://github.com/UnitTestBot/UTBotJava/issues/1478 steps 1-8 with plugin from [this build](https://github.com/UnitTestBot/UTBotJava/actions/runs/3739306191)

Expected result: generated tests, for example:

```python
import sys
sys.path.append('..')
import builtins
import types
import sample
import unittest


class TestTopLevelFunctions(unittest.TestCase):
    # region Test suites for executable sample.print_hi
    
    # region
    
    def test_print_hi(self):
        actual = sample.print_hi((1 << 100))
        
        self.assertEqual(None, actual)
    
    def test_print_hi_throws_t(self):
        sample.print_hi(str(b'\xf0\xa3\x91\x96', 'utf-8'))
        
        # raises builtins.UnicodeEncodeError
    # endregion
    
    # endregion
    
    # region Test suites for executable sample.div
    
    # region
    
    def test_div(self):
        actual = sample.div(1, 1)
        
        self.assertEqual(1.0, actual)
    # endregion
    
    # endregion
```

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [x] All tests pass locally with my changes
