### PR TITLE
New treating of artificial errors

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/math/OverflowAsErrorTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/math/OverflowAsErrorTest.kt
@@ -2,6 +2,7 @@ package org.utbot.examples.math
 
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.utbot.engine.OverflowDetectionError
 import org.utbot.examples.algorithms.Sort
 import org.utbot.framework.plugin.api.CodegenLanguage
 import org.utbot.testcheckers.eq
@@ -31,8 +32,8 @@ internal class OverflowAsErrorTest : UtValueTestCaseChecker(
             checkWithException(
                 OverflowExamples::intOverflow,
                 eq(5),
-                { x, _, r -> x * x * x <= 0 && x > 0 && r.isException<ArithmeticException>() }, // through overflow
-                { x, _, r -> x * x * x <= 0 && x > 0 && r.isException<ArithmeticException>() }, // through overflow (2nd '*')
+                { x, _, r -> x * x * x <= 0 && x > 0 && r.isException<OverflowDetectionError>() }, // through overflow
+                { x, _, r -> x * x * x <= 0 && x > 0 && r.isException<OverflowDetectionError>() }, // through overflow (2nd '*')
                 { x, _, r -> x * x * x >= 0 && x >= 0 && r.getOrNull() == 0 },
                 { x, y, r -> x * x * x > 0 && x > 0 && y == 10 && r.getOrNull() == 1 },
                 { x, y, r -> x * x * x > 0 && x > 0 && y != 10 && r.getOrNull() == 0 },
@@ -47,11 +48,11 @@ internal class OverflowAsErrorTest : UtValueTestCaseChecker(
             checkWithException(
                 OverflowExamples::byteAddOverflow,
                 eq(2),
-                { _, _, r -> !r.isException<ArithmeticException>() },
+                { _, _, r -> !r.isException<OverflowDetectionError>() },
                 { x, y, r ->
                     val negOverflow = ((x + y).toByte() >= 0 && x < 0 && y < 0)
                     val posOverflow = ((x + y).toByte() <= 0 && x > 0 && y > 0)
-                    (negOverflow || posOverflow) && r.isException<ArithmeticException>()
+                    (negOverflow || posOverflow) && r.isException<OverflowDetectionError>()
                 }, // through overflow
             )
         }
@@ -63,11 +64,11 @@ internal class OverflowAsErrorTest : UtValueTestCaseChecker(
             checkWithException(
                 OverflowExamples::byteSubOverflow,
                 eq(2),
-                { _, _, r -> !r.isException<ArithmeticException>() },
+                { _, _, r -> !r.isException<OverflowDetectionError>() },
                 { x, y, r ->
                     val negOverflow = ((x - y).toByte() >= 0 && x < 0 && y > 0)
                     val posOverflow = ((x - y).toByte() <= 0 && x > 0 && y < 0)
-                    (negOverflow || posOverflow) && r.isException<ArithmeticException>()
+                    (negOverflow || posOverflow) && r.isException<OverflowDetectionError>()
                 }, // through overflow
             )
         }
@@ -79,8 +80,8 @@ internal class OverflowAsErrorTest : UtValueTestCaseChecker(
             checkWithException(
                 OverflowExamples::byteMulOverflow,
                 eq(2),
-                { _, _, r -> !r.isException<ArithmeticException>() },
-                { _, _, r -> r.isException<ArithmeticException>() }, // through overflow
+                { _, _, r -> !r.isException<OverflowDetectionError>() },
+                { _, _, r -> r.isException<OverflowDetectionError>() }, // through overflow
             )
         }
     }
@@ -91,11 +92,11 @@ internal class OverflowAsErrorTest : UtValueTestCaseChecker(
             checkWithException(
                 OverflowExamples::shortAddOverflow,
                 eq(2),
-                { _, _, r -> !r.isException<ArithmeticException>() },
+                { _, _, r -> !r.isException<OverflowDetectionError>() },
                 { x, y, r ->
                     val negOverflow = ((x + y).toShort() >= 0 && x < 0 && y < 0)
                     val posOverflow = ((x + y).toShort() <= 0 && x > 0 && y > 0)
-                    (negOverflow || posOverflow) && r.isException<ArithmeticException>()
+                    (negOverflow || posOverflow) && r.isException<OverflowDetectionError>()
                 }, // through overflow
             )
         }
@@ -107,11 +108,11 @@ internal class OverflowAsErrorTest : UtValueTestCaseChecker(
             checkWithException(
                 OverflowExamples::shortSubOverflow,
                 eq(2),
-                { _, _, r -> !r.isException<ArithmeticException>() },
+                { _, _, r -> !r.isException<OverflowDetectionError>() },
                 { x, y, r ->
                     val negOverflow = ((x - y).toShort() >= 0 && x < 0 && y > 0)
                     val posOverflow = ((x - y).toShort() <= 0 && x > 0 && y < 0)
-                    (negOverflow || posOverflow) && r.isException<ArithmeticException>()
+                    (negOverflow || posOverflow) && r.isException<OverflowDetectionError>()
                 }, // through overflow
             )
         }
@@ -123,8 +124,8 @@ internal class OverflowAsErrorTest : UtValueTestCaseChecker(
             checkWithException(
                 OverflowExamples::shortMulOverflow,
                 eq(2),
-                { _, _, r -> !r.isException<ArithmeticException>() },
-                { _, _, r -> r.isException<ArithmeticException>() }, // through overflow
+                { _, _, r -> !r.isException<OverflowDetectionError>() },
+                { _, _, r -> r.isException<OverflowDetectionError>() }, // through overflow
             )
         }
     }
@@ -135,11 +136,11 @@ internal class OverflowAsErrorTest : UtValueTestCaseChecker(
             checkWithException(
                 OverflowExamples::intAddOverflow,
                 eq(2),
-                { _, _, r -> !r.isException<ArithmeticException>() },
+                { _, _, r -> !r.isException<OverflowDetectionError>() },
                 { x, y, r ->
                     val negOverflow = ((x + y) >= 0 && x < 0 && y < 0)
                     val posOverflow = ((x + y) <= 0 && x > 0 && y > 0)
-                    (negOverflow || posOverflow) && r.isException<ArithmeticException>()
+                    (negOverflow || posOverflow) && r.isException<OverflowDetectionError>()
                 }, // through overflow
             )
         }
@@ -151,11 +152,11 @@ internal class OverflowAsErrorTest : UtValueTestCaseChecker(
             checkWithException(
                 OverflowExamples::intSubOverflow,
                 eq(2),
-                { _, _, r -> !r.isException<ArithmeticException>() },
+                { _, _, r -> !r.isException<OverflowDetectionError>() },
                 { x, y, r ->
                     val negOverflow = ((x - y) >= 0 && x < 0 && y > 0)
                     val posOverflow = ((x - y) <= 0 && x > 0 && y < 0)
-                    (negOverflow || posOverflow) && r.isException<ArithmeticException>()
+                    (negOverflow || posOverflow) && r.isException<OverflowDetectionError>()
                 }, // through overflow
             )
         }
@@ -171,8 +172,8 @@ internal class OverflowAsErrorTest : UtValueTestCaseChecker(
                 checkWithException(
                     OverflowExamples::intMulOverflow,
                     eq(2),
-                    { _, _, r -> !r.isException<ArithmeticException>() },
-                    { _, _, r -> r.isException<ArithmeticException>() }, // through overflow
+                    { _, _, r -> !r.isException<OverflowDetectionError>() },
+                    { _, _, r -> r.isException<OverflowDetectionError>() }, // through overflow
                 )
             }
         }
@@ -184,11 +185,11 @@ internal class OverflowAsErrorTest : UtValueTestCaseChecker(
             checkWithException(
                 OverflowExamples::longAddOverflow,
                 eq(2),
-                { _, _, r -> !r.isException<ArithmeticException>() },
+                { _, _, r -> !r.isException<OverflowDetectionError>() },
                 { x, y, r ->
                     val negOverflow = ((x + y) >= 0 && x < 0 && y < 0)
                     val posOverflow = ((x + y) <= 0 && x > 0 && y > 0)
-                    (negOverflow || posOverflow) && r.isException<ArithmeticException>()
+                    (negOverflow || posOverflow) && r.isException<OverflowDetectionError>()
                 }, // through overflow
             )
         }
@@ -200,11 +201,11 @@ internal class OverflowAsErrorTest : UtValueTestCaseChecker(
             checkWithException(
                 OverflowExamples::longSubOverflow,
                 eq(2),
-                { _, _, r -> !r.isException<ArithmeticException>() },
+                { _, _, r -> !r.isException<OverflowDetectionError>() },
                 { x, y, r ->
                     val negOverflow = ((x - y) >= 0 && x < 0 && y > 0)
                     val posOverflow = ((x - y) <= 0 && x > 0 && y < 0)
-                    (negOverflow || posOverflow) && r.isException<ArithmeticException>()
+                    (negOverflow || posOverflow) && r.isException<OverflowDetectionError>()
                 }, // through overflow
             )
         }
@@ -221,8 +222,8 @@ internal class OverflowAsErrorTest : UtValueTestCaseChecker(
                 checkWithException(
                     OverflowExamples::longMulOverflow,
                     eq(2),
-                    { _, _, r -> !r.isException<ArithmeticException>() },
-                    { _, _, r -> r.isException<ArithmeticException>() }, // through overflow
+                    { _, _, r -> !r.isException<OverflowDetectionError>() },
+                    { _, _, r -> r.isException<OverflowDetectionError>() }, // through overflow
                 )
             }
         }
@@ -234,8 +235,8 @@ internal class OverflowAsErrorTest : UtValueTestCaseChecker(
             checkWithException(
                 OverflowExamples::incOverflow,
                 eq(2),
-                { _, r -> !r.isException<ArithmeticException>() },
-                { _, r -> r.isException<ArithmeticException>() }, // through overflow
+                { _, r -> !r.isException<OverflowDetectionError>() },
+                { _, r -> r.isException<OverflowDetectionError>() }, // through overflow
             )
         }
     }
@@ -251,8 +252,8 @@ internal class OverflowAsErrorTest : UtValueTestCaseChecker(
                 // Can't use abs(x) below, because abs(Int.MIN_VALUE) == Int.MIN_VALUE.
                 // (Int.MAX_VALUE shr 16) is the border of square overflow and cube overflow.
                 // Int.MAX_VALUE.toDouble().pow(1/3.toDouble())
-                { x, r -> (x > -sqrtIntMax && x < sqrtIntMax) && r.isException<ArithmeticException>() }, // through overflow
-                { x, r -> (x <= -sqrtIntMax || x >= sqrtIntMax) && r.isException<ArithmeticException>() }, // through overflow
+                { x, r -> (x > -sqrtIntMax && x < sqrtIntMax) && r.isException<OverflowDetectionError>() }, // through overflow
+                { x, r -> (x <= -sqrtIntMax || x >= sqrtIntMax) && r.isException<OverflowDetectionError>() }, // through overflow
             )
         }
     }
@@ -265,8 +266,8 @@ internal class OverflowAsErrorTest : UtValueTestCaseChecker(
             checkWithException(
                 Sort::quickSort,
                 ignoreExecutionsNumber,
-                { _, _, _, r -> !r.isException<ArithmeticException>() },
-                { _, _, _, r -> r.isException<ArithmeticException>() }, // through overflow
+                { _, _, _, r -> !r.isException<OverflowDetectionError>() },
+                { _, _, _, r -> r.isException<OverflowDetectionError>() }, // through overflow
             )
         }
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ArtificialErrors.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ArtificialErrors.kt
@@ -1,0 +1,18 @@
+package org.utbot.engine
+
+/**
+ * Represents an error that may be detected or not
+ * during analysis in accordance with custom settings.
+ *
+ * Usually execution may be continued somehow after such error,
+ * but the result may be different from basic expectations.
+ */
+sealed class ArtificialError(message: String): Error(message)
+
+/**
+ * Represents overflow detection errors in symbolic engine,
+ * if a mode to detect them is turned on.
+ *
+ * See [TraversalContext.intOverflowCheck] for more details.
+ */
+class OverflowDetectionError(message: String): ArtificialError(message)

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/DataClasses.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/DataClasses.kt
@@ -63,11 +63,11 @@ fun explicitThrown(exception: Throwable, addr: UtAddrExpression, inNestedMethod:
 /**
  * Implicitly thrown exception. There are no difference if it happens in nested call or not.
  */
-fun implicitThrown(exception: Throwable, addr: UtAddrExpression, inNestedMethod: Boolean) =
-    SymbolicFailure(symbolic(exception, addr), exception, explicit = false, inNestedMethod = inNestedMethod)
+fun implicitThrown(throwable: Throwable, addr: UtAddrExpression, inNestedMethod: Boolean) =
+    SymbolicFailure(symbolic(throwable, addr), throwable, explicit = false, inNestedMethod = inNestedMethod)
 
-private fun symbolic(exception: Throwable, addr: UtAddrExpression) =
-    objectValue(Scene.v().getRefType(exception.javaClass.canonicalName), addr, ThrowableWrapper(exception))
+private fun symbolic(throwable: Throwable, addr: UtAddrExpression) =
+    objectValue(Scene.v().getRefType(throwable.javaClass.canonicalName), addr, ThrowableWrapper(throwable))
 
 private fun extractConcrete(symbolic: SymbolicValue) =
     (symbolic.asWrapperOrNull as? ThrowableWrapper)?.throwable

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Resolver.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Resolver.kt
@@ -390,10 +390,9 @@ class Resolver(
         return if (explicit) {
             UtExplicitlyThrownException(exception, inNestedMethod)
         } else {
-            when {
-                // TODO SAT-1561
-                exception is ArithmeticException && exception.message?.contains("overflow") == true -> UtOverflowFailure(exception)
-                exception is AccessControlException -> UtSandboxFailure(exception)
+            when (exception) {
+                is OverflowDetectionError -> UtOverflowFailure(exception)
+                is AccessControlException -> UtSandboxFailure(exception)
                 else -> UtImplicitlyThrownException(exception, inNestedMethod)
             }
         }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
@@ -178,6 +178,7 @@ abstract class TestFramework(
     abstract val mainPackage: String
     abstract val assertionsClass: ClassId
     abstract val arraysAssertionsClass: ClassId
+    abstract val kotlinFailureAssertionsClass: ClassId
     abstract val testAnnotation: String
     abstract val testAnnotationId: ClassId
     abstract val testAnnotationFqn: String
@@ -226,10 +227,18 @@ abstract class TestFramework(
 
     val assertNotEquals by lazy { assertionId("assertNotEquals", objectClassId, objectClassId) }
 
+    val fail by lazy { assertionId("fail", objectClassId) }
+
+    val kotlinFail by lazy { kotlinFailAssertionId("fail", objectClassId) }
+
     protected open fun assertionId(name: String, vararg params: ClassId): MethodId =
         builtinStaticMethodId(assertionsClass, name, voidClassId, *params)
+
     private fun arrayAssertionId(name: String, vararg params: ClassId): MethodId =
         builtinStaticMethodId(arraysAssertionsClass, name, voidClassId, *params)
+
+    private fun kotlinFailAssertionId(name: String, vararg params: ClassId): MethodId =
+        builtinStaticMethodId(kotlinFailureAssertionsClass, name, voidClassId, *params)
 
     abstract fun getRunTestsCommand(
         executionInvoke: String,
@@ -271,6 +280,8 @@ object TestNg : TestFramework(id = "TestNG",displayName = "TestNG") {
         canonicalName = TEST_NG_ARRAYS_ASSERTIONS,
         simpleName = "ArrayAsserts"
     )
+
+    override val kotlinFailureAssertionsClass = assertionsClass
 
     override val assertBooleanArrayEquals by lazy { assertionId("assertEquals", booleanArrayClassId, booleanArrayClassId) }
 
@@ -389,6 +400,7 @@ object Junit4 : TestFramework(id = "JUnit4",displayName = "JUnit 4") {
         simpleName = "Assert"
     )
     override val arraysAssertionsClass = assertionsClass
+    override val kotlinFailureAssertionsClass = assertionsClass
 
     val ignoreAnnotationClassId = with("$JUNIT4_PACKAGE.Ignore") {
         BuiltinClassId(
@@ -484,6 +496,11 @@ object Junit5 : TestFramework(id = "JUnit5", displayName = "JUnit 5") {
     )
 
     override val arraysAssertionsClass = assertionsClass
+
+    override val kotlinFailureAssertionsClass = BuiltinClassId(
+        canonicalName = "org.junit.jupiter.api",
+        simpleName = "Assertions"
+    )
 
     val assertThrows = builtinStaticMethodId(
         classId = assertionsClass,

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/CgElement.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/CgElement.kt
@@ -309,6 +309,7 @@ enum class CgTestMethodType(val displayName: String, val isThrowing: Boolean) {
     PASSED_EXCEPTION(displayName = "Thrown exceptions marked as passed", isThrowing = true),
     FAILING(displayName = "Failing tests (with exceptions)", isThrowing = true),
     TIMEOUT(displayName = "Failing tests (with timeout)", isThrowing = true),
+    ARTIFICIAL(displayName = "Failing tests (with custom exception)", isThrowing = true),
     CRASH(displayName = "Possibly crashing tests", isThrowing = true),
     PARAMETRIZED(displayName = "Parametrized tests", isThrowing = false);
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/reports/TestsGenerationReport.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/reports/TestsGenerationReport.kt
@@ -16,6 +16,7 @@ data class TestsGenerationReport(
     var successfulExecutions: MethodGeneratedTests = mutableMapOf(),
     var timeoutExecutions: MethodGeneratedTests = mutableMapOf(),
     var failedExecutions: MethodGeneratedTests = mutableMapOf(),
+    var artificiallyFailedExecutions: MethodGeneratedTests = mutableMapOf(),
     var crashExecutions: MethodGeneratedTests = mutableMapOf(),
     var errors: MutableMap<ExecutableId, ErrorsCount> = mutableMapOf()
 ) {
@@ -39,6 +40,10 @@ data class TestsGenerationReport(
                 "Failing because of unexpected exception test methods: ${testMethodsStatistic.sumOf { it.failing }}"
             )
             appendHtmlLine(
+                "Failing because of exception (according to custom settings) test methods: " +
+                        "${testMethodsStatistic.sumOf { it.artificiallyFailing }}"
+            )
+            appendHtmlLine(
                 "Failing because of exceeding timeout test methods: ${testMethodsStatistic.sumOf { it.timeout }}"
             )
             appendHtmlLine(
@@ -59,6 +64,7 @@ data class TestsGenerationReport(
                 when (it.type) {
                     CgTestMethodType.SUCCESSFUL, CgTestMethodType.PASSED_EXCEPTION -> updateExecutions(it, successfulExecutions)
                     CgTestMethodType.FAILING -> updateExecutions(it, failedExecutions)
+                    CgTestMethodType.ARTIFICIAL -> updateExecutions(it, artificiallyFailedExecutions)
                     CgTestMethodType.TIMEOUT -> updateExecutions(it, timeoutExecutions)
                     CgTestMethodType.CRASH -> updateExecutions(it, crashExecutions)
                     CgTestMethodType.PARAMETRIZED -> {
@@ -91,8 +97,9 @@ data class TestsGenerationReport(
     private fun ExecutableId.countTestMethods(): TestMethodStatistic = TestMethodStatistic(
         testMethodsNumber(successfulExecutions),
         testMethodsNumber(failedExecutions),
+        testMethodsNumber(artificiallyFailedExecutions),
         testMethodsNumber(timeoutExecutions),
-        testMethodsNumber(crashExecutions)
+        testMethodsNumber(crashExecutions),
     )
 
     private fun ExecutableId.countErrors(): Int = errors.getOrDefault(this, emptyMap()).values.sum()
@@ -104,7 +111,13 @@ data class TestsGenerationReport(
         executions.getOrPut(this) { mutableSetOf() } += it
     }
 
-    private data class TestMethodStatistic(val successful: Int, val failing: Int, val timeout: Int, val crashes: Int) {
-        val count: Int = successful + failing + timeout + crashes
+    private data class TestMethodStatistic(
+        val successful: Int,
+        val failing: Int,
+        val artificiallyFailing: Int,
+        val timeout: Int,
+        val crashes: Int,
+    ) {
+        val count: Int = successful + failing + artificiallyFailing + timeout + crashes
     }
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/TestFrameworkManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/TestFrameworkManager.kt
@@ -66,6 +66,9 @@ abstract class TestFrameworkManager(val context: CgContext)
     val assertTrue = context.testFramework.assertTrue
     val assertFalse = context.testFramework.assertFalse
 
+    val fail = context.testFramework.fail
+    val kotlinFail = context.testFramework.kotlinFail
+
     val assertArrayEquals = context.testFramework.assertArrayEquals
     val assertBooleanArrayEquals = context.testFramework.assertBooleanArrayEquals
     val assertByteArrayEquals = context.testFramework.assertByteArrayEquals
@@ -172,6 +175,15 @@ abstract class TestFrameworkManager(val context: CgContext)
     }
 
     fun assertBoolean(actual: CgExpression) = assertBoolean(expected = true, actual)
+
+    fun fail(actual: CgExpression) {
+        // failure assertion may be implemented in different packages in Java and Kotlin
+        // more details at https://stackoverflow.com/questions/52967039/junit-5-assertions-fail-can-not-infer-type-in-kotlin
+        when (codegenLanguage) {
+            CodegenLanguage.JAVA -> +assertions[fail](actual)
+            CodegenLanguage.KOTLIN -> +assertions[kotlinFail](actual)
+        }
+    }
 
     // Exception expectation differs between test frameworks
     // JUnit4 requires to add a specific argument to the test method annotation

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/minimization/Minimization.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/minimization/Minimization.kt
@@ -29,6 +29,7 @@ import org.utbot.framework.plugin.api.UtVoidModel
  * * Regression suite
  * * Error suite (invocations in which implicitly thrown unchecked exceptions reached to the top)
  * * Crash suite (invocations in which the instrumented process crashed or unexpected exception in our code occurred)
+ * * Artificial error suite (invocations in which some custom exception like overflow detection occurred)
  * * Timeout suite
  *
  * We want to minimize tests independently in each of these suites.

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/util/SootUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/util/SootUtils.kt
@@ -197,6 +197,7 @@ private val classesToLoad = arrayOf(
     org.utbot.engine.overrides.stream.IntStream::class,
     org.utbot.engine.overrides.stream.LongStream::class,
     org.utbot.engine.overrides.stream.DoubleStream::class,
+    org.utbot.engine.OverflowDetectionError::class,
 ).map { it.java }.toTypedArray()
 
 private const val UTBOT_PACKAGE_PREFIX = "org.utbot"

--- a/utbot-js/src/main/kotlin/framework/codegen/JsDomain.kt
+++ b/utbot-js/src/main/kotlin/framework/codegen/JsDomain.kt
@@ -13,6 +13,7 @@ object Mocha : TestFramework(id = "Mocha", displayName = "Mocha") {
     override val mainPackage = ""
     override val assertionsClass = jsUndefinedClassId
     override val arraysAssertionsClass = jsUndefinedClassId
+    override val kotlinFailureAssertionsClass: ClassId = jsUndefinedClassId
     override val testAnnotation = ""
     override val testAnnotationFqn = ""
 

--- a/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/PythonDomain.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/PythonDomain.kt
@@ -15,6 +15,7 @@ object Pytest : TestFramework(displayName = "pytest", id = "pytest") {
     override val mainPackage: String = "pytest"
     override val assertionsClass: ClassId = pythonNoneClassId
     override val arraysAssertionsClass: ClassId = assertionsClass
+    override val kotlinFailureAssertionsClass: ClassId = assertionsClass
     override val testAnnotation: String
         get() = TODO("Not yet implemented")
     override val testAnnotationId: ClassId = BuiltinClassId(
@@ -51,6 +52,7 @@ object Unittest : TestFramework(displayName = "Unittest", id = "Unittest") {
     override val mainPackage: String = "unittest"
     override val assertionsClass: ClassId = PythonClassId("self")
     override val arraysAssertionsClass: ClassId = assertionsClass
+    override val kotlinFailureAssertionsClass: ClassId = assertionsClass
     override val testAnnotation: String = ""
     override val testAnnotationId: ClassId = BuiltinClassId(
         canonicalName = "Unittest",


### PR DESCRIPTION
# Description

Currently generated unit tests for OverflowExamples from utbot-samples are false negatives if the mode to treat overflows as errors is selected.

The only sign of something wrong is a comment about failing test. Test passes whenever it's behavior is unpredictable.

We should add failing assertion and show that actual result is not reliable. It requires changes in
- engine (new way to traverse and resolve overflows)
- engine tests (correct OverflowDetectionAndErrors test)
- codegen (new approach to render overflow detections, new assert introduced)
- reporting (support one more behavior type - artificial errors)
- summarization (new display names, test method names, summaries)

Everything except summarization is ready now.

Fixes # ([1272](https://github.com/UnitTestBot/UTBotJava/issues/1272))

## Type of Change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Regression and integration tests

`OverflowAsErrorTest`

as far as no new scenarios were added to the symbolic engine, we just corrected current tests

## Manual Scenario 

Stanfard checks on both codegen languages and used test frameworks that generated code with failure assertion is compilable and test run results correlate with our expectations.
