### PR TITLE
Fixed creating chunk for field in wrapper with package-private type

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Hierarchy.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Hierarchy.kt
@@ -36,7 +36,12 @@ class Hierarchy(private val typeRegistry: TypeRegistry) {
         // Since wrapper UtThread does not inherit java.lang.Thread, we cannot use this inheritance condition only.
         // The possible presence of hidden field is not important here - we just need
         // to know whether we have at least one such field.
-        val realTypeHasFieldByName = realType.sootClass.getFieldUnsafe(field.subSignature) != null
+
+        // NOTE: we cannot use `getFieldByNameUnsafe` here because of possible hidden fields presence, and we also
+        // cannot use `ClassId::hasField` here because it use classloader to check it but we cannot load our wrappers.
+        // Also, we cannot `getFieldUnsafe` by signature of field, because, for example, `threadLocals` field in `UtThread`
+        // is declared with `Object` type since its real type is package-private.
+        val realTypeHasFieldByName = realType.sootClass.fields.any { it.name == field.name }
         val realTypeIsInheritor = realFieldDeclaringType.sootClass in ancestors(realType.sootClass.id)
 
         if (!realTypeIsInheritor && !realTypeHasFieldByName) {


### PR DESCRIPTION
# Description

Field `threadLocals` in `java.lang.Thread` has package-private type `ThreadLocal.ThreadLocalMap`, so in the corresponding wrapper this field has type `Object`. But `Hierarchy`  searches a field by subsignature, what is not applicable in such case. So, we need to search only by name.

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

`com.alibaba.fescar.core.rpc.netty.MessageCodecHandler.<init>`.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
