### PR TITLE
Add options for clinit sections

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -515,7 +515,7 @@ object UtSettings : AbstractSettings(logger, defaultKeyForSettingsPath, defaultS
     /**
      * Process all clinit sections concretely.
      *
-     * If [enableClinitSectionsAnalysis] is true, it disables effect of this option as well.
+     * If [enableClinitSectionsAnalysis] is false, it disables effect of this option as well.
      * Note that values processed concretely won't be replaced with unbounded symbolic variables.
      */
     var processAllClinitSectionsConcretely by getBooleanProperty(false)

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -505,6 +505,19 @@ object UtSettings : AbstractSettings(logger, defaultKeyForSettingsPath, defaultS
      * The behaviour of further analysis if tests generation cancellation is requested.
      */
     var cancellationStrategyType by getEnumProperty(CancellationStrategyType.SAVE_PROCESSED_RESULTS)
+
+    /**
+     * Depending on this option, <clinit> sections might be analyzed or not.
+     * Note that some clinit sections still will be initialized using runtime information.
+     */
+    var disableClinitSectionsAnalysis by getBooleanProperty(false)
+
+    /**
+     * Process all clinit sections concretely.
+     *
+     * If [disableClinitSectionsAnalysis] is true, it disables effect of this function as well.
+     */
+    var processAllClinitSectionsConcretely by getBooleanProperty(false)
 }
 
 /**

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -510,12 +510,13 @@ object UtSettings : AbstractSettings(logger, defaultKeyForSettingsPath, defaultS
      * Depending on this option, <clinit> sections might be analyzed or not.
      * Note that some clinit sections still will be initialized using runtime information.
      */
-    var disableClinitSectionsAnalysis by getBooleanProperty(false)
+    var enableClinitSectionsAnalysis by getBooleanProperty(true)
 
     /**
      * Process all clinit sections concretely.
      *
-     * If [disableClinitSectionsAnalysis] is true, it disables effect of this function as well.
+     * If [enableClinitSectionsAnalysis] is true, it disables effect of this option as well.
+     * Note that values processed concretely won't be replaced with unbounded symbolic variables.
      */
     var processAllClinitSectionsConcretely by getBooleanProperty(false)
 }

--- a/utbot-framework-api/src/main/kotlin/org/utbot/testcheckers/SettingsModificators.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/testcheckers/SettingsModificators.kt
@@ -109,19 +109,19 @@ inline fun <reified T> withoutConcrete(block: () -> T): T {
     }
 }
 
-inline fun <reified T> withoutProcessingClinitSections(block: () -> T): T {
-    val prev = UtSettings.disableClinitSectionsAnalysis
-    UtSettings.disableClinitSectionsAnalysis = true
+inline fun <reified T> withProcessingClinitSections(value: Boolean, block: () -> T): T {
+    val prev = UtSettings.enableClinitSectionsAnalysis
+    UtSettings.enableClinitSectionsAnalysis = value
     try {
         return block()
     } finally {
-        UtSettings.disableClinitSectionsAnalysis = prev
+        UtSettings.enableClinitSectionsAnalysis = prev
     }
 }
 
-inline fun <reified T> withProcessingAllClinitSectionsConcretely(block: () -> T): T {
+inline fun <reified T> withProcessingAllClinitSectionsConcretely(value: Boolean, block: () -> T): T {
     val prev = UtSettings.processAllClinitSectionsConcretely
-    UtSettings.processAllClinitSectionsConcretely = true
+    UtSettings.processAllClinitSectionsConcretely = value
     try {
         return block()
     } finally {

--- a/utbot-framework-api/src/main/kotlin/org/utbot/testcheckers/SettingsModificators.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/testcheckers/SettingsModificators.kt
@@ -109,6 +109,27 @@ inline fun <reified T> withoutConcrete(block: () -> T): T {
     }
 }
 
+inline fun <reified T> withoutProcessingClinitSections(block: () -> T): T {
+    val prev = UtSettings.disableClinitSectionsAnalysis
+    UtSettings.disableClinitSectionsAnalysis = true
+    try {
+        return block()
+    } finally {
+        UtSettings.disableClinitSectionsAnalysis = prev
+    }
+}
+
+inline fun <reified T> withProcessingAllClinitSectionsConcretely(block: () -> T): T {
+    val prev = UtSettings.processAllClinitSectionsConcretely
+    UtSettings.processAllClinitSectionsConcretely = true
+    try {
+        return block()
+    } finally {
+        UtSettings.processAllClinitSectionsConcretely = prev
+    }
+}
+
+
 /**
  * Run [block] with disabled sandbox in the concrete executor
  */

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/objects/ClassForTestClinitSectionsTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/objects/ClassForTestClinitSectionsTest.kt
@@ -1,0 +1,53 @@
+package org.utbot.examples.objects
+
+import org.junit.jupiter.api.Test
+import org.utbot.testcheckers.eq
+import org.utbot.testcheckers.withProcessingAllClinitSectionsConcretely
+import org.utbot.testcheckers.withoutProcessingClinitSections
+import org.utbot.testing.UtValueTestCaseChecker
+import org.utbot.testing.atLeast
+
+internal class ClassForTestClinitSectionsTest : UtValueTestCaseChecker(testClass = ClassForTestClinitSections::class) {
+    @Test
+    fun testClinitWithoutClinitAnalysis() {
+        withoutProcessingClinitSections {
+            check(
+                ClassForTestClinitSections::resultDependingOnStaticSection,
+                eq(2)
+            )
+        }
+    }
+
+    @Test
+    fun testClinitWithClinitAnalysis() {
+        check(
+            ClassForTestClinitSections::resultDependingOnStaticSection,
+            eq(1),
+            coverage = atLeast(71)
+        )
+    }
+
+    @Test
+    fun testProcessConcretelyWithoutClinitAnalysis() {
+        withoutProcessingClinitSections {
+            withProcessingAllClinitSectionsConcretely {
+                check(
+                    ClassForTestClinitSections::resultDependingOnStaticSection,
+                    eq(2)
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testProcessClinitConcretely() {
+        withProcessingAllClinitSectionsConcretely {
+            check(
+                ClassForTestClinitSections::resultDependingOnStaticSection,
+                eq(1),
+                coverage = atLeast(71)
+            )
+        }
+    }
+}
+

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/objects/ClassForTestClinitSectionsTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/objects/ClassForTestClinitSectionsTest.kt
@@ -3,50 +3,65 @@ package org.utbot.examples.objects
 import org.junit.jupiter.api.Test
 import org.utbot.testcheckers.eq
 import org.utbot.testcheckers.withProcessingAllClinitSectionsConcretely
-import org.utbot.testcheckers.withoutProcessingClinitSections
+import org.utbot.testcheckers.withoutConcrete
+import org.utbot.testcheckers.withProcessingClinitSections
 import org.utbot.testing.UtValueTestCaseChecker
 import org.utbot.testing.atLeast
 
 internal class ClassForTestClinitSectionsTest : UtValueTestCaseChecker(testClass = ClassForTestClinitSections::class) {
     @Test
     fun testClinitWithoutClinitAnalysis() {
-        withoutProcessingClinitSections {
-            check(
-                ClassForTestClinitSections::resultDependingOnStaticSection,
-                eq(2)
-            )
-        }
-    }
-
-    @Test
-    fun testClinitWithClinitAnalysis() {
-        check(
-            ClassForTestClinitSections::resultDependingOnStaticSection,
-            eq(1),
-            coverage = atLeast(71)
-        )
-    }
-
-    @Test
-    fun testProcessConcretelyWithoutClinitAnalysis() {
-        withoutProcessingClinitSections {
-            withProcessingAllClinitSectionsConcretely {
+        withoutConcrete {
+            withProcessingClinitSections(value = false) {
                 check(
                     ClassForTestClinitSections::resultDependingOnStaticSection,
-                    eq(2)
+                    eq(2),
+                    { r -> r == -1 },
+                    { r -> r == 1 }
                 )
             }
         }
     }
 
     @Test
-    fun testProcessClinitConcretely() {
-        withProcessingAllClinitSectionsConcretely {
+    fun testClinitWithClinitAnalysis() {
+        withoutConcrete {
             check(
                 ClassForTestClinitSections::resultDependingOnStaticSection,
-                eq(1),
-                coverage = atLeast(71)
+                eq(2),
+                { r -> r == -1 },
+                { r -> r == 1 }
             )
+        }
+    }
+
+    @Test
+    fun testProcessConcretelyWithoutClinitAnalysis() {
+        withoutConcrete {
+            withProcessingClinitSections(value = false) {
+                withProcessingAllClinitSectionsConcretely(value = true) {
+                    check(
+                        ClassForTestClinitSections::resultDependingOnStaticSection,
+                        eq(2),
+                        { r -> r == -1 },
+                        { r -> r == 1 }
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testProcessClinitConcretely() {
+        withoutConcrete {
+            withProcessingAllClinitSectionsConcretely(value = true) {
+                check(
+                    ClassForTestClinitSections::resultDependingOnStaticSection,
+                    eq(1),
+                    { r -> r == -1 },
+                    coverage = atLeast(71)
+                )
+            }
         }
     }
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -487,6 +487,14 @@ class Traverser(
             return processStaticFieldConcretely(fieldRef, stmt)
         }
 
+        if (UtSettings.disableClinitSectionsAnalysis) {
+            return false
+        }
+
+        if (UtSettings.processAllClinitSectionsConcretely) {
+            return processStaticFieldConcretely(fieldRef, stmt)
+        }
+
         val field = fieldRef.field
         val declaringClass = field.declaringClass
         val declaringClassId = declaringClass.id

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -483,14 +483,19 @@ class Traverser(
         fieldRef: StaticFieldRef,
         stmt: Stmt
     ): Boolean {
+        // This order of processing options is important.
+        // First, we should process classes that
+        // cannot be analyzed without clinit sections, e.g., enums
         if (shouldProcessStaticFieldConcretely(fieldRef)) {
             return processStaticFieldConcretely(fieldRef, stmt)
         }
 
-        if (UtSettings.disableClinitSectionsAnalysis) {
+        // Then we should check if we should analyze clinit sections at all
+        if (!UtSettings.enableClinitSectionsAnalysis) {
             return false
         }
 
+        // Finally, we decide whether we should analyze clinit sections concretely or not
         if (UtSettings.processAllClinitSectionsConcretely) {
             return processStaticFieldConcretely(fieldRef, stmt)
         }

--- a/utbot-sample/src/main/java/org/utbot/examples/objects/ClassForTestClinitSections.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/objects/ClassForTestClinitSections.java
@@ -1,0 +1,13 @@
+package org.utbot.examples.objects;
+
+public class ClassForTestClinitSections {
+    private static int x = 5;
+
+    public int resultDependingOnStaticSection() {
+        if (x == 5) {
+            return -1;
+        }
+
+        return 1;
+    }
+}


### PR DESCRIPTION
# Description

Add two options for clinit sections: one for processing all clinit sections concretely and one for not processing them at all. 
Depending on these options, we can disable some parts of the analysis and significantly increase our performance. 

## Type of Change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Regression and integration tests

The same as automatic tests.

## Automated Testing

Tests from `org.utbot.examples.objects.ClassForTestClinitSectionsTest`

## Manual Scenario 

Checked on contest estimator and `guava-26` project

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] New tests have been added
- [x] All tests pass locally with my changes
