### PR TITLE
Add string interpolation support in codegen

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/CgElement.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/CgElement.kt
@@ -87,6 +87,7 @@ interface CgElement {
             is CgNotNullAssertion -> visit(element)
             is CgVariable -> visit(element)
             is CgParameterDeclaration -> visit(element)
+            is CgFormattedString -> visit(element)
             is CgLiteral -> visit(element)
             is CgNonStaticRunnable -> visit(element)
             is CgStaticRunnable -> visit(element)
@@ -822,6 +823,11 @@ class CgArrayInitializer(val arrayType: ClassId, val elementType: ClassId, val v
 // Spread operator (for Kotlin, empty for Java)
 
 class CgSpread(override val type: ClassId, val array: CgExpression) : CgExpression
+
+// Interpolated string
+// e.g. String.format() for Java, "${}" for Kotlin
+
+class CgFormattedString(val array: List<CgExpression>) : CgElement
 
 // Enum constant
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgAbstractRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgAbstractRenderer.kt
@@ -595,7 +595,11 @@ abstract class CgAbstractRenderer(
     // Primitive and String literals
 
     override fun visit(element: CgLiteral) {
-        val value = with(element.value) {
+        print(element.toStringConstant())
+    }
+
+    protected fun CgLiteral.toStringConstant(asRawString: Boolean = false) =
+        with(this.value) {
             when (this) {
                 is Byte -> toStringConstant()
                 is Char -> toStringConstant()
@@ -605,12 +609,11 @@ abstract class CgAbstractRenderer(
                 is Float -> toStringConstant()
                 is Double -> toStringConstant()
                 is Boolean -> toStringConstant()
-                is String -> toStringConstant()
+                // String is "\"" + "str" + "\"", RawString is "str"
+                is String -> if (asRawString) "$this".escapeCharacters() else toStringConstant()
                 else -> "$this"
             }
         }
-        print(value)
-    }
 
     // Non-static runnable like this::toString or (new Object())::toString etc
     override fun visit(element: CgNonStaticRunnable) {
@@ -924,7 +927,7 @@ abstract class CgAbstractRenderer(
     private fun Boolean.toStringConstant() =
         if (this) "true" else "false"
 
-    private fun String.toStringConstant(): String = "\"" + escapeCharacters() + "\""
+    protected fun String.toStringConstant(): String = "\"" + escapeCharacters() + "\""
 
     protected abstract fun String.escapeCharacters(): String
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgKotlinRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgKotlinRenderer.kt
@@ -38,8 +38,11 @@ import org.utbot.framework.codegen.domain.models.CgSwitchCase
 import org.utbot.framework.codegen.domain.models.CgSwitchCaseLabel
 import org.utbot.framework.codegen.domain.models.CgClass
 import org.utbot.framework.codegen.domain.models.CgClassBody
+import org.utbot.framework.codegen.domain.models.CgFormattedString
+import org.utbot.framework.codegen.domain.models.CgLiteral
 import org.utbot.framework.codegen.domain.models.CgTestMethod
 import org.utbot.framework.codegen.domain.models.CgTypeCast
+import org.utbot.framework.codegen.domain.models.CgValue
 import org.utbot.framework.codegen.domain.models.CgVariable
 import org.utbot.framework.codegen.util.nullLiteral
 import org.utbot.framework.plugin.api.BuiltinClassId
@@ -478,6 +481,29 @@ internal class CgKotlinRenderer(context: CgRendererContext, printer: CgPrinter =
             element.defaultLabel?.accept(this)
         }
         println("}")
+    }
+
+    override fun visit(element: CgFormattedString) {
+        print("\"")
+        element.array.forEachIndexed { index, cgElement ->
+            if (cgElement is CgLiteral)
+                print(cgElement.toStringConstant(asRawString = true))
+            else {
+                print("$")
+                when (cgElement) {
+                    // It is not necessary to wrap variables with curly brackets
+                    is CgVariable -> cgElement.accept(this)
+                    else -> {
+                        print("{")
+                        cgElement.accept(this)
+                        print("}")
+                    }
+                }
+            }
+
+            if (index < element.array.lastIndex) print(" ")
+        }
+        print("\"")
     }
 
     override fun toStringConstantImpl(byte: Byte): String = buildString {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgVisitor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgVisitor.kt
@@ -76,6 +76,7 @@ import org.utbot.framework.codegen.domain.models.CgSwitchCaseLabel
 import org.utbot.framework.codegen.domain.models.CgClass
 import org.utbot.framework.codegen.domain.models.CgClassBody
 import org.utbot.framework.codegen.domain.models.CgDocRegularLineStmt
+import org.utbot.framework.codegen.domain.models.CgFormattedString
 import org.utbot.framework.codegen.domain.models.CgNestedClassesRegion
 import org.utbot.framework.codegen.domain.models.CgTestMethod
 import org.utbot.framework.codegen.domain.models.CgTestMethodCluster
@@ -222,6 +223,9 @@ interface CgVisitor<R> {
 
     // Spread operator
     fun visit(element: CgSpread): R
+
+    // Formatted string
+    fun visit(element: CgFormattedString): R
 
     // Enum constant
     fun visit(element: CgEnumConstantAccess): R

--- a/utbot-js/src/main/kotlin/framework/codegen/model/constructor/visitor/CgJsRenderer.kt
+++ b/utbot-js/src/main/kotlin/framework/codegen/model/constructor/visitor/CgJsRenderer.kt
@@ -21,6 +21,7 @@ import org.utbot.framework.codegen.domain.models.CgExecutableCall
 import org.utbot.framework.codegen.domain.models.CgExpression
 import org.utbot.framework.codegen.domain.models.CgFieldAccess
 import org.utbot.framework.codegen.domain.models.CgForLoop
+import org.utbot.framework.codegen.domain.models.CgFormattedString
 import org.utbot.framework.codegen.domain.models.CgGetJavaClass
 import org.utbot.framework.codegen.domain.models.CgGetKotlinClass
 import org.utbot.framework.codegen.domain.models.CgGetLength
@@ -338,6 +339,10 @@ internal class CgJsRenderer(context: CgRendererContext, printer: CgPrinter = CgP
         } else {
             renderExecutableCallArguments(element)
         }
+    }
+
+    override fun visit(element: CgFormattedString) {
+        throw NotImplementedError("String interpolation is not supported in JavaScript renderer")
     }
 
     //TODO MINOR: check

--- a/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/constructor/visitor/CgPythonRenderer.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/constructor/visitor/CgPythonRenderer.kt
@@ -28,6 +28,7 @@ import org.utbot.framework.codegen.domain.models.CgExecutableCall
 import org.utbot.framework.codegen.domain.models.CgExpression
 import org.utbot.framework.codegen.domain.models.CgForEachLoop
 import org.utbot.framework.codegen.domain.models.CgForLoop
+import org.utbot.framework.codegen.domain.models.CgFormattedString
 import org.utbot.framework.codegen.domain.models.CgGetJavaClass
 import org.utbot.framework.codegen.domain.models.CgGetKotlinClass
 import org.utbot.framework.codegen.domain.models.CgGetLength
@@ -528,6 +529,10 @@ internal class CgPythonRenderer(
 
     override fun visit(element: CgLiteral) {
         print(element.value.toString())
+    }
+
+    override fun visit(element: CgFormattedString) {
+        throw NotImplementedError("String interpolation is not supported in Python renderer")
     }
 
     override fun String.escapeCharacters(): String =


### PR DESCRIPTION
# Description

This PR adds string interpolation support for Java and Kotlin codegen.

Fixes # ([1546](https://github.com/UnitTestBot/UTBotJava/issues/1546))

## Type of Change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Regression and integration tests

## Automated Testing

utbot-samples.

## Manual Scenario
Usage example:
```kotlin
CgFormattedString(
    listOf(
        stringLiteral("Custom message:"),
        actual,
        stringLiteral("has to be"),
        expected
    )
)
```

It will produce the following results:
For Java:
```java
String.format("Custom message: %s has to be 1", actual)
```


For Kotlin:
```kotlin
"Custom message: $actual has to be 1"
```