### PR TITLE
Fixed wrong sort during resolving StringBuilder

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/strings/StringExamplesTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/strings/StringExamplesTest.kt
@@ -302,6 +302,15 @@ internal class StringExamplesTest : UtValueTestCaseChecker(
     }
 
     @Test
+    fun testStringBuilderAsParameterExample() {
+        check(
+            StringExamples::stringBuilderAsParameterExample,
+            eq(1),
+            coverage = FullWithAssumptions(assumeCallsNumber = 1)
+        )
+    }
+
+    @Test
     fun testNullableStringBuffer() {
         checkWithException(
             StringExamples::nullableStringBuffer,

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Strings.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Strings.kt
@@ -220,7 +220,7 @@ sealed class UtAbstractStringBuilderWrapper(className: String) : BaseOverriddenW
         val arrayValuesChunkId = typeRegistry.arrayChunkId(charArrayType)
 
         val valuesFieldChunkId = hierarchy.chunkIdForField(overriddenClass.type, overriddenClass.valueField)
-        val valuesArrayAddrDescriptor = MemoryChunkDescriptor(valuesFieldChunkId, wrapper.type, charType)
+        val valuesArrayAddrDescriptor = MemoryChunkDescriptor(valuesFieldChunkId, wrapper.type, charArrayType)
         val valuesArrayAddr = findArray(valuesArrayAddrDescriptor, MemoryState.CURRENT).select(wrapper.addr)
 
         val valuesArrayDescriptor = MemoryChunkDescriptor(arrayValuesChunkId, charArrayType, charType)

--- a/utbot-sample/src/main/java/org/utbot/examples/strings/StringExamples.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/strings/StringExamples.java
@@ -209,6 +209,11 @@ public class StringExamples {
         return buffer.toString();
     }
 
+    // This test checks StringBuilder can be correctly constructed
+    public void stringBuilderAsParameterExample(StringBuilder sb) {
+        UtMock.assume(sb != null);
+    }
+
     public String nullableStringBuffer(StringBuffer buffer, int i) {
         if (i >= 0) {
             buffer.append("Positive");


### PR DESCRIPTION
# Description

Fixed the wrong sort for the index during resolving StringBuilder.

Fixes #1627.

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

```org.utbot.examples.strings.StringExamples#stringBuilderAsParameterExample```

## Manual Scenario 

```org.antlr.v4.codegen.target.GoTarget.appendUnicodeEscapedCodePoint``` in Contest Estimator.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] No new warnings
- [x] New tests have been added
- [x] All tests pass locally with my changes
