### PR TITLE
Turn off sandbox as it breaks class loading in case of exception in static constructor

### DIFF
--- a/utbot-junit-contest/src/main/kotlin/org/utbot/contest/Contest.kt
+++ b/utbot-junit-contest/src/main/kotlin/org/utbot/contest/Contest.kt
@@ -170,6 +170,7 @@ fun setOptions() {
     UtSettings.testMinimizationStrategyType = TestSelectionStrategyType.COVERAGE_STRATEGY
     UtSettings.ignoreStringLiterals = true
     UtSettings.maximizeCoverageUsingReflection = true
+    UtSettings.useSandbox = false
 }
 
 


### PR DESCRIPTION
Turn off sandbox as it breaks class loading in case of exception in static constructor. 
Fix #1665
Possible fix #1650 - split issues in case

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual testing on `spoon-core-7.0.0`