### PR TITLE
Fix error tests handling in reporting

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/reports/TestsGenerationReport.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/reports/TestsGenerationReport.kt
@@ -53,6 +53,7 @@ data class TestsGenerationReport(
         }
 
     fun addMethodErrors(testSet: CgMethodTestSet, errors: Map<String, Int>) {
+        this.executables += testSet.executableId
         this.errors[testSet.executableId] = errors
     }
 


### PR DESCRIPTION
# Description

This PR fixes error window popping up when not real but *only* error tests were generated as described in the issue.
The tests looks like the following:
```java
public void testMethodWithException_errors() {
    // Couldn't generate some tests. List of errors:
    // 
    // 1 occurrences of:
    // Index 100 out of bounds for length 3
}
```
Now, in case of only error tests there is no error window.

Fixes # ([1425](https://github.com/UnitTestBot/UTBotJava/issues/1425))

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Regression and integration tests

## Automated Testing

utbot-samples.

## Manual Scenario

Code from the issue did not cause the error window popping up, so it was decided to cause it artificially by tweaking *CgTestClassConstructor*.
