### PR TITLE
Add constraints to the start line field in SARIF

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/sarif/DataClasses.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/sarif/DataClasses.kt
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import kotlin.math.max
 
 /**
  * Useful links:
@@ -224,7 +223,12 @@ data class SarifRegion(
             val startColumn = neededLine?.run {
                 takeWhile { it.toString().isBlank() }.length + 1 // to one-based
             }
-            val safeStartLine = max(1, startLine) // we don't want to fail if for some reason startLine < 1
+            val safeStartLine = if (startLine < 1) {
+                logger.warn { "For some reason startLine < 1, so now it is equal to 1" }
+                1 // we don't want to fail, so just set the line number to 1
+            } else {
+                startLine
+            }
             return SarifRegion(startLine = safeStartLine, startColumn = startColumn)
         }
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/sarif/DataClasses.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/sarif/DataClasses.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import kotlin.math.max
 
 /**
  * Useful links:
@@ -203,7 +204,9 @@ data class SarifArtifact(
     val uriBaseId: String = "%SRCROOT%"
 )
 
-// all fields should be one-based
+/**
+ * All fields should be one-based.
+ */
 data class SarifRegion(
     val startLine: Int,
     val endLine: Int? = null,
@@ -214,13 +217,15 @@ data class SarifRegion(
         /**
          * Makes [startColumn] the first non-whitespace character in [startLine] in the [text].
          * If the [text] contains less than [startLine] lines, [startColumn] == null.
+         * @param startLine should be one-based
          */
         fun withStartLine(text: String, startLine: Int): SarifRegion {
             val neededLine = text.split('\n').getOrNull(startLine - 1) // to zero-based
             val startColumn = neededLine?.run {
                 takeWhile { it.toString().isBlank() }.length + 1 // to one-based
             }
-            return SarifRegion(startLine = startLine, startColumn = startColumn)
+            val safeStartLine = max(1, startLine) // we don't want to fail if for some reason startLine < 1
+            return SarifRegion(startLine = safeStartLine, startColumn = startColumn)
         }
     }
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/sarif/SarifReport.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/sarif/SarifReport.kt
@@ -328,7 +328,7 @@ class SarifReport(
                 message = Message("$classFqn.$methodName($sourceFileName:$lineNumber)"),
                 physicalLocation = SarifPhysicalLocation(
                     SarifArtifact(uri = sourceFilePath),
-                    SarifRegion(startLine = lineNumber)
+                    SarifRegion(startLine = lineNumber) // lineNumber is one-based
                 )
             ))
         }
@@ -440,7 +440,7 @@ class SarifReport(
         val lastCoveredInstruction = coveredInstructions?.lastOrNull()
         if (lastCoveredInstruction != null)
             return Pair(
-                lastCoveredInstruction.lineNumber,
+                lastCoveredInstruction.lineNumber, // .lineNumber is one-based
                 lastCoveredInstruction.className.replace('/', '.')
             )
 
@@ -448,7 +448,7 @@ class SarifReport(
         val lastPathElementLineNumber = try {
             // path/fullPath might be empty when engine executes in another process -
             // soot entities cannot be passed to the main process because kryo cannot deserialize them
-            (utExecution as? UtSymbolicExecution)?.path?.lastOrNull()?.stmt?.javaSourceStartLineNumber
+            (utExecution as? UtSymbolicExecution)?.path?.lastOrNull()?.stmt?.javaSourceStartLineNumber // one-based
         } catch (t: Throwable) {
             null
         }

--- a/utbot-framework/src/main/kotlin/org/utbot/sarif/SarifReport.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/sarif/SarifReport.kt
@@ -1,11 +1,14 @@
 package org.utbot.sarif
 
+import mu.KotlinLogging
 import org.utbot.common.PathUtil.fileExtension
 import org.utbot.common.PathUtil.toPath
 import org.utbot.framework.UtSettings
 import org.utbot.framework.plugin.api.*
 import java.nio.file.Path
 import kotlin.io.path.nameWithoutExtension
+
+internal val logger = KotlinLogging.logger {}
 
 /**
  * Used for the SARIF report creation by given test cases and generated tests code.


### PR DESCRIPTION
## Description

Made sure that `startLine` field in the `SarifRegion` is greater than zero after calling the `SarifRegion.withStartLine` method.

Fixes #1759 

## How to test

### Automated tests

Regression: `org.utbot.sarif.SarifReportTest`

### Manual tests

Please, repeat the scenario from the issue #1759

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.