### PR TITLE
Remove redundant and harmful casts in overloads processing

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/access/CgCallableAccessManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/access/CgCallableAccessManager.kt
@@ -518,12 +518,15 @@ internal class CgCallableAccessManagerImpl(val context: CgContext) : CgCallableA
             // in case arg type exactly equals target type, do nothing
             if (arg.type == targetType) return@map arg
 
-            // arg type is subtype of target type
-            // check other overloads for ambiguous types
-            val typesInOverloadings = ambiguousOverloads.map { it.parameters[i] }
-            val ancestors = typesInOverloadings.filter { arg.type.isSubtypeOf(it) }
+            // if we are here, arg type is a subtype of target type
+            // we should check other overloads for ambiguous types
+            val anotherTypesInOverloadings = ambiguousOverloads
+                .map { it.parameters[i] }
+                .filter { arg.type.isSubtypeOf(it) }
+                .filterNot { it == targetType }
+                .isNotEmpty()
 
-            if (ancestors.isNotEmpty()) typeCast(targetType, arg) else arg
+            if (anotherTypesInOverloadings) typeCast(targetType, arg) else arg
         }
 
     /**


### PR DESCRIPTION
# Description

Remove redundant and harmful casts in overloads processing

Fixes # ([1641](https://github.com/UnitTestBot/UTBotJava/issues/1641))

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Verify the scenario described in the issue
- Check that there are no new compilation errors with type casts using utbot-samples pipeline