### PR TITLE
Remove undue 'byFuzzer' suffix rendering

### DIFF
--- a/utbot-summary/src/main/kotlin/org/utbot/summary/fuzzer/names/MethodBasedNameSuggester.kt
+++ b/utbot-summary/src/main/kotlin/org/utbot/summary/fuzzer/names/MethodBasedNameSuggester.kt
@@ -3,9 +3,17 @@ package org.utbot.summary.fuzzer.names
 import org.utbot.framework.plugin.api.UtExecutionResult
 import org.utbot.fuzzer.FuzzedMethodDescription
 import org.utbot.fuzzer.FuzzedValue
+import org.utbot.summary.MethodDescriptionSource
 
-class MethodBasedNameSuggester : NameSuggester {
-    override fun suggest(description: FuzzedMethodDescription, values: List<FuzzedValue>, result: UtExecutionResult?): Sequence<TestSuggestedInfo> {
-        return sequenceOf(TestSuggestedInfo("test${description.compilableName?.capitalize() ?: "Created"}ByFuzzer"))
+class MethodBasedNameSuggester(private val source: MethodDescriptionSource = MethodDescriptionSource.FUZZER) : NameSuggester {
+    override fun suggest(
+        description: FuzzedMethodDescription,
+        values: List<FuzzedValue>,
+        result: UtExecutionResult?
+    ): Sequence<TestSuggestedInfo> {
+        val compilableName = description.compilableName?.capitalize() ?: "Created"
+        // See [Summarization.generateSummariesForTests].
+        val suffix = if (source == MethodDescriptionSource.FUZZER) "ByFuzzer" else ""
+        return sequenceOf(TestSuggestedInfo("test${compilableName}${suffix}"))
     }
 }


### PR DESCRIPTION
# Description

Some test methods had *byFuzzer* suffix even when they were generated by Symbolic Engine.
The PR fixed that.

Fixes # ([1666](https://github.com/UnitTestBot/UTBotJava/issues/1666))

## Type of Change

- Bug fix (non-breaking change which fixes an issue)
- Refactoring (typos and non-functional changes) 

# How Has This Been Tested?

## Manual Scenario 

Reproduced the problem from the issue with no unwanted *byFuzzer* suffix.