### PR TITLE
Fixed JavaScript `UtContext` error & removed annotation for framework outer classes 

### DIFF
--- a/utbot-js/src/main/kotlin/framework/api/js/JsApi.kt
+++ b/utbot-js/src/main/kotlin/framework/api/js/JsApi.kt
@@ -1,12 +1,12 @@
 package framework.api.js
 
-import java.lang.reflect.Modifier
+import framework.api.js.util.toJsClassId
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.ConstructorId
 import org.utbot.framework.plugin.api.MethodId
 import org.utbot.framework.plugin.api.UtModel
-import framework.api.js.util.toJsClassId
 import org.utbot.framework.plugin.api.primitiveModelValueToClassId
+import java.lang.reflect.Modifier
 
 open class JsClassId(
     private val jsName: String,
@@ -17,6 +17,9 @@ open class JsClassId(
     elementClassId: JsClassId? = null
 ) : ClassId(jsName, elementClassId) {
     override val simpleName: String
+        get() = jsName
+
+    override val simpleNameWithEnclosingClasses: String
         get() = jsName
 
     override val allMethods: Sequence<JsMethodId>

--- a/utbot-js/src/main/kotlin/framework/codegen/model/constructor/tree/JsTestFrameworkManager.kt
+++ b/utbot-js/src/main/kotlin/framework/codegen/model/constructor/tree/JsTestFrameworkManager.kt
@@ -44,8 +44,6 @@ class MochaManager(context: CgContext) : TestFrameworkManager(context) {
         get() = TODO("Not yet implemented")
     override val annotationForNestedClasses: CgAnnotation
         get() = TODO("Not yet implemented")
-    override val annotationForOuterClasses: CgAnnotation
-        get() = TODO("Not yet implemented")
 
     override fun assertEquals(expected: CgValue, actual: CgValue) {
         +assertions[jsAssertEquals](expected, actual)


### PR DESCRIPTION
# Description

* Fixed JavaScript `UtContext` error: override `simpleNameWithEnclosingClasses` in `JsClassId`.
* Removed annotation for framework outer classes for JavaScript according #1674 
## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

Manually 

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] No new warnings
- [x] All tests pass locally with my changes
