### PR TITLE
Fixed copyOf, copyOfRange and asList failures

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/arrays/CopyOfExampleTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/arrays/CopyOfExampleTest.kt
@@ -1,0 +1,34 @@
+package org.utbot.examples.arrays
+
+import org.junit.jupiter.api.Test
+import org.utbot.testing.AtLeast
+import org.utbot.testing.FullWithAssumptions
+import org.utbot.testing.UtValueTestCaseChecker
+import org.utbot.testing.ignoreExecutionsNumber
+import org.utbot.testing.isException
+
+class CopyOfExampleTest : UtValueTestCaseChecker(testClass = CopyOfExample::class) {
+    @Test
+    fun testCopyOf() {
+        checkWithException(
+            CopyOfExample::copyOfExample,
+            ignoreExecutionsNumber,
+            { _, l, r -> l < 0 && r.isException<NegativeArraySizeException>() },
+            { arr, l, r -> arr.copyOf(l).contentEquals(r.getOrThrow()) },
+            coverage = FullWithAssumptions(assumeCallsNumber = 1)
+        )
+    }
+
+    @Test
+    fun testCopyOfRange() {
+        checkWithException(
+            CopyOfExample::copyOfRangeExample,
+            ignoreExecutionsNumber,
+            { _, from, _, r -> from < 0 && r.isException<ArrayIndexOutOfBoundsException>() },
+            { arr, from, _, r -> from > arr.size && r.isException<ArrayIndexOutOfBoundsException>() },
+            { _, from, to, r -> from > to && r.isException<IllegalArgumentException>() },
+            { arr, from, to, r -> arr.copyOfRange(from, to).contentEquals(r.getOrThrow()) },
+            coverage = AtLeast(82)
+        )
+    }
+}

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/collections/ListsPart3Test.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/collections/ListsPart3Test.kt
@@ -5,8 +5,10 @@ import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.utbot.testcheckers.eq
 import org.utbot.testcheckers.ge
+import org.utbot.testcheckers.withoutConcrete
 import org.utbot.testing.CodeGeneration
 import org.utbot.testing.DoNotCalculate
+import org.utbot.testing.FullWithAssumptions
 import org.utbot.testing.UtValueTestCaseChecker
 import org.utbot.testing.between
 import org.utbot.testing.isException
@@ -215,6 +217,19 @@ internal class ListsPart3Test : UtValueTestCaseChecker(
             },
             coverage = DoNotCalculate
         )
+    }
+
+    @Test
+    fun testAsListExample() {
+        withoutConcrete { // TODO Concrete fail matchers with "Cannot show class" error
+            check(
+                Lists::asListExample,
+                eq(2),
+                { arr, r -> arr.isEmpty() && r!!.isEmpty() },
+                { arr, r -> arr.isNotEmpty() && arr.contentEquals(r!!.toTypedArray()) },
+                coverage = FullWithAssumptions(assumeCallsNumber = 1)
+            )
+        }
     }
 
     @Test

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/collections/ListsPart3Test.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/collections/ListsPart3Test.kt
@@ -221,14 +221,16 @@ internal class ListsPart3Test : UtValueTestCaseChecker(
 
     @Test
     fun testAsListExample() {
-        withoutConcrete { // TODO Concrete fail matchers with "Cannot show class" error
-            check(
-                Lists::asListExample,
-                eq(2),
-                { arr, r -> arr.isEmpty() && r!!.isEmpty() },
-                { arr, r -> arr.isNotEmpty() && arr.contentEquals(r!!.toTypedArray()) },
-                coverage = FullWithAssumptions(assumeCallsNumber = 1)
-            )
+        withEnabledTestingCodeGeneration(testCodeGeneration = false) { // TODO Assemble model for java.util.ArrayList is returned, but actual type is java.util.Arrays.ArrayList https://github.com/UnitTestBot/UTBotJava/issues/398
+            withoutConcrete { // TODO Concrete fail matchers with "Cannot show class" error
+                check(
+                    Lists::asListExample,
+                    eq(2),
+                    { arr, r -> arr.isEmpty() && r!!.isEmpty() },
+                    { arr, r -> arr.isNotEmpty() && arr.contentEquals(r!!.toTypedArray()) },
+                    coverage = FullWithAssumptions(assumeCallsNumber = 1)
+                )
+            }
         }
     }
 

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/collections/MapsPart2Test.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/collections/MapsPart2Test.kt
@@ -1,5 +1,6 @@
 package org.utbot.examples.collections
 
+import org.junit.jupiter.api.Disabled
 import org.utbot.framework.plugin.api.CodegenLanguage
 import org.junit.jupiter.api.Test
 import org.utbot.testcheckers.ge
@@ -68,7 +69,7 @@ internal class MapsPart2Test : UtValueTestCaseChecker(
         }
     }
 
-    @Test
+    @Disabled("Flaky https://github.com/UnitTestBot/UTBotJava/issues/1695")
     fun testPutAllEntries() {
         withPushingStateFromPathSelectorForConcrete {
             check(

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/System.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/System.java
@@ -210,7 +210,7 @@ public class System {
             }
 
             UtArrayMock.arraycopy(srcArray, srcPos, destArray, destPos, length);
-        } else {
+        } else if (src instanceof Object[]) {
             if (!(dest instanceof Object[])) {
                 throw new ArrayStoreException();
             }
@@ -223,6 +223,9 @@ public class System {
             }
 
             UtArrayMock.arraycopy(srcArray, srcPos, destArray, destPos, length);
+        } else {
+            // From docs: if the src argument refers to an object that is not an array, an ArrayStoreException will be thrown
+            throw new ArrayStoreException();
         }
     }
 }

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/stream/Arrays.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/stream/Arrays.java
@@ -1,6 +1,7 @@
 package org.utbot.engine.overrides.stream;
 
 import org.utbot.api.annotation.UtClassMock;
+import org.utbot.api.mock.UtMock;
 import org.utbot.engine.overrides.collections.UtArrayList;
 
 import java.util.List;
@@ -21,7 +22,7 @@ public class Arrays {
         return new UtStream<>(array, startInclusive, endExclusive);
     }
 
-    // from docs - array is assumed to be umnodified during use
+    // from docs - array is assumed to be unmodified during use
     public static IntStream stream(int[] array, int startInclusive, int endExclusive) {
         int size = array.length;
 
@@ -37,7 +38,7 @@ public class Arrays {
         return new UtIntStream(data, startInclusive, endExclusive);
     }
 
-    // from docs - array is assumed to be umnodified during use
+    // from docs - array is assumed to be unmodified during use
     public static LongStream stream(long[] array, int startInclusive, int endExclusive) {
         int size = array.length;
 
@@ -53,7 +54,7 @@ public class Arrays {
         return new UtLongStream(data, startInclusive, endExclusive);
     }
 
-    // from docs - array is assumed to be umnodified during use
+    // from docs - array is assumed to be unmodified during use
     public static DoubleStream stream(double[] array, int startInclusive, int endExclusive) {
         int size = array.length;
 
@@ -75,6 +76,4 @@ public class Arrays {
         // TODO immutable collection https://github.com/UnitTestBot/UTBotJava/issues/398
         return new UtArrayList<>(a);
     }
-
-    // TODO primitive arrays https://github.com/UnitTestBot/UTBotJava/issues/146
 }

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/stream/Arrays.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/stream/Arrays.java
@@ -1,7 +1,6 @@
 package org.utbot.engine.overrides.stream;
 
 import org.utbot.api.annotation.UtClassMock;
-import org.utbot.api.mock.UtMock;
 import org.utbot.engine.overrides.collections.UtArrayList;
 
 import java.util.List;

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/CollectionWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/CollectionWrappers.kt
@@ -414,24 +414,18 @@ private val UT_GENERIC_ASSOCIATIVE_CLASS
 private val UT_GENERIC_ASSOCIATIVE_SET_EQUAL_GENERIC_TYPE_SIGNATURE =
     UT_GENERIC_ASSOCIATIVE_CLASS.getMethodByName(UtGenericAssociative<*, *>::setEqualGenericType.name).signature
 
-val LIST_TYPE: RefType
-    get() = Scene.v().getSootClass(java.util.List::class.java.canonicalName).type
 val ARRAY_LIST_TYPE: RefType
     get() = Scene.v().getSootClass(java.util.ArrayList::class.java.canonicalName).type
 val LINKED_LIST_TYPE: RefType
     get() = Scene.v().getSootClass(java.util.LinkedList::class.java.canonicalName).type
-val DEQUE_TYPE: RefType
-    get() = Scene.v().getSootClass(java.util.Deque::class.java.canonicalName).type
+val ARRAY_DEQUE_TYPE: RefType
+    get() = Scene.v().getSootClass(java.util.ArrayDeque::class.java.canonicalName).type
 
-val SET_TYPE: RefType
-    get() = Scene.v().getSootClass(java.util.Set::class.java.canonicalName).type
 val LINKED_HASH_SET_TYPE: RefType
     get() = Scene.v().getSootClass(java.util.LinkedHashSet::class.java.canonicalName).type
 val HASH_SET_TYPE: RefType
     get() = Scene.v().getSootClass(java.util.HashSet::class.java.canonicalName).type
 
-val MAP_TYPE: RefType
-    get() = Scene.v().getSootClass(java.util.Map::class.java.canonicalName).type
 val LINKED_HASH_MAP_TYPE: RefType
     get() = Scene.v().getSootClass(java.util.LinkedHashMap::class.java.canonicalName).type
 val HASH_MAP_TYPE: RefType

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/CollectionWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/CollectionWrappers.kt
@@ -414,16 +414,24 @@ private val UT_GENERIC_ASSOCIATIVE_CLASS
 private val UT_GENERIC_ASSOCIATIVE_SET_EQUAL_GENERIC_TYPE_SIGNATURE =
     UT_GENERIC_ASSOCIATIVE_CLASS.getMethodByName(UtGenericAssociative<*, *>::setEqualGenericType.name).signature
 
+val LIST_TYPE: RefType
+    get() = Scene.v().getSootClass(java.util.List::class.java.canonicalName).type
 val ARRAY_LIST_TYPE: RefType
     get() = Scene.v().getSootClass(java.util.ArrayList::class.java.canonicalName).type
 val LINKED_LIST_TYPE: RefType
     get() = Scene.v().getSootClass(java.util.LinkedList::class.java.canonicalName).type
+val DEQUE_TYPE: RefType
+    get() = Scene.v().getSootClass(java.util.Deque::class.java.canonicalName).type
 
+val SET_TYPE: RefType
+    get() = Scene.v().getSootClass(java.util.Set::class.java.canonicalName).type
 val LINKED_HASH_SET_TYPE: RefType
     get() = Scene.v().getSootClass(java.util.LinkedHashSet::class.java.canonicalName).type
 val HASH_SET_TYPE: RefType
     get() = Scene.v().getSootClass(java.util.HashSet::class.java.canonicalName).type
 
+val MAP_TYPE: RefType
+    get() = Scene.v().getSootClass(java.util.Map::class.java.canonicalName).type
 val LINKED_HASH_MAP_TYPE: RefType
     get() = Scene.v().getSootClass(java.util.LinkedHashMap::class.java.canonicalName).type
 val HASH_MAP_TYPE: RefType

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ObjectWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ObjectWrappers.kt
@@ -262,15 +262,15 @@ private val wrappers: Map<ClassId, (RefType, UtAddrExpression) -> ObjectValue> =
         wrap(UtCountDownLatch::class) { _, addr -> objectValue(COUNT_DOWN_LATCH_TYPE, addr, CountDownLatchWrapper()) },
         wrap(UtCompletableFuture::class) { _, addr -> objectValue(COMPLETABLE_FUTURE_TYPE, addr, CompletableFutureWrapper()) },
 
-        wrap(UtArrayList::class) { _, addr -> objectValue(LIST_TYPE, addr, ListWrapper(UT_ARRAY_LIST)) },
-        wrap(UtLinkedList::class) { _, addr -> objectValue(LIST_TYPE, addr, ListWrapper(UT_LINKED_LIST)) },
+        wrap(UtArrayList::class) { _, addr -> objectValue(ARRAY_LIST_TYPE, addr, ListWrapper(UT_ARRAY_LIST)) },
+        wrap(UtLinkedList::class) { _, addr -> objectValue(LINKED_LIST_TYPE, addr, ListWrapper(UT_LINKED_LIST)) },
         wrap(UtLinkedListWithNullableCheck::class) { _, addr ->
-            objectValue(DEQUE_TYPE, addr, ListWrapper(UT_LINKED_LIST_WITH_NULLABLE_CHECK))
+            objectValue(ARRAY_DEQUE_TYPE, addr, ListWrapper(UT_LINKED_LIST_WITH_NULLABLE_CHECK))
         },
 
-        wrap(UtHashSet::class) { _, addr -> objectValue(SET_TYPE, addr, SetWrapper()) },
+        wrap(UtHashSet::class) { _, addr -> objectValue(HASH_SET_TYPE, addr, SetWrapper()) },
 
-        wrap(UtHashMap::class) { _, addr -> objectValue(MAP_TYPE, addr, MapWrapper()) },
+        wrap(UtHashMap::class) { _, addr -> objectValue(HASH_MAP_TYPE, addr, MapWrapper()) },
 
         wrap(UtStream::class) { _, addr -> objectValue(STREAM_TYPE, addr, CommonStreamWrapper()) },
         wrap(UtIntStream::class) { _, addr -> objectValue(INT_STREAM_TYPE, addr, IntStreamWrapper()) },

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ObjectWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ObjectWrappers.kt
@@ -15,19 +15,49 @@ import org.utbot.engine.UtStreamClass.UT_LONG_STREAM
 import org.utbot.engine.UtStreamClass.UT_STREAM
 import org.utbot.engine.overrides.collections.AssociativeArray
 import org.utbot.engine.overrides.collections.RangeModifiableUnlimitedArray
+import org.utbot.engine.overrides.collections.UtArrayList
 import org.utbot.engine.overrides.collections.UtHashMap
 import org.utbot.engine.overrides.collections.UtHashSet
+import org.utbot.engine.overrides.collections.UtLinkedList
+import org.utbot.engine.overrides.collections.UtLinkedListWithNullableCheck
+import org.utbot.engine.overrides.collections.UtOptional
+import org.utbot.engine.overrides.collections.UtOptionalDouble
+import org.utbot.engine.overrides.collections.UtOptionalInt
+import org.utbot.engine.overrides.collections.UtOptionalLong
 import org.utbot.engine.overrides.security.UtSecurityManager
+import org.utbot.engine.overrides.stream.UtDoubleStream
+import org.utbot.engine.overrides.stream.UtIntStream
+import org.utbot.engine.overrides.stream.UtLongStream
+import org.utbot.engine.overrides.stream.UtStream
 import org.utbot.engine.overrides.strings.UtString
 import org.utbot.engine.overrides.strings.UtStringBuffer
 import org.utbot.engine.overrides.strings.UtStringBuilder
 import org.utbot.engine.overrides.threads.UtCompletableFuture
+import org.utbot.engine.overrides.threads.UtCountDownLatch
+import org.utbot.engine.overrides.threads.UtExecutorService
+import org.utbot.engine.overrides.threads.UtThread
+import org.utbot.engine.overrides.threads.UtThreadGroup
 import org.utbot.engine.pc.UtAddrExpression
+import org.utbot.engine.types.COMPLETABLE_FUTURE_TYPE
+import org.utbot.engine.types.COUNT_DOWN_LATCH_TYPE
+import org.utbot.engine.types.EXECUTOR_SERVICE_TYPE
+import org.utbot.engine.types.OPTIONAL_DOUBLE_TYPE
+import org.utbot.engine.types.OPTIONAL_INT_TYPE
+import org.utbot.engine.types.OPTIONAL_LONG_TYPE
+import org.utbot.engine.types.OPTIONAL_TYPE
+import org.utbot.engine.types.SECURITY_MANAGER_TYPE
+import org.utbot.engine.types.STRING_BUFFER_TYPE
+import org.utbot.engine.types.STRING_BUILDER_TYPE
+import org.utbot.engine.types.STRING_TYPE
+import org.utbot.engine.types.THREAD_GROUP_TYPE
+import org.utbot.engine.types.THREAD_TYPE
+import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.UtAssembleModel
 import org.utbot.framework.plugin.api.UtExecutableCallModel
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtPrimitiveModel
 import org.utbot.framework.plugin.api.id
+import org.utbot.framework.plugin.api.util.UtContext
 import org.utbot.framework.plugin.api.util.constructorId
 import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.stringClassId
@@ -36,18 +66,6 @@ import soot.RefType
 import soot.Scene
 import soot.SootClass
 import soot.SootMethod
-import java.util.Optional
-import java.util.OptionalDouble
-import java.util.OptionalInt
-import java.util.OptionalLong
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.CompletionStage
-import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.ForkJoinPool
-import java.util.concurrent.ScheduledThreadPoolExecutor
-import java.util.concurrent.ThreadPoolExecutor
 import kotlin.reflect.KClass
 
 typealias TypeToBeWrapped = RefType
@@ -60,39 +78,31 @@ typealias WrapperType = RefType
 val classToWrapper: MutableMap<TypeToBeWrapped, WrapperType> =
     mutableMapOf<TypeToBeWrapped, WrapperType>().apply {
         putSootClass(java.lang.StringBuilder::class, utStringBuilderClass)
-        putSootClass(UtStringBuilder::class, utStringBuilderClass)
         putSootClass(java.lang.StringBuffer::class, utStringBufferClass)
-        putSootClass(UtStringBuffer::class, utStringBufferClass)
         putSootClass(java.lang.CharSequence::class, utStringClass)
         putSootClass(java.lang.String::class, utStringClass)
-        putSootClass(UtString::class, utStringClass)
-        putSootClass(Optional::class, UT_OPTIONAL.className)
-        putSootClass(OptionalInt::class, UT_OPTIONAL_INT.className)
-        putSootClass(OptionalLong::class, UT_OPTIONAL_LONG.className)
-        putSootClass(OptionalDouble::class, UT_OPTIONAL_DOUBLE.className)
+        putSootClass(java.util.Optional::class, UT_OPTIONAL.className)
+        putSootClass(java.util.OptionalInt::class, UT_OPTIONAL_INT.className)
+        putSootClass(java.util.OptionalLong::class, UT_OPTIONAL_LONG.className)
+        putSootClass(java.util.OptionalDouble::class, UT_OPTIONAL_DOUBLE.className)
 
         // threads
         putSootClass(java.lang.Thread::class, utThreadClass)
         putSootClass(java.lang.ThreadGroup::class, utThreadGroupClass)
 
         // executors, futures and latches
-        putSootClass(ExecutorService::class, utExecutorServiceClass)
-        putSootClass(ThreadPoolExecutor::class, utExecutorServiceClass)
-        putSootClass(ForkJoinPool::class, utExecutorServiceClass)
-        putSootClass(ScheduledThreadPoolExecutor::class, utExecutorServiceClass)
-        putSootClass(CountDownLatch::class, utCountDownLatchClass)
-        putSootClass(CompletableFuture::class, utCompletableFutureClass)
-        putSootClass(CompletionStage::class, utCompletableFutureClass)
-        // A hack to be able to create UtCompletableFuture in its methods as a wrapper
-        putSootClass(UtCompletableFuture::class, utCompletableFutureClass)
-
-        putSootClass(RangeModifiableUnlimitedArray::class, RangeModifiableUnlimitedArrayWrapper::class)
-        putSootClass(AssociativeArray::class, AssociativeArrayWrapper::class)
+        putSootClass(java.util.concurrent.ExecutorService::class, utExecutorServiceClass)
+        putSootClass(java.util.concurrent.ThreadPoolExecutor::class, utExecutorServiceClass)
+        putSootClass(java.util.concurrent.ForkJoinPool::class, utExecutorServiceClass)
+        putSootClass(java.util.concurrent.ScheduledThreadPoolExecutor::class, utExecutorServiceClass)
+        putSootClass(java.util.concurrent.CountDownLatch::class, utCountDownLatchClass)
+        putSootClass(java.util.concurrent.CompletableFuture::class, utCompletableFutureClass)
+        putSootClass(java.util.concurrent.CompletionStage::class, utCompletableFutureClass)
 
         putSootClass(java.util.List::class, UT_ARRAY_LIST.className)
         putSootClass(java.util.AbstractList::class, UT_ARRAY_LIST.className)
         putSootClass(java.util.ArrayList::class, UT_ARRAY_LIST.className)
-        putSootClass(CopyOnWriteArrayList::class, UT_ARRAY_LIST.className)
+        putSootClass(java.util.concurrent.CopyOnWriteArrayList::class, UT_ARRAY_LIST.className)
         putSootClass(java.util.LinkedList::class, UT_LINKED_LIST.className)
         putSootClass(java.util.AbstractSequentialList::class, UT_LINKED_LIST.className)
 
@@ -120,6 +130,17 @@ val classToWrapper: MutableMap<TypeToBeWrapped, WrapperType> =
         putSootClass(java.util.stream.DoubleStream::class, UT_DOUBLE_STREAM.className)
 
         putSootClass(java.lang.SecurityManager::class, UtSecurityManager::class)
+
+        putSootClass(RangeModifiableUnlimitedArray::class, RangeModifiableUnlimitedArrayWrapper::class)
+        putSootClass(AssociativeArray::class, AssociativeArray::class)
+    }.apply {
+        // Each wrapper has to wrap itself to make possible to create it but with the underlying type in UtMocks or in wrappers.
+        // We take this particular classloader because current classloader cannot load our classes
+        val applicationClassLoader = UtContext::class.java.classLoader
+        values.distinct().forEach {
+            val kClass = applicationClassLoader.loadClass(it.className).kotlin
+            putSootClass(kClass, it)
+        }
     }
 
 /**
@@ -154,46 +175,32 @@ private fun MutableMap<TypeToBeWrapped, WrapperType>.putSootClass(
     value: RefType
 ) = put(Scene.v().getSootClass(key.java.canonicalName).type, value)
 
-private val wrappers = mapOf(
+private val wrappers: Map<ClassId, (RefType, UtAddrExpression) -> ObjectValue> = mutableMapOf(
     wrap(java.lang.StringBuilder::class) { type, addr -> objectValue(type, addr, UtStringBuilderWrapper()) },
-    wrap(UtStringBuilder::class) { type, addr -> objectValue(type, addr, UtStringBuilderWrapper()) },
     wrap(java.lang.StringBuffer::class) { type, addr -> objectValue(type, addr, UtStringBufferWrapper()) },
-    wrap(UtStringBuffer::class) { type, addr -> objectValue(type, addr, UtStringBufferWrapper()) },
     wrap(java.lang.CharSequence::class) { type, addr -> objectValue(type, addr, StringWrapper()) },
     wrap(java.lang.String::class) { type, addr -> objectValue(type, addr, StringWrapper()) },
-    wrap(UtString::class) { type, addr -> objectValue(type, addr, StringWrapper()) },
-    wrap(Optional::class) { type, addr -> objectValue(type, addr, OptionalWrapper(UT_OPTIONAL)) },
-    wrap(OptionalInt::class) { type, addr -> objectValue(type, addr, OptionalWrapper(UT_OPTIONAL_INT)) },
-    wrap(OptionalLong::class) { type, addr -> objectValue(type, addr, OptionalWrapper(UT_OPTIONAL_LONG)) },
-    wrap(OptionalDouble::class) { type, addr -> objectValue(type, addr, OptionalWrapper(UT_OPTIONAL_DOUBLE)) },
+    wrap(java.util.Optional::class) { type, addr -> objectValue(type, addr, OptionalWrapper(UT_OPTIONAL)) },
+    wrap(java.util.OptionalInt::class) { type, addr -> objectValue(type, addr, OptionalWrapper(UT_OPTIONAL_INT)) },
+    wrap(java.util.OptionalLong::class) { type, addr -> objectValue(type, addr, OptionalWrapper(UT_OPTIONAL_LONG)) },
+    wrap(java.util.OptionalDouble::class) { type, addr -> objectValue(type, addr, OptionalWrapper(UT_OPTIONAL_DOUBLE)) },
 
     // threads
-    wrap(Thread::class) { type, addr -> objectValue(type, addr, ThreadWrapper()) },
-    wrap(ThreadGroup::class) { type, addr -> objectValue(type, addr, ThreadGroupWrapper()) },
-    wrap(ExecutorService::class) { type, addr -> objectValue(type, addr, ExecutorServiceWrapper()) },
-    wrap(ThreadPoolExecutor::class) { type, addr -> objectValue(type, addr, ExecutorServiceWrapper()) },
-    wrap(ForkJoinPool::class) { type, addr -> objectValue(type, addr, ExecutorServiceWrapper()) },
-    wrap(ScheduledThreadPoolExecutor::class) { type, addr -> objectValue(type, addr, ExecutorServiceWrapper()) },
-    wrap(CountDownLatch::class) { type, addr -> objectValue(type, addr, CountDownLatchWrapper()) },
-    wrap(CompletableFuture::class) { type, addr -> objectValue(type, addr, CompletableFutureWrapper()) },
-    wrap(CompletionStage::class) { type, addr -> objectValue(type, addr, CompletableFutureWrapper()) },
-    // A hack to be able to create UtCompletableFuture in its methods as a wrapper
-    wrap(UtCompletableFuture::class) { type, addr -> objectValue(type, addr, CompletableFutureWrapper()) },
-
-    wrap(RangeModifiableUnlimitedArray::class) { type, addr ->
-        objectValue(type, addr, RangeModifiableUnlimitedArrayWrapper())
-    },
-    wrap(AssociativeArray::class) { type, addr ->
-        objectValue(type, addr, AssociativeArrayWrapper())
-    },
+    wrap(java.lang.Thread::class) { type, addr -> objectValue(type, addr, ThreadWrapper()) },
+    wrap(java.lang.ThreadGroup::class) { type, addr -> objectValue(type, addr, ThreadGroupWrapper()) },
+    wrap(java.util.concurrent.ExecutorService::class) { type, addr -> objectValue(type, addr, ExecutorServiceWrapper()) },
+    wrap(java.util.concurrent.ThreadPoolExecutor::class) { type, addr -> objectValue(type, addr, ExecutorServiceWrapper()) },
+    wrap(java.util.concurrent.ForkJoinPool::class) { type, addr -> objectValue(type, addr, ExecutorServiceWrapper()) },
+    wrap(java.util.concurrent.ScheduledThreadPoolExecutor::class) { type, addr -> objectValue(type, addr, ExecutorServiceWrapper()) },
+    wrap(java.util.concurrent.CountDownLatch::class) { type, addr -> objectValue(type, addr, CountDownLatchWrapper()) },
+    wrap(java.util.concurrent.CompletableFuture::class) { type, addr -> objectValue(type, addr, CompletableFutureWrapper()) },
+    wrap(java.util.concurrent.CompletionStage::class) { type, addr -> objectValue(type, addr, CompletableFutureWrapper()) },
 
     // list wrappers
     wrap(java.util.List::class) { _, addr -> objectValue(ARRAY_LIST_TYPE, addr, ListWrapper(UT_ARRAY_LIST)) },
     wrap(java.util.AbstractList::class) { _, addr -> objectValue(ARRAY_LIST_TYPE, addr, ListWrapper(UT_ARRAY_LIST)) },
     wrap(java.util.ArrayList::class) { _, addr -> objectValue(ARRAY_LIST_TYPE, addr, ListWrapper(UT_ARRAY_LIST)) },
-
-
-    wrap(CopyOnWriteArrayList::class) { type, addr -> objectValue(type, addr, ListWrapper(UT_ARRAY_LIST)) },
+    wrap(java.util.concurrent.CopyOnWriteArrayList::class) { type, addr -> objectValue(type, addr, ListWrapper(UT_ARRAY_LIST)) },
 
     wrap(java.util.LinkedList::class) { _, addr -> objectValue(LINKED_LIST_TYPE, addr, ListWrapper(UT_LINKED_LIST)) },
     wrap(java.util.AbstractSequentialList::class) { _, addr -> objectValue(LINKED_LIST_TYPE, addr, ListWrapper(UT_LINKED_LIST)) },
@@ -236,8 +243,50 @@ private val wrappers = mapOf(
     wrap(java.util.stream.DoubleStream::class) { _, addr -> objectValue(DOUBLE_STREAM_TYPE, addr, DoubleStreamWrapper()) },
 
     // Security-related wrappers
-    wrap(SecurityManager::class) { type, addr -> objectValue(type, addr, SecurityManagerWrapper()) },
-).also {
+    wrap(java.lang.SecurityManager::class) { type, addr -> objectValue(type, addr, SecurityManagerWrapper()) },
+).apply {
+    // Each wrapper has to wrap itself to make possible to create it but with the underlying type in UtMocks or in wrappers
+    arrayOf(
+        wrap(UtStringBuilder::class) { _, addr -> objectValue(STRING_BUILDER_TYPE, addr, UtStringBuilderWrapper()) },
+        wrap(UtStringBuffer::class) { _, addr -> objectValue(STRING_BUFFER_TYPE, addr, UtStringBufferWrapper()) },
+        wrap(UtString::class) { _, addr -> objectValue(STRING_TYPE, addr, StringWrapper()) },
+
+        wrap(UtOptional::class) { _, addr -> objectValue(OPTIONAL_TYPE, addr, OptionalWrapper(UT_OPTIONAL)) },
+        wrap(UtOptionalInt::class) { _, addr -> objectValue(OPTIONAL_INT_TYPE, addr, OptionalWrapper(UT_OPTIONAL_INT)) },
+        wrap(UtOptionalLong::class) { _, addr -> objectValue(OPTIONAL_LONG_TYPE, addr, OptionalWrapper(UT_OPTIONAL_LONG)) },
+        wrap(UtOptionalDouble::class) { _, addr -> objectValue(OPTIONAL_DOUBLE_TYPE, addr, OptionalWrapper(UT_OPTIONAL_DOUBLE)) },
+
+        wrap(UtThread::class) { _, addr -> objectValue(THREAD_TYPE, addr, ThreadWrapper()) },
+        wrap(UtThreadGroup::class) { _, addr -> objectValue(THREAD_GROUP_TYPE, addr, ThreadGroupWrapper()) },
+        wrap(UtExecutorService::class) { _, addr -> objectValue(EXECUTOR_SERVICE_TYPE, addr, ExecutorServiceWrapper()) },
+        wrap(UtCountDownLatch::class) { _, addr -> objectValue(COUNT_DOWN_LATCH_TYPE, addr, CountDownLatchWrapper()) },
+        wrap(UtCompletableFuture::class) { _, addr -> objectValue(COMPLETABLE_FUTURE_TYPE, addr, CompletableFutureWrapper()) },
+
+        wrap(UtArrayList::class) { _, addr -> objectValue(LIST_TYPE, addr, ListWrapper(UT_ARRAY_LIST)) },
+        wrap(UtLinkedList::class) { _, addr -> objectValue(LIST_TYPE, addr, ListWrapper(UT_LINKED_LIST)) },
+        wrap(UtLinkedListWithNullableCheck::class) { _, addr ->
+            objectValue(DEQUE_TYPE, addr, ListWrapper(UT_LINKED_LIST_WITH_NULLABLE_CHECK))
+        },
+
+        wrap(UtHashSet::class) { _, addr -> objectValue(SET_TYPE, addr, SetWrapper()) },
+
+        wrap(UtHashMap::class) { _, addr -> objectValue(MAP_TYPE, addr, MapWrapper()) },
+
+        wrap(UtStream::class) { _, addr -> objectValue(STREAM_TYPE, addr, CommonStreamWrapper()) },
+        wrap(UtIntStream::class) { _, addr -> objectValue(INT_STREAM_TYPE, addr, IntStreamWrapper()) },
+        wrap(UtLongStream::class) { _, addr -> objectValue(LONG_STREAM_TYPE, addr, LongStreamWrapper()) },
+        wrap(UtDoubleStream::class) { _, addr -> objectValue(DOUBLE_STREAM_TYPE, addr, DoubleStreamWrapper()) },
+
+        wrap(UtSecurityManager::class) { _, addr -> objectValue(SECURITY_MANAGER_TYPE, addr, SecurityManagerWrapper()) },
+
+        wrap(RangeModifiableUnlimitedArray::class) { type, addr ->
+            objectValue(type, addr, RangeModifiableUnlimitedArrayWrapper())
+        },
+        wrap(AssociativeArray::class) { type, addr ->
+            objectValue(type, addr, AssociativeArrayWrapper())
+        },
+    ).let { putAll(it) }
+}.also {
     // check every `wrapped` class has a corresponding value in [classToWrapper]
     val missedWrappers = it.keys.filterNot { key ->
         Scene.v().getSootClass(key.name).type in classToWrapper.keys

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/types/TypeResolver.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/types/TypeResolver.kt
@@ -351,7 +351,7 @@ internal val CLASS_REF_NUM_DIMENSIONS_DESCRIPTOR: MemoryChunkDescriptor
 internal val CLASS_REF_SOOT_CLASS: SootClass
     get() = Scene.v().getSootClass(CLASS_REF_CLASSNAME)
 internal val ARRAYS_SOOT_CLASS: SootClass
-    get() = Scene.v().getSootClass("java.util.Arrays")
+    get() = Scene.v().getSootClass(java.util.Arrays::class.java.canonicalName)
 
 internal val OBJECT_TYPE: RefType
     get() = Scene.v().getSootClass(Object::class.java.canonicalName).type

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/types/TypeResolver.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/types/TypeResolver.kt
@@ -44,6 +44,7 @@ import soot.Type
 import soot.VoidType
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
 class TypeResolver(private val typeRegistry: TypeRegistry, private val hierarchy: Hierarchy) {
@@ -349,11 +350,25 @@ internal val CLASS_REF_NUM_DIMENSIONS_DESCRIPTOR: MemoryChunkDescriptor
 
 internal val CLASS_REF_SOOT_CLASS: SootClass
     get() = Scene.v().getSootClass(CLASS_REF_CLASSNAME)
+internal val ARRAYS_SOOT_CLASS: SootClass
+    get() = Scene.v().getSootClass("java.util.Arrays")
 
 internal val OBJECT_TYPE: RefType
     get() = Scene.v().getSootClass(Object::class.java.canonicalName).type
 internal val STRING_TYPE: RefType
     get() = Scene.v().getSootClass(String::class.java.canonicalName).type
+internal val STRING_BUILDER_TYPE: RefType
+    get() = Scene.v().getSootClass(java.lang.StringBuilder::class.java.canonicalName).type
+internal val STRING_BUFFER_TYPE: RefType
+    get() = Scene.v().getSootClass(java.lang.StringBuffer::class.java.canonicalName).type
+internal val OPTIONAL_TYPE: RefType
+    get() = Scene.v().getSootClass(java.util.Optional::class.java.canonicalName).type
+internal val OPTIONAL_INT_TYPE: RefType
+    get() = Scene.v().getSootClass(java.util.OptionalInt::class.java.canonicalName).type
+internal val OPTIONAL_LONG_TYPE: RefType
+    get() = Scene.v().getSootClass(java.util.OptionalLong::class.java.canonicalName).type
+internal val OPTIONAL_DOUBLE_TYPE: RefType
+    get() = Scene.v().getSootClass(java.util.OptionalDouble::class.java.canonicalName).type
 internal val CLASS_REF_TYPE: RefType
     get() = CLASS_REF_SOOT_CLASS.type
 internal val THREAD_TYPE: RefType
@@ -364,8 +379,12 @@ internal val COMPLETABLE_FUTURE_TYPE: RefType
     get() = Scene.v().getSootClass(CompletableFuture::class.java.canonicalName).type
 internal val EXECUTORS_TYPE: RefType
     get() = Scene.v().getSootClass(Executors::class.java.canonicalName).type
+internal val EXECUTOR_SERVICE_TYPE: RefType
+    get() = Scene.v().getSootClass(ExecutorService::class.java.canonicalName).type
 internal val COUNT_DOWN_LATCH_TYPE: RefType
     get() = Scene.v().getSootClass(CountDownLatch::class.java.canonicalName).type
+internal val SECURITY_MANAGER_TYPE: RefType
+    get() = Scene.v().getSootClass(SecurityManager::class.java.canonicalName).type
 
 internal val NEW_INSTANCE_SIGNATURE: String = CLASS_REF_SOOT_CLASS.getMethodByName("newInstance").subSignature
 

--- a/utbot-sample/src/main/java/org/utbot/examples/arrays/CopyOfExample.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/arrays/CopyOfExample.java
@@ -1,0 +1,45 @@
+package org.utbot.examples.arrays;
+
+import org.utbot.api.mock.UtMock;
+
+import java.util.Arrays;
+
+public class CopyOfExample {
+    @SuppressWarnings("IfStatementWithIdenticalBranches")
+    Integer[] copyOfExample(Integer[] values, int newLength) {
+        UtMock.assume(values != null);
+
+        if (values.length == 0) {
+            if (newLength <= 0) {
+                return Arrays.copyOf(values, newLength);
+            } else {
+                return Arrays.copyOf(values, newLength);
+            }
+        } else {
+            if (newLength <= 0) {
+                return Arrays.copyOf(values, newLength);
+            } else {
+                return Arrays.copyOf(values, newLength);
+            }
+        }
+    }
+
+    @SuppressWarnings("IfStatementWithIdenticalBranches")
+    Integer[] copyOfRangeExample(Integer[] values, int from, int to) {
+        UtMock.assume(values != null);
+
+        if (from < 0) {
+            return Arrays.copyOfRange(values, from, to);
+        }
+
+        if (from > to) {
+            return Arrays.copyOfRange(values, from, to);
+        }
+
+        if (from > values.length) {
+            return Arrays.copyOfRange(values, from, to);
+        }
+
+        return Arrays.copyOfRange(values, from, to);
+    }
+}

--- a/utbot-sample/src/main/java/org/utbot/examples/collections/Lists.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/collections/Lists.java
@@ -3,6 +3,7 @@ package org.utbot.examples.collections;
 import org.utbot.api.mock.UtMock;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -158,5 +159,16 @@ public class Lists {
             list.addAll(i, newList);
         }
         return list;
+    }
+
+    @SuppressWarnings("IfStatementWithIdenticalBranches")
+    List<String> asListExample(String[] values) {
+        UtMock.assume(values != null);
+
+        if (values.length == 0) {
+            return Arrays.asList(values);
+        } else {
+            return Arrays.asList(values);
+        }
     }
 }


### PR DESCRIPTION
# Description

Since real implementations of `Arrays.copyOf` and `Arrays.copyOfRange` are pretty difficult (due to reflection usage) for the symbolic engine, symbolic implementations are added in this PR. Also, since the mock implementation of `Arrays.asList` returns an instance of our class `UtArrayList`, some wrap hacks were added to prevent its appearance as a result of execution.

Fixes #1699 .

## Type of Change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

## Automated Testing

`org.utbot.examples.arrays.CopyOfExampleTest` and `org.utbot.examples.collections.ListsPart3Test#testAsListExample`

## Manual Scenario 

`org.antlr.v4.codegen.model.Recognizer.translateTokenStringsToTarget` in Contest Estimator.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] New documentation is provided or existed one is altered
- [x] No new warnings
- [x] New tests have been added
