### PR TITLE
Fix NoClassDefFoundError in Kotlin projects #1793

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/KtLightMethodUtil.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/KtLightMethodUtil.kt
@@ -1,0 +1,24 @@
+package org.utbot.intellij.plugin.util
+
+import org.jetbrains.kotlin.asJava.elements.KtLightMethod
+import org.jetbrains.kotlin.psi.KtCallableDeclaration
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.psi.KtProperty
+
+
+/*
+ * TODO: Remove the following methods after Kotlin version transition from [1.7.20].
+ * See [https://github.com/UnitTestBot/UTBotJava/issues/1793].
+ */
+val KtLightMethod.isGetter: Boolean
+    get() = isAccessor(true)
+
+val KtLightMethod.isSetter: Boolean
+    get() = isAccessor(false)
+
+private fun KtLightMethod.isAccessor(getter: Boolean): Boolean {
+    val origin = kotlinOrigin as? KtCallableDeclaration ?: return false
+    if (origin !is KtProperty && origin !is KtParameter) return false
+    val expectedParametersCount = (if (getter) 0 else 1) + (if (origin.receiverTypeReference != null) 1 else 0)
+    return parameterList.parametersCount == expectedParametersCount
+}

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/PsiClassHelper.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/PsiClassHelper.kt
@@ -9,8 +9,6 @@ import com.intellij.refactoring.util.classMembers.MemberInfo
 import com.intellij.testIntegration.TestIntegrationUtils
 import org.jetbrains.kotlin.asJava.elements.KtLightMember
 import org.jetbrains.kotlin.asJava.elements.KtLightMethod
-import org.jetbrains.kotlin.asJava.elements.isGetter
-import org.jetbrains.kotlin.asJava.elements.isSetter
 import org.jetbrains.kotlin.psi.KtClass
 import org.utbot.common.filterWhen
 import org.utbot.framework.UtSettings


### PR DESCRIPTION
## Description

This PR *hot-fixes* the bug regarding Kotlin version update by storing necessary methods (*isGetter*, *isSetter*) from Kotlin library as utility methods in order to have them regardless of Kotlin version. Those meant to be deleted after plugin Kotlin version transition from `1.7.10` to a higher version.

Fixes #1793

## How to test

### Automated tests

Not relevant.

### Manual tests

Run `runIde`, create new Kotlin project with Kotlin version 1.8.10 or higher installed. Verify that the plugin works fine when trying to open the generation window and generate tests.