### PR TITLE
Fixed searching for inherited ambiguous methods

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/ConstructorUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/ConstructorUtils.kt
@@ -342,8 +342,9 @@ internal fun ClassId.getAmbiguousOverloadsOf(executableId: ExecutableId): Sequen
         is ConstructorId -> allConstructors
     }
 
+    // We should take here not only declared methods but also inherited
     return allExecutables.filter {
-        it.name == executableId.name && it.parameters.size == executableId.executable.parameters.size && it.classId == executableId.classId
+        it.name == executableId.name && it.parameters.size == executableId.executable.parameters.size
     }
 }
 


### PR DESCRIPTION
# Description

During searching of ambiguous methods, we should check inherited methods too.

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

Tests for `spoon.pattern.internal.parameter.MapParameterInfo.addValueAs` should compile.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
