### PR TITLE
Replace 'UTBot' name mentions with 'UnitTestBot'

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerationController.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerationController.kt
@@ -151,7 +151,7 @@ object CodeGenerationController {
                 val testFilePointer = SmartPointerManager.getInstance(model.project)
                     .createSmartPsiElementPointer(testClass.containingFile)
                 val cut = psi2KClass[srcClass] ?: error("Didn't find KClass instance for class ${srcClass.name}")
-                runWriteCommandAction(model.project, "Generate tests with UtBot", null, {
+                runWriteCommandAction(model.project, "Generate tests with UnitTestBot", null, {
                     generateCodeAndReport(
                         process,
                         testSetsId,
@@ -349,7 +349,7 @@ object CodeGenerationController {
             (utUtilsFile as PsiClassOwner).classes.first()
         }
 
-        runWriteCommandAction(model.project, "UtBot util class reformatting", null, {
+        runWriteCommandAction(model.project, "UnitTestBot util class reformatting", null, {
             reformat(model, SmartPointerManager.getInstance(model.project).createSmartPsiElementPointer(utUtilsFile), utUtilsClass)
         })
 
@@ -730,7 +730,7 @@ object CodeGenerationController {
 //                        IntentionHelper(model.project, editor, filePointer).applyIntentions()
                         run(EDT_LATER, indicator, "Tests reformatting") {
                             try {
-                                runWriteCommandAction(filePointer.project, "UtBot tests reformatting", null, {
+                                runWriteCommandAction(filePointer.project, "UnitTestBot tests reformatting", null, {
                                     reformat(model, filePointer, testClassUpdated)
                                 })
                                 unblockDocument(testClassUpdated.project, editor.document)

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -346,7 +346,7 @@ object UtTestsDialogProcessor {
         }
 
     private fun errorMessage(className: String?, timeout: Long) = buildString {
-        appendLine("UtBot failed to generate any test cases for class $className.")
+        appendLine("UnitTestBot failed to generate any test cases for class $className.")
         appendLine()
         appendLine("Try to alter test generation configuration, e.g. enable mocking and static mocking.")
         appendLine("Alternatively, you could try to increase current timeout $timeout sec for generating tests in generation dialog.")

--- a/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/ui/Notifications.kt
+++ b/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/ui/Notifications.kt
@@ -89,7 +89,7 @@ object UnsupportedJdkNotifier : ErrorNotifier() {
 object InvalidClassNotifier : WarningNotifier() {
     override val displayId: String = "Invalid class"
     override fun content(project: Project?, module: Module?, info: String): String =
-        "Generate tests with UtBot for the $info is not supported."
+        "Generate tests with UnitTestBot for the $info is not supported."
 }
 
 object MissingLibrariesNotifier : WarningNotifier() {
@@ -140,7 +140,7 @@ object SarifReportNotifier : EventLogNotifier() {
 object TestsReportNotifier : InformationUrlNotifier() {
     override val displayId: String = "Generated unit tests report"
 
-    override val titleText: String = "UTBot: unit tests generated successfully"
+    override val titleText: String = "UnitTestBot: unit tests generated successfully"
 
     public override val urlOpeningListener: TestReportUrlOpeningListener = TestReportUrlOpeningListener
 }
@@ -149,7 +149,7 @@ object TestsReportNotifier : InformationUrlNotifier() {
 object WarningTestsReportNotifier : WarningUrlNotifier() {
     override val displayId: String = "Generated unit tests report"
 
-    override val titleText: String = "UTBot: unit tests generated with warnings"
+    override val titleText: String = "UnitTestBot: unit tests generated with warnings"
 
     public override val urlOpeningListener: TestReportUrlOpeningListener = TestReportUrlOpeningListener
 }
@@ -157,7 +157,7 @@ object WarningTestsReportNotifier : WarningUrlNotifier() {
 object DetailsTestsReportNotifier : EventLogNotifier() {
     override val displayId: String = "Test report details"
 
-    override val titleText: String = "Test report details of the unit tests generation via UtBot"
+    override val titleText: String = "Test report details of the unit tests generation via UnitTestBot"
 
     public override val urlOpeningListener: TestReportUrlOpeningListener = TestReportUrlOpeningListener
 }
@@ -200,7 +200,7 @@ object GotItTooltipActivity : StartupActivity {
             val shortcut = ActionManager.getInstance()
                 .getKeyboardShortcut("org.utbot.intellij.plugin.ui.actions.GenerateTestsAction")?:return@invokeLater
             val shortcutText = KeymapUtil.getShortcutText(shortcut)
-            val message = GotItMessage.createMessage("UTBot is ready!",
+            val message = GotItMessage.createMessage("UnitTestBot is ready!",
                 "<div style=\"font-size:${JBFont.label().biggerOn(2.toFloat()).size}pt;\">" +
                         "You can get test coverage for methods, Java classes,<br>and even for whole source roots<br> with <b>$shortcutText</b></div>")
             message.setCallback { PropertiesComponent.getInstance().setValue(KEY, true) }


### PR DESCRIPTION
## Description

Fixes #1727 , old mentions of 'UTBot' in string literals we show to user were replaced with 'UnitTestBot'

## How to test

### Manual tests

1. Check the very first "Got it!" message 
2. Check status bar messages during generation: "Generate tests with/util class reformatting/tests reformatting"
3. Check notifications and error messages we show just after generation: "failed to generate/ Invalid class/ generated successfully/generated with warnings/test report details"

## Self-check list

Check off the item if the statement is true:

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.