### PR TITLE
Fix internal UTBot timeout exception rendering in summaries

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/ArtificialErrors.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/ArtificialErrors.kt
@@ -16,8 +16,3 @@ sealed class ArtificialError(message: String): Error(message)
  * See [TraversalContext.intOverflowCheck] for more details.
  */
 class OverflowDetectionError(message: String): ArtificialError(message)
-
-fun ArtificialError.getPrettyName(): String =
-    when (this) {
-        is OverflowDetectionError -> "Overflow"
-    }

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/ThrowableUtils.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/ThrowableUtils.kt
@@ -1,10 +1,20 @@
 package org.utbot.framework.plugin.api.util
 
+import org.utbot.framework.plugin.api.OverflowDetectionError
+import org.utbot.framework.plugin.api.TimeoutException
+
 val Throwable.description
     get() = message?.replace('\n', '\t') ?: "<Throwable with empty message>"
 
 val Throwable.isCheckedException
     get() = !(this is RuntimeException || this is Error)
+
+val Throwable.prettyName
+    get() = when (this) {
+        is OverflowDetectionError -> "Overflow"
+        is TimeoutException -> "Timeout"
+        else -> this::class.simpleName
+    }
 
 val Class<*>.isCheckedException
     get() = !(RuntimeException::class.java.isAssignableFrom(this) || Error::class.java.isAssignableFrom(this))

--- a/utbot-sample/src/main/java/org/utbot/examples/exceptions/ExceptionExamples.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/exceptions/ExceptionExamples.java
@@ -102,6 +102,13 @@ public class ExceptionExamples {
         return new IllegalArgumentException("Here we are: " + Math.sqrt(10));
     }
 
+    public int hangForSeconds(int seconds) throws InterruptedException {
+        for (int i = 0; i < seconds; i++) {
+            Thread.sleep(1000);
+        }
+        return seconds;
+    }
+
     public int dontCatchDeepNestedThrow(int i) {
         return callNestedWithThrow(i);
     }

--- a/utbot-summary-tests/src/test/kotlin/examples/exceptions/SummaryExceptionExampleTest.kt
+++ b/utbot-summary-tests/src/test/kotlin/examples/exceptions/SummaryExceptionExampleTest.kt
@@ -58,4 +58,43 @@ class SummaryExceptionExampleTest : SummaryTestCaseGeneratorTest(
 
         summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
     }
+
+    @Test
+    fun testHangForSeconds() {
+        val summary1 = "@utbot.classUnderTest {@link ExceptionExamples}\n" +
+                "@utbot.methodUnderTest {@link org.utbot.examples.exceptions.ExceptionExamples#hangForSeconds(int)}\n" +
+                "@utbot.returnsFrom {@code return seconds;}\n"
+        val summary2 = "@utbot.classUnderTest {@link ExceptionExamples}\n" +
+                "@utbot.methodUnderTest {@link org.utbot.examples.exceptions.ExceptionExamples#hangForSeconds(int)}\n" +
+                "@utbot.iterates iterate the loop {@code for(int i = 0; i < seconds; i++)} once\n" +
+                "@utbot.returnsFrom {@code return seconds;}\n" +
+                "@utbot.detectsSuspiciousBehavior in: return seconds;\n"
+
+        val methodName1 = "testHangForSeconds_ReturnSeconds"
+        val methodName2 = "testHangForSeconds_ThreadSleep"
+
+        val displayName1 = "-> return seconds"
+        val displayName2 = "return seconds -> TimeoutExceeded"
+
+        val summaryKeys = listOf(
+            summary1,
+            summary2
+        )
+
+        val displayNames = listOf(
+            displayName1,
+            displayName2
+        )
+
+        val methodNames = listOf(
+            methodName1,
+            methodName2
+        )
+
+        val method = ExceptionExamples::hangForSeconds
+        val mockStrategy = MockStrategyApi.NO_MOCKS
+        val coverage = DoNotCalculate
+
+        summaryCheck(method, mockStrategy, coverage, summaryKeys, methodNames, displayNames)
+    }
 }

--- a/utbot-summary/src/main/kotlin/org/utbot/summary/comment/classic/symbolic/SimpleCommentBuilder.kt
+++ b/utbot-summary/src/main/kotlin/org/utbot/summary/comment/classic/symbolic/SimpleCommentBuilder.kt
@@ -13,6 +13,7 @@ import org.utbot.framework.plugin.api.DocPreTagStatement
 import org.utbot.framework.plugin.api.DocRegularStmt
 import org.utbot.framework.plugin.api.DocStatement
 import org.utbot.framework.plugin.api.Step
+import org.utbot.framework.plugin.api.TimeoutException
 import org.utbot.framework.plugin.api.exceptionOrNull
 import org.utbot.summary.AbstractTextBuilder
 import org.utbot.summary.SummarySentenceConstants.CARRIAGE_RETURN
@@ -70,6 +71,7 @@ open class SimpleCommentBuilder(
             val reason = findExceptionReason(currentMethod, it)
 
             when (it) {
+                is TimeoutException,
                 is ArtificialError -> root.detectedError = reason
                 else -> root.exceptionThrow = "$exceptionName $reason"
             }

--- a/utbot-summary/src/main/kotlin/org/utbot/summary/comment/customtags/symbolic/CustomJavaDocCommentBuilder.kt
+++ b/utbot-summary/src/main/kotlin/org/utbot/summary/comment/customtags/symbolic/CustomJavaDocCommentBuilder.kt
@@ -3,6 +3,7 @@ package org.utbot.summary.comment.customtags.symbolic
 import org.utbot.framework.plugin.api.ArtificialError
 import org.utbot.framework.plugin.api.DocCustomTagStatement
 import org.utbot.framework.plugin.api.DocStatement
+import org.utbot.framework.plugin.api.TimeoutException
 import org.utbot.framework.plugin.api.exceptionOrNull
 import org.utbot.summary.SummarySentenceConstants.CARRIAGE_RETURN
 import org.utbot.summary.ast.JimpleToASTMap
@@ -58,6 +59,7 @@ class CustomJavaDocCommentBuilder(
                 .replace(CARRIAGE_RETURN, "")
 
             when (thrownException) {
+                is TimeoutException,
                 is ArtificialError -> comment.detectsSuspiciousBehavior = reason
                 else -> comment.throwsException = "{@link $exceptionName} $reason"
             }

--- a/utbot-summary/src/main/kotlin/org/utbot/summary/name/NameUtil.kt
+++ b/utbot-summary/src/main/kotlin/org/utbot/summary/name/NameUtil.kt
@@ -2,7 +2,8 @@ package org.utbot.summary.name
 
 import org.utbot.framework.plugin.api.ArtificialError
 import org.utbot.framework.plugin.api.Step
-import org.utbot.framework.plugin.api.getPrettyName
+import org.utbot.framework.plugin.api.TimeoutException
+import org.utbot.framework.plugin.api.util.prettyName
 import org.utbot.summary.tag.UniquenessTag
 import soot.SootMethod
 
@@ -51,7 +52,16 @@ data class TestNameDescription(
 }
 
 enum class NameType {
-    Condition, Return, Invoke, SwitchCase, CaughtException, NoIteration, ThrowsException, StartIteration, ArtificialError
+    Condition,
+    Return,
+    Invoke,
+    SwitchCase,
+    CaughtException,
+    NoIteration,
+    ThrowsException,
+    StartIteration,
+    ArtificialError,
+    TimeoutError
 }
 
 data class DisplayNameCandidate(val name: String, val uniquenessTag: UniquenessTag, val index: Int)
@@ -66,11 +76,12 @@ fun List<TestNameDescription>.returnsToUnique() = this.map {
 }
 
 fun buildNameFromThrowable(exception: Throwable): String? {
-    val exceptionName = exception::class.simpleName
+    val exceptionName = exception.prettyName
 
     if (exceptionName.isNullOrEmpty()) return null
     return when (exception) {
-        is ArtificialError -> "Detect${exception.getPrettyName()}"
+        is TimeoutException -> "${exception.prettyName}Exceeded"
+        is ArtificialError -> "Detect${exception.prettyName}"
         else -> "Throw$exceptionName"
     }
 }
@@ -78,6 +89,7 @@ fun buildNameFromThrowable(exception: Throwable): String? {
 fun getThrowableNameType(exception: Throwable): NameType {
     return when (exception) {
         is ArtificialError -> NameType.ArtificialError
+        is TimeoutException -> NameType.TimeoutError
         else -> NameType.ThrowsException
     }
 }

--- a/utbot-summary/src/main/kotlin/org/utbot/summary/name/SimpleNameBuilder.kt
+++ b/utbot-summary/src/main/kotlin/org/utbot/summary/name/SimpleNameBuilder.kt
@@ -146,14 +146,10 @@ class SimpleNameBuilder(
     }
 
     private fun fromNameDescriptionToCandidateSimpleName(nameDescription: TestNameDescription): DisplayNameCandidate? {
-        if (nameDescription.nameType == NameType.ArtificialError) {
-            return DisplayNameCandidate(
-                nameDescription.name,
-                nameDescription.uniquenessTag,
-                traceTag.path.size + 1
-            )
-        }
-        if (nameDescription.nameType == NameType.ThrowsException) {
+        if (nameDescription.nameType == NameType.ArtificialError ||
+            nameDescription.nameType == NameType.TimeoutError ||
+            nameDescription.nameType == NameType.ThrowsException
+        ) {
             return DisplayNameCandidate(
                 nameDescription.name,
                 nameDescription.uniquenessTag,


### PR DESCRIPTION
## Description

This PR makes TimoutException originating from the engine being rendered as a suspicious behavior not as an thrown exception.
Also, added extra summary test (SummaryExceptionExampleTest::testHangForSeconds) regarding the fix.

Previous rendering:
```java
@utbot.throwsException { @link org.utbot.framework.plugin.api.TimeoutException } in: return seconds;
```

Current rendering:
```java
@utbot.detectsSuspiciousBehavior in: return seconds;
```

Fixes #1832

## How to test

### Automated tests

utbot-samples.

Also, added extra summary test (SummaryExceptionExampleTest::testHangForSeconds) regarding the fix.