### PR TITLE
Add @JsonIgnore to the allResults field in SARIF

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/sarif/DataClasses.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/sarif/DataClasses.kt
@@ -47,6 +47,7 @@ data class Sarif(
             .writerWithDefaultPrettyPrinter()
             .writeValueAsString(this)
 
+    @JsonIgnore
     fun getAllResults(): List<SarifResult> =
         runs.flatMap { it.results }
 }


### PR DESCRIPTION
## Description

The `allResults` field duplicates all the result stored in the report, so now this field is not shown

Fixes #1867

## How to test

### Automated tests

org.utbot.sarif.SarifReportTest

### Manual tests

Repeat the scenario from the issue #1867 and check the result

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] The **documentation** for the functionality I've been working on is up-to-date.