### PR TITLE
Assemble constModel in UtArrayModel if required

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssembleModelGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssembleModelGenerator.kt
@@ -230,10 +230,13 @@ class AssembleModelGenerator(private val basePackageName: String) {
 
             instantiatedModels[this] = assembleModel
 
-            assembleModel.constModel = assembleModel(constModel)
             assembleModel.stores += stores
                 .mapValues { assembleModel(it.value) }
                 .toMutableMap()
+
+            if (arrayModel.stores.count() < arrayModel.length) {
+                assembleModel.constModel = assembleModel(constModel)
+            }
 
             assembleModel
         }


### PR DESCRIPTION
## Description

The logic of `AssembleModelGenerator` is designed to traverse all models recursively and try to assemble them.

`UtArrayModel` has `constModel` field, but it is not involved in instance creation if all elements are set with `stores`. We should not assemble `constModel` in such case.

## How to test

### Automated tests

- The set of `AssembleModelGeneratorTests`
- Tests in `arrays` package of `utbot-samples`

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.