### PR TITLE
Return soot initialization for contest after its removal

### DIFF
--- a/utbot-junit-contest/src/main/kotlin/org/utbot/contest/Contest.kt
+++ b/utbot-junit-contest/src/main/kotlin/org/utbot/contest/Contest.kt
@@ -122,6 +122,10 @@ fun main(args: Array<String>) {
 
 
     withUtContext(context) {
+        // Initialize the soot before a contest is started.
+        // This saves the time budget for real work instead of soot initialization.
+        TestCaseGenerator(listOf(classfileDir), classpathString, dependencyPath, JdkInfoService.provide())
+
         logger.info().bracket("warmup: kotlin reflection :: init") {
             prepareClass(ConcreteExecutorPool::class.java, "")
             prepareClass(Warmup::class.java, "")


### PR DESCRIPTION
# Description

Returns soot initialization into ContestKt.main. It is required for saving time budget in the main loop.

The calling was removed in #540.

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

Ran it manually from the contest infrastructure.
