### PR TITLE
Cannot get resident body for phantom method on io.seata.core.rpc.nett…

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -499,6 +499,19 @@ object UtSettings : AbstractSettings(logger, defaultKeyForSettingsPath, defaultS
      * Note that values processed concretely won't be replaced with unbounded symbolic variables.
      */
     var processAllClinitSectionsConcretely by getBooleanProperty(false)
+
+    /**
+     * In cases where we don't have a body for a method, we can either throw an exception
+     * or treat this a method as a source of an unbounded symbolic variable returned as a result.
+     *
+     * If this option is set in true, instead of analysis we will return an unbounded symbolic
+     * variable with a corresponding type. Otherwise, an exception will be thrown.
+     *
+     * Default value is false since it is not a common situation when you cannot retrieve a body
+     * from a regular method. Setting this option in true might be suitable in situations when
+     * it is more important not to fall at all rather than work precisely.
+     */
+    var treatAbsentMethodsAsUnboundedValue by getBooleanProperty(false)
 }
 
 /**


### PR DESCRIPTION
Cannot get resident body for phantom method on `io.seata.core.rpc.netty.RpcServer.destroy` #1689

# Description

Add a check for phantom methods. The actual reason seems to be a broken library set seata-core-0.5.0 where **seata-discovery-core** JAR file is absent.

As a fix, an option was added that allows processing such methods without bodies as a source for an unbounded symbolic variable.

Fixes #1689

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Manual Scenario 

See the issue: with this fix, there is no mentioned RuntimeException anymore.

# Checklist (remove irrelevant options):

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] No new warnings
