### PR TITLE
Make toMethodResult function safer

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Resolver.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Resolver.kt
@@ -1235,7 +1235,14 @@ fun Traverser.toMethodResult(value: Any?, sootType: Type): MethodResult {
 
                 val createdElement = if (elementType is RefType) {
                     val className = value[it]!!.javaClass.id.name
-                    createObject(addr, Scene.v().getRefType(className), useConcreteType = true)
+                    // Try to take an instance of class we find in Runtime
+                    // If it is impossible, take the default `elementType` without a concrete type instead.
+                    val (type, useConcreteType) =
+                        Scene.v().getRefTypeUnsafe(className)
+                            ?.let { type -> type to true }
+                            ?: (elementType to false)
+
+                    createObject(addr, type, useConcreteType)
                 } else {
                     require(elementType is ArrayType)
                     // We cannot use concrete types since we do not receive
@@ -1262,7 +1269,14 @@ fun Traverser.toMethodResult(value: Any?, sootType: Type): MethodResult {
 
                 return asMethodResult {
                     val addr = UtAddrExpression(mkBVConst("staticVariable${value.hashCode()}", UtInt32Sort))
-                    createObject(addr, Scene.v().getRefType(refTypeName), useConcreteType = true)
+                    // Try to take a type from an object from the Runtime.
+                    // If it is impossible, create an instance of a default `sootType` without a concrete type.
+                    val (type, useConcreteType) = Scene.v()
+                        .getRefTypeUnsafe(refTypeName)
+                        ?.let { type -> type to true }
+                        ?: (sootType as RefType to false)
+
+                    createObject(addr, type, useConcreteType)
                 }
             }
         }


### PR DESCRIPTION
# Description

Replace in the `toMethodResult` function unsafe access to soot classes with a safe one (surprisingly called `unsafe`). If we cannot upload a concrete type from the Runtime, we create an unbounded variable with a type belonging to a field we construct.

Fixes #1670 

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Regression and integration tests

There are no regression tests since it is quite hard to imitate the problem since it'd require working with a "broken" classpath.

## Automated Testing

There are no automatic tests due for the same reason.

## Manual Scenario 

Run contest estimator reproducing steps from #1670 and check that there are no produced errors.

# Checklist:

- [x] The change followed the style guidelines of the UTBot project
- [x] Self-review of the code is passed
- [x] The change contains enough commentaries, particularly in hard-to-understand areas
- [x] No new warnings
- [x] All tests pass locally with my changes
