### PR TITLE
Allowed local classes in type storages

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/objects/LocalClassExampleTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/objects/LocalClassExampleTest.kt
@@ -1,0 +1,16 @@
+package org.utbot.examples.objects
+
+import org.junit.jupiter.api.Test
+import org.utbot.testcheckers.eq
+import org.utbot.testing.UtValueTestCaseChecker
+
+class LocalClassExampleTest : UtValueTestCaseChecker(testClass = LocalClassExample::class) {
+    @Test
+    fun testLocalClassFieldExample() {
+        check(
+            LocalClassExample::localClassFieldExample,
+            eq(1),
+            { y, r -> r == y + 42 }
+        )
+    }
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Extensions.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Extensions.kt
@@ -178,10 +178,10 @@ val SootClass.isAppropriate
     get() = !isInappropriate
 
 /**
- * Returns true if the class is abstract, interface, local or if the class has UtClassMock annotation, false otherwise.
+ * Returns true if the class is abstract, interface, or if the class has UtClassMock annotation, false otherwise.
  */
 val SootClass.isInappropriate
-    get() = isAbstract || isInterface || isLocal || findMockAnnotationOrNull != null
+    get() = isAbstract || isInterface || findMockAnnotationOrNull != null
 
 private val isLocalRegex = ".*\\$\\d+[\\p{L}\\p{M}0-9][\\p{L}\\p{M}0-9]*".toRegex()
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/types/TypeResolver.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/types/TypeResolver.kt
@@ -17,7 +17,6 @@ import org.utbot.engine.isArtificialEntity
 import org.utbot.engine.isInappropriate
 import org.utbot.engine.isJavaLangObject
 import org.utbot.engine.isLambda
-import org.utbot.engine.isLocal
 import org.utbot.engine.isOverridden
 import org.utbot.engine.isUtMock
 import org.utbot.engine.makeArrayType
@@ -136,7 +135,7 @@ class TypeResolver(private val typeRegistry: TypeRegistry, private val hierarchy
     fun constructTypeStorage(type: Type, possibleTypes: Collection<Type>): TypeStorage {
         val concretePossibleTypes = possibleTypes
             .map { (if (it is ArrayType) it.baseType else it) to it.numDimensions }
-            .filterNot { (baseType, numDimensions) -> isInappropriateOrArrayOfMocksOrLocals(numDimensions, baseType) }
+            .filterNot { (baseType, numDimensions) -> isInappropriateOrArrayOfMocks(numDimensions, baseType) }
             .mapTo(mutableSetOf()) { (baseType, numDimensions) ->
                 if (numDimensions == 0) baseType else baseType.makeArrayType(numDimensions)
             }
@@ -144,7 +143,7 @@ class TypeResolver(private val typeRegistry: TypeRegistry, private val hierarchy
         return TypeStorage.constructTypeStorageUnsafe(type, concretePossibleTypes).removeInappropriateTypes()
     }
 
-    private fun isInappropriateOrArrayOfMocksOrLocals(numDimensions: Int, baseType: Type?): Boolean {
+    private fun isInappropriateOrArrayOfMocks(numDimensions: Int, baseType: Type?): Boolean {
         if (baseType !is RefType) {
             return false
         }
@@ -158,12 +157,12 @@ class TypeResolver(private val typeRegistry: TypeRegistry, private val hierarchy
         }
 
         if (numDimensions == 0 && baseSootClass.isInappropriate) {
-            // interface, abstract class, or local, or mock could not be constructed
+            // interface, abstract class, or mock could not be constructed
             return true
         }
 
-        if (numDimensions > 0 && (baseSootClass.isLocal || baseSootClass.findMockAnnotationOrNull != null)) {
-            // array of mocks or locals could not be constructed, but array of interfaces or abstract classes could be
+        if (numDimensions > 0 && baseSootClass.findMockAnnotationOrNull != null) {
+            // array of mocks could not be constructed, but array of interfaces or abstract classes could be
             return true
         }
 

--- a/utbot-sample/src/main/java/org/utbot/examples/objects/LocalClassExample.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/objects/LocalClassExample.java
@@ -1,0 +1,17 @@
+package org.utbot.examples.objects;
+
+public class LocalClassExample {
+    int localClassFieldExample(int y) {
+        class LocalClass {
+            final int x;
+
+            public LocalClass(int x) {
+                this.x = x;
+            }
+        }
+
+        LocalClass localClass = new LocalClass(42);
+
+        return localClass.x + y;
+    }
+}


### PR DESCRIPTION
# Description

Local classes are allowed in type storage like common types.

Fixes #1631.

## Type of Change

- New feature (non-breaking change which adds functionality).

# How Has This Been Tested?

## Automated Testing

`org.utbot.examples.objects.LocalClassExampleTest#testLocalClassFieldExample`

## Manual Scenario 

`org.utbot.examples.objects.LocalClassExampleTest#testLocalClassFieldExample`.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] New tests have been added
