### PR TITLE
When enum is not accessible, it shouldn't be created by fuzzer (#1660)

### DIFF
--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzing/providers/Enums.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzing/providers/Enums.kt
@@ -20,11 +20,14 @@ class EnumValueProvider(
         description: FuzzedDescription,
         type: FuzzedType
     ) = sequence<Seed<FuzzedType, FuzzedValue>> {
-        type.classId.jClass.enumConstants.filterIsInstance<Enum<*>>().forEach { enum ->
-            val id = idGenerator.getOrCreateIdForValue(enum)
-            yield(Seed.Simple(UtEnumConstantModel(id, type.classId, enum).fuzzed {
-                summary = "%var% = $enum"
-            }))
+        val jClass = type.classId.jClass
+        if (isAccessible(jClass, description.description.packageName)) {
+            jClass.enumConstants.filterIsInstance<Enum<*>>().forEach { enum ->
+                val id = idGenerator.getOrCreateIdForValue(enum)
+                yield(Seed.Simple(UtEnumConstantModel(id, type.classId, enum).fuzzed {
+                    summary = "%var% = $enum"
+                }))
+            }
         }
     }
 }

--- a/utbot-fuzzers/src/test/java/org/utbot/fuzzing/samples/AccessibleObjects.java
+++ b/utbot-fuzzers/src/test/java/org/utbot/fuzzing/samples/AccessibleObjects.java
@@ -16,4 +16,18 @@ public class AccessibleObjects {
             }
         }
     }
+
+    public int ordinal(InnEn val) {
+        switch (val) {
+            case ONE:
+                return 0;
+            case TWO:
+                return 1;
+        }
+        return -1;
+    }
+
+    private enum InnEn {
+        ONE, TWO
+    }
 }

--- a/utbot-fuzzers/src/test/kotlin/org/utbot/fuzzing/JavaFuzzingTest.kt
+++ b/utbot-fuzzers/src/test/kotlin/org/utbot/fuzzing/JavaFuzzingTest.kt
@@ -217,6 +217,23 @@ class JavaFuzzingTest {
     }
 
     @Test
+    fun `fuzzing should not generate values of private enums`() {
+        var exec = 0
+        runBlockingWithContext {
+            runJavaFuzzing(
+                TestIdentityPreservingIdGenerator,
+                methodUnderTest = AccessibleObjects::class.java.declaredMethods.first { it.name == "ordinal" }.executableId,
+                constants = emptyList(),
+                names = emptyList(),
+            ) { _, _, _ ->
+                exec += 1
+                BaseFeedback(Trie.emptyNode(), Control.STOP)
+            }
+        }
+        assertEquals(0, exec) { "Fuzzer should not create any values of private classes" }
+    }
+
+    @Test
     fun `fuzzing generate single test in case of collection with fail-to-generate generic type`() {
         val size = 100
         var exec = size


### PR DESCRIPTION
## Description

Before there's no accessibility check for enum types.

Fixes #1660 

## How to test

### Automated tests

> `utbot-fuzzer/src/test/kotlin/org/utbot/fuzzing/JavaFuzzingTest.kt`

### Manual tests

Run this example:

```java
public class PrivateTest {
    public void foo(Call call) {

    }

    private enum Call {
        ONE;
    }
}
```

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.