### PR TITLE
Enabled assemble model generator for contest

### DIFF
--- a/utbot-junit-contest/src/main/kotlin/org/utbot/contest/Contest.kt
+++ b/utbot-junit-contest/src/main/kotlin/org/utbot/contest/Contest.kt
@@ -157,7 +157,8 @@ fun setOptions() {
     Settings.defaultConcreteExecutorPoolSize = 1
     UtSettings.useFuzzing = true
     UtSettings.classfilesCanChange = false
-    UtSettings.useAssembleModelGenerator = false
+    // We need to use assemble model generator to increase readability
+    UtSettings.useAssembleModelGenerator = true
     UtSettings.enableSummariesGeneration = false
     UtSettings.preferredCexOption = false
     UtSettings.warmupConcreteExecution = true


### PR DESCRIPTION
# Description

As SBFT 2023 introduces score for tests readability, we need to enable assemble model generator for the contest.

## Type of Change

- New feature (non-breaking change which adds functionality)
