### PR TITLE
Remove builtins modules from sys.path

### DIFF
--- a/utbot-intellij-python/src/main/kotlin/org/utbot/intellij/plugin/language/python/PythonDialogProcessor.kt
+++ b/utbot-intellij-python/src/main/kotlin/org/utbot/intellij/plugin/language/python/PythonDialogProcessor.kt
@@ -278,10 +278,18 @@ fun getDirectoriesForSysPath(
             if (element != null) {
                 val directory = element.parent
                 if (directory is PsiDirectory) {
-                    sources.add(directory.virtualFile)
+                    if (sources.any { source ->
+                            val sourcePath = source.canonicalPath
+                            if (source.isDirectory && sourcePath != null) {
+                                directory.virtualFile.canonicalPath?.startsWith(sourcePath) ?: false
+                            } else {
+                                false
+                            }
+                        }) {
+                        sources.add(directory.virtualFile)
+                    }
                 }
             }
-
         }
     }
 
@@ -290,7 +298,7 @@ fun getDirectoriesForSysPath(
         importPath += "."
 
     return Pair(
-        sources.map { it.path }.toSet(),
+        sources.map { it.path.replace("\\", "\\\\") }.toSet(),
         "${importPath}${file.name}".removeSuffix(".py").toPath().joinToString(".").replace("/", File.separator)
     )
 }

--- a/utbot-python/src/main/kotlin/org/utbot/python/utils/TemporaryFileManager.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/utils/TemporaryFileManager.kt
@@ -15,7 +15,7 @@ object TemporaryFileManager {
     }
 
     fun assignTemporaryFile(fileName_: String? = null, tag: String? = null, addToCleaner: Boolean = true): File {
-        val fileName = fileName_ ?: ("${nextId++}_" + (tag ?: ""))
+        val fileName = fileName_ ?: ("tmp_${nextId++}_" + (tag ?: ""))
         val fullpath = Paths.get(tmpDirectory.toString(), fileName)
         val result = fullpath.toFile()
         if (addToCleaner)


### PR DESCRIPTION
# Description

Now we add in sys.path only subpaths of project path. Also temporary files don't start with numbers now, this modification can help with problems on Windows when some path has structure `...\123_run_...`.

Fixes # (issue)

## Type of Change

- Minor bug fix (non-breaking small changes)
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

1. Open python project
2. Create file with import (not from your project), for example `import collections`:
```python
import collections
def generate_collections(collection: collections.Counter):
    collection[0] = 100
    elements = list(collection.items())
    return [
        collection,
        collections.Counter(collection),
        elements
    ]
```
4. Generate tests
5. __Expected__: no one of sys.path contains path to module `collections`

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
