### PR TITLE
Remove name generation logic from CgVariableConstructor

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/MockFrameworkManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/MockFrameworkManager.kt
@@ -37,8 +37,10 @@ import org.utbot.framework.codegen.domain.models.CgSwitchCase
 import org.utbot.framework.codegen.domain.models.CgSwitchCaseLabel
 import org.utbot.framework.codegen.domain.models.CgValue
 import org.utbot.framework.codegen.domain.models.CgVariable
+import org.utbot.framework.codegen.services.CgNameGenerator
 import org.utbot.framework.codegen.services.access.CgCallableAccessManager
 import org.utbot.framework.codegen.services.access.CgCallableAccessManagerImpl
+import org.utbot.framework.codegen.tree.CgComponents.getNameGeneratorBy
 import org.utbot.framework.codegen.tree.CgComponents.getVariableConstructorBy
 import org.utbot.framework.codegen.tree.CgStatementConstructor
 import org.utbot.framework.codegen.tree.CgStatementConstructorImpl
@@ -72,6 +74,7 @@ abstract class CgVariableConstructorComponent(val context: CgContext) :
         CgCallableAccessManager by CgCallableAccessManagerImpl(context),
         CgStatementConstructor by CgStatementConstructorImpl(context) {
 
+    val nameGenerator: CgNameGenerator = getNameGeneratorBy(context)
     val variableConstructor: CgVariableConstructor by lazy { getVariableConstructorBy(context) }
 
     fun mockitoArgumentMatchersFor(executable: ExecutableId): Array<CgMethodCall> =
@@ -220,7 +223,7 @@ private class MockitoStaticMocker(context: CgContext, private val mocker: Object
 
         val mockClassCounter = CgDeclaration(
             atomicIntegerClassId,
-            variableConstructor.constructVarName(MOCK_CLASS_COUNTER_NAME),
+            nameGenerator.variableName(MOCK_CLASS_COUNTER_NAME),
             CgConstructorCall(ConstructorId(atomicIntegerClassId, emptyList()), emptyList())
         )
         +mockClassCounter
@@ -241,7 +244,7 @@ private class MockitoStaticMocker(context: CgContext, private val mocker: Object
         )
         val mockedConstructionDeclaration = CgDeclaration(
             MockitoStaticMocking.mockedConstructionClassId,
-            variableConstructor.constructVarName(MOCKED_CONSTRUCTION_NAME),
+            nameGenerator.variableName(MOCKED_CONSTRUCTION_NAME),
             mockConstructionInitializer
         )
         resources += mockedConstructionDeclaration
@@ -300,7 +303,7 @@ private class MockitoStaticMocker(context: CgContext, private val mocker: Object
         mockedStaticForMethods.getOrPut(classId) {
             val modelClass = getClassOf(classId)
             val classMockStaticCall = mockStatic(modelClass)
-            val mockedStaticVariableName = variableConstructor.constructVarName(MOCKED_STATIC_NAME)
+            val mockedStaticVariableName = nameGenerator.variableName(MOCKED_STATIC_NAME)
             CgDeclaration(
                 MockitoStaticMocking.mockedStaticClassId,
                 mockedStaticVariableName,
@@ -319,11 +322,11 @@ private class MockitoStaticMocker(context: CgContext, private val mocker: Object
     ): CgMethodCall {
         val mockParameter = variableConstructor.declareParameter(
             classId,
-            variableConstructor.constructVarName(classId.simpleName, isMock = true)
+            nameGenerator.variableName(classId.simpleName, isMock = true)
         )
         val contextParameter = variableConstructor.declareParameter(
             mockedConstructionContextClassId,
-            variableConstructor.constructVarName("context")
+            nameGenerator.variableName("context")
         )
 
         val caseLabels = mutableListOf<CgSwitchCaseLabel>()

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgMethodConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgMethodConstructor.kt
@@ -640,7 +640,7 @@ open class CgMethodConstructor(val context: CgContext) : CgContextOwner by conte
                     val actualObject: CgVariable = when (codegenLanguage) {
                         CodegenLanguage.KOTLIN -> newVar(
                             baseType = objectClassId,
-                            baseName = variableConstructor.constructVarName("actualObject"),
+                            baseName = nameGenerator.variableName("actualObject"),
                             init = { CgTypeCast(objectClassId, actual) }
                         )
                         else -> actual
@@ -793,7 +793,7 @@ open class CgMethodConstructor(val context: CgContext) : CgContextOwner by conte
     ): CgDeclaration {
         val cgGetLengthDeclaration = CgDeclaration(
             intClassId,
-            variableConstructor.constructVarName("${expected.name}Size"),
+            nameGenerator.variableName("${expected.name}Size"),
             expected.length(this@CgMethodConstructor)
         )
         currentBlock += cgGetLengthDeclaration
@@ -847,13 +847,13 @@ open class CgMethodConstructor(val context: CgContext) : CgContextOwner by conte
                 statements = block {
                     val expectedNestedElement = newVar(
                         baseType = expected.type.elementClassId!!,
-                        baseName = variableConstructor.constructVarName("${expected.name}NestedElement"),
+                        baseName = nameGenerator.variableName("${expected.name}NestedElement"),
                         init = { CgArrayElementAccess(expected, i) }
                     )
 
                     val actualNestedElement = newVar(
                         baseType = actual.type.elementClassId!!,
-                        baseName = variableConstructor.constructVarName("${actual.name}NestedElement"),
+                        baseName = nameGenerator.variableName("${actual.name}NestedElement"),
                         init = { CgArrayElementAccess(actual, i) }
                     )
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSimpleTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSimpleTestClassConstructor.kt
@@ -22,7 +22,6 @@ import org.utbot.framework.codegen.domain.models.CgTripleSlashMultilineComment
 import org.utbot.framework.codegen.domain.models.CgUtilEntity
 import org.utbot.framework.codegen.domain.models.CgUtilMethod
 import org.utbot.framework.codegen.domain.models.SimpleTestClassModel
-import org.utbot.framework.codegen.domain.models.TestClassModel
 import org.utbot.framework.codegen.renderer.importUtilMethodDependencies
 import org.utbot.framework.codegen.reports.TestsGenerationReport
 import org.utbot.framework.codegen.tree.CgComponents.clearContextRelatedStorage

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgVariableConstructor.kt
@@ -68,7 +68,6 @@ import org.utbot.framework.plugin.api.util.wrapperByPrimitive
 /**
  * Constructs CgValue or CgVariable given a UtModel
  */
-@Suppress("unused")
 open class CgVariableConstructor(val context: CgContext) :
     CgContextOwner by context,
     CgCallableAccessManager by getCallableAccessManagerBy(context),
@@ -204,7 +203,7 @@ open class CgVariableConstructor(val context: CgContext) :
         return obj
     }
 
-    fun constructAssemble(model: UtAssembleModel, baseName: String?): CgValue {
+    private fun constructAssemble(model: UtAssembleModel, baseName: String?): CgValue {
         val instantiationCall = model.instantiationCall
         processInstantiationStatement(model, instantiationCall, baseName)
 
@@ -391,11 +390,13 @@ open class CgVariableConstructor(val context: CgContext) :
         return array
     }
 
-    // TODO: cannot be used now but will be useful in case of storing stores in generated code
     /**
      * Splits sorted by indices pairs of index and value from stores to continuous by index chunks
      * [indexedValuesFromStores] have to be sorted by key
+     *
+     * Сan not be used now but will be useful in case of storing stores in generated code
      */
+    @Suppress("unused")
     private fun splitSettingFromStoresToForLoops(
         array: CgVariable,
         indexedValuesFromStores: List<MutableMap.MutableEntry<Int, UtModel>>
@@ -499,7 +500,6 @@ open class CgVariableConstructor(val context: CgContext) :
     /**
      * Create loop initializer expression
      */
-    @Suppress("SameParameterValue")
     internal fun loopInitialization(
         variableType: ClassId,
         baseVariableName: String,
@@ -536,9 +536,6 @@ open class CgVariableConstructor(val context: CgContext) :
             this.at(i) `=` arrayElement
         }
     }
-
-    internal fun constructVarName(baseName: String, isMock: Boolean = false): String =
-        nameGenerator.variableName(baseName, isMock)
 
     private fun String.toVarName(): String = nameGenerator.variableName(this)
 


### PR DESCRIPTION
## Description

Name generation in codegen is the responsibility of `NameGenerator`.
This logic should not be implemented in `CgVariableConstructor`. API of this class reduced.


## How to test

### Automated tests

Running `utbot-sample` pipeline is enough for regression checks.
No new logic in PR.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.