### PR TITLE
Initilial implementation of Spring test classes code generation

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -1503,7 +1503,7 @@ class Traverser(
             return createMockedObject(addr, type, mockInfoGenerator, nullEqualityConstraint)
         }
 
-        val concreteImplementation = when (applicationContext.typeReplacementMode) {
+        val concreteImplementation: Concrete? = when (applicationContext.typeReplacementMode) {
             AnyImplementor -> findConcreteImplementation(addr, type, typeHardConstraint, nullEqualityConstraint)
 
             // If our type is not abstract, both in `KnownImplementors` and `NoImplementors` mode,
@@ -1521,14 +1521,14 @@ class Traverser(
             NoImplementors -> {
                 if (!type.isAbstractType) {
                     findConcreteImplementation(addr, type, typeHardConstraint, nullEqualityConstraint)
-                }
+                } else {
+                    mockInfoGenerator?.let {
+                        return createMockedObject(addr, type, it, nullEqualityConstraint)
+                    }
 
-                mockInfoGenerator?.let {
-                    return createMockedObject(addr, type, it, nullEqualityConstraint)
+                    queuedSymbolicStateUpdates += mkFalse().asHardConstraint()
+                    null
                 }
-
-                queuedSymbolicStateUpdates += mkFalse().asHardConstraint()
-                null
             }
         }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/CodeGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/CodeGenerator.kt
@@ -90,7 +90,7 @@ open class CodeGenerator(
 
     private fun generateForSimpleClass(testSets: List<CgMethodTestSet>): CodeGeneratorResult {
         val astConstructor = CgSimpleTestClassConstructor(context)
-        val testClassModel = SimpleTestClassModelBuilder().createTestClassModel(classUnderTest, testSets)
+        val testClassModel = SimpleTestClassModelBuilder(context).createTestClassModel(classUnderTest, testSets)
 
         logger.info { "Code generation phase started at ${now()}" }
         val testClassFile = astConstructor.construct(testClassModel)
@@ -107,7 +107,7 @@ open class CodeGenerator(
 
     private fun generateForSpringClass(testSets: List<CgMethodTestSet>): CodeGeneratorResult {
         val astConstructor = CgSpringTestClassConstructor(context)
-        val testClassModel = SpringTestClassModelBuilder().createTestClassModel(classUnderTest, testSets)
+        val testClassModel = SpringTestClassModelBuilder(context).createTestClassModel(classUnderTest, testSets)
 
         logger.info { "Code generation phase started at ${now()}" }
         val testClassFile = astConstructor.construct(testClassModel)

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
@@ -3,6 +3,7 @@ package org.utbot.framework.codegen.domain
 import org.utbot.framework.DEFAULT_EXECUTION_TIMEOUT_IN_INSTRUMENTED_PROCESS_MS
 import org.utbot.framework.codegen.domain.builtin.mockitoClassId
 import org.utbot.framework.codegen.domain.builtin.ongoingStubbingClassId
+import org.utbot.framework.codegen.domain.context.CgContext
 import org.utbot.framework.codegen.domain.models.CgClassId
 import org.utbot.framework.codegen.tree.argumentsClassId
 import org.utbot.framework.plugin.api.BuiltinClassId
@@ -11,6 +12,8 @@ import org.utbot.framework.plugin.api.CodeGenerationSettingBox
 import org.utbot.framework.plugin.api.CodeGenerationSettingItem
 import org.utbot.framework.plugin.api.MethodId
 import org.utbot.framework.plugin.api.TypeParameters
+import org.utbot.framework.plugin.api.UtModel
+import org.utbot.framework.plugin.api.idOrNull
 import org.utbot.framework.plugin.api.isolateCommandLineArgumentsToArgumentFile
 import org.utbot.framework.plugin.api.util.booleanArrayClassId
 import org.utbot.framework.plugin.api.util.booleanClassId
@@ -773,3 +776,17 @@ object SpringBoot : DependencyInjectionFramework(
     id = "spring-boot",
     displayName = "Spring Boot"
 )
+
+/**
+ * Extended id of [UtModel], unique for whole test set.
+ *
+ * Allows to distinguish models from different executions,
+ * even if they have the same value of `UtModel.id`.
+ */
+data class ModelId(
+    private val id: Int?,
+    private val executionId: Int,
+)
+
+fun UtModel.withId(executionId: Int = -1) = this to ModelId(this.idOrNull(), executionId)
+

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
@@ -788,5 +788,5 @@ data class ModelId(
     private val executionId: Int,
 )
 
-fun UtModel.withId(executionId: Int = -1) = this to ModelId(this.idOrNull(), executionId)
+fun UtModel.withExecutionId(executionId: Int = -1) = ModelId(this.idOrNull(), executionId)
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/builtin/MockitoBuiltins.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/builtin/MockitoBuiltins.kt
@@ -20,6 +20,16 @@ internal val mockitoClassId = BuiltinClassId(
     simpleName = "Mockito",
 )
 
+internal val mockClassId = BuiltinClassId(
+    canonicalName = "org.mockito.Mock",
+    simpleName = "Mock",
+)
+
+internal val injectMocksClassId = BuiltinClassId(
+    canonicalName = "org.mockito.InjectMocks",
+    simpleName = "InjectMocks",
+)
+
 internal val ongoingStubbingClassId = BuiltinClassId(
     canonicalName = "org.mockito.stubbing.OngoingStubbing",
     simpleName = "OngoingStubbing",

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/context/CgContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/context/CgContext.kt
@@ -571,15 +571,7 @@ data class CgContext(
         }
     }
 
-    override fun getIdByModel(model: UtModel): ModelId {
-        if (model !in modelIds) {
-            modelIds[model] = model.withExecutionId()
-        }
-
-        return modelIds.getOrElse(model) {
-            error("ModelId for $model should have also been created")
-        }
-    }
+    override fun getIdByModel(model: UtModel): ModelId = modelIds.getOrPut(model) { model.withExecutionId() }
 
     private fun createClassIdForNestedClass(testClassModel: SimpleTestClassModel): ClassId {
         val simpleName = "${testClassModel.classUnderTest.simpleName}Test"
@@ -599,6 +591,7 @@ data class CgContext(
         requiredUtilMethods.clear()
         valueByModel.clear()
         valueByModelId.clear()
+        modelIds.clear()
         mockFrameworkUsed = false
     }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/context/CgContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/context/CgContext.kt
@@ -232,7 +232,7 @@ interface CgContextOwner {
      * Gives a unique identifier to model in test set.
      * Determines which execution current model belongs to.
      */
-    var modelIds: PersistentMap<UtModel, ModelId>
+    var modelIds: MutableMap<UtModel, ModelId>
 
     fun block(init: () -> Unit): Block {
         val prevBlock = currentBlock
@@ -492,7 +492,7 @@ data class CgContext(
     override lateinit var actual: CgVariable
     override lateinit var successfulExecutionsModels: List<UtModel>
 
-    override var modelIds: PersistentMap<UtModel, ModelId> = persistentMapOf()
+    override var modelIds: MutableMap<UtModel, ModelId> = mutableMapOf()
 
     /**
      * This property cannot be accessed outside of test class file scope
@@ -573,7 +573,7 @@ data class CgContext(
 
     override fun getIdByModel(model: UtModel): ModelId {
         if (model !in modelIds) {
-            modelIds.put(model, model.withExecutionId())
+            modelIds[model] = model.withExecutionId()
         }
 
         return modelIds.getOrElse(model) {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/TestClassModel.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/TestClassModel.kt
@@ -1,6 +1,7 @@
 package org.utbot.framework.codegen.domain.models
 
 import org.utbot.framework.plugin.api.ClassId
+import org.utbot.framework.plugin.api.UtModel
 
 /**
  * Stores method test sets in a structure that replicates structure of their methods in [classUnderTest].
@@ -13,7 +14,7 @@ abstract class TestClassModel(
     val nestedClasses: List<SimpleTestClassModel>,
 )
 
-open class SimpleTestClassModel(
+class SimpleTestClassModel(
     classUnderTest: ClassId,
     methodTestSets: List<CgMethodTestSet>,
     nestedClasses: List<SimpleTestClassModel> = listOf(),
@@ -29,7 +30,7 @@ class SpringTestClassModel(
     classUnderTest: ClassId,
     methodTestSets: List<CgMethodTestSet>,
     nestedClasses: List<SimpleTestClassModel>,
-    val injectingMocksClass: ClassId? = null,
-    val mockedClasses: Set<ClassId> = setOf(),
+    val injectedMockModels: Map<ClassId, Set<UtModel>> = mapOf(),
+    val mockedModels: Map<ClassId, Set<UtModel>> = mapOf(),
 ): TestClassModel(classUnderTest, methodTestSets, nestedClasses)
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/TestClassModel.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/TestClassModel.kt
@@ -3,6 +3,8 @@ package org.utbot.framework.codegen.domain.models
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.UtModel
 
+typealias ClassModels = Map<ClassId, Set<UtModel>>
+
 /**
  * Stores method test sets in a structure that replicates structure of their methods in [classUnderTest].
  * I.e., if some method is declared in nested class of [classUnderTest], its testset will be put
@@ -30,7 +32,7 @@ class SpringTestClassModel(
     classUnderTest: ClassId,
     methodTestSets: List<CgMethodTestSet>,
     nestedClasses: List<SimpleTestClassModel>,
-    val injectedMockModels: Map<ClassId, Set<UtModel>> = mapOf(),
-    val mockedModels: Map<ClassId, Set<UtModel>> = mapOf(),
+    val injectedMockModels: ClassModels = mapOf(),
+    val mockedModels: ClassModels = mapOf(),
 ): TestClassModel(classUnderTest, methodTestSets, nestedClasses)
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/builders/SimpleTestClassModelBuilder.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/builders/SimpleTestClassModelBuilder.kt
@@ -1,12 +1,16 @@
 package org.utbot.framework.codegen.domain.models.builders
 
+import org.utbot.framework.codegen.domain.context.CgContext
 import org.utbot.framework.codegen.domain.models.CgMethodTestSet
 import org.utbot.framework.codegen.domain.models.SimpleTestClassModel
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.util.enclosingClass
 
-open class SimpleTestClassModelBuilder: TestClassModelBuilder() {
-    override fun createTestClassModel(classUnderTest: ClassId, testSets: List<CgMethodTestSet>): SimpleTestClassModel {
+open class SimpleTestClassModelBuilder(context: CgContext): TestClassModelBuilder() {
+    override fun createTestClassModel(
+        classUnderTest: ClassId,
+        testSets: List<CgMethodTestSet>,
+    ): SimpleTestClassModel {
         // For each class stores list of methods declared in this class (methods from nested classes are excluded)
         val class2methodTestSets = testSets.groupBy { it.executableId.classId }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/builders/SpringTestClassModelBuilder.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/builders/SpringTestClassModelBuilder.kt
@@ -1,7 +1,9 @@
 package org.utbot.framework.codegen.domain.models.builders
 
+import org.utbot.framework.codegen.domain.context.CgContext
 import org.utbot.framework.codegen.domain.models.CgMethodTestSet
 import org.utbot.framework.codegen.domain.models.SpringTestClassModel
+import org.utbot.framework.codegen.domain.withId
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.UtArrayModel
 import org.utbot.framework.plugin.api.UtAssembleModel
@@ -10,63 +12,75 @@ import org.utbot.framework.plugin.api.UtCompositeModel
 import org.utbot.framework.plugin.api.UtDirectSetFieldModel
 import org.utbot.framework.plugin.api.UtEnumConstantModel
 import org.utbot.framework.plugin.api.UtExecutableCallModel
-import org.utbot.framework.plugin.api.UtExecutionSuccess
 import org.utbot.framework.plugin.api.UtLambdaModel
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtNullModel
 import org.utbot.framework.plugin.api.UtPrimitiveModel
 import org.utbot.framework.plugin.api.UtVoidModel
+import org.utbot.framework.plugin.api.isMockModel
 
-class SpringTestClassModelBuilder: TestClassModelBuilder() {
+class SpringTestClassModelBuilder(val context: CgContext): TestClassModelBuilder() {
 
     override fun createTestClassModel(classUnderTest: ClassId, testSets: List<CgMethodTestSet>): SpringTestClassModel {
-        val baseModel = SimpleTestClassModelBuilder().createTestClassModel(classUnderTest, testSets)
-        val mockedClasses = collectMockedClassIds(classUnderTest, testSets)
+        val baseModel = SimpleTestClassModelBuilder(context).createTestClassModel(classUnderTest, testSets)
+        val (injectedModels, mockedModels) = collectInjectedAndMockedModels(testSets)
 
         return SpringTestClassModel(
             baseModel.classUnderTest,
             baseModel.methodTestSets,
             baseModel.nestedClasses,
-            classUnderTest,
-            mockedClasses,
+            injectedModels,
+            mockedModels,
         )
     }
 
-    private fun collectMockedClassIds(
-        classUnderTest: ClassId,
+    private fun collectInjectedAndMockedModels(
         testSets: List<CgMethodTestSet>,
-    ): Set<ClassId> {
-        val allModelsInExecution = mutableListOf<UtModel>()
+    ): Pair<Map<ClassId, Set<UtModel>>, Map<ClassId, Set<UtModel>>> {
+        val thisInstances = mutableSetOf<UtModel>()
+        val thisInstancesDependentModels = mutableSetOf<UtModel>()
 
         for (testSet in testSets) {
-            for (execution in testSet.executions) {
-                execution.stateBefore.thisInstance?.let { allModelsInExecution += it }
-                execution.stateAfter.thisInstance?.let { allModelsInExecution += it }
+            for ((index, execution) in testSet.executions.withIndex()) {
+                execution.stateBefore.thisInstance?.let { model ->
+                    thisInstances += model
+                    thisInstancesDependentModels += collectByThisInstanceModel(model, index)
+                }
 
-                allModelsInExecution += execution.stateBefore.parameters
-                allModelsInExecution += execution.stateAfter.parameters
-
-                (execution.result as? UtExecutionSuccess)?.model?.let { allModelsInExecution += it }
+                execution.stateAfter.thisInstance?.let { model ->
+                    thisInstances += model
+                    thisInstancesDependentModels += collectByThisInstanceModel(model, index)
+                }
             }
         }
 
-        val allConstructedModels = mutableSetOf<UtModel>()
-        allModelsInExecution.forEach { model -> collectRecursively(model, allConstructedModels) }
+        val dependentMockModels =
+            thisInstancesDependentModels.filterTo(mutableSetOf()) { it.isMockModel() && it !in thisInstances }
 
-        return allConstructedModels
-            .filter { it.isMockComposite() || it.isMockAssemble() }
-            .map { it.classId }
-            .filter {  it != classUnderTest }
-            .toSet()
+        return thisInstances.groupByClassId() to dependentMockModels.groupByClassId()
+    }
 
+    private fun collectByThisInstanceModel(model: UtModel, executionIndex: Int): Set<UtModel> {
+        context.modelIds += model.withId(executionIndex)
+
+        val dependentModels = mutableSetOf<UtModel>()
+        collectRecursively(model, dependentModels)
+
+        dependentModels.forEach { model ->
+            context.modelIds += model.withId(executionIndex)
+        }
+
+        return dependentModels
+    }
+
+    private fun Set<UtModel>.groupByClassId(): Map<ClassId, Set<UtModel>> {
+        return this.groupBy { it.classId }.mapValues { it.value.toSet() }
     }
 
     private fun collectRecursively(currentModel: UtModel, allModels: MutableSet<UtModel>) {
-        if (currentModel in allModels) {
+        if (!allModels.add(currentModel)) {
             return
         }
-
-        allModels += currentModel
 
         when (currentModel) {
             is UtNullModel,
@@ -104,9 +118,4 @@ class SpringTestClassModelBuilder: TestClassModelBuilder() {
             //Python, JavaScript, Go models are not required in Spring
         }
     }
-
-    private fun UtModel.isMockComposite(): Boolean = this is UtCompositeModel && this.isMock
-
-    //TODO: Having an assemble model often means that we do not use its origin, so is this composite mock redundant?
-    private fun UtModel.isMockAssemble(): Boolean = this is UtAssembleModel && this.origin?.isMock == true
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/builders/SpringTestClassModelBuilder.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/builders/SpringTestClassModelBuilder.kt
@@ -60,13 +60,13 @@ class SpringTestClassModelBuilder(val context: CgContext): TestClassModelBuilder
     }
 
     private fun collectByThisInstanceModel(model: UtModel, executionIndex: Int): Set<UtModel> {
-        context.modelIds.put(model, model.withExecutionId(executionIndex))
+        context.modelIds[model] = model.withExecutionId(executionIndex)
 
         val dependentModels = mutableSetOf<UtModel>()
         collectRecursively(model, dependentModels)
 
         dependentModels.forEach { model ->
-            context.modelIds.put(model, model.withExecutionId(executionIndex))
+            context.modelIds[model] = model.withExecutionId(executionIndex)
         }
 
         return dependentModels

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgAbstractRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgAbstractRenderer.kt
@@ -41,6 +41,7 @@ import org.utbot.framework.codegen.domain.models.CgExecutableCall
 import org.utbot.framework.codegen.domain.models.CgMethodsCluster
 import org.utbot.framework.codegen.domain.models.CgExpression
 import org.utbot.framework.codegen.domain.models.CgFieldAccess
+import org.utbot.framework.codegen.domain.models.CgFieldDeclaration
 import org.utbot.framework.codegen.domain.models.CgForEachLoop
 import org.utbot.framework.codegen.domain.models.CgForLoop
 import org.utbot.framework.codegen.domain.models.CgFrameworkUtilMethod
@@ -83,6 +84,7 @@ import org.utbot.framework.codegen.domain.models.CgTryCatch
 import org.utbot.framework.codegen.domain.models.CgUtilMethod
 import org.utbot.framework.codegen.domain.models.CgVariable
 import org.utbot.framework.codegen.domain.models.CgWhileLoop
+import org.utbot.framework.codegen.tree.VisibilityModifier
 import org.utbot.framework.codegen.tree.ututils.UtilClassKind
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.CodegenLanguage
@@ -574,6 +576,14 @@ abstract class CgAbstractRenderer(
         println(statementEnding)
     }
 
+    // Class field declaration
+
+    override fun visit(element: CgFieldDeclaration) {
+        element.annotation?.accept(this)
+        renderVisibility(element.visibility)
+        element.declaration.accept(this)
+    }
+
     // Variable assignment
 
     override fun visit(element: CgAssignment) {
@@ -891,7 +901,7 @@ abstract class CgAbstractRenderer(
         }
     }
 
-    protected abstract fun renderClassVisibility(classId: ClassId)
+    protected abstract fun renderVisibility(modifier: VisibilityModifier)
 
     protected abstract fun renderClassModality(aClass: CgClass)
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgJavaRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgJavaRenderer.kt
@@ -402,9 +402,8 @@ internal class CgJavaRenderer(context: CgRendererContext, printer: CgPrinter = C
             VisibilityModifier.PUBLIC -> print("public ")
             VisibilityModifier.PRIVATE -> print("private ")
             VisibilityModifier.PROTECTED -> print("protected ")
-            VisibilityModifier.INTERNAL -> print("internal ")
-            VisibilityModifier.PACKAGEPRIVATE -> Unit
-            else -> error("Java: unexpected visibility modifier -- $modifier")
+            VisibilityModifier.PACKAGE_PRIVATE -> Unit
+            VisibilityModifier.INTERNAL -> error("Java: unexpected visibility modifier -- $modifier")
         }
     }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgKotlinRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgKotlinRenderer.kt
@@ -572,7 +572,7 @@ internal class CgKotlinRenderer(context: CgRendererContext, printer: CgPrinter =
             VisibilityModifier.PRIVATE -> print("private ")
             VisibilityModifier.PROTECTED -> print("protected ")
             VisibilityModifier.INTERNAL -> print("internal ")
-            else -> error("Kotlin: unexpected visibility modifier -- $modifier")
+            VisibilityModifier.PACKAGE_PRIVATE -> error("Kotlin: unexpected visibility modifier -- $modifier")
         }
     }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgKotlinRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgKotlinRenderer.kt
@@ -43,17 +43,14 @@ import org.utbot.framework.codegen.domain.models.CgFrameworkUtilMethod
 import org.utbot.framework.codegen.domain.models.CgLiteral
 import org.utbot.framework.codegen.domain.models.CgTestMethod
 import org.utbot.framework.codegen.domain.models.CgTypeCast
-import org.utbot.framework.codegen.domain.models.CgValue
 import org.utbot.framework.codegen.domain.models.CgVariable
+import org.utbot.framework.codegen.tree.VisibilityModifier
 import org.utbot.framework.codegen.util.nullLiteral
 import org.utbot.framework.plugin.api.BuiltinClassId
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.TypeParameters
 import org.utbot.framework.plugin.api.WildcardTypeParameter
 import org.utbot.framework.plugin.api.util.isFinal
-import org.utbot.framework.plugin.api.util.isPrivate
-import org.utbot.framework.plugin.api.util.isProtected
-import org.utbot.framework.plugin.api.util.isPublic
 import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.isArray
 import org.utbot.framework.plugin.api.util.isKotlinFile
@@ -85,7 +82,7 @@ internal class CgKotlinRenderer(context: CgRendererContext, printer: CgPrinter =
             annotation.accept(this)
         }
 
-        renderClassVisibility(element.id)
+        renderVisibility(element.visibility)
         renderClassModality(element)
         if (!element.isStatic && element.isNested) {
             print("inner ")
@@ -569,12 +566,13 @@ internal class CgKotlinRenderer(context: CgRendererContext, printer: CgPrinter =
     override fun escapeNamePossibleKeywordImpl(s: String): String =
         if (isLanguageKeyword(s, context.cgLanguageAssistant)) "`$s`" else s
 
-    override fun renderClassVisibility(classId: ClassId) {
-        when {
-            // Kotlin classes are public by default
-            classId.isPublic -> Unit
-            classId.isProtected -> print("protected ")
-            classId.isPrivate -> print("private ")
+    override fun renderVisibility(modifier: VisibilityModifier) {
+        when (modifier) {
+            VisibilityModifier.PUBLIC -> Unit
+            VisibilityModifier.PRIVATE -> print("private ")
+            VisibilityModifier.PROTECTED -> print("protected ")
+            VisibilityModifier.INTERNAL -> print("internal ")
+            else -> error("Kotlin: unexpected visibility modifier -- $modifier")
         }
     }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgVisitor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgVisitor.kt
@@ -76,6 +76,7 @@ import org.utbot.framework.codegen.domain.models.CgSwitchCaseLabel
 import org.utbot.framework.codegen.domain.models.CgClass
 import org.utbot.framework.codegen.domain.models.CgClassBody
 import org.utbot.framework.codegen.domain.models.CgDocRegularLineStmt
+import org.utbot.framework.codegen.domain.models.CgFieldDeclaration
 import org.utbot.framework.codegen.domain.models.CgFormattedString
 import org.utbot.framework.codegen.domain.models.CgFrameworkUtilMethod
 import org.utbot.framework.codegen.domain.models.CgNestedClassesRegion
@@ -184,6 +185,9 @@ interface CgVisitor<R> {
 
     // Variable declaration
     fun visit(element: CgDeclaration): R
+
+    // Field declaration
+    fun visit(element: CgFieldDeclaration): R
 
     // Variable assignment
     fun visit(element: CgAssignment): R

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/MockFrameworkManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/MockFrameworkManager.kt
@@ -140,7 +140,7 @@ class MockFrameworkManager(context: CgContext) : CgVariableConstructorComponent(
 
     fun createMockForVariable(model: UtCompositeModel, variable: CgVariable) =
         withMockFramework {
-            require(model.isMock) { "Mock model is expected in MockObjectConstructor" }
+            require(model.isMock) { "Mock model $model is expected in MockObjectConstructor" }
             objectMocker.mockForVariable(model, variable)
         }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/MockFrameworkManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/MockFrameworkManager.kt
@@ -138,6 +138,12 @@ class MockFrameworkManager(context: CgContext) : CgVariableConstructorComponent(
         objectMocker.createMock(model, baseName)
     }
 
+    fun createMockForVariable(model: UtCompositeModel, variable: CgVariable) =
+        withMockFramework {
+            require(model.isMock) { "Mock model is expected in MockObjectConstructor" }
+            objectMocker.mockForVariable(model, variable)
+        }
+
     fun mockNewInstance(mock: UtNewInstanceInstrumentation) {
         staticMocker?.mockNewInstance(mock)
     }
@@ -177,6 +183,12 @@ private class MockitoMocker(context: CgContext) : ObjectMocker(context) {
         val modelClass = getClassOf(model.classId)
         val mockObject = newVar(model.classId, baseName = baseName, isMock = true) { mock(modelClass) }
 
+        mockForVariable(model, mockObject)
+
+        return mockObject
+    }
+
+    fun mockForVariable(model: UtCompositeModel, mockObject: CgVariable) {
         for ((executable, values) in model.mocks) {
             // void method
             if (executable.returnType == voidClassId) {
@@ -201,8 +213,6 @@ private class MockitoMocker(context: CgContext) : ObjectMocker(context) {
                 else -> error("ConstructorId was not expected to appear in simple mocker but got $executable")
             }
         }
-
-        return mockObject
     }
 
     override fun mock(clazz: CgExpression): CgMethodCall =

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/language/CgLanguageAssistant.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/language/CgLanguageAssistant.kt
@@ -1,5 +1,6 @@
 package org.utbot.framework.codegen.services.language
 
+import org.utbot.framework.codegen.domain.ProjectType
 import org.utbot.framework.codegen.domain.context.TestClassContext
 import org.utbot.framework.codegen.domain.context.CgContext
 import org.utbot.framework.codegen.renderer.CgPrinter
@@ -15,6 +16,7 @@ import org.utbot.framework.codegen.tree.CgMethodConstructor
 import org.utbot.framework.codegen.tree.CgStatementConstructor
 import org.utbot.framework.codegen.tree.CgStatementConstructorImpl
 import org.utbot.framework.codegen.tree.CgVariableConstructor
+import org.utbot.framework.codegen.tree.CgSpringVariableConstructor
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.CodegenLanguage
 
@@ -44,7 +46,12 @@ abstract class CgLanguageAssistant {
     open fun getCallableAccessManagerBy(context: CgContext): CgCallableAccessManager =
         CgCallableAccessManagerImpl(context)
     open fun getStatementConstructorBy(context: CgContext): CgStatementConstructor = CgStatementConstructorImpl(context)
-    open fun getVariableConstructorBy(context: CgContext): CgVariableConstructor = CgVariableConstructor(context)
+
+    open fun getVariableConstructorBy(context: CgContext): CgVariableConstructor = when (context.projectType) {
+            ProjectType.Spring -> CgSpringVariableConstructor(context)
+            else -> CgVariableConstructor(context)
+        }
+
     open fun getMethodConstructorBy(context: CgContext): CgMethodConstructor = CgMethodConstructor(context)
     open fun getCgFieldStateManager(context: CgContext): CgFieldStateManager = CgFieldStateManagerImpl(context)
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/Builders.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/Builders.kt
@@ -13,6 +13,7 @@ import org.utbot.framework.codegen.domain.models.CgElement
 import org.utbot.framework.codegen.domain.models.CgErrorTestMethod
 import org.utbot.framework.codegen.domain.models.CgExceptionHandler
 import org.utbot.framework.codegen.domain.models.CgExpression
+import org.utbot.framework.codegen.domain.models.CgFieldDeclaration
 import org.utbot.framework.codegen.domain.models.CgForEachLoop
 import org.utbot.framework.codegen.domain.models.CgForLoop
 import org.utbot.framework.codegen.domain.models.CgLoop
@@ -66,7 +67,7 @@ class CgClassBodyBuilder(val classId: ClassId) : CgBuilder<CgClassBody> {
     val methodRegions: MutableList<CgMethodsCluster> = mutableListOf()
     val staticDeclarationRegions: MutableList<CgStaticsRegion> = mutableListOf()
     val nestedClassRegions: MutableList<CgNestedClassesRegion<*>> = mutableListOf()
-    val fields: MutableList<CgDeclaration> = mutableListOf()
+    val fields: MutableSet<CgFieldDeclaration> = mutableSetOf()
 
     override fun build() = CgClassBody(classId, methodRegions, staticDeclarationRegions, nestedClassRegions, fields)
 }
@@ -101,8 +102,8 @@ class CgTestMethodBuilder : CgMethodBuilder<CgTestMethod> {
         statements,
         exceptions,
         annotations,
-        methodType,
-        documentation,
+        type = methodType,
+        documentation = documentation,
     )
 }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringTestClassConstructor.kt
@@ -2,11 +2,14 @@ package org.utbot.framework.codegen.tree
 
 import org.utbot.framework.codegen.domain.builtin.TestClassUtilMethodProvider
 import org.utbot.framework.codegen.domain.builtin.closeMethodId
+import org.utbot.framework.codegen.domain.builtin.injectMocksClassId
+import org.utbot.framework.codegen.domain.builtin.mockClassId
 import org.utbot.framework.codegen.domain.builtin.openMocksMethodId
 import org.utbot.framework.codegen.domain.context.CgContext
 import org.utbot.framework.codegen.domain.models.CgAssignment
 import org.utbot.framework.codegen.domain.models.CgClassBody
 import org.utbot.framework.codegen.domain.models.CgDeclaration
+import org.utbot.framework.codegen.domain.models.CgFieldDeclaration
 import org.utbot.framework.codegen.domain.models.CgFrameworkUtilMethod
 import org.utbot.framework.codegen.domain.models.CgMethod
 import org.utbot.framework.codegen.domain.models.CgMethodCall
@@ -18,13 +21,16 @@ import org.utbot.framework.codegen.domain.models.CgStatementExecutableCall
 import org.utbot.framework.codegen.domain.models.CgStaticsRegion
 import org.utbot.framework.codegen.domain.models.CgVariable
 import org.utbot.framework.codegen.domain.models.SpringTestClassModel
+import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.UtCompositeModel
+import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.objectClassId
 
 class CgSpringTestClassConstructor(context: CgContext): CgAbstractTestClassConstructor<SpringTestClassModel>(context) {
 
-    private val variableConstructor: CgVariableConstructor = CgComponents.getVariableConstructorBy(context)
+    private val variableConstructor: CgSpringVariableConstructor =
+        CgComponents.getVariableConstructorBy(context) as CgSpringVariableConstructor
     private val statementConstructor: CgStatementConstructor = CgComponents.getStatementConstructorBy(context)
 
     override fun constructTestClassBody(testClassModel: SpringTestClassModel): CgClassBody {
@@ -32,7 +38,8 @@ class CgSpringTestClassConstructor(context: CgContext): CgAbstractTestClassConst
 
             // TODO: support inner classes here
 
-            // TODO: create class variables with Mock/InjectMock annotations using testClassModel
+            fields += constructClassFields(testClassModel.injectedMockModels, injectMocksClassId)
+            fields += constructClassFields(testClassModel.mockedModels, mockClassId)
 
             val (closeableField, closeableMethods) = constructMockitoCloseables()
             fields += closeableField
@@ -77,7 +84,35 @@ class CgSpringTestClassConstructor(context: CgContext): CgAbstractTestClassConst
         return if (regions.any()) regions else null
     }
 
-    private fun constructMockitoCloseables(): Pair<CgDeclaration, CgMethodsCluster> {
+    private fun constructClassFields(
+        groupedModelsByClassId: Map<ClassId, Set<UtModel>>,
+        annotationClassId: ClassId
+    ): MutableList<CgFieldDeclaration> {
+        if (annotationClassId != injectMocksClassId && annotationClassId != mockClassId) {
+            error("Unexpected annotation ClassId -- $annotationClassId")
+        }
+
+        val annotation = statementConstructor.annotation(annotationClassId)
+
+        val constructedDeclarations = mutableListOf<CgFieldDeclaration>()
+        for ((classId, listOfUtModels) in groupedModelsByClassId) {
+            val model = listOfUtModels.firstOrNull() ?: continue
+            val createdVariable = variableConstructor.getOrCreateVariable(model) as? CgVariable
+                ?: error("[UtCompositeModel] model was expected")
+
+            val declaration = CgDeclaration(classId, variableName = createdVariable.name, initializer = null)
+            constructedDeclarations += CgFieldDeclaration(ownerClassId = currentTestClass, declaration, annotation)
+
+            when (annotationClassId) {
+                injectMocksClassId -> variableConstructor.injectedMocksModelsVariables += listOfUtModels to createdVariable
+                mockClassId -> variableConstructor.mockedModelsVariables += listOfUtModels to createdVariable
+            }
+        }
+
+        return constructedDeclarations
+    }
+
+    private fun constructMockitoCloseables(): Pair<CgFieldDeclaration, CgMethodsCluster> {
         val mockitoCloseableVarName = "mockitoCloseable"
         val mockitoCloseableVarType = java.lang.AutoCloseable::class.id
 
@@ -89,7 +124,8 @@ class CgSpringTestClassConstructor(context: CgContext): CgAbstractTestClassConst
 
         val mockitoCloseableVariable =
             variableConstructor.getOrCreateVariable(mockitoCloseableModel, mockitoCloseableVarName)
-        val mockitoCloseableField = CgDeclaration(mockitoCloseableVarType, mockitoCloseableVarName, initializer = null)
+        val mockitoCloseableDeclaration = CgDeclaration(mockitoCloseableVarType, mockitoCloseableVarName, initializer = null)
+        val mockitoCloseableFieldDeclaration = CgFieldDeclaration(ownerClassId = currentTestClass, mockitoCloseableDeclaration)
 
         importIfNeeded(openMocksMethodId)
 
@@ -127,6 +163,6 @@ class CgSpringTestClassConstructor(context: CgContext): CgAbstractTestClassConst
             listOf(CgSimpleRegion(header = null, listOf(beforeMethod, afterMethod)))
         )
 
-        return mockitoCloseableField to methodCluster
+        return mockitoCloseableFieldDeclaration to methodCluster
     }
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringTestClassConstructor.kt
@@ -39,12 +39,16 @@ class CgSpringTestClassConstructor(context: CgContext): CgAbstractTestClassConst
 
             // TODO: support inner classes here
 
-            fields += constructClassFields(testClassModel.injectedMockModels, injectMocksClassId)
-            fields += constructClassFields(testClassModel.mockedModels, mockClassId)
+            val mockedFields = constructClassFields(testClassModel.mockedModels, mockClassId)
 
-            val (closeableField, closeableMethods) = constructMockitoCloseables()
-            fields += closeableField
-            methodRegions += closeableMethods
+            if (mockedFields.isNotEmpty()) {
+                fields += constructClassFields(testClassModel.injectedMockModels, injectMocksClassId)
+                fields += mockedFields
+
+                val (closeableField, closeableMethods) = constructMockitoCloseables()
+                fields += closeableField
+                methodRegions += closeableMethods
+            }
 
             for (testSet in testClassModel.methodTestSets) {
                 updateCurrentExecutable(testSet.executableId)
@@ -89,8 +93,8 @@ class CgSpringTestClassConstructor(context: CgContext): CgAbstractTestClassConst
         groupedModelsByClassId: ClassModels,
         annotationClassId: ClassId
     ): MutableList<CgFieldDeclaration> {
-        if (annotationClassId != injectMocksClassId && annotationClassId != mockClassId) {
-            error("Unexpected annotation ClassId -- $annotationClassId")
+        require(annotationClassId == injectMocksClassId || annotationClassId == mockClassId) {
+            error("Unexpected annotation classId -- $annotationClassId")
         }
 
         val annotation = statementConstructor.annotation(annotationClassId)

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringTestClassConstructor.kt
@@ -20,6 +20,7 @@ import org.utbot.framework.codegen.domain.models.CgSimpleRegion
 import org.utbot.framework.codegen.domain.models.CgStatementExecutableCall
 import org.utbot.framework.codegen.domain.models.CgStaticsRegion
 import org.utbot.framework.codegen.domain.models.CgVariable
+import org.utbot.framework.codegen.domain.models.ClassModels
 import org.utbot.framework.codegen.domain.models.SpringTestClassModel
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.UtCompositeModel
@@ -85,7 +86,7 @@ class CgSpringTestClassConstructor(context: CgContext): CgAbstractTestClassConst
     }
 
     private fun constructClassFields(
-        groupedModelsByClassId: Map<ClassId, Set<UtModel>>,
+        groupedModelsByClassId: ClassModels,
         annotationClassId: ClassId
     ): MutableList<CgFieldDeclaration> {
         if (annotationClassId != injectMocksClassId && annotationClassId != mockClassId) {
@@ -98,7 +99,7 @@ class CgSpringTestClassConstructor(context: CgContext): CgAbstractTestClassConst
         for ((classId, listOfUtModels) in groupedModelsByClassId) {
             val model = listOfUtModels.firstOrNull() ?: continue
             val createdVariable = variableConstructor.getOrCreateVariable(model) as? CgVariable
-                ?: error("[UtCompositeModel] model was expected")
+                ?: error("`UtCompositeModel` model was expected, but $model was found")
 
             val declaration = CgDeclaration(classId, variableName = createdVariable.name, initializer = null)
             constructedDeclarations += CgFieldDeclaration(ownerClassId = currentTestClass, declaration, annotation)

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringVariableConstructor.kt
@@ -47,7 +47,7 @@ class CgSpringVariableConstructor(context: CgContext) : CgVariableConstructor(co
     private fun findCgValueByModel(model: UtModel, modelToValueMap: Map<Set<UtModel>, CgValue>): CgValue? =
         modelToValueMap
             .filter { it.key.contains(model) }
-            .asSequence()
+            .entries
             .singleOrNull()
             ?.value
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringVariableConstructor.kt
@@ -1,0 +1,52 @@
+package org.utbot.framework.codegen.tree
+
+import com.jetbrains.rd.util.firstOrNull
+import org.utbot.framework.codegen.domain.context.CgContext
+import org.utbot.framework.codegen.domain.models.CgValue
+import org.utbot.framework.codegen.domain.models.CgVariable
+import org.utbot.framework.plugin.api.UtAssembleModel
+import org.utbot.framework.plugin.api.UtCompositeModel
+import org.utbot.framework.plugin.api.UtModel
+import org.utbot.framework.plugin.api.isMockModel
+
+class CgSpringVariableConstructor(context: CgContext) : CgVariableConstructor(context) {
+    val injectedMocksModelsVariables: MutableMap<Set<UtModel>, CgValue> = mutableMapOf()
+    val mockedModelsVariables: MutableMap<Set<UtModel>, CgValue> = mutableMapOf()
+
+    private val mockFrameworkManager = CgComponents.getMockFrameworkManagerBy(context)
+
+    override fun getOrCreateVariable(model: UtModel, name: String?): CgValue {
+        val alreadyCreatedInjectMocks = findCgValueByModel(model, injectedMocksModelsVariables)
+        if (alreadyCreatedInjectMocks != null) {
+            val fields: Collection<UtModel> = when (model) {
+                is UtCompositeModel -> model.fields.values
+                is UtAssembleModel -> model.origin?.fields?.values ?: emptyList()
+                else -> emptyList()
+            }
+
+            fields.forEach { getOrCreateVariable(it) }
+
+            return alreadyCreatedInjectMocks
+        }
+
+        val alreadyCreatedMock = findCgValueByModel(model, mockedModelsVariables)
+        if (alreadyCreatedMock != null) {
+            if (model.isMockModel()) {
+                mockFrameworkManager.createMockForVariable(
+                    model as UtCompositeModel,
+                    alreadyCreatedMock as CgVariable,
+                )
+            }
+
+            return alreadyCreatedMock
+        }
+
+        return super.getOrCreateVariable(model, name)
+    }
+
+    private fun findCgValueByModel(model: UtModel, modelToValueMap: Map<Set<UtModel>, CgValue>): CgValue? =
+        modelToValueMap
+            .filter { it.key.contains(model) }
+            .firstOrNull()
+            ?.value
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringVariableConstructor.kt
@@ -47,6 +47,7 @@ class CgSpringVariableConstructor(context: CgContext) : CgVariableConstructor(co
     private fun findCgValueByModel(model: UtModel, modelToValueMap: Map<Set<UtModel>, CgValue>): CgValue? =
         modelToValueMap
             .filter { it.key.contains(model) }
-            .firstOrNull()
+            .asSequence()
+            .singleOrNull()
             ?.value
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/DeclarationUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/DeclarationUtils.kt
@@ -22,5 +22,5 @@ enum class VisibilityModifier {
     PRIVATE,
     PROTECTED,
     INTERNAL,
-    PACKAGEPRIVATE,
+    PACKAGE_PRIVATE,
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/DeclarationUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/DeclarationUtils.kt
@@ -13,3 +13,14 @@ fun needExpectedDeclaration(model: UtModel): Boolean {
     val representsBoolean = model is UtPrimitiveModel && model.value is Boolean
     return !(representsNull || representsBoolean)
 }
+
+/**
+ * Contains all possible visibility modifiers that may be used in code generation.
+ */
+enum class VisibilityModifier {
+    PUBLIC,
+    PRIVATE,
+    PROTECTED,
+    INTERNAL,
+    PACKAGEPRIVATE,
+}

--- a/utbot-js/src/main/kotlin/framework/codegen/model/constructor/tree/JsCgVariableConstructor.kt
+++ b/utbot-js/src/main/kotlin/framework/codegen/model/constructor/tree/JsCgVariableConstructor.kt
@@ -9,6 +9,7 @@ import framework.api.js.util.jsDoubleClassId
 import framework.api.js.util.jsNumberClassId
 import framework.api.js.util.jsStringClassId
 import framework.api.js.util.jsUndefinedClassId
+import org.utbot.framework.codegen.domain.ModelId
 import org.utbot.framework.codegen.domain.context.CgContext
 import org.utbot.framework.codegen.domain.models.CgAllocateArray
 import org.utbot.framework.codegen.domain.models.CgArrayInitializer

--- a/utbot-js/src/main/kotlin/framework/codegen/model/constructor/tree/JsCgVariableConstructor.kt
+++ b/utbot-js/src/main/kotlin/framework/codegen/model/constructor/tree/JsCgVariableConstructor.kt
@@ -39,7 +39,9 @@ class JsCgVariableConstructor(ctx: CgContext) : CgVariableConstructor(ctx) {
     private val nameGenerator = CgComponents.getNameGeneratorBy(context)
     
     override fun getOrCreateVariable(model: UtModel, name: String?): CgValue {
-        return if (model is UtAssembleModel) valueByModelId.getOrPut(model.id) {
+        val modelId: ModelId = context.getIdByModel(model)
+
+        return if (model is UtAssembleModel) valueByModelId.getOrPut(modelId) {
             // TODO SEVERE: May lead to unexpected behavior in case of changes to the original method
             super.getOrCreateVariable(model, name)
         } else valueByModel.getOrPut(model) {
@@ -128,7 +130,9 @@ class JsCgVariableConstructor(ctx: CgContext) : CgVariableConstructor(ctx) {
         }
 
         val array = newVar(arrayModel.classId, baseName) { initializer }
-        valueByModelId[arrayModel.id] = array
+        val arrayModelId = context.getIdByModel(arrayModel)
+
+        valueByModelId[arrayModelId] = array
 
         if (canInitWithValues) {
             return array

--- a/utbot-js/src/main/kotlin/framework/codegen/model/constructor/visitor/CgJsRenderer.kt
+++ b/utbot-js/src/main/kotlin/framework/codegen/model/constructor/visitor/CgJsRenderer.kt
@@ -50,6 +50,8 @@ import org.utbot.framework.codegen.renderer.CgAbstractRenderer
 import org.utbot.framework.codegen.renderer.CgPrinter
 import org.utbot.framework.codegen.renderer.CgPrinterImpl
 import org.utbot.framework.codegen.renderer.CgRendererContext
+import org.utbot.framework.codegen.services.language.isLanguageKeyword
+import org.utbot.framework.codegen.tree.VisibilityModifier
 import org.utbot.framework.plugin.api.BuiltinMethodId
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.TypeParameters
@@ -410,7 +412,7 @@ internal class CgJsRenderer(context: CgRendererContext, printer: CgPrinter = CgP
 
     override fun escapeNamePossibleKeywordImpl(s: String): String = s
 
-    override fun renderClassVisibility(classId: ClassId) {
+    override fun renderVisibility(modifier: VisibilityModifier) {
         TODO("Not yet implemented")
     }
 

--- a/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/constructor/visitor/CgPythonRenderer.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/constructor/visitor/CgPythonRenderer.kt
@@ -58,6 +58,7 @@ import org.utbot.framework.codegen.renderer.CgPrinter
 import org.utbot.framework.codegen.renderer.CgPrinterImpl
 import org.utbot.framework.codegen.renderer.CgAbstractRenderer
 import org.utbot.framework.codegen.renderer.CgRendererContext
+import org.utbot.framework.codegen.tree.VisibilityModifier
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.TypeParameters
 import org.utbot.framework.plugin.api.WildcardTypeParameter
@@ -420,7 +421,7 @@ internal class CgPythonRenderer(
     }
 
     override fun escapeNamePossibleKeywordImpl(s: String): String = s
-    override fun renderClassVisibility(classId: ClassId) {
+    override fun renderVisibility(modifier: VisibilityModifier) {
         throw UnsupportedOperationException()
     }
 


### PR DESCRIPTION
## Description

This PR adds support for necessary test class fields rendering (see *InjectMocks*, *Mock* below).
Also, in case of mocks it constructs them in test method (see *(when(...))*).

```java
@Service
public class OrderService {
    @Autowired
    private OrderRepository orderRepository;

    public List<Order> getOrders() {
        return orderRepository.findAll();
    }
}
```

```java
public final class OrderServiceTest {
    @InjectMocks
    public OrderService orderService;

    @Mock
    public OrderRepository orderRepositoryMock;

    public AutoCloseable mockitoCloseable;

    @BeforeEach
    public void setUp() {
        mockitoCloseable = openMocks(this);
    }

    @AfterEach
    public void tearDown() throws Exception {
        mockitoCloseable.close();
    }

    @Test
    public void testGetOrders1() {
        (when(orderRepositoryMock.findAll())).thenReturn(((List) null));

        List actual = orderService.getOrders();

        assertNull(actual);
    }
}
```

Fixes nothing, adds new feature.

## How to test

### Automated tests

No automated tests are present at this moment.

### Manual tests

Tested manually on a third-party Spring project.