### PR TITLE
Reduce summarization API to one method

### DIFF
--- a/utbot-cli/src/main/kotlin/org/utbot/cli/GenerateTestsAbstractCommand.kt
+++ b/utbot-cli/src/main/kotlin/org/utbot/cli/GenerateTestsAbstractCommand.kt
@@ -162,7 +162,7 @@ abstract class GenerateTestsAbstractCommand(name: String, help: String) :
             chosenClassesToMockAlways,
             generationTimeout
         ).map {
-            if (sourceCodeFile != null) it.summarize(sourceCodeFile.toFile(), searchDirectory) else it
+            if (sourceCodeFile != null) it.summarize(searchDirectory, sourceCodeFile.toFile()) else it
         }
 
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/sarif/GenerateTestsAndSarifReportFacade.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/sarif/GenerateTestsAndSarifReportFacade.kt
@@ -60,7 +60,7 @@ class GenerateTestsAndSarifReportFacade(
                 sarifProperties.classesToMockAlways,
                 sarifProperties.generationTimeout
             ).map {
-                it.summarize(targetClass.sourceCodeFile, workingDirectory)
+                it.summarize(workingDirectory, targetClass.sourceCodeFile)
             }
 
     private fun generateTestCode(targetClass: TargetClassWrapper, testSets: List<UtMethodTestSet>): String =

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineProcessMain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineProcessMain.kt
@@ -113,7 +113,7 @@ private fun EngineProcessModel.setup(kryoHelper: KryoHelper, watchdog: IdleWatch
                 fuzzingValue = params.fuzzingValue
             })
             .apply { logger.info("generation ended, starting summarization, result size: ${this.size}") }
-            .map { it.summarize(Paths.get(params.searchDirectory)) }
+            .map { it.summarize(Paths.get(params.searchDirectory), sourceFile = null) }
             .apply { logger.info("summarization ended") }
             .filterNot { it.executions.isEmpty() && it.errors.isEmpty() }
 

--- a/utbot-junit-contest/src/main/kotlin/org/utbot/contest/Contest.kt
+++ b/utbot-junit-contest/src/main/kotlin/org/utbot/contest/Contest.kt
@@ -403,7 +403,7 @@ fun runGeneration(
 
         val testSets = testsByMethod.map { (method, executions) ->
             UtMethodTestSet(method, minimizeExecutions(executions), jimpleBody(method))
-                .summarize(cut.classfileDir.toPath())
+                .summarize(cut.classfileDir.toPath(), sourceFile = null)
         }
 
         logger.info().bracket("Flushing tests for [${cut.simpleName}] on disk") {

--- a/utbot-summary-tests/src/test/kotlin/examples/SummaryTestCaseGeneratorTest.kt
+++ b/utbot-summary-tests/src/test/kotlin/examples/SummaryTestCaseGeneratorTest.kt
@@ -55,7 +55,6 @@ open class SummaryTestCaseGeneratorTest(
     ) {
         workaround(WorkaroundReason.HACK) {
             // @todo change to the constructor parameter
-            summaryGenerationType = SummariesGenerationType.LIGHT
             checkSolverTimeoutMillis = 0
             checkNpeInNestedMethods = true
             checkNpeInNestedNotPrivateMethods = true

--- a/utbot-summary-tests/src/test/kotlin/examples/SummaryTestCaseGeneratorTest.kt
+++ b/utbot-summary-tests/src/test/kotlin/examples/SummaryTestCaseGeneratorTest.kt
@@ -3,9 +3,11 @@ package examples
 import org.junit.jupiter.api.*
 import org.utbot.common.WorkaroundReason
 import org.utbot.common.workaround
+import org.utbot.framework.SummariesGenerationType
 import org.utbot.framework.UtSettings.checkNpeInNestedMethods
 import org.utbot.framework.UtSettings.checkNpeInNestedNotPrivateMethods
 import org.utbot.framework.UtSettings.checkSolverTimeoutMillis
+import org.utbot.framework.UtSettings.summaryGenerationType
 import org.utbot.framework.plugin.api.*
 import org.utbot.framework.plugin.api.util.UtContext
 import org.utbot.framework.plugin.api.util.executableId
@@ -53,12 +55,13 @@ open class SummaryTestCaseGeneratorTest(
     ) {
         workaround(WorkaroundReason.HACK) {
             // @todo change to the constructor parameter
+            summaryGenerationType = SummariesGenerationType.LIGHT
             checkSolverTimeoutMillis = 0
             checkNpeInNestedMethods = true
             checkNpeInNestedNotPrivateMethods = true
         }
         val testSet = executionsModel(method.executableId, mockStrategy)
-        val testSetWithSummarization = testSet.summarize(searchDirectory)
+        val testSetWithSummarization = testSet.summarize(searchDirectory, sourceFile = null)
 
         testSetWithSummarization.executions.checkMatchersWithTextSummary(summaryKeys)
         testSetWithSummarization.executions.checkMatchersWithMethodNames(methodNames)

--- a/utbot-testing/src/main/kotlin/org/utbot/testing/UtValueTestCaseChecker.kt
+++ b/utbot-testing/src/main/kotlin/org/utbot/testing/UtValueTestCaseChecker.kt
@@ -2452,7 +2452,7 @@ abstract class UtValueTestCaseChecker(
             } else {
                 walk(executableId, mockStrategy, additionalDependenciesClassPath)
             }
-            testSet.summarize(searchDirectory)
+            testSet.summarize(searchDirectory, sourceFile = null)
             val valueTestCase = testSet.toValueTestCase()
 
             assertTrue(testSet.errors.isEmpty()) {


### PR DESCRIPTION
## Description

We had two very similar methods in summarization API, and one of them had implicit and long sources analysis.
A unique method with explicit logic is introduced instead of them.

## How to test

### Automated tests

Our pipeline will do all auomated checks itself.

### Manual tests

Standard summaries checks in utbot-plugin.

## Self-check list

Check off the item if the statement is true:

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments**, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.