### PR TITLE
Corrected UtLambdaModel processing in AssembleModelGenerator

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssembleModelGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssembleModelGenerator.kt
@@ -187,8 +187,8 @@ class AssembleModelGenerator(private val basePackageName: String) {
                     is UtPrimitiveModel,
                     is UtClassRefModel,
                     is UtVoidModel,
-                    is UtEnumConstantModel,
-                    is UtLambdaModel -> utModel
+                    is UtEnumConstantModel -> utModel
+                    is UtLambdaModel -> assembleLambdaModel(utModel)
                     is UtArrayModel -> assembleArrayModel(utModel)
                     is UtCompositeModel -> assembleCompositeModel(utModel)
                     is UtAssembleModel -> assembleAssembleModel(utModel)
@@ -202,6 +202,18 @@ class AssembleModelGenerator(private val basePackageName: String) {
 
         callChain = collectedCallChain
         return assembledModel
+    }
+
+    private fun assembleLambdaModel(lambdaModel: UtLambdaModel): UtModel {
+        instantiatedModels[lambdaModel]?.let { return it }
+
+        return UtLambdaModel(
+            lambdaModel.id,
+            lambdaModel.samType,
+            lambdaModel.declaringClass,
+            lambdaModel.lambdaName,
+            capturedValues = lambdaModel.capturedValues.map { assembleModel(it) }.toMutableList(),
+        )
     }
 
     /**


### PR DESCRIPTION
## Description

The logic of `AssembleModelGenerator` is designed to traverse all models recursively and try to assemble them.
`UtLambdaModel` internals were not traversed due to some reasons. However, it has inner models.

## How to test

### Automated tests

- The set of `AssembleModelGeneratorTests`
- Tests in `lambda` package of `utbot-samples`

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.