### PR TITLE
Remove error from generics processing

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/types/GenericsTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/types/GenericsTest.kt
@@ -3,6 +3,7 @@ package org.utbot.examples.types
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.utbot.testcheckers.eq
+import org.utbot.testing.DoNotCalculate
 import org.utbot.testing.UtValueTestCaseChecker
 import org.utbot.testing.ignoreExecutionsNumber
 
@@ -13,7 +14,7 @@ internal class GenericsTest : UtValueTestCaseChecker(
     @Test
     fun mapAsParameterTest() {
         check(
-            Generics::mapAsParameter,
+            Generics<*>::mapAsParameter,
             eq(2),
             { map, _ -> map == null },
             { map, r -> map != null && r == "value" },
@@ -24,7 +25,7 @@ internal class GenericsTest : UtValueTestCaseChecker(
     @Disabled("https://github.com/UnitTestBot/UTBotJava/issues/1620 wrong equals")
     fun genericAsFieldTest() {
         check(
-            Generics::genericAsField,
+            Generics<*>::genericAsField,
             ignoreExecutionsNumber,
             { obj, r -> obj?.field == null && r == false },
             // we can cover this line with any of these two conditions
@@ -35,7 +36,7 @@ internal class GenericsTest : UtValueTestCaseChecker(
     @Test
     fun mapAsStaticFieldTest() {
         check(
-            Generics::mapAsStaticField,
+            Generics<*>::mapAsStaticField,
             ignoreExecutionsNumber,
             { r -> r == "value" },
         )
@@ -44,7 +45,7 @@ internal class GenericsTest : UtValueTestCaseChecker(
     @Test
     fun mapAsNonStaticFieldTest() {
         check(
-            Generics::mapAsNonStaticField,
+            Generics<*>::mapAsNonStaticField,
             ignoreExecutionsNumber,
             { map, _ -> map == null },
             { map, r -> map != null && r == "value" },
@@ -54,10 +55,20 @@ internal class GenericsTest : UtValueTestCaseChecker(
     @Test
     fun methodWithRawTypeTest() {
         check(
-            Generics::methodWithRawType,
+            Generics<*>::methodWithRawType,
             eq(2),
             { map, _ -> map == null },
             { map, r -> map != null && r == "value" },
+        )
+    }
+
+    @Test
+    fun testMethodWithArrayTypeBoundary() {
+        checkWithException(
+            Generics<*>::methodWithArrayTypeBoundary,
+            eq(1),
+            { r -> r.exceptionOrNull() is java.lang.NullPointerException },
+            coverage = DoNotCalculate
         )
     }
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -1111,7 +1111,8 @@ class Traverser(
 
                     if (allTypes.any { it is GenericArrayType }) {
                         val errorTypes = allTypes.filterIsInstance<GenericArrayType>()
-                        TODO("we do not support GenericArrayTypeImpl yet, and $errorTypes found. SAT-1446")
+                        logger.warn { "we do not support GenericArrayTypeImpl yet, and $errorTypes found. SAT-1446" }
+                        return
                     }
 
                     val upperBoundsTypes = typeResolver.intersectInheritors(upperBounds)
@@ -1124,7 +1125,8 @@ class Traverser(
 
                     if (upperBounds.any { it is GenericArrayType }) {
                         val errorTypes = upperBounds.filterIsInstance<GenericArrayType>()
-                        TODO("we do not support GenericArrayType yet, and $errorTypes found. SAT-1446")
+                        logger.warn { "we do not support GenericArrayType yet, and $errorTypes found. SAT-1446" }
+                        return
                     }
 
                     val upperBoundsTypes = typeResolver.intersectInheritors(upperBounds)

--- a/utbot-sample/src/main/java/org/utbot/examples/types/Generics.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/types/Generics.java
@@ -1,8 +1,10 @@
 package org.utbot.examples.types;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
-public class Generics {
+public class Generics<T> {
     public boolean genericAsField(CollectionAsField<String> object) {
         if (object != null && object.field != null) {
             return object.field.equals("abc");
@@ -37,5 +39,19 @@ public class Generics {
     @SuppressWarnings("UnusedReturnValue")
     private Map<String, String> nestedMethodWithGenericInfo(Map<String, String> map) {
         return map;
+    }
+
+    public int methodWithArrayTypeBoundary() {
+        return new ArrayTypeParameters<T>().methodWithArrayTypeBoundary(null);
+    }
+}
+
+class ArrayTypeParameters<T> {
+    public int methodWithArrayTypeBoundary(List<? extends T[]> list) {
+        if (list.isEmpty()) {
+            return -1;
+        }
+
+        return 1;
     }
 }


### PR DESCRIPTION
# Description

We have some unsupported types of generic parameters that were mocked with `TODO` function, which led to exceptions when these types are encountered. This request replaces `TODO` instruction with logging

## Type of Change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

## Regression and integration tests

Same as automatic tests.

## Automated Testing

`org.utbot.examples.types.GenericsTest#testMethodWithArrayTypeBoundary`

## Manual Scenario 

Didn't check manually, only in the debugger for the automatic test above.

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
- [x] New tests have been added
- [x] All tests pass locally with my changes
