### PR TITLE
Add Tern auto-installation for JavaScript

### DIFF
--- a/utbot-intellij-js/src/main/kotlin/org/utbot/intellij/plugin/language/js/NycSourceFileChooser.kt
+++ b/utbot-intellij-js/src/main/kotlin/org/utbot/intellij/plugin/language/js/NycSourceFileChooser.kt
@@ -24,7 +24,6 @@ class NycSourceFileChooser(val model: JsTestsModel) : TextFieldWithBrowseButton(
         addBrowseFolderListener(
             TextBrowseFolderListener(descriptor, model.project)
         )
-        nycData.findPackagePath() ?: installMissingRequirement(model.project, model.pathToNPM, nycData)
         text = (replaceSeparator(nycData.findPackagePath() ?: "Nyc was not found")
                 + OsProvider.getProviderByOs().npmPackagePostfix)
     }

--- a/utbot-js/src/main/kotlin/settings/JsPackagesSettings.kt
+++ b/utbot-js/src/main/kotlin/settings/JsPackagesSettings.kt
@@ -6,9 +6,7 @@ import utils.OsProvider
 object JsPackagesSettings {
     val mochaData: PackageData = PackageData("mocha", "-l")
     val nycData: PackageData = PackageData("nyc", "-g")
-
-    // TODO(MINOR): Add tern auto installation
-    val ternData: PackageData? = null
+    val ternData: PackageData = PackageData("tern", "-l")
 }
 
 data class PackageData(


### PR DESCRIPTION
## Description

The required Tern package is installed automatically if it was not found in the user's project.

* The presence of an already installed package in the user's project is taken into account.

Fixes #1780

## How to test

### Manual tests

Various scenarios have been tested, in the absence of the necessary package in the user directory. You can find the examples in the folder `/utbot-js/samples' and try to run UTBot with the Tern package installed or missing.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.