### PR TITLE
Added symbolic wrappers for Ut iterators

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/collections/ListIteratorsTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/collections/ListIteratorsTest.kt
@@ -5,8 +5,10 @@ import org.utbot.framework.plugin.api.CodegenLanguage
 import kotlin.math.min
 import org.junit.jupiter.api.Test
 import org.utbot.testcheckers.eq
+import org.utbot.testcheckers.withoutConcrete
 import org.utbot.testing.CodeGeneration
 import org.utbot.testing.DoNotCalculate
+import org.utbot.testing.FullWithAssumptions
 import org.utbot.testing.UtValueTestCaseChecker
 import org.utbot.testing.ignoreExecutionsNumber
 
@@ -19,6 +21,31 @@ internal class ListIteratorsTest : UtValueTestCaseChecker(
         TestLastStage(CodegenLanguage.KOTLIN, CodeGeneration)
     )
 ) {
+    @Test
+    fun testReturnIterator() {
+        withoutConcrete { // We need to check that a real class is returned but not `Ut` one
+            check(
+                ListIterators::returnIterator,
+                ignoreExecutionsNumber,
+                { l, r -> l.isEmpty() && r!!.asSequence().toList().isEmpty() },
+                { l, r -> l.isNotEmpty() && r!!.asSequence().toList() == l },
+                coverage = FullWithAssumptions(assumeCallsNumber = 1)
+            )
+        }
+    }
+
+    @Test
+    fun testReturnListIterator() {
+        withoutConcrete { // We need to check that a real class is returned but not `Ut` one
+            check(
+                ListIterators::returnListIterator,
+                ignoreExecutionsNumber,
+                { l, r -> l.isEmpty() && r!!.asSequence().toList().isEmpty() },
+                { l, r -> l.isNotEmpty() && r!!.asSequence().toList() == l },
+                coverage = FullWithAssumptions(assumeCallsNumber = 1)
+            )
+        }
+    }
 
     @Test
     fun testIterate() {

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/collections/SetIteratorsTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/collections/SetIteratorsTest.kt
@@ -3,7 +3,9 @@ package org.utbot.examples.collections
 import org.utbot.framework.plugin.api.CodegenLanguage
 import org.junit.jupiter.api.Test
 import org.utbot.testcheckers.ge
+import org.utbot.testcheckers.withoutConcrete
 import org.utbot.testing.CodeGeneration
+import org.utbot.testing.FullWithAssumptions
 import org.utbot.testing.UtValueTestCaseChecker
 import org.utbot.testing.between
 import org.utbot.testing.ignoreExecutionsNumber
@@ -18,6 +20,19 @@ class SetIteratorsTest : UtValueTestCaseChecker(
         TestLastStage(CodegenLanguage.KOTLIN, CodeGeneration)
     )
 ) {
+    @Test
+    fun testReturnIterator() {
+        withoutConcrete { // We need to check that a real class is returned but not `Ut` one
+            check(
+                SetIterators::returnIterator,
+                ignoreExecutionsNumber,
+                { s, r -> s.isEmpty() && r!!.asSequence().toSet().isEmpty() },
+                { s, r -> s.isNotEmpty() && r!!.asSequence().toSet() == s },
+                coverage = FullWithAssumptions(assumeCallsNumber = 1)
+            )
+        }
+    }
+
     @Test
     fun testIteratorHasNext() {
         check(

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtArrayList.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtArrayList.java
@@ -322,7 +322,7 @@ public class UtArrayList<E> extends AbstractList<E>
     @Override
     public Iterator<E> iterator() {
         preconditionCheck();
-        return new UtArrayListIterator(0);
+        return new UtArrayListSimpleIterator(0);
     }
 
     @NotNull
@@ -403,6 +403,43 @@ public class UtArrayList<E> extends AbstractList<E>
 
         executeConcretely();
         return this.toList().subList(fromIndex, toIndex);
+    }
+
+    public class UtArrayListSimpleIterator implements Iterator<E> {
+        int index;
+        int prevIndex = -1;
+
+        UtArrayListSimpleIterator(int index) {
+            rangeCheckForAdd(index);
+            this.index = index;
+        }
+
+        @Override
+        public boolean hasNext() {
+            preconditionCheck();
+            return index != elementData.end;
+        }
+
+        @Override
+        public E next() {
+            preconditionCheck();
+            if (index == elementData.end) {
+                throw new NoSuchElementException();
+            }
+            prevIndex = index;
+            return elementData.get(index++);
+        }
+
+        @Override
+        public void remove() {
+            preconditionCheck();
+            if (prevIndex == -1) {
+                throw new IllegalStateException();
+            }
+            elementData.end--;
+            elementData.remove(prevIndex);
+            prevIndex = -1;
+        }
     }
 
     public class UtArrayListIterator implements ListIterator<E> {

--- a/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtLinkedList.java
+++ b/utbot-framework/src/main/java/org/utbot/engine/overrides/collections/UtLinkedList.java
@@ -435,6 +435,8 @@ public class UtLinkedList<E> extends AbstractSequentialList<E>
     @Override
     public Iterator<E> iterator() {
         preconditionCheck();
+
+        // Some implementations of `iterator` return an instance of ListIterator
         return new UtLinkedListIterator(elementData.begin);
     }
 
@@ -449,7 +451,7 @@ public class UtLinkedList<E> extends AbstractSequentialList<E>
     @Override
     public Iterator<E> descendingIterator() {
         preconditionCheck();
-        return new ReverseIteratorWrapper(elementData.end);
+        return new UtReverseIterator(elementData.end);
     }
 
     @Override
@@ -467,12 +469,12 @@ public class UtLinkedList<E> extends AbstractSequentialList<E>
         return stream();
     }
 
-    public class ReverseIteratorWrapper implements ListIterator<E> {
+    public class UtReverseIterator implements ListIterator<E> {
 
         int index;
         int prevIndex = -1;
 
-        ReverseIteratorWrapper(int index) {
+        UtReverseIterator(int index) {
             this.index = index;
         }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/CollectionIteratorWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/CollectionIteratorWrappers.kt
@@ -1,0 +1,108 @@
+package org.utbot.engine
+
+import org.utbot.engine.overrides.collections.UtArrayList.UtArrayListIterator
+import org.utbot.engine.overrides.collections.UtArrayList.UtArrayListSimpleIterator
+import org.utbot.engine.overrides.collections.UtHashSet.UtHashSetIterator
+import org.utbot.engine.overrides.collections.UtLinkedList.UtReverseIterator
+import org.utbot.framework.plugin.api.ClassId
+import org.utbot.framework.plugin.api.FieldId
+import org.utbot.framework.plugin.api.MethodId
+import org.utbot.framework.plugin.api.UtAssembleModel
+import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtModel
+import org.utbot.framework.plugin.api.UtReferenceModel
+import org.utbot.framework.plugin.api.util.id
+import org.utbot.framework.plugin.api.util.methodId
+import soot.SootClass
+import soot.SootMethod
+import kotlin.reflect.KClass
+import kotlin.reflect.jvm.jvmName
+
+/**
+ * Abstract wrapper for iterator of [java.util.Collection].
+ */
+abstract class CollectionIteratorWrapper(overriddenClass: KClass<*>) : BaseOverriddenWrapper(overriddenClass.jvmName) {
+    protected abstract val modelName: String
+    protected abstract val javaCollectionClassId: ClassId
+    protected abstract val iteratorMethodId: MethodId
+    protected abstract val iteratorClassId: ClassId
+
+    override fun Traverser.overrideInvoke(
+        wrapper: ObjectValue,
+        method: SootMethod,
+        parameters: List<SymbolicValue>
+    ): List<InvokeResult>? = null
+
+    override fun value(resolver: Resolver, wrapper: ObjectValue): UtModel = resolver.run {
+        val addr = holder.concreteAddr(wrapper.addr)
+        val fieldModels = collectFieldModels(wrapper.addr, overriddenClass.type)
+
+        val containerFieldId = overriddenClass.enclosingClassField
+        val containerFieldModel = fieldModels[containerFieldId] as UtReferenceModel
+
+        val instantiationCall = UtExecutableCallModel(
+            instance = containerFieldModel,
+            executable = iteratorMethodId,
+            params = emptyList()
+        )
+
+        UtAssembleModel(addr, iteratorClassId, modelName, instantiationCall)
+    }
+}
+
+class IteratorOfListWrapper : CollectionIteratorWrapper(UtArrayListSimpleIterator::class) {
+    override val modelName: String = "iteratorOfList"
+    override val javaCollectionClassId: ClassId = java.util.List::class.id
+    override val iteratorClassId: ClassId = java.util.Iterator::class.id
+    override val iteratorMethodId: MethodId = methodId(
+        classId = javaCollectionClassId,
+        name = "iterator",
+        returnType = iteratorClassId,
+        arguments = emptyArray()
+    )
+}
+
+class ListIteratorOfListWrapper : CollectionIteratorWrapper(UtArrayListIterator::class) {
+    override val modelName: String = "listIteratorOfList"
+    override val javaCollectionClassId: ClassId = java.util.List::class.id
+    override val iteratorClassId: ClassId = java.util.ListIterator::class.id
+    override val iteratorMethodId: MethodId = methodId(
+        classId = javaCollectionClassId,
+        name = "listIterator",
+        returnType = iteratorClassId,
+        arguments = emptyArray()
+    )
+}
+
+class IteratorOfSetWrapper : CollectionIteratorWrapper(UtHashSetIterator::class) {
+    override val modelName: String = "iteratorOfSet"
+    override val javaCollectionClassId: ClassId = java.util.Set::class.id
+    override val iteratorClassId: ClassId = java.util.Iterator::class.id
+    override val iteratorMethodId: MethodId = methodId(
+        classId = javaCollectionClassId,
+        name = "iterator",
+        returnType = iteratorClassId,
+        arguments = emptyArray()
+    )
+}
+
+class ReverseIteratorWrapper :CollectionIteratorWrapper(UtReverseIterator::class) {
+    override val modelName: String = "reverseIterator"
+    override val javaCollectionClassId: ClassId = java.util.Deque::class.id
+    override val iteratorClassId: ClassId = java.util.Iterator::class.id
+    override val iteratorMethodId: MethodId = methodId(
+        classId = javaCollectionClassId,
+        name = "descendingIterator",
+        returnType = iteratorClassId,
+        arguments = emptyArray()
+    )
+}
+
+internal val SootClass.enclosingClassField: FieldId
+    get() {
+        require(isInnerClass) {
+            "Cannot get field for enclosing class of non-inner class $this"
+        }
+
+        return getFieldByName("this$0").fieldId
+    }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/CollectionWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/CollectionWrappers.kt
@@ -460,6 +460,11 @@ val LINKED_HASH_MAP_TYPE: RefType
 val HASH_MAP_TYPE: RefType
     get() = Scene.v().getSootClass(java.util.HashMap::class.java.canonicalName).type
 
+val ITERATOR_TYPE: RefType
+    get() = Scene.v().getSootClass(java.util.Iterator::class.java.canonicalName).type
+val LIST_ITERATOR_TYPE: RefType
+    get() = Scene.v().getSootClass(java.util.ListIterator::class.java.canonicalName).type
+
 val STREAM_TYPE: RefType
     get() = Scene.v().getSootClass(java.util.stream.Stream::class.java.canonicalName).type
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/util/SootUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/util/SootUtils.kt
@@ -2,6 +2,7 @@ package org.utbot.framework.util
 
 import org.utbot.common.FileUtil
 import org.utbot.engine.jimpleBody
+import org.utbot.engine.overrides.collections.UtLinkedList
 import org.utbot.engine.pureJavaSignature
 import org.utbot.framework.UtSettings
 import org.utbot.framework.plugin.api.ExecutableId
@@ -159,11 +160,12 @@ private val classesToLoad = arrayOf(
     org.utbot.engine.overrides.collections.UtOptionalLong::class,
     org.utbot.engine.overrides.collections.UtOptionalDouble::class,
     org.utbot.engine.overrides.collections.UtArrayList::class,
+    org.utbot.engine.overrides.collections.UtArrayList.UtArrayListSimpleIterator::class,
     org.utbot.engine.overrides.collections.UtArrayList.UtArrayListIterator::class,
     org.utbot.engine.overrides.collections.UtLinkedList::class,
     org.utbot.engine.overrides.collections.UtLinkedListWithNullableCheck::class,
     org.utbot.engine.overrides.collections.UtLinkedList.UtLinkedListIterator::class,
-    org.utbot.engine.overrides.collections.UtLinkedList.ReverseIteratorWrapper::class,
+    org.utbot.engine.overrides.collections.UtLinkedList.UtReverseIterator::class,
     org.utbot.engine.overrides.collections.UtHashSet::class,
     org.utbot.engine.overrides.collections.UtHashSet.UtHashSetIterator::class,
     org.utbot.engine.overrides.collections.UtHashMap::class,

--- a/utbot-sample/src/main/java/org/utbot/examples/collections/ListIterators.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/collections/ListIterators.java
@@ -1,11 +1,34 @@
 package org.utbot.examples.collections;
 
+import org.utbot.api.mock.UtMock;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 
 public class ListIterators {
+    @SuppressWarnings({"IfStatementWithIdenticalBranches", "RedundantOperationOnEmptyContainer"})
+    Iterator<Integer> returnIterator(List<Integer> list) {
+        UtMock.assume(list != null);
+
+        if (list.isEmpty()) {
+            return list.iterator();
+        } else {
+            return list.iterator();
+        }
+    }
+
+    @SuppressWarnings("IfStatementWithIdenticalBranches")
+    ListIterator<Integer> returnListIterator(List<Integer> list) {
+        UtMock.assume(list != null);
+
+        if (list.isEmpty()) {
+            return list.listIterator();
+        } else {
+            return list.listIterator();
+        }
+    }
 
     List<Integer> iterate(List<Integer> list) {
         Iterator<Integer> iterator = list.iterator();

--- a/utbot-sample/src/main/java/org/utbot/examples/collections/SetIterators.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/collections/SetIterators.java
@@ -1,9 +1,22 @@
 package org.utbot.examples.collections;
 
+import org.utbot.api.mock.UtMock;
+
 import java.util.Iterator;
 import java.util.Set;
 
 public class SetIterators {
+    @SuppressWarnings({"IfStatementWithIdenticalBranches", "RedundantOperationOnEmptyContainer"})
+    Iterator<Integer> returnIterator(Set<Integer> set) {
+        UtMock.assume(set != null);
+
+        if (set.isEmpty()) {
+            return set.iterator();
+        } else {
+            return set.iterator();
+        }
+    }
+
     int iteratorHasNext(Set<Integer> s) {
         Iterator<Integer> iterator = s.iterator();
         if (!iterator.hasNext()) {


### PR DESCRIPTION
## Description

For now, resulted symbolic model for `java.util.List#iterator`, `java.util.List#listIterator`, and `java.util.Set#iterator` are assemble models for our own classes Ut*Iterator that could not be constructed in child process or purely returned to the end user. This PR adds proper symbolic wrappers for these internal iterators to make able to construct the real classes in the result.

## How to test

### Automated tests

`org.utbot.examples.collections.ListIteratorsTest#testReturnIterator`
`org.utbot.examples.collections.ListIteratorsTest#testReturnListIterator`
`org.utbot.examples.collections.SetIteratorsTest#testReturnIterator`

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments**, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] The **documentation** for the functionality I've been working on is up-to-date.