### PR TITLE
Locate inner classes tests in outer test class if JUnit4 is used

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
@@ -409,11 +409,6 @@ object Junit4 : TestFramework(id = "JUnit4",displayName = "JUnit 4") {
         )
     }
 
-    val enclosedClassId = BuiltinClassId(
-        canonicalName = "org.junit.experimental.runners.Enclosed",
-        simpleName = "Enclosed"
-    )
-
     override val nestedClassesShouldBeStatic = true
 
     override val argListClassId: ClassId

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/TestFrameworkManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/TestFrameworkManager.kt
@@ -88,8 +88,6 @@ abstract class TestFrameworkManager(val context: CgContext)
 
     abstract val annotationForNestedClasses: CgAnnotation?
 
-    abstract val annotationForOuterClasses: CgAnnotation?
-
     /**
      * Determines whether appearance of expected exception in test method breaks current test execution or not.
      */
@@ -261,9 +259,6 @@ internal class TestNgManager(context: CgContext) : TestFrameworkManager(context)
     override val annotationForNestedClasses: CgAnnotation?
         get() = null
 
-    override val annotationForOuterClasses: CgAnnotation?
-        get() = null
-
     override val isExpectedExceptionExecutionBreaking: Boolean = false
 
     override val timeoutArgumentName: String = "timeOut"
@@ -409,20 +404,6 @@ internal class Junit4Manager(context: CgContext) : TestFrameworkManager(context)
     override val annotationForNestedClasses: CgAnnotation?
         get() = null
 
-    override val annotationForOuterClasses: CgAnnotation
-        get() {
-            require(testFramework is Junit4) { "According to settings, JUnit4 was expected, but got: $testFramework" }
-            return statementConstructor.annotation(
-                testFramework.runWithAnnotationClassId,
-                testFramework.enclosedClassId.let {
-                    when (codegenLanguage) {
-                        CodegenLanguage.JAVA   -> CgGetJavaClass(it)
-                        CodegenLanguage.KOTLIN -> CgGetKotlinClass(it)
-                    }
-                }
-            )
-        }
-
     override val isExpectedExceptionExecutionBreaking: Boolean = true
 
     override fun expectException(exception: ClassId, block: () -> Unit) {
@@ -481,12 +462,8 @@ internal class Junit5Manager(context: CgContext) : TestFrameworkManager(context)
     override val annotationForNestedClasses: CgAnnotation
         get() {
             require(testFramework is Junit5) { "According to settings, JUnit5 was expected, but got: $testFramework" }
-
             return statementConstructor.annotation(testFramework.nestedTestClassAnnotationId)
         }
-
-    override val annotationForOuterClasses: CgAnnotation?
-        get() = null
 
     override val isExpectedExceptionExecutionBreaking: Boolean = false
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgTestClassConstructor.kt
@@ -1,7 +1,10 @@
 package org.utbot.framework.codegen.tree
 
 import org.utbot.framework.UtSettings
+import org.utbot.framework.codegen.domain.Junit4
+import org.utbot.framework.codegen.domain.Junit5
 import org.utbot.framework.codegen.domain.ParametrizedTestSource
+import org.utbot.framework.codegen.domain.TestNg
 import org.utbot.framework.codegen.domain.builtin.TestClassUtilMethodProvider
 import org.utbot.framework.codegen.domain.context.CgContext
 import org.utbot.framework.codegen.domain.context.CgContextOwner
@@ -77,23 +80,30 @@ open class CgTestClassConstructor(val context: CgContext) :
                     currentTestClassContext.collectedTestClassAnnotations += it
                 }
             }
-            if (testClassModel.nestedClasses.isNotEmpty()) {
-                testFrameworkManager.annotationForOuterClasses?.let {
-                    currentTestClassContext.collectedTestClassAnnotations += it
-                }
-            }
 
             body = buildClassBody(currentTestClass) {
+                val notYetConstructedTestSets = testClassModel.methodTestSets.toMutableList()
+
                 for (nestedClass in testClassModel.nestedClasses) {
-                    nestedClassRegions += CgRealNestedClassesRegion(
-                        "Tests for ${nestedClass.classUnderTest.simpleName}",
-                        listOf(
-                            withNestedClassScope(nestedClass) { constructTestClass(nestedClass) }
-                        )
-                    )
+                    // It is not possible to run tests for both outer and inner class in JUnit4 at once,
+                    // so we locate all test methods in outer test class for JUnit4.
+                    // see https://stackoverflow.com/questions/69770700/how-to-run-tests-from-outer-class-and-nested-inner-classes-simultaneously-in-jun
+                    // or https://stackoverflow.com/questions/28230277/test-cases-in-inner-class-and-outer-class-with-junit4
+                    when (testFramework) {
+                        Junit4 -> {
+                            notYetConstructedTestSets += nestedClass.methodTestSets
+                        }
+                        Junit5,
+                        TestNg -> {
+                            nestedClassRegions += CgRealNestedClassesRegion(
+                                "Tests for ${nestedClass.classUnderTest.simpleName}",
+                                listOf(withNestedClassScope(nestedClass) { constructTestClass(nestedClass) })
+                            )
+                        }
+                    }
                 }
 
-                for (testSet in testClassModel.methodTestSets) {
+                for (testSet in notYetConstructedTestSets) {
                     updateCurrentExecutable(testSet.executableId)
                     val currentMethodUnderTestRegions = constructTestSet(testSet) ?: continue
                     val executableUnderTestCluster = CgMethodsCluster(

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgTestClassConstructor.kt
@@ -91,7 +91,7 @@ open class CgTestClassConstructor(val context: CgContext) :
                     // or https://stackoverflow.com/questions/28230277/test-cases-in-inner-class-and-outer-class-with-junit4
                     when (testFramework) {
                         Junit4 -> {
-                            notYetConstructedTestSets += nestedClass.methodTestSets
+                            notYetConstructedTestSets += collectTestSetsFromInnerClasses(nestedClass)
                         }
                         Junit5,
                         TestNg -> {
@@ -169,6 +169,15 @@ open class CgTestClassConstructor(val context: CgContext) :
         }
 
         return if (regions.any()) regions else null
+    }
+
+    private fun collectTestSetsFromInnerClasses(model: TestClassModel): List<CgMethodTestSet> {
+        val testSets = model.methodTestSets.toMutableList()
+        for (nestedClass in model.nestedClasses) {
+            testSets += collectTestSetsFromInnerClasses(nestedClass)
+        }
+
+        return testSets
     }
 
     private fun processFailure(testSet: CgMethodTestSet, failure: Throwable) {

--- a/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/constructor/tree/PythonTestFrameworkManager.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/constructor/tree/PythonTestFrameworkManager.kt
@@ -53,8 +53,6 @@ internal class PytestManager(context: CgContext) : TestFrameworkManager(context)
     override val dataProviderMethodsHolder: TestClassContext get() = TODO()
     override val annotationForNestedClasses: CgAnnotation
         get() = TODO("Not yet implemented")
-    override val annotationForOuterClasses: CgAnnotation
-        get() = TODO("Not yet implemented")
 
     override fun assertEquals(expected: CgValue, actual: CgValue) {
         +CgPythonAssertEquals(
@@ -85,8 +83,6 @@ internal class UnittestManager(context: CgContext) : TestFrameworkManager(contex
     override val dataProviderMethodsHolder: TestClassContext
         get() = TODO()
     override val annotationForNestedClasses: CgAnnotation
-        get() = TODO("Not yet implemented")
-    override val annotationForOuterClasses: CgAnnotation
         get() = TODO("Not yet implemented")
 
     override fun expectException(exception: ClassId, block: () -> Unit) {


### PR DESCRIPTION
# Description

JUnit4 does not allow to run tests for both outer and inner class.
To avoid losing coverage, we locate all test methods for inner class in a body of outer test class.

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Regression and integration tests

Standard scenarios to generate and run tests with nested classes for ALL supported test frameworks
Regression checks for classes without nested ones.

## Manual Scenario 

Check test generation for the following class

```java
public class OuterClass {

    public int sum(int a, int b) {
        return a + b;
    }

    public class InnerClass {
        public int min(int a, int b) {
            if (a > b) return b;
            else return a;
        }
    }
```

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [+] The change followed the style guidelines of the UTBot project
- [+] Self-review of the code is passed
- [+] The change contains enough commentaries, particularly in hard-to-understand areas
- [ ] New documentation is provided or existed one is altered
- [+] No new warnings
- [ ] New tests have been added
- [ ] All tests pass locally with my changes
