### PR TITLE
Fix IU plugin compilation 

### DIFF
--- a/utbot-js/src/main/kotlin/framework/codegen/model/constructor/visitor/CgJsRenderer.kt
+++ b/utbot-js/src/main/kotlin/framework/codegen/model/constructor/visitor/CgJsRenderer.kt
@@ -22,6 +22,7 @@ import org.utbot.framework.codegen.domain.models.CgExpression
 import org.utbot.framework.codegen.domain.models.CgFieldAccess
 import org.utbot.framework.codegen.domain.models.CgForLoop
 import org.utbot.framework.codegen.domain.models.CgFormattedString
+import org.utbot.framework.codegen.domain.models.CgFrameworkUtilMethod
 import org.utbot.framework.codegen.domain.models.CgGetJavaClass
 import org.utbot.framework.codegen.domain.models.CgGetKotlinClass
 import org.utbot.framework.codegen.domain.models.CgGetLength
@@ -39,7 +40,6 @@ import org.utbot.framework.codegen.domain.models.CgStaticsRegion
 import org.utbot.framework.codegen.domain.models.CgSwitchCase
 import org.utbot.framework.codegen.domain.models.CgSwitchCaseLabel
 import org.utbot.framework.codegen.domain.models.CgTestMethod
-import org.utbot.framework.codegen.domain.models.CgThrowStatement
 import org.utbot.framework.codegen.domain.models.CgTypeCast
 import org.utbot.framework.codegen.domain.models.CgVariable
 import org.utbot.framework.codegen.renderer.CgAbstractRenderer
@@ -280,10 +280,6 @@ internal class CgJsRenderer(context: CgRendererContext, printer: CgPrinter = CgP
     override fun visit(element: CgErrorTestMethod) {
         renderMethodSignature(element)
         visit(element as CgMethod)
-    }
-
-    override fun visit(element: CgThrowStatement) {
-        // TODO: Should we render throw statement right here?
     }
 
     override fun visit(element: CgClassBody) {


### PR DESCRIPTION
## Description

Fixed the build of the plugin for the IU version due to a compilation error in the JavaScript module after last codegen changes

## How to test

### Manual tests

Various scenarios have been tested. You can find the examples in the folder `/utbot-js/samples' and try to run UTBot.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.