### PR TITLE
HACK: Do not generate long commented blocks in contest

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgAbstractRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgAbstractRenderer.kt
@@ -394,18 +394,13 @@ abstract class CgAbstractRenderer(
 
         val isBlockTooLarge = workaround(LONG_CODE_FRAGMENTS) { block.size > LARGE_CODE_BLOCK_SIZE }
 
-        if (isBlockTooLarge) {
-            print("/*")
-            println(" This block of code is ${block.size} lines long and could lead to compilation error")
-        }
-
-        withIndent {
-            for (statement in block) {
-                statement.accept(this)
+        if (!isBlockTooLarge) {
+            withIndent {
+                for (statement in block) {
+                    statement.accept(this)
+                }
             }
         }
-
-        if (isBlockTooLarge) println("*/")
 
         print("}")
 
@@ -959,6 +954,6 @@ abstract class CgAbstractRenderer(
         /**
          * @see [LONG_CODE_FRAGMENTS]
          */
-        private const val LARGE_CODE_BLOCK_SIZE: Int = 1000
+        private const val LARGE_CODE_BLOCK_SIZE: Int = 150
     }
 }


### PR DESCRIPTION
# Description

We do not need long commented blocks of code in the contest for readability reasons.

## Type of Change

- Hack for contest.

# How Has This Been Tested?

## Manual Scenario 

ContestEstimator,
`methodFilter=spoon.support.reflect.code.CtStatementListImpl.clone`

