### PR TITLE
Labels corrected in Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: 'cat-bug'
+labels: 'ctg-bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for the UTBot project
 title: ''
-labels: 'cat-enhancement'
+labels: 'ctg-enhancement'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/test_request.md
+++ b/.github/ISSUE_TEMPLATE/test_request.md
@@ -2,7 +2,7 @@
 name: Manual testing checklist
 about: Checklist of testing process
 title: 'Manual testing of build#'
-labels: 'cat-qa'
+labels: 'ctg-qa'
 assignees: ''
 
 ---


### PR DESCRIPTION
# Description

Labels are changed: ctg-qa, ctg-bug, ctg-enhancement.
Here is the corresponding change in github ISSUE_TEMPLATES.

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Manual Scenario 

Need to check new issues have labels when PR is merged.

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [x] Self-review of the code is passed
