### PR TITLE
Avoid generating wrong enum assertions produced by engine bug

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgMethodConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgMethodConstructor.kt
@@ -552,6 +552,13 @@ open class CgMethodConstructor(val context: CgContext) : CgContextOwner by conte
         val beforeVariable = cache.before[path]?.variable
         val (afterVariable, afterModel) = cache.after[path]!!
 
+        // TODO: remove the following after the issue fix
+        // We do not generate some assertions for Enums due to [https://github.com/UnitTestBot/UTBotJava/issues/1704].
+        val beforeModel = cache.before[path]?.model
+        if (beforeModel !is UtEnumConstantModel && afterModel is UtEnumConstantModel) {
+            return
+        }
+
         if (afterModel !is UtReferenceModel) {
             val expectedAfter =
                 variableConstructor.getOrCreateVariable(afterModel, "expected" + afterVariable.name.capitalize())


### PR DESCRIPTION
# Description

There are cases when we generate false assertion for enums. Refer to the issue [no. 1704](https://github.com/UnitTestBot/UTBotJava/issues/1704)

Fixes # ([1672](https://github.com/UnitTestBot/UTBotJava/issues/1672))

## Type of Change

- Minor bug fix (non-breaking small changes)

# How Has This Been Tested?

## Automated Testing

utbot-samples.

## Manual Scenario 

Use the following estimator settings:
```
timeLimit = 160
methodFilter = "com.google.common.base.CaseFormat.*"
projectFilter = listOf("guava-26.0")
```
Verify that, for example, *testDoBackward2* method in the generated file does not have an assertion for initial and final fields.