### PR TITLE
Fix broken summary indention

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -1428,3 +1428,12 @@ class DocRegularStmt(val stmt: String) : DocStatement() {
 
     override fun hashCode(): Int = stmt.hashCode()
 }
+
+class DocRegularLineStmt(val stmt: String) : DocStatement() {
+    override fun toString(): String = stmt
+
+    override fun equals(other: Any?): Boolean =
+        if (other is DocRegularLineStmt) this.hashCode() == other.hashCode() else false
+
+    override fun hashCode(): Int = stmt.hashCode()
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/CgElement.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/CgElement.kt
@@ -15,6 +15,7 @@ import org.utbot.framework.plugin.api.DocCodeStmt
 import org.utbot.framework.plugin.api.DocCustomTagStatement
 import org.utbot.framework.plugin.api.DocMethodLinkStmt
 import org.utbot.framework.plugin.api.DocPreTagStatement
+import org.utbot.framework.plugin.api.DocRegularLineStmt
 import org.utbot.framework.plugin.api.DocRegularStmt
 import org.utbot.framework.plugin.api.DocStatement
 import org.utbot.framework.plugin.api.ExecutableId
@@ -473,6 +474,7 @@ fun convertDocToCg(stmt: DocStatement): CgDocStatement {
             CgCustomTagStatement(statements = stmts)
         }
         is DocRegularStmt -> CgDocRegularStmt(stmt = stmt.stmt)
+        is DocRegularLineStmt -> CgDocRegularLineStmt(stmt = stmt.stmt)
         is DocClassLinkStmt -> CgDocClassLinkStmt(className = stmt.className)
         is DocMethodLinkStmt -> CgDocMethodLinkStmt(methodName = stmt.methodName, stmt = stmt.className)
         is DocCodeStmt -> CgDocCodeStmt(stmt = stmt.stmt)

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgAbstractRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgAbstractRenderer.kt
@@ -330,7 +330,7 @@ abstract class CgAbstractRenderer(
         if (element.lines.all { it.isEmpty() }) return
 
         println("/**")
-        for (line in element.lines) line.accept(this)
+        element.lines.forEach { it.accept(this) }
         println(" */")
     }
     override fun visit(element: CgDocPreTagStatement) {
@@ -343,9 +343,7 @@ abstract class CgAbstractRenderer(
     override fun visit(element: CgCustomTagStatement) {
         if (element.statements.all { it.isEmpty() }) return
 
-        for (stmt in element.statements) {
-            stmt.accept(this)
-        }
+        element.statements.forEach { it.accept(this) }
     }
 
     override fun visit(element: CgDocCodeStmt) {
@@ -366,7 +364,10 @@ abstract class CgAbstractRenderer(
     override fun visit(element: CgDocRegularLineStmt){
         if (element.isEmpty()) return
 
-        print(" * " + element.stmt + "\n")
+        // It is better to avoid using \n in print, using println is preferred.
+        // Mixing println's and print's with '\n' BREAKS indention.
+        // See [https://stackoverflow.com/questions/6685665/system-out-println-vs-n-in-java].
+        println(" * " + element.stmt)
     }
     override fun visit(element: CgDocClassLinkStmt) {
         if (element.isEmpty()) return

--- a/utbot-summary/src/main/kotlin/org/utbot/summary/comment/customtags/CustomJavaDocTagProvider.kt
+++ b/utbot-summary/src/main/kotlin/org/utbot/summary/comment/customtags/CustomJavaDocTagProvider.kt
@@ -1,6 +1,8 @@
 package org.utbot.summary.comment.customtags.symbolic
 
+import org.utbot.framework.plugin.api.DocRegularLineStmt
 import org.utbot.framework.plugin.api.DocRegularStmt
+import org.utbot.framework.plugin.api.DocStatement
 import org.utbot.summary.comment.customtags.fuzzer.CommentWithCustomTagForTestProducedByFuzzer
 
 /**
@@ -85,11 +87,11 @@ sealed class CustomJavaDocTag(
         }
 
     // TODO: could be universal with the function above after creation of hierarchy data classes related to the comments
-    fun generateDocStatementForTestProducedByFuzzer(comment: CommentWithCustomTagForTestProducedByFuzzer): DocRegularStmt? {
+    fun generateDocStatementForTestProducedByFuzzer(comment: CommentWithCustomTagForTestProducedByFuzzer): DocStatement? {
         if (valueRetrieverFuzzer != null) { //TODO: it required only when we have two different retrievers
             return when (val value = valueRetrieverFuzzer!!.invoke(comment)) { // TODO: unsafe !! - resolve
                 is String -> value.takeIf { it.isNotEmpty() }?.let {
-                    DocRegularStmt("@$name $value\n")
+                    DocRegularLineStmt("@$name $value")
                 }
 
                 is List<*> -> value.takeIf { it.isNotEmpty() }?.let {

--- a/utbot-testing/src/main/kotlin/org/utbot/testing/UtValueTestCaseChecker.kt
+++ b/utbot-testing/src/main/kotlin/org/utbot/testing/UtValueTestCaseChecker.kt
@@ -24,6 +24,7 @@ import org.utbot.framework.plugin.api.DocCodeStmt
 import org.utbot.framework.plugin.api.DocCustomTagStatement
 import org.utbot.framework.plugin.api.DocMethodLinkStmt
 import org.utbot.framework.plugin.api.DocPreTagStatement
+import org.utbot.framework.plugin.api.DocRegularLineStmt
 import org.utbot.framework.plugin.api.DocRegularStmt
 import org.utbot.framework.plugin.api.DocStatement
 import org.utbot.framework.plugin.api.ExecutableId
@@ -2827,6 +2828,7 @@ private fun flattenDocStatements(summary: List<DocStatement>): List<DocStatement
             is DocMethodLinkStmt -> flatten.add(s)
             is DocCodeStmt -> flatten.add(s)
             is DocRegularStmt -> flatten.add(s)
+            is DocRegularLineStmt -> flatten.add(s)
             is DocCustomTagStatement -> flatten.add(s)
         }
     }


### PR DESCRIPTION
# Description

Test generated by Contest Estimator had summaries with bad formatting. This PR fixes the issue.
The problem was with mixing usage of print with '\n' inside and println.

> There is a functional difference between the two. The first version outputs line breaks using the platform's preferred line separator. The second version outputs newline characters, which is likely to be inappropriate on Windows or Mac OS.
[source](https://stackoverflow.com/questions/6685665/system-out-println-vs-n-in-java)

Fixes # ([1667](https://github.com/UnitTestBot/UTBotJava/issues/1667))

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

utbot-samples.

## Manual Scenario 
Run contest estimator as described in the issue.
The following summaries will be generated, meaning that the indention problem was fixed.
```java
///region FUZZER: SUCCESSFUL EXECUTIONS for method max(short[])

/**
 * @utbot.classUnderTest {@link com.google.common.primitives.Shorts}
 * @utbot.methodUnderTest {@link com.google.common.primitives.Shorts#max(short[])}
 */
@Test
public void testMaxReturnsZeroWithNonEmptyPrimitiveArray() {
    short[] shortArray = {java.lang.Short.MIN_VALUE, (short) 0, (short) 0};
    
    short actual = Shorts.max(shortArray);
    
    assertEquals((short) 0, actual);
}
///endregion
```