### PR TITLE
Improve Contest Estimator performance #1659

### DIFF
--- a/utbot-junit-contest/src/main/kotlin/org/utbot/contest/Contest.kt
+++ b/utbot-junit-contest/src/main/kotlin/org/utbot/contest/Contest.kt
@@ -293,7 +293,7 @@ fun runGeneration(
                     UtSettings.fuzzingTimeoutInMillis = (budgetForMethod * fuzzingRatio).toLong()
 
                     //start controller that will activate symbolic execution
-                    GlobalScope.launch(currentContext) {
+                    launch(currentContext) {
                         delay(budgetForSymbolicExecution)
 
                         if (methodJob.isActive) {
@@ -366,8 +366,7 @@ fun runGeneration(
                 controller.job = job
 
                 //don't start other methods while last method still in progress
-                while (job.isActive)
-                    yield()
+                job.join()
 
                 remainingMethodsCount--
             }

--- a/utbot-junit-contest/src/main/kotlin/org/utbot/contest/Contest.kt
+++ b/utbot-junit-contest/src/main/kotlin/org/utbot/contest/Contest.kt
@@ -366,7 +366,11 @@ fun runGeneration(
                 controller.job = job
 
                 //don't start other methods while last method still in progress
-                job.join()
+                try {
+                    job.join()
+                } catch (t: Throwable) {
+                    logger.error(t) { "Internal job error" }
+                }
 
                 remainingMethodsCount--
             }

--- a/utbot-junit-contest/src/main/kotlin/org/utbot/contest/Contest.kt
+++ b/utbot-junit-contest/src/main/kotlin/org/utbot/contest/Contest.kt
@@ -293,7 +293,7 @@ fun runGeneration(
                     UtSettings.fuzzingTimeoutInMillis = (budgetForMethod * fuzzingRatio).toLong()
 
                     //start controller that will activate symbolic execution
-                    launch(currentContext) {
+                    GlobalScope.launch(currentContext) {
                         delay(budgetForSymbolicExecution)
 
                         if (methodJob.isActive) {

--- a/utbot-junit-contest/src/main/kotlin/org/utbot/contest/Contest.kt
+++ b/utbot-junit-contest/src/main/kotlin/org/utbot/contest/Contest.kt
@@ -199,7 +199,7 @@ fun runGeneration(
         setOptions()
         //will not be executed in real contest
         logger.info().bracket("warmup: 1st optional soot initialization and executor warmup (not to be counted in time budget)") {
-            TestCaseGenerator(listOf(cut.classfileDir.toPath()), classpathString, dependencyPath, JdkInfoService.provide())
+            TestCaseGenerator(listOf(cut.classfileDir.toPath()), classpathString, dependencyPath, JdkInfoService.provide(), forceSootReload = false)
         }
         logger.info().bracket("warmup (first): kotlin reflection :: init") {
             prepareClass(ConcreteExecutorPool::class.java, "")
@@ -241,7 +241,7 @@ fun runGeneration(
 
         val testCaseGenerator =
             logger.info().bracket("2nd optional soot initialization") {
-                TestCaseGenerator(listOf(cut.classfileDir.toPath()), classpathString, dependencyPath, JdkInfoService.provide())
+                TestCaseGenerator(listOf(cut.classfileDir.toPath()), classpathString, dependencyPath, JdkInfoService.provide(), forceSootReload = false)
             }
 
 


### PR DESCRIPTION
# Description

Use non-blocking `job.join` instead of spinlock for waiting until subjob is done (fixes #1659). Also, do not force reloading soot, because it takes budget time as much as 1 initialization does.

Fixes #1659

## Type of Change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

Run the example from the issue. It generates tests with coverage > 50%. 

```
<StatsForClass(com.google.common.primitives.Shorts)> :
	canceled by timeout = true
	#methods = 49, 
	#methods started symbolic exploration = 49
	#methods with at least one TC = 24
	#methods with exceptions = 0
	#generated TC = 175
	#total coverage = 505/891
	#fuzzed coverage = 505/891
	#concolic coverage = 0/891
```

Also, profiler's result is much clearer:

![image](https://user-images.githubusercontent.com/720952/211978766-c8cd90be-a92e-49fe-b977-fccb226d49eb.png)


<details>
<summary><h3>Test generation with only `forceSootReload = false` optimization</h3></summary>

```
<StatsForClass(com.google.common.primitives.Shorts)> :
	canceled by timeout = true
	#methods = 49, 
	#methods started symbolic exploration = 49
	#methods with at least one TC = 20
	#methods with exceptions = 0
	#generated TC = 90
	#total coverage = 464/891
	#fuzzed coverage = 464/891
	#concolic coverage = 0/891
```

![image](https://user-images.githubusercontent.com/720952/211981968-07ab2db3-6e0e-479d-be1a-7e05c593c586.png)

</details>

<details>
<summary><h3>Test generation with only `job.join` optimization</h3></summary>

```
<StatsForClass(com.google.common.primitives.Shorts)> :
	canceled by timeout = true
	#methods = 49, 
	#methods started symbolic exploration = 49
	#methods with at least one TC = 23
	#methods with exceptions = 0
	#generated TC = 165
	#total coverage = 487/891
	#fuzzed coverage = 487/891
	#concolic coverage = 0/891
```

![image](https://user-images.githubusercontent.com/720952/211982873-3f5a00b5-be45-403f-9e23-e09d17b5b701.png)

</details>

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [ ] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [x] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes

