### PR TITLE
Labels corrected in Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: 'bug'
+labels: 'cat-bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for the UTBot project
 title: ''
-labels: 'enhancement'
+labels: 'cat-enhancement'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/test_request.md
+++ b/.github/ISSUE_TEMPLATE/test_request.md
@@ -2,7 +2,7 @@
 name: Manual testing checklist
 about: Checklist of testing process
 title: 'Manual testing of build#'
-labels: 'qa'
+labels: 'cat-qa'
 assignees: ''
 
 ---


### PR DESCRIPTION
# Description

Labels were renamed to have prefixes inside names: https://github.com/UnitTestBot/UTBotJava/labels?page=1&sort=name-asc
Issue templates should be corrected accordingly.

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

Copy-pasted labels' names into MD-files.

# Checklist (remove irrelevant options):

- [x] Self-review of the code is passed
- [x] No new warnings
