### PR TITLE
Fixed test class name for nested class in Contest Estimator

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -865,11 +865,11 @@ open class ClassId @JvmOverloads constructor(
      * It is needed because [simpleName] for inner classes does not
      * take into account enclosing classes' names.
      */
-    open val simpleNameWithEnclosings: String
+    open val simpleNameWithEnclosingClasses: String
         get() {
             val clazz = jClass
             return if (clazz.isMemberClass) {
-                "${clazz.enclosingClass.id.simpleNameWithEnclosings}.$simpleName"
+                "${clazz.enclosingClass.id.simpleNameWithEnclosingClasses}.$simpleName"
             } else {
                 simpleName
             }
@@ -910,7 +910,7 @@ class BuiltinClassId(
     // set name manually only if it differs from canonical (e.g. for nested classes)
     name: String = canonicalName,
     // by default, we assume that the class is not a member class
-    override val simpleNameWithEnclosings: String = simpleName,
+    override val simpleNameWithEnclosingClasses: String = simpleName,
     override val isNullable: Boolean = false,
     isPublic: Boolean = true,
     isProtected: Boolean = false,

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/IdUtil.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/IdUtil.kt
@@ -206,6 +206,12 @@ val ClassId.isKotlinFile: Boolean
         KotlinClassHeader.Kind.getById(it.kind) == KotlinClassHeader.Kind.FILE_FACADE
     } ?: false
 
+/**
+ * Returns [ClassId.simpleNameWithEnclosingClasses] with '.' replaced with '_' - to use it as a class name.
+ */
+val ClassId.nameWithEnclosingClassesAsContigousString: String
+    get() = simpleNameWithEnclosingClasses.replace('.', '_')
+
 val voidClassId = ClassId("void")
 val booleanClassId = ClassId("boolean")
 val byteClassId = ClassId("byte")

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgAbstractRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgAbstractRenderer.kt
@@ -848,7 +848,7 @@ abstract class CgAbstractRenderer(
         if (!context.shouldOptimizeImports) return canonicalName
 
         // use simpleNameWithEnclosings instead of simpleName to consider nested classes case
-        return if (this.isAccessibleBySimpleName()) simpleNameWithEnclosings else canonicalName
+        return if (this.isAccessibleBySimpleName()) simpleNameWithEnclosingClasses else canonicalName
     }
 
     private fun renderClassPackage(element: CgClass) {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/ConstructorUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/ConstructorUtils.kt
@@ -406,7 +406,7 @@ internal fun ClassId.utilMethodId(
 ): MethodId =
     BuiltinMethodId(this, name, returnType, arguments.toList(), isStatic = isStatic)
 
-fun ClassId.toImport(): RegularImport = RegularImport(packageName, simpleNameWithEnclosings)
+fun ClassId.toImport(): RegularImport = RegularImport(packageName, simpleNameWithEnclosingClasses)
 
 // Immutable collections utils
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/utils/CodeLanguageUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/utils/CodeLanguageUtils.kt
@@ -1,6 +1,7 @@
 package org.utbot.framework.plugin.api.utils
 
 import org.utbot.framework.plugin.api.ClassId
+import org.utbot.framework.plugin.api.util.nameWithEnclosingClassesAsContigousString
 
 fun testClassNameGenerator(
     testClassCustomName: String?,
@@ -8,7 +9,7 @@ fun testClassNameGenerator(
     classUnderTest: ClassId
 ): Pair<String, String> {
     val packagePrefix = if (testClassPackageName.isNotEmpty()) "$testClassPackageName." else ""
-    val simpleName = testClassCustomName ?: "${classUnderTest.simpleName}Test"
+    val simpleName = testClassCustomName ?: "${classUnderTest.nameWithEnclosingClassesAsContigousString}Test"
     val name = "$packagePrefix$simpleName"
     return Pair(name, simpleName)
 }

--- a/utbot-junit-contest/src/main/kotlin/org/utbot/contest/ClassUnderTest.kt
+++ b/utbot-junit-contest/src/main/kotlin/org/utbot/contest/ClassUnderTest.kt
@@ -2,6 +2,7 @@ package org.utbot.contest
 
 import org.utbot.common.FileUtil
 import org.utbot.framework.plugin.api.ClassId
+import org.utbot.framework.plugin.api.util.nameWithEnclosingClassesAsContigousString
 import org.utbot.framework.plugin.api.util.utContext
 import java.io.File
 import java.nio.file.Paths
@@ -32,11 +33,12 @@ class ClassUnderTest(
 //    val classpathDir : File get() = FileUtil.locateClassPath(kotlinClass)?.absoluteFile !!
 
 
-    val packageName: String get() = fqn.substringBeforeLast('.', "")
-    val simpleName: String get() = createTestClassName(fqn)
-
+    /**
+     * These properties should be obtained only with utContext set
+     */
+    private val packageName: String get() = classId.packageName
+    val simpleName: String get() = classId.nameWithEnclosingClassesAsContigousString
     val testClassSimpleName: String get() = simpleName + "Test"
-
     val generatedTestFile: File
         get() = Paths.get(
             generatedTestsSourcesDir.canonicalPath,
@@ -51,13 +53,4 @@ class ClassUnderTest(
             "\n    generatedTestsSourcesDir: $generatedTestsSourcesDir" +
             "\n]"
     }
-
-    /**
-     * Creates a name of test class.
-     * We need the name in code and the name of test class file be similar.
-     * On this way we need to avoid symbols like '$'.
-     */
-    private fun createTestClassName(name: String): String = name
-        .substringAfterLast('.')
-        .replace('\$', '_')
 }

--- a/utbot-junit-contest/src/main/kotlin/org/utbot/contest/ContestEstimator.kt
+++ b/utbot-junit-contest/src/main/kotlin/org/utbot/contest/ContestEstimator.kt
@@ -1,5 +1,6 @@
 package org.utbot.contest
 
+import kotlinx.coroutines.ObsoleteCoroutinesApi
 import java.io.File
 import java.io.FileInputStream
 import java.net.URLClassLoader
@@ -126,6 +127,7 @@ object Paths {
 @Suppress("unused")
 enum class Tool {
     UtBot {
+        @OptIn(ObsoleteCoroutinesApi::class)
         @Suppress("EXPERIMENTAL_API_USAGE")
         override fun run(
             project: ProjectToEstimate,
@@ -136,19 +138,17 @@ enum class Tool {
             statsForProject: StatsForProject,
             compiledTestDir: File,
             classFqn: String
-        ) {
+        ) = withUtContext(ContextManager.createNewContext(project.classloader)) {
             val classStats: StatsForClass = try {
-                withUtContext(ContextManager.createNewContext(project.classloader)) {
-                    runGeneration(
-                        project.name,
-                        cut,
-                        timeLimit,
-                        fuzzingRatio,
-                        project.sootClasspathString,
-                        runFromEstimator = true,
-                        methodNameFilter
-                    )
-                }
+                runGeneration(
+                    project.name,
+                    cut,
+                    timeLimit,
+                    fuzzingRatio,
+                    project.sootClasspathString,
+                    runFromEstimator = true,
+                    methodNameFilter
+                )
             } catch (e: CancellationException) {
                 logger.info { "[$classFqn] finished with CancellationException" }
                 return


### PR DESCRIPTION
# Description

Fixed test class name non-mathcing with test filename for nested classes in ContestEstimator.

Fixes #1622.

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

The mentioned in the issue test is successfully compiled.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
