### PR TITLE
Correct accessibily for package-private fields

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgMethodConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgMethodConstructor.kt
@@ -151,6 +151,7 @@ import org.utbot.framework.plugin.api.util.doubleStreamClassId
 import org.utbot.framework.plugin.api.util.doubleStreamToArrayMethodId
 import org.utbot.framework.plugin.api.util.intStreamClassId
 import org.utbot.framework.plugin.api.util.intStreamToArrayMethodId
+import org.utbot.framework.plugin.api.util.isPackagePrivate
 import org.utbot.framework.plugin.api.util.isSubtypeOf
 import org.utbot.framework.plugin.api.util.longStreamClassId
 import org.utbot.framework.plugin.api.util.longStreamToArrayMethodId
@@ -1112,7 +1113,11 @@ open class CgMethodConstructor(val context: CgContext) : CgContextOwner by conte
     private fun FieldId.getAccessExpression(variable: CgVariable): CgExpression =
         // Can directly access field only if it is declared in variable class (or in its ancestors)
         // and is accessible from current package
-        if (variable.type.hasField(this) && canBeReadFrom(context)) {
+        if (variable.type.hasField(this)
+            //TODO: think about moving variable type checks into [isAccessibleFrom] after contest
+            && (!isPackagePrivate || variable.type.packageName == context.testClassPackageName)
+            && canBeReadFrom(context)
+        ) {
             if (jField.isStatic) CgStaticFieldAccess(this) else CgFieldAccess(variable, this)
         } else {
             utilsClassId[getFieldValue](variable, this.declaringClass.name, this.name)


### PR DESCRIPTION
# Description

Consider the following scenario:
 - we need to access package-private field
 - it is declared in a class that is in the same package as a test class
 - but the resolved variable type is represented in a class from another package

Thus we get compilation error. Here is a fix for it.

Fixes # ([1677](https://github.com/UnitTestBot/UTBotJava/issues/1677))

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Automated Testing

Run ContestEstimator with the following filter:

```
methodFilter = "spoon.support.reflect.code.CtAssignmentImpl.*"
```

## Manual Scenario 

Standard regression checks on package-private fields accessors.

# Checklist (remove irrelevant options):

_This is the author self-check list_

- [+] The change followed the style guidelines of the UTBot project
- [+] Self-review of the code is passed
- [+] No new warnings
