### PR TITLE
Fix Python plugin locking UI

### DIFF
--- a/utbot-intellij-python/src/main/kotlin/org/utbot/intellij/plugin/language/python/PythonLanguageAssistant.kt
+++ b/utbot-intellij-python/src/main/kotlin/org/utbot/intellij/plugin/language/python/PythonLanguageAssistant.kt
@@ -12,6 +12,7 @@ import com.jetbrains.python.psi.PyFunction
 import com.jetbrains.python.sdk.PythonSdkType
 import org.jetbrains.kotlin.idea.util.projectStructure.module
 import org.jetbrains.kotlin.idea.util.projectStructure.sdk
+import org.utbot.framework.plugin.api.util.LockFile
 import org.utbot.intellij.plugin.language.agnostic.LanguageAssistant
 
 object PythonLanguageAssistant : LanguageAssistant() {
@@ -40,7 +41,7 @@ object PythonLanguageAssistant : LanguageAssistant() {
     }
 
     override fun update(e: AnActionEvent) {
-        e.presentation.isEnabled = getPsiTargets(e) != null
+        e.presentation.isEnabled = !LockFile.isLocked() && getPsiTargets(e) != null
     }
 
     private fun getPsiTargets(e: AnActionEvent): Targets? {


### PR DESCRIPTION
# Description

Now if we are generating tests we cannot open plugin action window.

Fixes #1568

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

See [issue](https://github.com/UnitTestBot/UTBotJava/issues/1568)

UI window cannot be opened while test generation process is working

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
