### PR TITLE
Fuzzer generates values even when class is private #1635

### DIFF
--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzing/providers/Objects.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzing/providers/Objects.kt
@@ -105,8 +105,18 @@ class ObjectValueProvider(
     }
 
     private fun isAccessible(member: Member, packageName: String?): Boolean {
+        var clazz = member.declaringClass
+        while (clazz != null) {
+            if (!isAccessible(clazz, packageName)) return false
+            clazz = clazz.enclosingClass
+        }
         return Modifier.isPublic(member.modifiers) ||
                 (packageName != null && isPackagePrivate(member.modifiers) && member.declaringClass.`package`?.name == packageName)
+    }
+
+    private fun isAccessible(clazz: Class<*>, packageName: String?): Boolean {
+        return Modifier.isPublic(clazz.modifiers) ||
+                (packageName != null && isPackagePrivate(clazz.modifiers) && clazz.declaringClass.`package`?.name == packageName)
     }
 
     private fun isPackagePrivate(modifiers: Int): Boolean {

--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzing/providers/Objects.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzing/providers/Objects.kt
@@ -104,28 +104,6 @@ class ObjectValueProvider(
                 || (type.isInner && !type.isStatic)
     }
 
-    private fun isAccessible(member: Member, packageName: String?): Boolean {
-        var clazz = member.declaringClass
-        while (clazz != null) {
-            if (!isAccessible(clazz, packageName)) return false
-            clazz = clazz.enclosingClass
-        }
-        return Modifier.isPublic(member.modifiers) ||
-                (packageName != null && isPackagePrivate(member.modifiers) && member.declaringClass.`package`?.name == packageName)
-    }
-
-    private fun isAccessible(clazz: Class<*>, packageName: String?): Boolean {
-        return Modifier.isPublic(clazz.modifiers) ||
-                (packageName != null && isPackagePrivate(clazz.modifiers) && clazz.declaringClass.`package`?.name == packageName)
-    }
-
-    private fun isPackagePrivate(modifiers: Int): Boolean {
-        val hasAnyAccessModifier = Modifier.isPrivate(modifiers)
-                || Modifier.isProtected(modifiers)
-                || Modifier.isProtected(modifiers)
-        return !hasAnyAccessModifier
-    }
-
     private fun findTypesOfNonRecursiveConstructor(type: FuzzedType, packageName: String?): List<ConstructorId> {
         return type.classId.allConstructors
             .filter { isAccessible(it.constructor, packageName) }
@@ -196,16 +174,22 @@ internal fun Class<*>.findPublicSetterGetterIfHasPublicGetter(field: Field, pack
     }
 }
 
-
-
 internal fun isAccessible(member: Member, packageName: String?): Boolean {
+    var clazz = member.declaringClass
+    while (clazz != null) {
+        if (!isAccessible(clazz, packageName)) return false
+        clazz = clazz.enclosingClass
+    }
     return Modifier.isPublic(member.modifiers) ||
-            (packageName != null && isPackagePrivate(member.modifiers) && member.declaringClass.`package`?.name == packageName)
+            (packageName != null && isNotPrivateOrProtected(member.modifiers) && member.declaringClass.`package`?.name == packageName)
 }
 
-internal fun isPackagePrivate(modifiers: Int): Boolean {
-    val hasAnyAccessModifier = Modifier.isPrivate(modifiers)
-            || Modifier.isProtected(modifiers)
-            || Modifier.isProtected(modifiers)
+internal fun isAccessible(clazz: Class<*>, packageName: String?): Boolean {
+    return Modifier.isPublic(clazz.modifiers) ||
+            (packageName != null && isNotPrivateOrProtected(clazz.modifiers) && clazz.declaringClass.`package`?.name == packageName)
+}
+
+private fun isNotPrivateOrProtected(modifiers: Int): Boolean {
+    val hasAnyAccessModifier = Modifier.isPrivate(modifiers) || Modifier.isProtected(modifiers)
     return !hasAnyAccessModifier
 }

--- a/utbot-fuzzers/src/test/java/org/utbot/fuzzing/samples/AccessibleObjects.java
+++ b/utbot-fuzzers/src/test/java/org/utbot/fuzzing/samples/AccessibleObjects.java
@@ -1,0 +1,19 @@
+package org.utbot.fuzzing.samples;
+
+@SuppressWarnings("unused")
+public class AccessibleObjects {
+
+    public boolean test(Inn.Node n) {
+        return n.value * n.value == 36;
+    }
+
+    private static class Inn {
+        static class Node {
+            public int value;
+
+            public Node() {
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Description

Fixes an issue when some declared type is private, but has public constructor, fields or setter/getter. Fuzzer cannot create such values without reflections therefore it is prohibited to produce them.

Fixes #1635 

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Regression and integration tests

Added new test `fuzzing should not generate values of private classes` into JavaFuzzingTest.kt

## Manual Scenario 

Try to reproduce issue's scenario. It should not create any test.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] New tests have been added
- [x] All tests pass locally with my changes
