### PR TITLE
Fix reports generation for Spring classes

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/CodeGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/CodeGenerator.kt
@@ -115,7 +115,7 @@ open class CodeGenerator(
         return CodeGeneratorResult(
             generatedCode = generatedCode,
             utilClassKind = UtilClassKind.fromCgContextOrNull(context),
-            testsGenerationReport = TestsGenerationReport()
+            testsGenerationReport = astConstructor.testsGenerationReport
         )
     }
 

--- a/utbot-intellij/src/main/resources/bundles/UtbotBundle.properties
+++ b/utbot-intellij/src/main/resources/bundles/UtbotBundle.properties
@@ -5,6 +5,6 @@ test.report.force.static.mock.warning=<b>Warning</b>: Some test cases were ignor
 Better results could be achieved by <a href="{0}{1}">configuring mockito-inline</a>.
 test.report.test.framework.warning=<b>Warning</b>: There are several test frameworks in the project.\
 To select run configuration, please refer to the documentation depending on the project build system:\
-<a href="https://docs.gradle.org/current/userguide/java_testing.html#sec:configuring_java_integration_tests">Gradle</a>,\
-<a href="https://maven.apache.org/surefire/maven-surefire-plugin/examples/providers.html">Maven</a>\
+<a href="https://docs.gradle.org/current/userguide/java_testing.html#sec:configuring_java_integration_tests">Gradle</a>, \
+<a href="https://maven.apache.org/surefire/maven-surefire-plugin/examples/providers.html">Maven</a> \
 or <a href="https://www.jetbrains.com/help/idea/run-debug-configuration.html#compound-configs">Idea</a>.


### PR DESCRIPTION
## Description

Fixes # ([issue](https://github.com/UnitTestBot/UTBotJava/issues/1834))

Missed test report generation added for Spring classes.
Text message in report corrected (added missed whitespaces)

## How to test

Problem existed for Spring classes only.
Retest for standard functionality is not required.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.