### PR TITLE
Handle non-physical PsiFile in utbot inspections

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/UnitTestBotInspectionTool.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/UnitTestBotInspectionTool.kt
@@ -60,8 +60,14 @@ class UnitTestBotInspectionTool : GlobalSimpleInspectionTool() {
             val errorPsiFile = srcFileLogicalLocation?.fullyQualifiedName?.let { errorClassFqn ->
                 val psiFacade = JavaPsiFacade.getInstance(srcPsiFile.project)
                 val psiClass = psiFacade.findClass(errorClassFqn, srcPsiFile.project.allScope())
-                // We can't just return `psiClass?.containingFile` because it may be non-physical
-                psiClass?.containingFile?.virtualFile?.toPsiFile(srcPsiFile.project)
+                val psiFile = psiClass?.containingFile ?: return@let null
+
+                // We can't just return psiFile because it may be non-physical
+                if (psiFile.isPhysical) {
+                    psiFile
+                } else {
+                    psiFile.virtualFile.toPsiFile(srcPsiFile.project)
+                }
             } ?: srcPsiFile
             val errorRegion = srcFilePhysicalLocation.region
             val errorTextRange = getTextRange(problemsHolder.project, errorPsiFile, errorRegion)

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/UnitTestBotInspectionTool.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/inspection/UnitTestBotInspectionTool.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
+import org.jetbrains.kotlin.idea.core.util.toPsiFile
 import org.jetbrains.kotlin.idea.search.allScope
 import org.utbot.sarif.*
 import java.nio.file.Path
@@ -59,7 +60,8 @@ class UnitTestBotInspectionTool : GlobalSimpleInspectionTool() {
             val errorPsiFile = srcFileLogicalLocation?.fullyQualifiedName?.let { errorClassFqn ->
                 val psiFacade = JavaPsiFacade.getInstance(srcPsiFile.project)
                 val psiClass = psiFacade.findClass(errorClassFqn, srcPsiFile.project.allScope())
-                psiClass?.containingFile
+                // We can't just return `psiClass?.containingFile` because it may be non-physical
+                psiClass?.containingFile?.virtualFile?.toPsiFile(srcPsiFile.project)
             } ?: srcPsiFile
             val errorRegion = srcFilePhysicalLocation.region
             val errorTextRange = getTextRange(problemsHolder.project, errorPsiFile, errorRegion)


### PR DESCRIPTION
# Description

In the utbot inspection may be received a non-physical file for which IDEA can't create problem descriptor. In this case we need to get somehow the corresponding physical file.

Now all is ok:

![image](https://user-images.githubusercontent.com/54814796/209668481-b6100811-b884-497e-8816-eb709225d665.png)

Fixes #1589

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

There are no unit tests for UI for now

## Manual Scenario 

Please, repeat the scenario from the issue #1589 

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] All tests pass locally with my changes
