### PR TITLE
Add missed mock generator for static fields

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/mock/MockStaticFieldExampleTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/mock/MockStaticFieldExampleTest.kt
@@ -6,15 +6,29 @@ import org.utbot.framework.plugin.api.MockInfo
 import org.utbot.framework.plugin.api.MockStrategyApi.OTHER_PACKAGES
 import kotlin.reflect.KClass
 import org.junit.jupiter.api.Test
+import org.utbot.examples.mock.others.ClassWithStaticField
+import org.utbot.framework.plugin.api.CodegenLanguage
+import org.utbot.framework.plugin.api.UtCompositeModel
+import org.utbot.framework.plugin.api.UtNewInstanceInstrumentation
 import org.utbot.testcheckers.eq
 import org.utbot.testcheckers.withoutConcrete
+import org.utbot.testing.CodeGeneration
 import org.utbot.testing.DoNotCalculate
+import org.utbot.testing.TestExecution
 import org.utbot.testing.UtValueTestCaseChecker
 import org.utbot.testing.singleMock
 import org.utbot.testing.singleMockOrNull
 import org.utbot.testing.value
 
-internal class MockStaticFieldExampleTest : UtValueTestCaseChecker(testClass = MockStaticFieldExample::class) {
+internal class MockStaticFieldExampleTest : UtValueTestCaseChecker(
+    testClass = MockStaticFieldExample::class,
+    testCodeGeneration = true,
+    pipelines = listOf(
+        TestLastStage(CodegenLanguage.JAVA, lastStage = TestExecution),
+        // disabled due to https://github.com/UnitTestBot/UTBotJava/issues/88
+        TestLastStage(CodegenLanguage.KOTLIN, lastStage = CodeGeneration)
+    )
+) {
 
     @Test
     fun testMockStaticField() {
@@ -66,6 +80,42 @@ internal class MockStaticFieldExampleTest : UtValueTestCaseChecker(testClass = M
                 mockStrategy = OTHER_PACKAGES
             )
         }
+    }
+
+    @Test
+    fun testCheckMocksInLeftAndRightAssignPartFinalField() {
+        checkMocks(
+            MockStaticFieldExample::checkMocksInLeftAndRightAssignPartFinalField,
+            eq(1),
+            { mocks, _ ->
+                val mock = mocks.singleMock("staticFinalField", ClassWithStaticField::foo)
+
+                mock.mocksStaticField(MockStaticFieldExample::class)
+            },
+            coverage = DoNotCalculate,
+            mockStrategy = OTHER_PACKAGES
+        )
+    }
+
+    @Test
+    fun testCheckMocksInLeftAndRightAssignPart() {
+        checkMocksAndInstrumentation(
+            MockStaticFieldExample::checkMocksInLeftAndRightAssignPart,
+            eq(2),
+            { _, statics, _ ->
+                val instrumentation = statics.single() as UtNewInstanceInstrumentation
+                val model = instrumentation.instances.last() as UtCompositeModel
+
+                model.fields.isEmpty() // NPE
+            },
+            { mocks, _, _ ->
+                val mock = mocks.singleMock("staticField", ClassWithStaticField::foo)
+
+                mock.mocksStaticField(MockStaticFieldExample::class)
+            },
+            coverage = DoNotCalculate,
+            mockStrategy = OTHER_PACKAGES
+        )
     }
 
     private fun MockInfo.mocksStaticField(kClass: KClass<*>) = when (val mock = mock) {

--- a/utbot-sample/src/main/java/org/utbot/examples/mock/MockStaticFieldExample.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/mock/MockStaticFieldExample.java
@@ -1,11 +1,15 @@
 package org.utbot.examples.mock;
 
+import org.utbot.examples.mock.others.ClassWithStaticField;
 import org.utbot.examples.mock.others.Generator;
 
 public class MockStaticFieldExample {
     @SuppressWarnings("unused")
     private static Generator privateGenerator;
     public static Generator publicGenerator;
+
+    public static final ClassWithStaticField staticFinalField = new ClassWithStaticField();
+    public static ClassWithStaticField staticField = new ClassWithStaticField();
 
     public int calculate(int threshold) {
         int a = privateGenerator.generateInt();
@@ -14,5 +18,21 @@ public class MockStaticFieldExample {
             return threshold;
         }
         return a + b + 1;
+    }
+
+    // This test is associated with https://github.com/UnitTestBot/UTBotJava/issues/1533
+    public int checkMocksInLeftAndRightAssignPartFinalField() {
+        staticFinalField.intField = 5;
+        staticFinalField.anotherIntField = staticFinalField.foo();
+
+        return staticFinalField.anotherIntField;
+    }
+
+    // This test is associated with https://github.com/UnitTestBot/UTBotJava/issues/1533
+    public int checkMocksInLeftAndRightAssignPart() {
+        staticField.intField = 5;
+        staticField.anotherIntField = staticField.foo();
+
+        return staticField.anotherIntField;
     }
 }

--- a/utbot-sample/src/main/java/org/utbot/examples/mock/others/ClassWithStaticField.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/mock/others/ClassWithStaticField.java
@@ -1,0 +1,10 @@
+package org.utbot.examples.mock.others;
+
+public class ClassWithStaticField {
+    public int intField;
+    public int anotherIntField;
+
+    public int foo() {
+        return 5;
+    }
+}


### PR DESCRIPTION
# Description

This request adds two missed generators for mocks that led to unexpected unsat results. 
It happened because when a static variable was on a right side of an assignment, it was created with the corresponding mock generator. Then, if some other variable related to the same class would be encountered on the left side of the assignment, it was created without such a generator, which led to a contradiction between `isMock` values in these two scenarios. 

There was one more missed generated related to final statics: when we reset statics, we should provide a corresponding mock generator.

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Regression and integration tests

The same as automatic tests.

## Automated Testing

`org.utbot.examples.mock.MockStaticFieldExampleTest#testCheckMocksInLeftAndRightAssignPartFinalField`
`org.utbot.examples.mock.MockStaticFieldExampleTest#testCheckMocksInLeftAndRightAssignPart`

## Manual Scenario 

There is no specific manual scenario.

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] New tests have been added
- [x] All tests pass locally with my changes
