### PR TITLE
Add support for virtual invokes on enums

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/enums/ClassWithEnumTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/enums/ClassWithEnumTest.kt
@@ -109,8 +109,10 @@ class ClassWithEnumTest : UtValueTestCaseChecker(testClass = ClassWithEnum::clas
             ClassWithEnum::changingStaticWithEnumInit,
             eq(1),
             { t, staticsAfter, r ->
-                // we cannot check x since it is not a meaningful value
-                // for some reasons x is inaccessible
+                // We cannot check `x` since it is not a meaningful value since
+                // it is accessed only in a static initializer.
+
+                // For some reasons x is inaccessible
                 // val x = FieldId(t.javaClass.id, "x").jField.get(t) as Int
 
                 val y = staticsAfter[FieldId(ClassWithEnum.ClassWithStaticField::class.id, "y")]!!.value as Int

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Memory.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Memory.kt
@@ -359,20 +359,7 @@ data class Memory( // TODO: split purely symbolic memory and information about s
     fun findTypeForArrayOrNull(addr: UtAddrExpression): ArrayType? = addrToArrayType[addr]
 
     fun getSymbolicEnumValues(classId: ClassId): List<ObjectValue> =
-        symbolicEnumValues.filter {
-            val symbolicValueClassId = it.type.id
-
-            // If symbolicValueClassId is not an enum in accordance with java.lang.Class.isEnum
-            // function, we have to take results for its superclass (a direct inheritor of java.lang.Enum).
-            // Otherwise, we should get results by its own classId.
-            val enumClass = if (symbolicValueClassId.isEnum) {
-                symbolicValueClassId
-            } else {
-                it.type.sootClass.superClassOrNull()?.id
-            }
-
-            enumClass == classId
-        }
+        extractSymbolicEnumValues(symbolicEnumValues, classId)
 }
 
 private fun initialArray(descriptor: MemoryChunkDescriptor) =
@@ -444,20 +431,7 @@ data class MemoryUpdate(
         )
 
     fun getSymbolicEnumValues(classId: ClassId): List<ObjectValue> =
-        symbolicEnumValues.filter {
-            val symbolicValueClassId = it.type.id
-
-            // If symbolicValueClassId is not an enum in accordance with java.lang.Class.isEnum
-            // function, we have to take results for its superclass (a direct inheritor of java.lang.Enum).
-            // Otherwise, we should get results by its own classId.
-            val enumClass = if (symbolicValueClassId.isEnum) {
-                symbolicValueClassId
-            } else {
-                it.type.sootClass.superClassOrNull()?.id
-            }
-
-            enumClass == classId
-        }
+        extractSymbolicEnumValues(symbolicEnumValues, classId)
 }
 
 // array - Java Array
@@ -597,4 +571,22 @@ private operator fun MockInfoEnriched.plus(update: MockInfoEnriched?): MockInfoE
 
 private fun <K, V> MutableMap<K, List<V>>.mergeValues(other: Map<K, List<V>>): Map<K, List<V>> = apply {
     other.forEach { (key, values) -> merge(key, values) { v1, v2 -> v1 + v2 } }
+}
+
+private fun extractSymbolicEnumValues(
+    symbolicEnumValuesSource: PersistentList<ObjectValue>,
+    classId: ClassId
+): List<ObjectValue> = symbolicEnumValuesSource.filter {
+    val symbolicValueClassId = it.type.id
+
+    // If symbolicValueClassId is not an enum in accordance with java.lang.Class.isEnum
+    // function, we have to take results for its superclass (a direct inheritor of java.lang.Enum).
+    // Otherwise, we should get results by its own classId.
+    val enumClass = if (symbolicValueClassId.isEnum) {
+        symbolicValueClassId
+    } else {
+        it.type.sootClass.superClassOrNull()?.id
+    }
+
+    enumClass == classId
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Memory.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Memory.kt
@@ -40,7 +40,7 @@ import kotlinx.collections.immutable.toPersistentMap
 import org.utbot.engine.types.STRING_TYPE
 import org.utbot.engine.types.SeqType
 import org.utbot.engine.types.TypeResolver
-import org.utbot.framework.plugin.api.classId
+import org.utbot.framework.plugin.api.id
 import soot.ArrayType
 import soot.CharType
 import soot.IntType
@@ -357,8 +357,9 @@ data class Memory( // TODO: split purely symbolic memory and information about s
 
     fun findTypeForArrayOrNull(addr: UtAddrExpression): ArrayType? = addrToArrayType[addr]
 
+    // We check a superclass here since we added a superclass in here, not enum instances
     fun getSymbolicEnumValues(classId: ClassId): List<ObjectValue> =
-        symbolicEnumValues.filter { it.type.classId == classId }
+        symbolicEnumValues.filter { it.type.sootClass.superClassOrNull()?.id == classId }
 }
 
 private fun initialArray(descriptor: MemoryChunkDescriptor) =
@@ -429,8 +430,9 @@ data class MemoryUpdate(
             symbolicEnumValues = symbolicEnumValues.addAll(other.symbolicEnumValues),
         )
 
+    // We check a superclass here since we added a superclass in here, not enum instances
     fun getSymbolicEnumValues(classId: ClassId): List<ObjectValue> =
-        symbolicEnumValues.filter { it.type.classId == classId }
+        symbolicEnumValues.filter { it.type.sootClass.superClassOrNull()?.id == classId }
 }
 
 // array - Java Array

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Resolver.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Resolver.kt
@@ -558,9 +558,19 @@ class Resolver(
         }
 
         val clazz = classLoader.loadClass(sootClass.name)
+        // If we have an actual type as an Enum instance (a direct inheritor of java.lang.Enum),
+        // we should construct it using information about corresponding ordinal.
+        // The right enum constant will be constructed due to constraints added to the solver.
+        if (clazz.isEnum) {
+            return constructEnum(concreteAddr, actualType, clazz)
+        }
+
+        // But, if we have the actualType that is not a direct inheritor of java.lang.Enum,
+        // we have to check its ancestor instead, because we might be in a situation when
+        // we worked with an enum constant as a parameter, and now we have correctly calculated actual type.
         // Since actualType for enums represents its instances and enum constants are not actually
-        // enum instances, we have to check the defaultType below instead on the actual one
-        // whether is it an Enum or not
+        // enum instances (in accordance to java.lang.Class#isEnum), we have to check
+        // the defaultType below instead on the actual one whether is it an Enum or not.
         val defaultClazz = classLoader.loadClass(defaultType.sootClass.name)
 
         if (defaultClazz.isEnum) {

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Resolver.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Resolver.kt
@@ -558,9 +558,13 @@ class Resolver(
         }
 
         val clazz = classLoader.loadClass(sootClass.name)
+        // Since actualType for enums represents its instances and enum constants are not actually
+        // enum instances, we have to check the defaultType below instead on the actual one
+        // whether is it an Enum or not
+        val defaultClazz = classLoader.loadClass(defaultType.sootClass.name)
 
-        if (clazz.isEnum) {
-            return constructEnum(concreteAddr, actualType, clazz)
+        if (defaultClazz.isEnum) {
+            return constructEnum(concreteAddr, actualType, defaultClazz)
         }
 
         // check if we have mock with this address

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -2324,7 +2324,7 @@ class Traverser(
         }
 
     private fun createEnum(type: RefType, addr: UtAddrExpression): ObjectValue {
-        val typeStorage = typeResolver.constructTypeStorage(type, useConcreteType = true)
+        val typeStorage = typeResolver.constructTypeStorage(type, useConcreteType = false)
 
         queuedSymbolicStateUpdates += typeRegistry.typeConstraint(addr, typeStorage).all().asHardConstraint()
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -2342,6 +2342,7 @@ class Traverser(
         return ObjectValue(typeStorage, addr)
     }
 
+    @Suppress("SameParameterValue")
     private fun arrayUpdate(array: ArrayValue, index: PrimitiveValue, value: UtExpression): MemoryUpdate {
         val type = array.type
         val chunkId = typeRegistry.arrayChunkId(type)

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -2314,7 +2314,9 @@ class Traverser(
                 queuedSymbolicStateUpdates += addrEq(addr, nullObjectAddr).asSoftConstraint()
 
                 if (type.sootClass.isEnum) {
-                    createEnum(type, addr)
+                    // We don't know which enum constant should we create, so we
+                    // have to create an instance of unknown type to support virtual invokes.
+                    createEnum(type, addr, useConcreteType = false)
                 } else {
                     createObject(addr, type, useConcreteType = false, mockInfoGenerator)
                 }
@@ -2323,8 +2325,8 @@ class Traverser(
             else -> error("Can't create const from ${type::class}")
         }
 
-    private fun createEnum(type: RefType, addr: UtAddrExpression): ObjectValue {
-        val typeStorage = typeResolver.constructTypeStorage(type, useConcreteType = false)
+    private fun createEnum(type: RefType, addr: UtAddrExpression, useConcreteType: Boolean): ObjectValue {
+        val typeStorage = typeResolver.constructTypeStorage(type, useConcreteType)
 
         queuedSymbolicStateUpdates += typeRegistry.typeConstraint(addr, typeStorage).all().asHardConstraint()
 

--- a/utbot-sample/src/main/java/org/utbot/examples/enums/ClassWithEnum.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/enums/ClassWithEnum.java
@@ -98,9 +98,28 @@ public class ClassWithEnum {
         return true;
     }
 
+    public int virtualFunction(StatusEnum parameter) {
+        int value = parameter.virtualFunction();
+        if (value > 0) {
+            return value;
+        }
+
+        return Math.abs(value);
+    }
+
     enum StatusEnum {
-        READY(0, 10, "200"),
-        ERROR(-1, -10, null);
+        READY(0, 10, "200") {
+            @Override
+            public int virtualFunction() {
+                return 0;
+            }
+        },
+        ERROR(-1, -10, null) {
+            @Override
+            int virtualFunction() {
+                return 1;
+            }
+        };
 
         int mutableInt;
         final int code;
@@ -137,6 +156,8 @@ public class ClassWithEnum {
         int publicGetCode() {
             return this == READY ? 10 : -10;
         }
+
+        abstract int virtualFunction();
     }
 
     enum ManyConstantsEnum {


### PR DESCRIPTION
## Description

Now we create enum instances without concrete type when it comes as a parameter into a function. This allows us to support virtual invokes on enum instances.

Also, this request contains some a fix related to resolving enum instances retrieved from concrete and its instantiation in the Resolver: we should use everywhere not a type for some enum constant, but a type of its superclass (since an enum constant is not an enum in accordance to `java.lang.Class#isEnum`). Corresponding comments are added to the code.

Fixes JIRA:1686, JIRA:1450

## How to test

### Automated tests

Tests from class `org.utbot.examples.enums.ClassWithEnumTest`

### Manual tests

There are no manual tests.

## Self-check list

Check off the item if the statement is true:

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments**, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.