### PR TITLE
Reduce the process of array construction to 200 stores

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/constructor/ValueConstructor.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/constructor/ValueConstructor.kt
@@ -275,44 +275,81 @@ class ValueConstructor {
 
         with(model) {
             val elementClassId = classId.elementClassId!!
+            var iterationCount = 0
+            val maxIterationCount = 200
             return when (elementClassId.jvmName) {
                 "B" -> ByteArray(length) { primitive(constModel) }.apply {
                     constructedObjects[model] = this
-                    stores.forEach { (index, model) -> this[index] = primitive(model) }
+                    stores.forEach { (index, model) ->
+                        iterationCount++
+                        if (iterationCount == maxIterationCount) return@forEach
+                        this[index] = primitive(model) }
                 }
                 "S" -> ShortArray(length) { primitive(constModel) }.apply {
                     constructedObjects[model] = this
-                    stores.forEach { (index, model) -> this[index] = primitive(model) }
+                    stores.forEach { (index, model) ->
+                        iterationCount++
+                        if (iterationCount == maxIterationCount) return@forEach
+                        this[index] = primitive(model)
+                    }
                 }
                 "C" -> CharArray(length) { primitive(constModel) }.apply {
                     constructedObjects[model] = this
-                    stores.forEach { (index, model) -> this[index] = primitive(model) }
+                    stores.forEach { (index, model) ->
+                        iterationCount++
+                        if (iterationCount == maxIterationCount) return@forEach
+                        this[index] = primitive(model)
+                    }
                 }
                 "I" -> IntArray(length) { primitive(constModel) }.apply {
                     constructedObjects[model] = this
-                    stores.forEach { (index, model) -> this[index] = primitive(model) }
+                    stores.forEach { (index, model) ->
+                        iterationCount++
+                        if (iterationCount == maxIterationCount) return@forEach
+                        this[index] = primitive(model)
+                    }
                 }
                 "J" -> LongArray(length) { primitive(constModel) }.apply {
                     constructedObjects[model] = this
-                    stores.forEach { (index, model) -> this[index] = primitive(model) }
+                    stores.forEach { (index, model) ->
+                        iterationCount++
+                        if (iterationCount == maxIterationCount) return@forEach
+                        this[index] = primitive(model)
+                    }
                 }
                 "F" -> FloatArray(length) { primitive(constModel) }.apply {
                     constructedObjects[model] = this
-                    stores.forEach { (index, model) -> this[index] = primitive(model) }
+                    stores.forEach { (index, model) ->
+                        iterationCount++
+                        if (iterationCount == maxIterationCount) return@forEach
+                        this[index] = primitive(model)
+                    }
                 }
                 "D" -> DoubleArray(length) { primitive(constModel) }.apply {
                     constructedObjects[model] = this
-                    stores.forEach { (index, model) -> this[index] = primitive(model) }
+                    stores.forEach { (index, model) ->
+                        iterationCount++
+                        if (iterationCount == maxIterationCount) return@forEach
+                        this[index] = primitive(model)
+                    }
                 }
                 "Z" -> BooleanArray(length) { primitive(constModel) }.apply {
                     constructedObjects[model] = this
-                    stores.forEach { (index, model) -> this[index] = primitive(model) }
+                    stores.forEach { (index, model) ->
+                        iterationCount++
+                        if (iterationCount == maxIterationCount) return@forEach
+                        this[index] = primitive(model)
+                    }
                 }
                 else -> {
                     val javaClass = javaClass(elementClassId)
                     val instance = java.lang.reflect.Array.newInstance(javaClass, length) as Array<*>
                     constructedObjects[model] = instance
+
                     for (i in instance.indices) {
+                        iterationCount++
+                        if (iterationCount == maxIterationCount) break
+
                         val elementModel = stores[i] ?: constModel
                         val value = construct(elementModel, null).value
                         java.lang.reflect.Array.set(instance, i, value)

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/MockValueConstructor.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/MockValueConstructor.kt
@@ -311,36 +311,75 @@ class MockValueConstructor(
             val elementClassId = classId.elementClassId ?: error(
                 "Provided incorrect UtArrayModel without elementClassId. ClassId: ${model.classId}, model: $model"
             )
+            var iterationCount = 0
+            val maxIterationCount = 200
+
             return when (elementClassId.jvmName) {
                 "B" -> ByteArray(length) { primitive(constModel) }.apply {
-                    stores.forEach { (index, model) -> this[index] = primitive(model) }
+
+                    stores.forEach { (index, model) ->
+                        iterationCount++
+                        if (iterationCount == maxIterationCount) return@forEach
+                        this[index] = primitive(model)
+                    }
                 }.also { constructedObjects[model] = it }
                 "S" -> ShortArray(length) { primitive(constModel) }.apply {
-                    stores.forEach { (index, model) -> this[index] = primitive(model) }
+                    stores.forEach { (index, model) ->
+                        iterationCount++
+                        if (iterationCount == maxIterationCount) return@forEach
+                        this[index] = primitive(model)
+                    }
                 }.also { constructedObjects[model] = it }
                 "C" -> CharArray(length) { primitive(constModel) }.apply {
-                    stores.forEach { (index, model) -> this[index] = primitive(model) }
+                    stores.forEach { (index, model) ->
+                        iterationCount++
+                        if (iterationCount == maxIterationCount) return@forEach
+                        this[index] = primitive(model)
+                    }
                 }.also { constructedObjects[model] = it }
                 "I" -> IntArray(length) { primitive(constModel) }.apply {
-                    stores.forEach { (index, model) -> this[index] = primitive(model) }
+                    stores.forEach { (index, model) ->
+                        iterationCount++
+                        if (iterationCount == maxIterationCount) return@forEach
+                        this[index] = primitive(model)
+                    }
                 }.also { constructedObjects[model] = it }
                 "J" -> LongArray(length) { primitive(constModel) }.apply {
-                    stores.forEach { (index, model) -> this[index] = primitive(model) }
+                    stores.forEach { (index, model) ->
+                        iterationCount++
+                        if (iterationCount == maxIterationCount) return@forEach
+                        this[index] = primitive(model)
+                    }
                 }.also { constructedObjects[model] = it }
                 "F" -> FloatArray(length) { primitive(constModel) }.apply {
-                    stores.forEach { (index, model) -> this[index] = primitive(model) }
+                    stores.forEach { (index, model) ->
+                        iterationCount++
+                        if (iterationCount == maxIterationCount) return@forEach
+                        this[index] = primitive(model)
+                    }
                 }.also { constructedObjects[model] = it }
                 "D" -> DoubleArray(length) { primitive(constModel) }.apply {
-                    stores.forEach { (index, model) -> this[index] = primitive(model) }
+                    stores.forEach { (index, model) ->
+                        iterationCount++
+                        if (iterationCount == maxIterationCount) return@forEach
+                        this[index] = primitive(model)
+                    }
                 }.also { constructedObjects[model] = it }
                 "Z" -> BooleanArray(length) { primitive(constModel) }.apply {
-                    stores.forEach { (index, model) -> this[index] = primitive(model) }
+                    stores.forEach { (index, model) ->
+                        iterationCount++
+                        if (iterationCount == maxIterationCount) return@forEach
+                        this[index] = primitive(model)
+                    }
                 }.also { constructedObjects[model] = it }
                 else -> {
                     val javaClass = javaClass(elementClassId)
                     val instance = java.lang.reflect.Array.newInstance(javaClass, length) as Array<*>
                     constructedObjects[model] = instance
                     for (i in instance.indices) {
+                        iterationCount++
+                        if (iterationCount == maxIterationCount) break
+
                         val elementModel = stores[i] ?: constModel
                         val value = construct(elementModel, null).value
                         try {


### PR DESCRIPTION
## Title

Reduce the process of array construction to 200 stores

## How to test

### Manual tests

Run ContestEstimator with the following settings:

```
projectFilter = listOf("guava-26.0")
Classes:
com.google.common.primitives.Booleans
com.google.common.primitives.Shorts
```

Verify that there are no significant regression in broken tests count after reducing array construction.
