### PR TITLE
Fix no targets for invocation for abstract this type

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/objects/AbstractAnonymousClassTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/objects/AbstractAnonymousClassTest.kt
@@ -1,0 +1,27 @@
+package org.utbot.examples.objects
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.utbot.testcheckers.eq
+import org.utbot.testing.UtValueTestCaseChecker
+
+class AbstractAnonymousClassTest : UtValueTestCaseChecker(testClass = AbstractAnonymousClass::class) {
+    @Test
+    fun testNonOverriddenMethod() {
+        check(
+            AbstractAnonymousClass::methodWithoutOverrides,
+            eq(1)
+        )
+    }
+
+    @Test
+    fun testOverriddenMethod() {
+        // check we have error during execution
+        assertThrows<org.opentest4j.AssertionFailedError> {
+            check(
+                AbstractAnonymousClass::methodWithOverride,
+                eq(0)
+            )
+        }
+    }
+}

--- a/utbot-sample/src/main/java/org/utbot/examples/objects/AbstractAnonymousClass.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/objects/AbstractAnonymousClass.java
@@ -4,6 +4,22 @@ abstract class AbstractAnonymousClass {
     abstract int constValue();
     abstract int add(int x);
 
+    public int methodWithoutOverrides(int x, int y) {
+        return y + addFortyTwo(x);
+    }
+
+    public int methodWithOverride(int x, int y) {
+        return y + addNumber(x);
+    }
+
+    public int addFortyTwo(int x) {
+        return x + 42;
+    }
+
+    public int addNumber(int x) {
+        return x + 27;
+    }
+
     public static AbstractAnonymousClass getInstance(int x) {
         if (x % 2 == 0) {
             return new AnonymousClassAlternative();
@@ -19,6 +35,11 @@ abstract class AbstractAnonymousClass {
             int add(int x) {
                 return x + 15;
             }
+
+            @Override
+            public int methodWithOverride(int x, int y) {
+                return x + 37;
+            }
         };
     }
 }
@@ -32,5 +53,10 @@ class AnonymousClassAlternative extends AbstractAnonymousClass {
     @Override
     int add(int x) {
         return x + 1;
+    }
+
+    @Override
+    public int methodWithOverride(int x, int y) {
+        return x + 17;
     }
 }


### PR DESCRIPTION
# Description

Add support for testing methods of the abstract classes which have instantiable inheritors. Early we didn't check whether we can create a `this` instance or not, now we can replace it with its inheritors if there is such an inheritors with non-overridden method under test.

Fixes #1624 

## Type of Change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

## Regression and integration tests

The same as automatic tests/

## Automated Testing

`org.utbot.examples.objects.AbstractAnonymousClassTest#testNonOverriddenMethod`

## Manual Scenario 

Run the contest estimator for `org.antlr.v4.codegen.Target.getTemplates` and check that there are no errors.

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] New tests have been added
- [x] All tests pass locally with my changes
