### PR TITLE
Add toString method to GlobalStats in ContestEstimator

### DIFF
--- a/utbot-junit-contest/src/main/kotlin/org/utbot/contest/Statistics.kt
+++ b/utbot-junit-contest/src/main/kotlin/org/utbot/contest/Statistics.kt
@@ -14,6 +14,9 @@ fun <T> Iterable<T>.printMultiline(printer: (T) -> Any?) = "\n" + joinToString("
 class GlobalStats {
     val projectStats = mutableListOf<StatsForProject>()
     var duration: Long? = null
+
+    override fun toString(): String = "\n<Global statistics> :" +
+            projectStats.joinToString(separator = "\n")
 }
 
 class StatsForProject(val project: String) {
@@ -72,7 +75,7 @@ class StatsForProject(val project: String) {
                 else this
             }
 
-    override fun toString(): String = "\n<Global statistics> :" +
+    override fun toString(): String = "\n<StatsForProject($project)> :" +
             "\n\t#classes for generation = $classesForGeneration" +
             "\n\t#tc generated = $testCasesGenerated" +
             "\n\t#classes without problems = $classesWithoutProblems" +
@@ -139,7 +142,7 @@ class StatsForClass(val project: String, val className: String) {
     fun getConcolicCoverageInfo(): CoverageStatistic =
         concolicCoverage.getCoverageInfo(testedClassNames)
 
-    override fun toString(): String = "\n<StatsForClass> :" +
+    override fun toString(): String = "\n<StatsForClass($className)> :" +
             "\n\tcanceled by timeout = $canceledByTimeout" +
             "\n\t#methods = $methodsCount, " +
             "\n\t#methods started symbolic exploration = ${statsForMethods.size}" +


### PR DESCRIPTION
# Description

Add custom `.toString()` method to the GlobalStats class in ContestEstimator to display aggregated statistics:

![image](https://user-images.githubusercontent.com/54814796/209681370-e6e7bab8-d6a3-46ed-9764-1f50a8a5435e.png)

Fixes #1593

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Regression and integration tests

Please, provide regression or integration tests for your code changes. If you don't do that, the reviewer can and highly likely **_will reject_** the PR. It is the contributor's responsibility to provide such tests or to reason why they are missing.

## Automated Testing

There is no need to test the ContestEstimator

## Manual Scenario 

Run ContestEstimator.main method and check the log

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] All tests pass locally with my changes
