### PR TITLE
Collect all necessary system paths for import other modules  

### DIFF
--- a/utbot-intellij-python/src/main/kotlin/org/utbot/intellij/plugin/language/python/PythonDialogProcessor.kt
+++ b/utbot-intellij-python/src/main/kotlin/org/utbot/intellij/plugin/language/python/PythonDialogProcessor.kt
@@ -271,6 +271,20 @@ fun getDirectoriesForSysPath(
     if (ancestor != null && !sources.contains(ancestor))
         sources.add(ancestor)
 
+    // Collect sys.path directories with imported modules
+    file.importTargets.forEach { importTarget ->
+        importTarget.multiResolve().forEach {
+            val element = it.element
+            if (element != null) {
+                val directory = element.parent
+                if (directory is PsiDirectory) {
+                    sources.add(directory.virtualFile)
+                }
+            }
+
+        }
+    }
+
     var importPath = ancestor?.let { VfsUtil.getParentDir(VfsUtilCore.getRelativeLocation(file.virtualFile, it)) } ?: ""
     if (importPath != "")
         importPath += "."


### PR DESCRIPTION
# Description

Now sys.path contains path to testing file and paths to all imported modules. Due to this we can generate test if function uses import from another file.

Fixes #1562

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

1. Create module (directory) `mod1`
2. Create two files `mod1/a.py`, `mod1/b.py`
3. Put this code:
```python
# file a
def sum(a, b):
    return a + b

#-------------------------------------------------
# file b
import a  # not <from mod1 import a>


def double_sum(n):
    return a.sum(n, n)
```
4. Try to generate tests for `double_sum` function

__Possible result__
![sHIjbVSfCE](https://user-images.githubusercontent.com/23080942/209075056-7f5987c9-dedf-427d-a67c-182f3aaa3952.png)

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] No new warnings
- [ ] All tests pass locally with my changes
