### PR TITLE
Removed unnecessary mock counter and switch during constructors mocking

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/CgElement.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/CgElement.kt
@@ -888,7 +888,7 @@ class CgIfStatement(
 
 data class CgSwitchCaseLabel(
     val label: CgLiteral? = null, // have to be compile time constant (null for default label)
-    val statements: MutableList<CgStatement>
+    val statements: List<CgStatement>
 ) : CgStatement
 
 data class CgSwitchCase(

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/CgElement.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/CgElement.kt
@@ -888,7 +888,8 @@ class CgIfStatement(
 
 data class CgSwitchCaseLabel(
     val label: CgLiteral? = null, // have to be compile time constant (null for default label)
-    val statements: List<CgStatement>
+    val statements: List<CgStatement>,
+    val addBreakStatementToEnd: Boolean = true // do not set this field to "true" value if you manually added "break" to statements
 ) : CgStatement
 
 data class CgSwitchCase(

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgJavaRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgJavaRenderer.kt
@@ -314,8 +314,6 @@ internal class CgJavaRenderer(context: CgRendererContext, printer: CgPrinter = C
             for (statement in element.statements) {
                 statement.accept(this)
             }
-            // break statement in the end
-            CgBreakStatement.accept(this)
         }
     }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgJavaRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgJavaRenderer.kt
@@ -314,6 +314,10 @@ internal class CgJavaRenderer(context: CgRendererContext, printer: CgPrinter = C
             for (statement in element.statements) {
                 statement.accept(this)
             }
+
+            if (element.addBreakStatementToEnd) {
+                CgBreakStatement.accept(this)
+            }
         }
     }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/MockFrameworkManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/MockFrameworkManager.kt
@@ -355,17 +355,14 @@ private class MockitoStaticMocker(context: CgContext, private val mocker: Object
                 }
             }
 
-            // Always add "break" statement to prevent fall-through.
-            statements += CgBreakStatement
-
             caseLabels += CgSwitchCaseLabel(CgLiteral(intClassId, index), statements)
         }
 
         val switchCase = CgSwitchCase(mockClassCounter[atomicIntegerGet](), caseLabels)
 
-        // If all switch-case labels contain only break statements,
+        // If all switch-case labels are empty,
         // it means we do not need this switch and mock counter itself at all.
-        val mockConstructionBody = if (caseLabels.map { it.statements }.all { it.singleOrNull() is CgBreakStatement }) {
+        val mockConstructionBody = if (caseLabels.map { it.statements }.all { it.isEmpty() }) {
             emptyList()
         } else {
             listOf(switchCase, CgStatementExecutableCall(mockClassCounter[atomicIntegerGetAndIncrement]()))

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/MockFrameworkManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/MockFrameworkManager.kt
@@ -22,6 +22,7 @@ import org.utbot.framework.codegen.domain.context.CgContext
 import org.utbot.framework.codegen.domain.context.CgContextOwner
 import org.utbot.framework.codegen.domain.models.CgAnonymousFunction
 import org.utbot.framework.codegen.domain.models.CgAssignment
+import org.utbot.framework.codegen.domain.models.CgBreakStatement
 import org.utbot.framework.codegen.domain.models.CgConstructorCall
 import org.utbot.framework.codegen.domain.models.CgDeclaration
 import org.utbot.framework.codegen.domain.models.CgExecutableCall
@@ -226,7 +227,6 @@ private class MockitoStaticMocker(context: CgContext, private val mocker: Object
             nameGenerator.variableName(MOCK_CLASS_COUNTER_NAME),
             CgConstructorCall(ConstructorId(atomicIntegerClassId, emptyList()), emptyList())
         )
-        +mockClassCounter
 
         val mocksExecutablesAnswers = mock
             .instances
@@ -242,13 +242,19 @@ private class MockitoStaticMocker(context: CgContext, private val mocker: Object
             mocksExecutablesAnswers,
             mockClassCounter.variable
         )
+
+        if (mockConstructionInitializer.isMockClassCounterRequired) {
+            // We should insert the counter declaration only if we use this counter, for better readability.
+            +mockClassCounter
+        }
+
         val mockedConstructionDeclaration = CgDeclaration(
             MockitoStaticMocking.mockedConstructionClassId,
             nameGenerator.variableName(MOCKED_CONSTRUCTION_NAME),
-            mockConstructionInitializer
+            mockConstructionInitializer.mockConstructionCall
         )
         resources += mockedConstructionDeclaration
-        +CgAssignment(mockedConstructionDeclaration.variable, mockConstructionInitializer)
+        +CgAssignment(mockedConstructionDeclaration.variable, mockConstructionInitializer.mockConstructionCall)
         mockedStaticConstructions += classId
     }
 
@@ -317,9 +323,9 @@ private class MockitoStaticMocker(context: CgContext, private val mocker: Object
     private fun mockConstruction(
         clazz: CgExpression,
         classId: ClassId,
-        mocksWhenAnswers: List<MutableMap<ExecutableId, List<UtModel>>>,
+        mocksWhenAnswers: List<Map<ExecutableId, List<UtModel>>>,
         mockClassCounter: CgVariable
-    ): CgMethodCall {
+    ): MockConstructionBlock {
         val mockParameter = variableConstructor.declareParameter(
             classId,
             nameGenerator.variableName(classId.simpleName, isMock = true)
@@ -333,6 +339,8 @@ private class MockitoStaticMocker(context: CgContext, private val mocker: Object
         for ((index, mockWhenAnswers) in mocksWhenAnswers.withIndex()) {
             val statements = mutableListOf<CgStatement>()
             for ((executable, values) in mockWhenAnswers) {
+                // For now, all constructors are considered like void methods, but it is proposed to be changed
+                // for better constructors testing.
                 if (executable.returnType == voidClassId) continue
 
                 when (executable) {
@@ -343,23 +351,47 @@ private class MockitoStaticMocker(context: CgContext, private val mocker: Object
                             mocker.`when`(mockParameter[executable](*matchers))[thenReturnMethodId](*results)
                         )
                     }
-                    else -> error("Expected MethodId but got ConstructorId $executable")
+                    is ConstructorId -> error("Expected MethodId but got ConstructorId $executable")
                 }
             }
+
+            // Always add "break" statement to prevent fall-through.
+            statements += CgBreakStatement
 
             caseLabels += CgSwitchCaseLabel(CgLiteral(intClassId, index), statements)
         }
 
         val switchCase = CgSwitchCase(mockClassCounter[atomicIntegerGet](), caseLabels)
 
+        // If all switch-case labels contain only break statements,
+        // it means we do not need this switch and mock counter itself at all.
+        val mockConstructionBody = if (caseLabels.map { it.statements }.all { it.singleOrNull() is CgBreakStatement }) {
+            emptyList()
+        } else {
+            listOf(switchCase, CgStatementExecutableCall(mockClassCounter[atomicIntegerGetAndIncrement]()))
+        }
+
         val answersBlock = CgAnonymousFunction(
             voidClassId,
             listOf(mockParameter, contextParameter).map { CgParameterDeclaration(it, isVararg = false) },
-            listOf(switchCase, CgStatementExecutableCall(mockClassCounter[atomicIntegerGetAndIncrement]()))
+            mockConstructionBody
         )
 
-        return mockitoClassId[MockitoStaticMocking.mockConstructionMethodId](clazz, answersBlock)
+        return MockConstructionBlock(
+            mockitoClassId[MockitoStaticMocking.mockConstructionMethodId](clazz, answersBlock),
+            mockConstructionBody.isNotEmpty()
+        )
     }
+
+    /**
+     * Represents a body for invocation of the [MockitoStaticMocking.mockConstructionMethodId] method and information
+     * whether we need to use a counter for different mocking invocations
+     * (i.e., on each mocking we expect possibly different results).
+     */
+    private data class MockConstructionBlock(
+        val mockConstructionCall: CgMethodCall,
+        val isMockClassCounterRequired: Boolean
+    )
 
     private fun mockStatic(clazz: CgExpression): CgMethodCall =
         mockitoClassId[MockitoStaticMocking.mockStaticMethodId](clazz)


### PR DESCRIPTION
## Description

Fixes #1878.

## How to test

### Automated tests

Common pipeline.

### Manual tests

The same as in the corresponding issue.

Generated test:
```java
///region Test suites for executable org.utbot.examples.mock.provider.impl.ProviderImpl.provideObject

///region SYMBOLIC EXECUTION: SUCCESSFUL EXECUTIONS for method provideObject()

/**
 * @utbot.classUnderTest {@link ProviderImpl}
 * @utbot.methodUnderTest {@link ProviderImpl#provideObject()}
 * @utbot.returnsFrom {@code return new ExampleClass(0);}
 */
@Test
@DisplayName("provideObject: -> return new ExampleClass(0)")
public void testProvideObject_Return() {
	org.mockito.MockedConstruction mockedConstruction = null;
	try {
		mockedConstruction = mockConstruction(ExampleClass.class, (ExampleClass ExampleClassMock, org.mockito.MockedConstruction.Context context) -> {
		});
		ProviderImpl providerImpl = new ProviderImpl();

		ExampleClass actual = providerImpl.provideObject();

		ExampleClass expectedMock = mock(ExampleClass.class);
		expectedMock.field = 0;
                // org.utbot.examples.mock.service.impl.ExampleClass has overridden equals method
                assertEquals(expectedMock, actual);
	} finally {
		mockedConstruction.close();
	}
}
///endregion
```

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.