### PR TITLE
Fix switch summary content & add extra summary test

### DIFF
--- a/utbot-sample/src/main/java/org/utbot/examples/controlflow/Switch.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/controlflow/Switch.java
@@ -46,6 +46,19 @@ public class Switch {
         return -1;
     }
 
+    public int charToIntSwitch(char c) {
+        switch (c) {
+            case 'I': return 1;
+            case 'V': return 5;
+            case 'X': return 10;
+            case 'L': return 50;
+            case 'C': return 100;
+            case 'D': return 500;
+            case 'M': return 1000;
+            default: throw new IllegalArgumentException("Unrecognized symbol: " + c);
+        }
+    }
+
     //TODO: String switch
 //    public int stringSwitch(String s) {
 //        switch (s) {

--- a/utbot-summary-tests/src/test/kotlin/examples/controlflow/SummarySwitchTest.kt
+++ b/utbot-summary-tests/src/test/kotlin/examples/controlflow/SummarySwitchTest.kt
@@ -13,7 +13,7 @@ class SummarySwitchTest : SummaryTestCaseGeneratorTest(
     Switch::class
 ) {
     @Test
-    fun testDifferentExceptions() {
+    fun testSimpleSwitch() {
         val summary1 = "@utbot.classUnderTest {@link Switch}\n" +
                 "@utbot.methodUnderTest {@link org.utbot.examples.controlflow.Switch#simpleSwitch(int)}\n" +
                 "@utbot.activatesSwitch {@code case 10}\n" +
@@ -63,6 +63,103 @@ class SummarySwitchTest : SummaryTestCaseGeneratorTest(
         )
 
         val method = Switch::simpleSwitch
+        val mockStrategy = MockStrategyApi.NO_MOCKS
+        val coverage = DoNotCalculate
+
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+    }
+
+    @Test
+    fun testCharToIntSwitch() {
+        val summary1 = "@utbot.classUnderTest {@link Switch}\n" +
+                "@utbot.methodUnderTest {@link org.utbot.examples.controlflow.Switch#charToIntSwitch(char)}\n" +
+                "@utbot.activatesSwitch {@code case 'C'}\n" +
+                "@utbot.returnsFrom {@code return 100;}\n"
+        val summary2 = "@utbot.classUnderTest {@link Switch}\n" +
+                "@utbot.methodUnderTest {@link org.utbot.examples.controlflow.Switch#charToIntSwitch(char)}\n" +
+                "@utbot.activatesSwitch {@code case 'V'}\n" +
+                "@utbot.returnsFrom {@code return 5;}\n"
+        val summary3 = "@utbot.classUnderTest {@link Switch}\n" +
+                "@utbot.methodUnderTest {@link org.utbot.examples.controlflow.Switch#charToIntSwitch(char)}\n" +
+                "@utbot.activatesSwitch {@code case 'I'}\n" +
+                "@utbot.returnsFrom {@code return 1;}\n"
+        val summary4 = "@utbot.classUnderTest {@link Switch}\n" +
+                "@utbot.methodUnderTest {@link org.utbot.examples.controlflow.Switch#charToIntSwitch(char)}\n" +
+                "@utbot.activatesSwitch {@code case 'X'}\n" +
+                "@utbot.returnsFrom {@code return 10;}\n"
+        val summary5 = "@utbot.classUnderTest {@link Switch}\n" +
+                "@utbot.methodUnderTest {@link org.utbot.examples.controlflow.Switch#charToIntSwitch(char)}\n" +
+                "@utbot.activatesSwitch {@code case 'M'}\n" +
+                "@utbot.returnsFrom {@code return 1000;}\n"
+        val summary6 = "@utbot.classUnderTest {@link Switch}\n" +
+                "@utbot.methodUnderTest {@link org.utbot.examples.controlflow.Switch#charToIntSwitch(char)}\n" +
+                "@utbot.activatesSwitch {@code case 'D'}\n" +
+                "@utbot.returnsFrom {@code return 500;}\n"
+        val summary7 = "@utbot.classUnderTest {@link Switch}\n" +
+                "@utbot.methodUnderTest {@link org.utbot.examples.controlflow.Switch#charToIntSwitch(char)}\n" +
+                "@utbot.activatesSwitch {@code case 'L'}\n" +
+                "@utbot.returnsFrom {@code return 50;}\n"
+        val summary8 = "@utbot.classUnderTest {@link Switch}\n" +
+                "@utbot.methodUnderTest {@link org.utbot.examples.controlflow.Switch#charToIntSwitch(char)}\n" +
+                "@utbot.invokes {@link java.lang.StringBuilder#append(java.lang.String)}\n" +
+                "@utbot.invokes {@link java.lang.StringBuilder#append(char)}\n" +
+                "@utbot.invokes {@link java.lang.StringBuilder#toString()}\n" +
+                "@utbot.activatesSwitch {@code case default}\n" +
+                "@utbot.throwsException {@link java.lang.IllegalArgumentException} in: default:\n" +
+                "    throw new IllegalArgumentException(\"Unrecognized symbol: \" + c);\n"
+
+        val methodName1 = "testCharToIntSwitch_Return100"
+        val methodName2 = "testCharToIntSwitch_Return5"
+        val methodName3 = "testCharToIntSwitch_Return1"
+        val methodName4 = "testCharToIntSwitch_Return10"
+        val methodName5 = "testCharToIntSwitch_Return1000"
+        val methodName6 = "testCharToIntSwitch_Return500"
+        val methodName7 = "testCharToIntSwitch_Return50"
+        val methodName8 = "testCharToIntSwitch_StringBuilderToString"
+
+        val displayName1 = "switch(c) case: 'C' -> return 100"
+        val displayName2 = "switch(c) case: 'V' -> return 5"
+        val displayName3 = "switch(c) case: 'I' -> return 1"
+        val displayName4 = "switch(c) case: 'X' -> return 10"
+        val displayName5 = "switch(c) case: 'M' -> return 1000"
+        val displayName6 = "switch(c) case: 'D' -> return 500"
+        val displayName7 = "switch(c) case: 'L' -> return 50"
+        val displayName8 = """default: throw new IllegalArgumentException("Unrecognized symbol: " + c)  -> ThrowIllegalArgumentException"""
+
+        val summaryKeys = listOf(
+            summary1,
+            summary2,
+            summary3,
+            summary4,
+            summary5,
+            summary6,
+            summary7,
+            summary8,
+        )
+
+        val displayNames = listOf(
+            displayName1,
+            displayName2,
+            displayName3,
+            displayName4,
+            displayName5,
+            displayName6,
+            displayName7,
+            displayName8,
+        )
+
+        val methodNames = listOf(
+            methodName1,
+            methodName2,
+            methodName3,
+            methodName4,
+            methodName5,
+            methodName6,
+            methodName7,
+            methodName8,
+        )
+
+        val method = Switch::charToIntSwitch
         val mockStrategy = MockStrategyApi.NO_MOCKS
         val coverage = DoNotCalculate
 

--- a/utbot-summary-tests/src/test/kotlin/math/SummaryIntMathPowTest.kt
+++ b/utbot-summary-tests/src/test/kotlin/math/SummaryIntMathPowTest.kt
@@ -11,7 +11,7 @@ class SummaryIntMathPowTest : SummaryTestCaseGeneratorTest(
 ) {
     @Test
     fun testPow() {
-        val summary1 = "Test activates switch case: 2, returns from: return 1;\n"
+        val summary1 = "Test activates switch case: 1, returns from: return 1;\n"
         val summary2 = "Test executes conditions:\n" +
                 "    (k < Integer.SIZE): False\n" +
                 "returns from: return 0;\n"
@@ -69,7 +69,7 @@ class SummaryIntMathPowTest : SummaryTestCaseGeneratorTest(
         val methodName13 = "testPow_KBitwiseAnd1NotEqualsZero_2"
         val methodName14 = "testPow_KBitwiseAnd1EqualsZero_2"
 
-        val displayName1 = "switch(b) case: 2 -> return 1"
+        val displayName1 = "switch(b) case: 1 -> return 1"
         val displayName2 = "k < Integer.SIZE : False -> return 0"
         val displayName3 = "k < Integer.SIZE : False -> return (k < Integer.SIZE) ? (1 << k) : 0"
         val displayName4 = "-> return b * accum" // TODO: weird display name with missed part before ->

--- a/utbot-summary/src/main/kotlin/org/utbot/summary/AbstractTextBuilder.kt
+++ b/utbot-summary/src/main/kotlin/org/utbot/summary/AbstractTextBuilder.kt
@@ -106,15 +106,14 @@ abstract class AbstractTextBuilder(
                 return JimpleToASTMap.getSwitchCaseLabel(astNode, case)
             }
         }
-        //needed more tests to cover these cases
         if (stmt is JTableSwitchStmt && astNode is SwitchStmt) {
-            val switchCase = JimpleToASTMap.mapSwitchCase(astNode, step.decision)
+            val switchCase = JimpleToASTMap.mapSwitchCase(astNode, step)
             if (switchCase is SwitchEntry) {
                 val case = switchCase.labels.first
-                if (case.isPresent) {
-                    return "${case.get()}"
+                return if (case.isPresent) {
+                    "${case.get()}"
                 } else {
-                    return "default"
+                    "default"
                 }
             }
         }

--- a/utbot-summary/src/main/kotlin/org/utbot/summary/ast/JimpleToASTMap.kt
+++ b/utbot-summary/src/main/kotlin/org/utbot/summary/ast/JimpleToASTMap.kt
@@ -25,6 +25,7 @@ import com.github.javaparser.ast.stmt.Statement
 import com.github.javaparser.ast.stmt.SwitchEntry
 import com.github.javaparser.ast.stmt.SwitchStmt
 import com.github.javaparser.ast.stmt.WhileStmt
+import org.utbot.framework.plugin.api.Step
 import org.utbot.summary.comment.isLoopStatement
 import java.util.LinkedList
 import java.util.Queue
@@ -339,12 +340,14 @@ class JimpleToASTMap(stmts: Iterable<Unit>, methodDeclaration: MethodDeclaration
         }
 
         /**
-         * @return SwitchEntry №decision
+         * @return SwitchEntry
          */
-        fun mapSwitchCase(switchStmt: SwitchStmt, decision: Int): SwitchEntry? {
-            val switchStmts = switchStmt.childNodes.filterIsInstance<SwitchEntry>()
-            return if (decision < switchStmts.size) switchStmts[decision]
-            else null
+        fun mapSwitchCase(switchStmt: SwitchStmt, step: Step): SwitchEntry? {
+            val neededLine = step.stmt.unitBoxes[step.decision].unit.javaSourceStartLineNumber
+            return switchStmt
+                .childNodes
+                .filterIsInstance<SwitchEntry>()
+                .find { neededLine in (it.range.get().begin.line..it.range.get().end.line) }
         }
 
         /**

--- a/utbot-summary/src/main/kotlin/org/utbot/summary/name/NodeConvertor.kt
+++ b/utbot-summary/src/main/kotlin/org/utbot/summary/name/NodeConvertor.kt
@@ -274,7 +274,7 @@ class NodeConvertor {
                 res += JimpleToASTMap.getSwitchCaseLabel(switchNode, case).capitalize()
             }
             if (stmt is JTableSwitchStmt) {
-                val switchCase = JimpleToASTMap.mapSwitchCase(switchNode, step.decision)
+                val switchCase = JimpleToASTMap.mapSwitchCase(switchNode, step)
                 if (switchCase is SwitchEntry) {
                     val case = switchCase.labels.first
                     res += if (case.isPresent) {


### PR DESCRIPTION
## Description

This PR fixes missing arguments in summary texts and unmatched display names.
Also, there was an incorrect summary test (*SummaryIntMathPowTest.kt*) which was fixed as well.

Fixes #756

## How to test

### Automated tests

utbot-samples.

### Manual tests

Generate a test for the following method:
```java
public int symbolToInt(char c) {
    switch (c) {
        case 'I': return 1;
        case 'V': return 5;
        case 'X': return 10;
        case 'L': return 50;
        case 'C': return 100;
        case 'D': return 500;
        case 'M': return 1000;
        default: throw new IllegalArgumentException("Unrecognized symbol: " + c);
    }
}
```

As the result, correct summaries and display names will be generated:
```java
    /**
     * @utbot.classUnderTest {@link Switch}
     * @utbot.methodUnderTest {@link org.utbot.examples.controlflow.Switch#symbolToInt(char)}
     * @utbot.activatesSwitch {@code case 'C'}
     * @utbot.returnsFrom {@code return 100;}
     */
    @Test
    @DisplayName("symbolToInt: switch(c) case: 'C' -> return 100")
    public void testSymbolToInt_Return100() {
        Switch switch1 = new Switch();
        
        int actual = switch1.symbolToInt('C');
        
        assertEquals(100, actual);
    }
    
    /**
     * @utbot.classUnderTest {@link Switch}
     * @utbot.methodUnderTest {@link org.utbot.examples.controlflow.Switch#symbolToInt(char)}
     * @utbot.activatesSwitch {@code case 'V'}
     * @utbot.returnsFrom {@code return 5;}
     */
    @Test
    @DisplayName("symbolToInt: switch(c) case: 'V' -> return 5")
    public void testSymbolToInt_Return5() {
        Switch switch1 = new Switch();
        
        int actual = switch1.symbolToInt('V');
        
        assertEquals(5, actual);
    }
```