### PR TITLE
Fix missing info in summaries

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/enums/ComplexEnumExamplesTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/enums/ComplexEnumExamplesTest.kt
@@ -75,7 +75,6 @@ class ComplexEnumExamplesTest : UtValueTestCaseChecker(
     }
 
     @Test
-    @Disabled("TODO: nested anonymous classes are not supported: https://github.com/UnitTestBot/UTBotJava/issues/617")
     fun testFindState() {
         check(
             ComplexEnumExamples::findState,

--- a/utbot-summary-tests/src/test/kotlin/examples/collections/SummaryListWrapperReturnsVoidTest.kt
+++ b/utbot-summary-tests/src/test/kotlin/examples/collections/SummaryListWrapperReturnsVoidTest.kt
@@ -16,15 +16,17 @@ class SummaryListWrapperReturnsVoidTest : SummaryTestCaseGeneratorTest(
 ) {
     @Test
     fun testRunForEach() {
-        val summary1 = "Test throws NullPointerException in: list.forEach(o -> {\n" +
+        val summary1 = "Test invokes:\n" +
+                "    {@link java.util.List#forEach(java.util.function.Consumer)} once\n" +
+                "throws NullPointerException in: list.forEach(o -> {\n" +
                 "    if (o == null)\n" +
                 "        i[0]++;\n" +
-                "});"
+                "});\n"
         val summary2 = "Test returns from: return i[0];"
         val summary3 = "Test returns from: return i[0];"
         val summary4 = "Test returns from: return i[0];"
 
-        val methodName1 = "testRunForEach_ThrowNullPointerException"
+        val methodName1 = "testRunForEach_ListForEach"
         val methodName2 = "testRunForEach_Return0OfI"
         val methodName3 = "testRunForEach_Return0OfI_1"
         val methodName4 = "testRunForEach_Return0OfI_2"

--- a/utbot-summary-tests/src/test/kotlin/examples/enums/SummaryComplexEnumExampleTest.kt
+++ b/utbot-summary-tests/src/test/kotlin/examples/enums/SummaryComplexEnumExampleTest.kt
@@ -9,7 +9,7 @@ import org.utbot.framework.plugin.api.MockStrategyApi
 import org.utbot.testing.DoNotCalculate
 
 @ExtendWith(CustomJavaDocTagsEnabler::class)
-class ComplexEnumExampleTest : SummaryTestCaseGeneratorTest(
+class SummaryComplexEnumExampleTest : SummaryTestCaseGeneratorTest(
     ComplexEnumExamples::class
 ) {
     @Test
@@ -80,6 +80,55 @@ class ComplexEnumExampleTest : SummaryTestCaseGeneratorTest(
 
 
         val method = ComplexEnumExamples::countEqualColors
+        val mockStrategy = MockStrategyApi.NO_MOCKS
+        val coverage = DoNotCalculate
+
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+    }
+
+    @Test
+    fun testFindState() {
+        val summary1 = "@utbot.classUnderTest {@link ComplexEnumExamples}\n" +
+                "@utbot.methodUnderTest {@link org.utbot.examples.enums.ComplexEnumExamples#findState(int)}\n" +
+                "@utbot.invokes {@link org.utbot.examples.enums.State#findStateByCode(int)}\n" +
+                "@utbot.returnsFrom {@code return State.findStateByCode(code);}\n"
+        val summary2 = "@utbot.classUnderTest {@link ComplexEnumExamples}\n" +
+                "@utbot.methodUnderTest {@link org.utbot.examples.enums.ComplexEnumExamples#findState(int)}\n" +
+                "@utbot.invokes {@link org.utbot.examples.enums.State#findStateByCode(int)}\n" +
+                "@utbot.returnsFrom {@code return State.findStateByCode(code);}\n"
+        val summary3 = "@utbot.classUnderTest {@link ComplexEnumExamples}\n" +
+                "@utbot.methodUnderTest {@link org.utbot.examples.enums.ComplexEnumExamples#findState(int)}\n" +
+                "@utbot.invokes {@link org.utbot.examples.enums.State#findStateByCode(int)}\n" +
+                "@utbot.returnsFrom {@code return State.findStateByCode(code);}\n"
+
+        val methodName1 = "testFindState_ReturnStateFindStateByCode"
+        val methodName2 = "testFindState_ReturnStateFindStateByCode_1"
+        val methodName3 = "testFindState_ReturnStateFindStateByCode_2"
+
+        val displayName1 = "-> return State.findStateByCode(code)"
+        val displayName2 = "-> return State.findStateByCode(code)"
+        val displayName3 = "-> return State.findStateByCode(code)"
+
+        val summaryKeys = listOf(
+            summary1,
+            summary2,
+            summary3
+        )
+
+        val displayNames = listOf(
+            displayName1,
+            displayName2,
+            displayName3
+        )
+
+        val methodNames = listOf(
+            methodName1,
+            methodName2,
+            methodName3
+        )
+
+
+        val method = ComplexEnumExamples::findState
         val mockStrategy = MockStrategyApi.NO_MOCKS
         val coverage = DoNotCalculate
 

--- a/utbot-summary-tests/src/test/kotlin/examples/mock/SummaryCommonMocksExample.kt
+++ b/utbot-summary-tests/src/test/kotlin/examples/mock/SummaryCommonMocksExample.kt
@@ -1,0 +1,41 @@
+package examples.mock
+
+import examples.SummaryTestCaseGeneratorTest
+import org.junit.jupiter.api.Test
+import org.utbot.examples.mock.CommonMocksExample
+import org.utbot.framework.plugin.api.MockStrategyApi
+import org.utbot.testing.DoNotCalculate
+
+class SummaryCommonMocksExample : SummaryTestCaseGeneratorTest(
+    CommonMocksExample::class,
+) {
+    @Test
+    fun testClinitMockExample() {
+        val summary1 = "Test invokes:\n" +
+                "    {@link java.lang.Integer#intValue()} twice\n" +
+                "returns from: return -ObjectWithFinalStatic.keyValue;\n"
+
+        val methodName1 = "testClinitMockExample_IntegerIntValue"
+
+        val displayName1 = "IntegerIntValue -> return -ObjectWithFinalStatic.keyValue"
+
+
+        val summaryKeys = listOf(
+            summary1
+        )
+
+        val displayNames = listOf(
+            displayName1
+        )
+
+        val methodNames = listOf(
+            methodName1
+        )
+
+        val method = CommonMocksExample::clinitMockExample
+        val mockStrategy = MockStrategyApi.OTHER_CLASSES
+        val coverage = DoNotCalculate
+
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+    }
+}

--- a/utbot-summary-tests/src/test/kotlin/examples/recursion/SummaryRecursionTest.kt
+++ b/utbot-summary-tests/src/test/kotlin/examples/recursion/SummaryRecursionTest.kt
@@ -26,6 +26,8 @@ class SummaryRecursionTest : SummaryTestCaseGeneratorTest(
         val summary3 = "@utbot.classUnderTest {@link Recursion}\n" +
                 "@utbot.methodUnderTest {@link org.utbot.examples.recursion.Recursion#fib(int)}\n" +
                 "@utbot.executesCondition {@code (n == 1): False}\n" +
+                "@utbot.invokes {@link org.utbot.examples.recursion.Recursion#fib(int)}\n" +
+                "@utbot.invokes {@link org.utbot.examples.recursion.Recursion#fib(int)}\n" +
                 "@utbot.triggersRecursion fib, where the test execute conditions:\n" +
                 "    {@code (n == 1): True}\n" +
                 "return from: {@code return 1;}" +
@@ -84,6 +86,7 @@ class SummaryRecursionTest : SummaryTestCaseGeneratorTest(
         val summary2 = "@utbot.classUnderTest {@link Recursion}\n" +
                 "@utbot.methodUnderTest {@link org.utbot.examples.recursion.Recursion#factorial(int)}\n" +
                 "@utbot.executesCondition {@code (n == 0): False}\n" +
+                "@utbot.invokes {@link org.utbot.examples.recursion.Recursion#factorial(int)}\n" +
                 "@utbot.triggersRecursion factorial, where the test return from: {@code return 1;}" +
                 "@utbot.returnsFrom {@code return n * factorial(n - 1);}"
         val summary3 = "@utbot.classUnderTest {@link Recursion}\n" +

--- a/utbot-summary-tests/src/test/kotlin/math/SummaryIntMathLogTest.kt
+++ b/utbot-summary-tests/src/test/kotlin/math/SummaryIntMathLogTest.kt
@@ -26,14 +26,14 @@ class SummaryIntMathLogTest : SummaryTestCaseGeneratorTest(
                 "@utbot.invokes {@link java.math.RoundingMode#ordinal()}\n" +
                 "@utbot.throwsException {@link java.lang.NullPointerException} in: mode"
 
-        val methodName1 = "testLog2"
-        val methodName2 = "testLog2_1"
-        val methodName3 = "testLog2_2"
+        val methodName1 = "testLog2_IntegerNumberOfLeadingZeros"
+        val methodName2 = "testLog2_IntegerNumberOfLeadingZeros_1"
+        val methodName3 = "testLog2_IntMathLessThanBranchFree"
         val methodName4 = "testLog2_RoundingModeOrdinal"
 
-        val displayName1 = ""
-        val displayName2 = ""
-        val displayName3 = ""
+        val displayName1 = "switch(mode) case: FLOOR -> return (Integer.SIZE - 1) - Integer.numberOfLeadingZeros(x)"
+        val displayName2 = "switch(mode) case: CEILING -> return Integer.SIZE - Integer.numberOfLeadingZeros(x - 1)"
+        val displayName3 = "switch(mode) case: HALF_EVEN -> return logFloor + lessThanBranchFree(cmp, x)"
         val displayName4 = "switch(mode) case:  -> ThrowNullPointerException"
 
         val summaryKeys = listOf(

--- a/utbot-summary-tests/src/test/kotlin/math/SummaryOfMathTest.kt
+++ b/utbot-summary-tests/src/test/kotlin/math/SummaryOfMathTest.kt
@@ -232,7 +232,9 @@ class SummaryOfMathTest : SummaryTestCaseGeneratorTest(
                             "        {@code (count == 0): True}\n" +
                             "    invoke:\n" +
                             "        {@link guava.examples.math.StatsAccumulator#isFinite(double)} twice\n" +
-                            "Tests next execute conditions:\n" +
+                            "Tests later invoke:\n" +
+                            "    {@link guava.examples.math.StatsAccumulator#add(double)} once\n" +
+                            "execute conditions:\n" +
                             "    {@code (null): False}\n" +
                             "call {@link guava.examples.math.StatsAccumulator#isFinite(double)},\n" +
                             "    there it invoke:\n" +


### PR DESCRIPTION
## Description
This PR fixes empty displaynames, missing info in summaries texts as it was described in the following issues.
Also, some extra tests were added to fixate the behavior.

Fixes #1588, #1734

## How to test

### Automated tests

utbot-summary-tests.

### Manual tests

Bug reproduction from issues verifies non-empty displaynames generation.