### PR TITLE
Fix broken summaries JavaDoc rendering

### DIFF
--- a/utbot-sample/src/main/java/org/utbot/examples/controlflow/Conditions.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/controlflow/Conditions.java
@@ -1,6 +1,21 @@
 package org.utbot.examples.controlflow;
 
 public class Conditions {
+
+    /**
+     * This Doc is here in order to check whether the summaries and display names are rendered correctly.
+     * Had not in hours of peace,
+     * It learned to lightly look on life.
+     *
+     * @param a some long value
+     * @param b some int value
+     * @return the result you won't expect.
+     */
+    public int returnCastFromTernaryOperator(long a, int b) {
+        a = a % b;
+        return (int) (a < 0 ? a + b : a);
+    }
+
     public int simpleCondition(boolean condition) {
         if (condition) {
             return 1;

--- a/utbot-summary-tests/src/test/kotlin/examples/controlflow/SummaryConditionsTest.kt
+++ b/utbot-summary-tests/src/test/kotlin/examples/controlflow/SummaryConditionsTest.kt
@@ -51,4 +51,49 @@ class SummaryConditionsTest : SummaryTestCaseGeneratorTest(
 
         summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
+
+    @Test
+    fun testReturnCastFromTernaryOperator() {
+        val summary1 = "@utbot.classUnderTest {@link Conditions}\n" +
+                "@utbot.methodUnderTest {@link org.utbot.examples.controlflow.Conditions#returnCastFromTernaryOperator(long,int)}\n" +
+                "@utbot.returnsFrom {@code return (int) (a < 0 ? a + b : a);}\n"
+        val summary2 = "@utbot.classUnderTest {@link Conditions}\n" +
+                "@utbot.methodUnderTest {@link org.utbot.examples.controlflow.Conditions#returnCastFromTernaryOperator(long,int)}\n" +
+                "@utbot.returnsFrom {@code return (int) (a < 0 ? a + b : a);}\n"
+        val summary3 = "@utbot.classUnderTest {@link Conditions}\n" +
+                "@utbot.methodUnderTest {@link org.utbot.examples.controlflow.Conditions#returnCastFromTernaryOperator(long,int)}\n" +
+                "@utbot.throwsException {@link java.lang.ArithmeticException} in: a = a % b;\n"
+
+        val methodName1 = "testReturnCastFromTernaryOperator_A0aba"
+        val methodName2 = "testReturnCastFromTernaryOperator_A0aba_1"
+        val methodName3 = "testReturnCastFromTernaryOperator_ThrowArithmeticException"
+
+        val displayName1 = "return (int) (a < 0 ? a + b : a) : False -> return (int) (a < 0 ? a + b : a)"
+        val displayName2 = "return (int) (a < 0 ? a + b : a) : True -> return (int) (a < 0 ? a + b : a)"
+        val displayName3 = "a = a % b -> ThrowArithmeticException"
+
+        val summaryKeys = listOf(
+            summary1,
+            summary2,
+            summary3
+        )
+
+        val displayNames = listOf(
+            displayName1,
+            displayName2,
+            displayName3
+        )
+
+        val methodNames = listOf(
+            methodName1,
+            methodName2,
+            methodName3
+        )
+
+        val method = Conditions::returnCastFromTernaryOperator
+        val mockStrategy = MockStrategyApi.NO_MOCKS
+        val coverage = DoNotCalculate
+
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+    }
 }

--- a/utbot-summary/src/main/kotlin/org/utbot/summary/ast/JimpleToASTMap.kt
+++ b/utbot-summary/src/main/kotlin/org/utbot/summary/ast/JimpleToASTMap.kt
@@ -188,9 +188,9 @@ class JimpleToASTMap(stmts: Iterable<Unit>, methodDeclaration: MethodDeclaration
         val stmts = stmtToASTNode.keys.toTypedArray()
         for (nonAlignedReturn in nonAlignedReturns) {
             val index = stmts.indexOf(nonAlignedReturn)
-            if (index - 1 >= 0 && stmts[index - 1] is JIfStmt) {
-                stmtToASTNode[nonAlignedReturn] = stmtToASTNode[stmts[index - 1]]
-            }
+            val ternaryIfStmtIndex = stmts.indexOfLast { it is JIfStmt && stmts.indexOf(it) <= index }
+
+            stmtToASTNode[nonAlignedReturn] = stmtToASTNode[stmts[ternaryIfStmtIndex]]
         }
     }
 


### PR DESCRIPTION
## Description

The problem was related to incorrect if-statement index evaluation after ternary operation mapping (in *JimpleToASTMap*).

Also, the new test was introduced in order to fixate summary generation behavior for methods with user defined docs.

Fixes # ([1605](https://github.com/UnitTestBot/UTBotJava/issues/1605))

## How to test

### Automated tests

utbot-samples.

### Manual tests

Generate a test for the following piece of code with 100% symbolic:
```java
class A {
    /**
     * Returns the .
     * Ttt
     * Tta
     *
     * @param a a
     * @param b b, ...
     * @return the result.
     */
    public int result(long a, int b) {
        return (int) (a < 0 ? a + b : a);
    }
}
```

Result must be compilable and be without user defined JavaDocs in JavaDocs.
```java
public final class ATest {
    ///region Test suites for executable A.result

    ///region SYMBOLIC EXECUTION: SUCCESSFUL EXECUTIONS for method result(long, int)

    /**
     * @utbot.classUnderTest {@link A}
     * @utbot.methodUnderTest {@link A#result(long, int)}
     * @utbot.returnsFrom {@code return (int) (a < 0 ? a + b : a);}
     */
    @Test
    @DisplayName("result: return (int) (a < 0 ? a + b : a) : False -> return (int) (a < 0 ? a + b : a)")
    public void testResult_A0aba() {
        A a = new A();

        int actual = a.result(0L, -255);

        assertEquals(0, actual);
    }

    /**
     * @utbot.classUnderTest {@link A}
     * @utbot.methodUnderTest {@link A#result(long, int)}
     * @utbot.returnsFrom {@code return (int) (a < 0 ? a + b : a);}
     */
    @Test
    @DisplayName("result: return (int) (a < 0 ? a + b : a) : True -> return (int) (a < 0 ? a + b : a)")
    public void testResult_A0aba_1() {
        A a = new A();

        int actual = a.result(-255L, -255);

        assertEquals(-510, actual);
    }
    ///endregion

    ///endregion
}
```