### PR TITLE
Use deep equality for mock results

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgMethodConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgMethodConstructor.kt
@@ -577,6 +577,7 @@ open class CgMethodConstructor(val context: CgContext) : CgContextOwner by conte
         val modelWithField = ModelWithField(expectedModel, expectedModelField)
         if (modelWithField in visitedModels) return
 
+        @Suppress("NAME_SHADOWING")
         var expected = expected
         if (expected == null) {
             require(!needExpectedDeclaration(expectedModel))
@@ -754,7 +755,8 @@ open class CgMethodConstructor(val context: CgContext) : CgContextOwner by conte
                         return
                     }
 
-                    if (expected.hasNotParametrizedCustomEquals()) {
+                    // We can use overridden equals if we have one, but not for mocks.
+                    if (expected.hasNotParametrizedCustomEquals() && !expectedModel.isMock) {
                         // We rely on already existing equals
                         currentBlock += CgSingleLineComment("${expected.type.canonicalName} has overridden equals method")
                         currentBlock += assertions[assertEquals](expected, actual).toStatement()


### PR DESCRIPTION
## Description

If a returned value in the method under test is mocked, we cannot use `assertEquals` because the `equals` method for mocks works differently. So, we need to use deep equality in such cases.

Fixes #1877.

## How to test

### Automated tests

Common pipeline.

### Manual tests

The same as in the corresponding issue.

Generated test:

```java
///region SYMBOLIC EXECUTION: SUCCESSFUL EXECUTIONS for method provideObject()

/**
 * @utbot.classUnderTest {@link ProviderImpl}
 * @utbot.methodUnderTest {@link ProviderImpl#provideObject()}
 * @utbot.returnsFrom {@code return new ExampleClass(0);}
 */
@Test
@DisplayName("provideObject: -> return new ExampleClass(0)")
public void testProvideObject_Return() {
    org.mockito.MockedConstruction mockedConstruction = null;
    try {
        java.util.concurrent.atomic.AtomicInteger mockClassCounter = new java.util.concurrent.atomic.AtomicInteger();
        mockedConstruction = mockConstruction(ExampleClass.class, (ExampleClass ExampleClassMock, org.mockito.MockedConstruction.Context context) -> {
            switch (mockClassCounter.get()) {
                case 0:
                    break;
            }
            mockClassCounter.getAndIncrement();
        });
        ProviderImpl providerImpl = new ProviderImpl();

        ExampleClass actual = providerImpl.provideObject();

        ExampleClass expectedMock = mock(ExampleClass.class);
        expectedMock.field = 0;
        int expectedMockField = expectedMock.field;
        int actualField = actual.field;
        assertEquals(expectedMockField, actualField);

    } finally {
        mockedConstruction.close();
    }
}
///endregion
```

As can be seen, deep equality is used here.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.