### PR TITLE
Render setUp and tearDown for Spring testing

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
@@ -182,6 +182,12 @@ abstract class TestFramework(
     abstract val testAnnotation: String
     abstract val testAnnotationId: ClassId
     abstract val testAnnotationFqn: String
+    abstract val beforeMethod: String
+    abstract val beforeMethodId: ClassId
+    abstract val beforeMethodFqn: String
+    abstract val afterMethod: String
+    abstract val afterMethodId: ClassId
+    abstract val afterMethodFqn: String
     abstract val parameterizedTestAnnotation: String
     abstract val parameterizedTestAnnotationId: ClassId
     abstract val parameterizedTestAnnotationFqn: String
@@ -261,8 +267,27 @@ abstract class TestFramework(
 
 object TestNg : TestFramework(id = "TestNG",displayName = "TestNG") {
     override val mainPackage: String = TEST_NG_PACKAGE
+
     override val testAnnotation: String = "@$mainPackage.Test"
     override val testAnnotationFqn: String = "$mainPackage.Test"
+    override val testAnnotationId: ClassId = BuiltinClassId(
+        canonicalName = "$mainPackage.annotations.Test",
+        simpleName = "Test"
+    )
+
+    override val beforeMethod = "@${mainPackage}.BeforeMethod"
+    override val beforeMethodFqn = "${mainPackage}.BeforeMethod"
+    override val beforeMethodId = BuiltinClassId(
+        canonicalName = "${mainPackage}.BeforeMethod",
+        simpleName = "BeforeMethod"
+    )
+
+    override val afterMethod = "@${mainPackage}.AfterMethod"
+    override val afterMethodFqn = "${mainPackage}.AfterMethod"
+    override val afterMethodId = BuiltinClassId(
+        canonicalName = "${mainPackage}.AfterMethod",
+        simpleName = "AfterMethod"
+    )
 
     override val parameterizedTestAnnotation: String = "@$mainPackage.Test"
     override val parameterizedTestAnnotationFqn: String = "@$mainPackage.Test"
@@ -299,11 +324,6 @@ object TestNg : TestFramework(id = "TestNG",displayName = "TestNG") {
             Class::class.id,
             throwingRunnableClassId
         )
-    )
-
-    override val testAnnotationId: ClassId = BuiltinClassId(
-        canonicalName = "$mainPackage.annotations.Test",
-        simpleName = "Test"
     )
 
     override val parameterizedTestAnnotationId: ClassId = BuiltinClassId(
@@ -370,8 +390,27 @@ object Junit4 : TestFramework(id = "JUnit4",displayName = "JUnit 4") {
         get() = error("Parametrized tests are not supported for JUnit 4")
 
     override val mainPackage: String = JUNIT4_PACKAGE
+
     override val testAnnotation = "@$mainPackage.Test"
     override val testAnnotationFqn: String = "$mainPackage.Test"
+    override val testAnnotationId = BuiltinClassId(
+        canonicalName = "$mainPackage.Test",
+        simpleName = "Test"
+    )
+
+    override val beforeMethod = "@$mainPackage.Before"
+    override val beforeMethodFqn = "$mainPackage.Before"
+    override val beforeMethodId = BuiltinClassId(
+        canonicalName = "$mainPackage.Before",
+        simpleName = "Before"
+    )
+
+    override val afterMethod = "@$mainPackage.After"
+    override val afterMethodFqn = "$mainPackage.After"
+    override val afterMethodId = BuiltinClassId(
+        canonicalName = "$mainPackage.After",
+        simpleName = "After"
+    )
 
     override val parameterizedTestAnnotation
         get() = parametrizedTestsNotSupportedError
@@ -381,11 +420,6 @@ object Junit4 : TestFramework(id = "JUnit4",displayName = "JUnit 4") {
         get() = parametrizedTestsNotSupportedError
     override val methodSourceAnnotationFqn
         get() = parametrizedTestsNotSupportedError
-
-    override val testAnnotationId = BuiltinClassId(
-        canonicalName = "$JUNIT4_PACKAGE.Test",
-        simpleName = "Test"
-    )
 
     override val parameterizedTestAnnotationId = voidClassId
     override val methodSourceAnnotationId = voidClassId
@@ -431,8 +465,28 @@ object Junit4 : TestFramework(id = "JUnit4",displayName = "JUnit 4") {
 
 object Junit5 : TestFramework(id = "JUnit5", displayName = "JUnit 5") {
     override val mainPackage: String = JUNIT5_PACKAGE
+
     override val testAnnotation = "@$mainPackage.Test"
     override val testAnnotationFqn: String = "$mainPackage.Test"
+    override val testAnnotationId = BuiltinClassId(
+        canonicalName = "$JUNIT5_PACKAGE.Test",
+        simpleName = "Test"
+    )
+
+    override val beforeMethod = "@${mainPackage}.BeforeEach"
+    override val beforeMethodFqn = "${mainPackage}.BeforeEach"
+    override val beforeMethodId = BuiltinClassId(
+        canonicalName = "${mainPackage}.BeforeEach",
+        simpleName = "BeforeEach"
+    )
+
+    override val afterMethod = "@${mainPackage}.AfterEach"
+    override val afterMethodFqn = "${mainPackage}.AfterEach"
+    override val afterMethodId = BuiltinClassId(
+        canonicalName = "${mainPackage}.AfterEach",
+        simpleName = "AfterEach"
+    )
+
     override val parameterizedTestAnnotation = "$JUNIT5_PARAMETERIZED_PACKAGE.ParameterizedTest"
     override val parameterizedTestAnnotationFqn: String = "$JUNIT5_PARAMETERIZED_PACKAGE.ParameterizedTest"
     override val methodSourceAnnotation: String = "$JUNIT5_PARAMETERIZED_PACKAGE.provider.MethodSource"
@@ -468,11 +522,6 @@ object Junit5 : TestFramework(id = "JUnit5", displayName = "JUnit 5") {
     val nestedTestClassAnnotationId = BuiltinClassId(
         canonicalName = "$JUNIT5_PACKAGE.Nested",
         simpleName = "Nested"
-    )
-
-    override val testAnnotationId = BuiltinClassId(
-        canonicalName = "$JUNIT5_PACKAGE.Test",
-        simpleName = "Test"
     )
 
     override val parameterizedTestAnnotationId = BuiltinClassId(

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/builtin/UtilMethodBuiltins.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/builtin/UtilMethodBuiltins.kt
@@ -1,5 +1,6 @@
 package org.utbot.framework.codegen.domain.builtin
 
+import org.mockito.MockitoAnnotations
 import org.utbot.framework.codegen.domain.MockitoStaticMocking
 import org.utbot.framework.codegen.domain.models.CgClassId
 import org.utbot.framework.codegen.renderer.utilMethodTextById
@@ -303,11 +304,18 @@ internal val utKotlinUtilsClassId: ClassId
 /**
  * [MethodId] for [AutoCloseable.close].
  */
+val openMocksMethodId = MethodId(
+    classId = MockitoAnnotations::class.id,
+    name = "openMocks",
+    returnType = AutoCloseable::class.java.id,
+    parameters = listOf(objectClassId),
+)
+
 val closeMethodId = MethodId(
     classId = AutoCloseable::class.java.id,
     name = "close",
     returnType = voidClassId,
-    parameters = emptyList()
+    parameters = emptyList(),
 )
 
 val mocksAutoCloseable: Set<ClassId> = setOf(

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/CgElement.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/CgElement.kt
@@ -44,6 +44,7 @@ interface CgElement {
             is CgMethodsCluster -> visit(element)
             is CgAuxiliaryClass -> visit(element)
             is CgUtilMethod -> visit(element)
+            is CgFrameworkUtilMethod -> visit(element)
             is CgTestMethod -> visit(element)
             is CgErrorTestMethod -> visit(element)
             is CgParameterizedTestDataProviderMethod -> visit(element)
@@ -282,7 +283,18 @@ class CgTestMethod(
     val type: CgTestMethodType,
     override val documentation: CgDocumentationComment = CgDocumentationComment(emptyList()),
     override val requiredFields: List<CgParameterDeclaration> = emptyList(),
-) : CgMethod(false)
+) : CgMethod(isStatic = false)
+
+class CgFrameworkUtilMethod(
+    override val name: String,
+    override val returnType: ClassId = voidClassId,
+    override val parameters: List<CgParameterDeclaration> = emptyList(),
+    override val statements: List<CgStatement>,
+    override val exceptions: Set<ClassId>,
+    override val annotations: List<CgAnnotation>,
+    override val documentation: CgDocumentationComment = CgDocumentationComment(emptyList()),
+    override val requiredFields: List<CgParameterDeclaration> = emptyList(),
+) : CgMethod(isStatic = false)
 
 class CgErrorTestMethod(
     override val name: String,

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/CgElement.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/CgElement.kt
@@ -287,20 +287,21 @@ class CgTestMethod(
 
 class CgFrameworkUtilMethod(
     override val name: String,
-    override val returnType: ClassId = voidClassId,
-    override val parameters: List<CgParameterDeclaration> = emptyList(),
     override val statements: List<CgStatement>,
     override val exceptions: Set<ClassId>,
     override val annotations: List<CgAnnotation>,
-    override val documentation: CgDocumentationComment = CgDocumentationComment(emptyList()),
-    override val requiredFields: List<CgParameterDeclaration> = emptyList(),
-) : CgMethod(isStatic = false)
+) : CgMethod(isStatic = false) {
+    override val returnType: ClassId = voidClassId
+    override val parameters: List<CgParameterDeclaration> = emptyList()
+    override val documentation: CgDocumentationComment = CgDocumentationComment(emptyList())
+    override val requiredFields: List<CgParameterDeclaration> = emptyList()
+}
 
 class CgErrorTestMethod(
     override val name: String,
     override val statements: List<CgStatement>,
     override val documentation: CgDocumentationComment = CgDocumentationComment(emptyList())
-) : CgMethod(false) {
+) : CgMethod(isStatic = false) {
     override val exceptions: Set<ClassId> = emptySet()
     override val returnType: ClassId = voidClassId
     override val parameters: List<CgParameterDeclaration> = emptyList()

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgAbstractRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgAbstractRenderer.kt
@@ -43,6 +43,7 @@ import org.utbot.framework.codegen.domain.models.CgExpression
 import org.utbot.framework.codegen.domain.models.CgFieldAccess
 import org.utbot.framework.codegen.domain.models.CgForEachLoop
 import org.utbot.framework.codegen.domain.models.CgForLoop
+import org.utbot.framework.codegen.domain.models.CgFrameworkUtilMethod
 import org.utbot.framework.codegen.domain.models.CgGreaterThan
 import org.utbot.framework.codegen.domain.models.CgIfStatement
 import org.utbot.framework.codegen.domain.models.CgIncrement
@@ -234,6 +235,14 @@ abstract class CgAbstractRenderer(
         // TODO introduce CgBlock
         print(" ")
         visit(element.statements, printNextLine = true)
+    }
+
+    override fun visit(element: CgFrameworkUtilMethod) {
+        for (annotation in element.annotations) {
+            annotation.accept(this)
+        }
+        renderMethodSignature(element)
+        visit(element as CgMethod)
     }
 
     override fun visit(element: CgTestMethod) {
@@ -751,6 +760,7 @@ abstract class CgAbstractRenderer(
     protected abstract fun renderMethodSignature(element: CgTestMethod)
     protected abstract fun renderMethodSignature(element: CgErrorTestMethod)
     protected abstract fun renderMethodSignature(element: CgParameterizedTestDataProviderMethod)
+    protected abstract fun renderMethodSignature(element: CgFrameworkUtilMethod)
 
     protected abstract fun renderForLoopVarControl(element: CgForLoop)
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgJavaRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgJavaRenderer.kt
@@ -33,6 +33,7 @@ import org.utbot.framework.codegen.domain.models.CgSwitchCaseLabel
 import org.utbot.framework.codegen.domain.models.CgClass
 import org.utbot.framework.codegen.domain.models.CgClassBody
 import org.utbot.framework.codegen.domain.models.CgFormattedString
+import org.utbot.framework.codegen.domain.models.CgFrameworkUtilMethod
 import org.utbot.framework.codegen.domain.models.CgLiteral
 import org.utbot.framework.codegen.domain.models.CgTestMethod
 import org.utbot.framework.codegen.domain.models.CgTypeCast
@@ -251,6 +252,15 @@ internal class CgJavaRenderer(context: CgRendererContext, printer: CgPrinter = C
         val returnType =
             if (element.returnType.simpleName == "Object[][]") "java.lang.Object[][]" else "${element.returnType}"
         print("public static $returnType ${element.name}()")
+        renderExceptions(element)
+    }
+
+    override fun renderMethodSignature(element: CgFrameworkUtilMethod) {
+        // framework util methods always have void return type
+        print("public void ")
+        print(element.name)
+        print("()")
+
         renderExceptions(element)
     }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgKotlinRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgKotlinRenderer.kt
@@ -39,6 +39,7 @@ import org.utbot.framework.codegen.domain.models.CgSwitchCaseLabel
 import org.utbot.framework.codegen.domain.models.CgClass
 import org.utbot.framework.codegen.domain.models.CgClassBody
 import org.utbot.framework.codegen.domain.models.CgFormattedString
+import org.utbot.framework.codegen.domain.models.CgFrameworkUtilMethod
 import org.utbot.framework.codegen.domain.models.CgLiteral
 import org.utbot.framework.codegen.domain.models.CgTestMethod
 import org.utbot.framework.codegen.domain.models.CgTypeCast
@@ -413,6 +414,14 @@ internal class CgKotlinRenderer(context: CgRendererContext, printer: CgPrinter =
     override fun renderMethodSignature(element: CgParameterizedTestDataProviderMethod) {
         val returnType = getKotlinClassString(element.returnType)
         println("fun ${element.name}(): $returnType")
+    }
+
+    override fun renderMethodSignature(element: CgFrameworkUtilMethod) {
+        print("fun ")
+        // TODO: resolve $ in name as in [CgTestMethod]
+        print(element.name)
+        print("()")
+        renderMethodReturnType(element)
     }
 
     private fun renderMethodReturnType(method: CgMethod) {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgVisitor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgVisitor.kt
@@ -77,6 +77,7 @@ import org.utbot.framework.codegen.domain.models.CgClass
 import org.utbot.framework.codegen.domain.models.CgClassBody
 import org.utbot.framework.codegen.domain.models.CgDocRegularLineStmt
 import org.utbot.framework.codegen.domain.models.CgFormattedString
+import org.utbot.framework.codegen.domain.models.CgFrameworkUtilMethod
 import org.utbot.framework.codegen.domain.models.CgNestedClassesRegion
 import org.utbot.framework.codegen.domain.models.CgTestMethod
 import org.utbot.framework.codegen.domain.models.CgTestMethodCluster
@@ -113,6 +114,7 @@ interface CgVisitor<R> {
     fun visit(element: CgTestMethod): R
     fun visit(element: CgErrorTestMethod): R
     fun visit(element: CgParameterizedTestDataProviderMethod): R
+    fun visit(element: CgFrameworkUtilMethod): R
 
     // Annotations
     fun visit(element: CgCommentedAnnotation): R

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringTestClassConstructor.kt
@@ -1,16 +1,31 @@
 package org.utbot.framework.codegen.tree
 
 import org.utbot.framework.codegen.domain.builtin.TestClassUtilMethodProvider
+import org.utbot.framework.codegen.domain.builtin.closeMethodId
+import org.utbot.framework.codegen.domain.builtin.openMocksMethodId
 import org.utbot.framework.codegen.domain.context.CgContext
+import org.utbot.framework.codegen.domain.models.CgAssignment
 import org.utbot.framework.codegen.domain.models.CgClassBody
+import org.utbot.framework.codegen.domain.models.CgDeclaration
+import org.utbot.framework.codegen.domain.models.CgFrameworkUtilMethod
 import org.utbot.framework.codegen.domain.models.CgMethod
+import org.utbot.framework.codegen.domain.models.CgMethodCall
 import org.utbot.framework.codegen.domain.models.CgMethodTestSet
 import org.utbot.framework.codegen.domain.models.CgMethodsCluster
 import org.utbot.framework.codegen.domain.models.CgRegion
+import org.utbot.framework.codegen.domain.models.CgSimpleRegion
+import org.utbot.framework.codegen.domain.models.CgStatementExecutableCall
 import org.utbot.framework.codegen.domain.models.CgStaticsRegion
+import org.utbot.framework.codegen.domain.models.CgVariable
 import org.utbot.framework.codegen.domain.models.SpringTestClassModel
+import org.utbot.framework.plugin.api.UtCompositeModel
+import org.utbot.framework.plugin.api.util.id
+import org.utbot.framework.plugin.api.util.objectClassId
 
 class CgSpringTestClassConstructor(context: CgContext): CgAbstractTestClassConstructor<SpringTestClassModel>(context) {
+
+    private val variableConstructor: CgVariableConstructor = CgComponents.getVariableConstructorBy(context)
+    private val statementConstructor: CgStatementConstructor = CgComponents.getStatementConstructorBy(context)
 
     override fun constructTestClassBody(testClassModel: SpringTestClassModel): CgClassBody {
         return buildClassBody(currentTestClass) {
@@ -18,10 +33,10 @@ class CgSpringTestClassConstructor(context: CgContext): CgAbstractTestClassConst
             // TODO: support inner classes here
 
             // TODO: create class variables with Mock/InjectMock annotations using testClassModel
-            fields += mutableListOf()
 
-            // TODO: create beforeEach/ afterEach methods
-            // Requires new implementation of CgMethod for test framework builtins
+            val (closeableField, closeableMethods) = constructMockitoCloseables()
+            fields += closeableField
+            methodRegions += closeableMethods
 
             for (testSet in testClassModel.methodTestSets) {
                 updateCurrentExecutable(testSet.executableId)
@@ -60,5 +75,58 @@ class CgSpringTestClassConstructor(context: CgContext): CgAbstractTestClassConst
         }
 
         return if (regions.any()) regions else null
+    }
+
+    private fun constructMockitoCloseables(): Pair<CgDeclaration, CgMethodsCluster> {
+        val mockitoCloseableVarName = "mockitoCloseable"
+        val mockitoCloseableVarType = java.lang.AutoCloseable::class.id
+
+        val mockitoCloseableModel = UtCompositeModel(
+            id = 239017,
+            classId = mockitoCloseableVarType,
+            isMock = false,
+        )
+
+        val mockitoCloseableVariable =
+            variableConstructor.getOrCreateVariable(mockitoCloseableModel, mockitoCloseableVarName)
+        val mockitoCloseableField = CgDeclaration(mockitoCloseableVarType, mockitoCloseableVarName, initializer = null)
+
+        importIfNeeded(openMocksMethodId)
+
+        val openMocksCall = CgMethodCall(
+            caller = null,
+            executableId = openMocksMethodId,
+            //TODO: this is a hack of this
+            arguments = listOf(CgVariable("this", objectClassId))
+        )
+
+        val closeCall = CgMethodCall(
+            caller = mockitoCloseableVariable,
+            executableId = closeMethodId,
+            arguments = emptyList(),
+        )
+
+        val openMocksStatement = CgAssignment(mockitoCloseableVariable, openMocksCall)
+        val beforeMethod = CgFrameworkUtilMethod(
+            name = "setUp",
+            statements = listOf(openMocksStatement),
+            exceptions = emptySet(),
+            annotations = listOf(statementConstructor.annotation(context.testFramework.beforeMethodId)),
+        )
+
+        val closeStatement = CgStatementExecutableCall(closeCall)
+        val afterMethod = CgFrameworkUtilMethod(
+            name = "tearDown",
+            statements = listOf(closeStatement),
+            exceptions = setOf(java.lang.Exception::class.id),
+            annotations = listOf(statementConstructor.annotation(context.testFramework.afterMethodId)),
+        )
+
+        val methodCluster = CgMethodsCluster(
+            "Test run utility methods",
+            listOf(CgSimpleRegion("Mocking utils", listOf(beforeMethod, afterMethod)))
+        )
+
+        return mockitoCloseableField to methodCluster
     }
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringTestClassConstructor.kt
@@ -82,7 +82,7 @@ class CgSpringTestClassConstructor(context: CgContext): CgAbstractTestClassConst
         val mockitoCloseableVarType = java.lang.AutoCloseable::class.id
 
         val mockitoCloseableModel = UtCompositeModel(
-            id = 239017,
+            id = null,
             classId = mockitoCloseableVarType,
             isMock = false,
         )

--- a/utbot-js/src/main/kotlin/framework/codegen/JsDomain.kt
+++ b/utbot-js/src/main/kotlin/framework/codegen/JsDomain.kt
@@ -17,6 +17,14 @@ object Mocha : TestFramework(id = "Mocha", displayName = "Mocha") {
     override val testAnnotation = ""
     override val testAnnotationFqn = ""
 
+    override val beforeMethod: String = ""
+    override val beforeMethodId: ClassId = jsUndefinedClassId
+    override val beforeMethodFqn: String = ""
+
+    override val afterMethod: String = ""
+    override val afterMethodId: ClassId = jsUndefinedClassId
+    override val afterMethodFqn: String = ""
+
     override val parameterizedTestAnnotation: String
         get() = throw UnsupportedOperationException("Parameterized tests are not supported for Mocha")
     override val parameterizedTestAnnotationFqn: String

--- a/utbot-js/src/main/kotlin/framework/codegen/model/constructor/visitor/CgJsRenderer.kt
+++ b/utbot-js/src/main/kotlin/framework/codegen/model/constructor/visitor/CgJsRenderer.kt
@@ -303,6 +303,10 @@ internal class CgJsRenderer(context: CgRendererContext, printer: CgPrinter = CgP
         throw UnsupportedOperationException()
     }
 
+    override fun renderMethodSignature(element: CgFrameworkUtilMethod) {
+        throw UnsupportedOperationException()
+    }
+
     override fun visit(element: CgNamedAnnotationArgument) {
 
     }

--- a/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/PythonDomain.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/PythonDomain.kt
@@ -24,6 +24,14 @@ object Pytest : TestFramework(displayName = "pytest", id = "pytest") {
     )
     override val testAnnotationFqn: String = ""
 
+    override val beforeMethod: String = ""
+    override val beforeMethodId: ClassId = pythonAnyClassId
+    override val beforeMethodFqn: String = ""
+
+    override val afterMethod: String = ""
+    override val afterMethodId: ClassId = pythonAnyClassId
+    override val afterMethodFqn: String = ""
+
     override val parameterizedTestAnnotation: String = ""
     override val parameterizedTestAnnotationId: ClassId = pythonAnyClassId
     override val parameterizedTestAnnotationFqn: String = ""
@@ -63,6 +71,14 @@ object Unittest : TestFramework(displayName = "Unittest", id = "Unittest") {
         simpleName = "Tests"
     )
     override val testAnnotationFqn: String = "unittest"
+
+    override val beforeMethod: String = ""
+    override val beforeMethodId: ClassId = pythonAnyClassId
+    override val beforeMethodFqn: String = ""
+
+    override val afterMethod: String = ""
+    override val afterMethodId: ClassId = pythonAnyClassId
+    override val afterMethodFqn: String = ""
 
     override val parameterizedTestAnnotation: String = ""
     override val parameterizedTestAnnotationId: ClassId = pythonAnyClassId

--- a/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/constructor/visitor/CgPythonRenderer.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/constructor/visitor/CgPythonRenderer.kt
@@ -30,6 +30,7 @@ import org.utbot.framework.codegen.domain.models.CgExpression
 import org.utbot.framework.codegen.domain.models.CgForEachLoop
 import org.utbot.framework.codegen.domain.models.CgForLoop
 import org.utbot.framework.codegen.domain.models.CgFormattedString
+import org.utbot.framework.codegen.domain.models.CgFrameworkUtilMethod
 import org.utbot.framework.codegen.domain.models.CgGetJavaClass
 import org.utbot.framework.codegen.domain.models.CgGetKotlinClass
 import org.utbot.framework.codegen.domain.models.CgGetLength
@@ -344,6 +345,10 @@ internal class CgPythonRenderer(
     override fun renderMethodSignature(element: CgParameterizedTestDataProviderMethod) {
         val returnType = element.returnType.canonicalName
         println("def ${element.name}() -> $returnType: pass")
+    }
+
+    override fun renderMethodSignature(element: CgFrameworkUtilMethod) {
+        throw UnsupportedOperationException()
     }
 
     override fun visit(element: CgInnerBlock) {


### PR DESCRIPTION
## Description

Adds `setUp` and `tearDown` methods for Spring unit testing as follows:

![image](https://user-images.githubusercontent.com/29856383/220316217-e4f2fab8-69e4-4620-925e-fb5a4752e21d.png)

## How to test

Should not be tested separately.
Does not affect the current implementation of Codegen.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.