### PR TITLE
Prune branches with unexpected mocks

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -1157,7 +1157,13 @@ class WildcardTypeParameter : TypeParameters(emptyList())
 open class StandardApplicationContext(
     val mockFrameworkInstalled: Boolean = true,
     val staticsMockingIsConfigured: Boolean = true,
-)
+) {
+    init {
+        if (!mockFrameworkInstalled) {
+            require(!staticsMockingIsConfigured) { "Static mocking cannot be used without mock framework" }
+        }
+    }
+}
 
 /**
  * Data we get from Spring application context

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -1151,7 +1151,7 @@ class WildcardTypeParameter : TypeParameters(emptyList())
 /**
  * A context to use when no specific data is required.
  */
-open class ApplicationContext(
+open class StandardApplicationContext(
     val mockFrameworkInstalled: Boolean = true,
     val staticsMockingIsConfigured: Boolean = true,
 )
@@ -1166,7 +1166,7 @@ class SpringApplicationContext(
     mockInstalled: Boolean,
     staticsMockingIsConfigured: Boolean,
     val beanQualifiedNames: List<String> = emptyList(),
-): ApplicationContext(mockInstalled, staticsMockingIsConfigured) {
+): StandardApplicationContext(mockInstalled, staticsMockingIsConfigured) {
     private val springInjectedClasses: List<ClassId> by lazy {
         beanQualifiedNames.map { fqn -> utContext.classLoader.loadClass(fqn).id }
     }

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -1150,6 +1150,9 @@ class WildcardTypeParameter : TypeParameters(emptyList())
 
 /**
  * A context to use when no specific data is required.
+ *
+ * @param mockFrameworkInstalled shows if we have installed framework dependencies
+ * @param staticsMockingIsConfigured shows if we have installed static mocking tools
  */
 open class StandardApplicationContext(
     val mockFrameworkInstalled: Boolean = true,

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -1149,14 +1149,12 @@ open class TypeParameters(val parameters: List<ClassId> = emptyList())
 class WildcardTypeParameter : TypeParameters(emptyList())
 
 /**
- * Additional data describing user project.
+ * A context to use when no specific data is required.
  */
-interface ApplicationContext
-
-/**
- * A context to use when no additional data is required.
- */
-object EmptyApplicationContext: ApplicationContext
+open class ApplicationContext(
+    val mockFrameworkInstalled: Boolean = true,
+    val staticsMockingIsConfigured: Boolean = true,
+)
 
 /**
  * Data we get from Spring application context
@@ -1164,9 +1162,11 @@ object EmptyApplicationContext: ApplicationContext
  *
  * @param beanQualifiedNames describes fqn of injected classes
  */
-data class SpringApplicationContext(
+class SpringApplicationContext(
+    mockInstalled: Boolean,
+    staticsMockingIsConfigured: Boolean,
     val beanQualifiedNames: List<String> = emptyList(),
-): ApplicationContext {
+): ApplicationContext(mockInstalled, staticsMockingIsConfigured) {
     private val springInjectedClasses: List<ClassId> by lazy {
         beanQualifiedNames.map { fqn -> utContext.classLoader.loadClass(fqn).id }
     }

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/mock/CommonMocksExampleTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/mock/CommonMocksExampleTest.kt
@@ -7,14 +7,27 @@ import org.utbot.testing.DoNotCalculate
 import org.utbot.testing.UtValueTestCaseChecker
 
 internal class CommonMocksExampleTest: UtValueTestCaseChecker(testClass = CommonMocksExample::class) {
+
     @Test
-    fun testMockInterfaceWithoutImplementors() {
+    fun testMockInterfaceWithoutImplementorsWithNoMocksStrategy() {
+        checkMocks(
+            CommonMocksExample::mockInterfaceWithoutImplementors,
+            eq(1),
+            { v, mocks, _ -> v == null && mocks.isEmpty() },
+            coverage = DoNotCalculate,
+            mockStrategy = MockStrategyApi.NO_MOCKS,
+        )
+    }
+
+    @Test
+    fun testMockInterfaceWithoutImplementorsWithMockingStrategy() {
         checkMocks(
             CommonMocksExample::mockInterfaceWithoutImplementors,
             eq(2),
             { v, mocks, _ -> v == null && mocks.isEmpty() },
             { _, mocks, _ -> mocks.singleOrNull() != null },
-            coverage = DoNotCalculate
+            coverage = DoNotCalculate,
+            mockStrategy = MockStrategyApi.OTHER_CLASSES,
         )
     }
 

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/mock/CommonMocksExampleTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/mock/CommonMocksExampleTest.kt
@@ -3,10 +3,12 @@ package org.utbot.examples.mock
 import org.utbot.framework.plugin.api.MockStrategyApi
 import org.junit.jupiter.api.Test
 import org.utbot.testcheckers.eq
-import org.utbot.testing.DoNotCalculate
 import org.utbot.testing.UtValueTestCaseChecker
+import org.utbot.testing.atLeast
 
 internal class CommonMocksExampleTest: UtValueTestCaseChecker(testClass = CommonMocksExample::class) {
+
+    //TODO: coverage values here require further investigation by experts
 
     @Test
     fun testMockInterfaceWithoutImplementorsWithNoMocksStrategy() {
@@ -14,8 +16,8 @@ internal class CommonMocksExampleTest: UtValueTestCaseChecker(testClass = Common
             CommonMocksExample::mockInterfaceWithoutImplementors,
             eq(1),
             { v, mocks, _ -> v == null && mocks.isEmpty() },
-            coverage = DoNotCalculate,
             mockStrategy = MockStrategyApi.NO_MOCKS,
+            coverage = atLeast(75),
         )
     }
 
@@ -26,8 +28,8 @@ internal class CommonMocksExampleTest: UtValueTestCaseChecker(testClass = Common
             eq(2),
             { v, mocks, _ -> v == null && mocks.isEmpty() },
             { _, mocks, _ -> mocks.singleOrNull() != null },
-            coverage = DoNotCalculate,
             mockStrategy = MockStrategyApi.OTHER_CLASSES,
+            coverage = atLeast(75),
         )
     }
 
@@ -40,7 +42,7 @@ internal class CommonMocksExampleTest: UtValueTestCaseChecker(testClass = Common
             { fst, _, mocks, _ -> fst == null && mocks.isEmpty() },
             { _, _, mocks, _ -> mocks.isEmpty() }, // should be changed to not null fst when 1449 will be finished
             mockStrategy = MockStrategyApi.OTHER_PACKAGES,
-            coverage = DoNotCalculate
+            coverage = atLeast(75)
         )
     }
 
@@ -55,7 +57,7 @@ internal class CommonMocksExampleTest: UtValueTestCaseChecker(testClass = Common
             // node == node.next
             // node.next.value == node.value + 1
             mockStrategy = MockStrategyApi.OTHER_CLASSES,
-            coverage = DoNotCalculate
+            coverage = atLeast(13)
         )
     }
 
@@ -66,7 +68,7 @@ internal class CommonMocksExampleTest: UtValueTestCaseChecker(testClass = Common
             eq(1),
             { r -> r == -420 },
             mockStrategy = MockStrategyApi.OTHER_CLASSES,
-            coverage = DoNotCalculate
+            coverage = atLeast(70),
         )
     }
 
@@ -76,7 +78,7 @@ internal class CommonMocksExampleTest: UtValueTestCaseChecker(testClass = Common
             CommonMocksExample::mocksForNullOfDifferentTypes,
             eq(1),
             mockStrategy = MockStrategyApi.OTHER_PACKAGES,
-            coverage = DoNotCalculate
+            coverage = atLeast(75)
         )
     }
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Mocks.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Mocks.kt
@@ -160,7 +160,9 @@ class Mocker(
     private val mocksDesired: Boolean = strategy != MockStrategy.NO_MOCKS
 
     fun construct(value: ObjectValue?): MockedObjectInfo =
-        value?.let { if (mocksDesired || mockAlways(it.type) ) ExpectedMock(it) else UnexpectedMock(it) } ?: NoMock
+        value
+            ?.let { if (mocksDesired || mockAlways(it.type)) ExpectedMock(it) else UnexpectedMock(it) }
+            ?: NoMock
 
     /**
      * Creates mocked instance of the [type] using mock info if it should be mocked by the mocker,

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Mocks.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Mocks.kt
@@ -151,7 +151,10 @@ class Mocker(
      * Creates mocked instance of the [type] using mock info. Unlike to [mock], it does not
      * check anything and always returns the constructed mock.
      */
-    fun forceMock(type: RefType, mockInfo: UtMockInfo): ObjectValue = createMockObject(type, mockInfo)
+    fun forceMock(type: RefType, mockInfo: UtMockInfo): ObjectValue {
+        mockListenerController?.onShouldMock(strategy, mockInfo)
+        return createMockObject(type, mockInfo)
+    }
 
     /**
      * Checks if Engine should mock objects of particular type with current mock strategy and mock type.

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Mocks.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Mocks.kt
@@ -203,8 +203,6 @@ class Mocker(
         }
     }
 
-    val areMocksAllowed: Boolean = strategy == MockStrategy.NO_MOCKS
-
     private fun checkIfShouldMock(
         type: RefType,
         mockInfo: UtMockInfo

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Mocks.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Mocks.kt
@@ -19,7 +19,7 @@ import kotlinx.collections.immutable.persistentListOf
 import org.utbot.common.nameOfPackage
 import org.utbot.engine.types.OBJECT_TYPE
 import org.utbot.engine.util.mockListeners.MockListenerController
-import org.utbot.framework.plugin.api.ApplicationContext
+import org.utbot.framework.plugin.api.StandardApplicationContext
 import org.utbot.framework.plugin.api.util.isInaccessibleViaReflection
 import soot.BooleanType
 import soot.RefType
@@ -157,10 +157,14 @@ class Mocker(
     private val hierarchy: Hierarchy,
     chosenClassesToMockAlways: Set<ClassId>,
     internal val mockListenerController: MockListenerController? = null,
-    private val applicationContext: ApplicationContext,
+    private val applicationContext: StandardApplicationContext,
 ) {
     private val mocksAreDesired: Boolean = strategy != MockStrategy.NO_MOCKS
 
+    /**
+     * Constructs [MockedObjectInfo]: enriches given value with
+     * an information if this mock is expected or not.
+     */
     fun construct(value: ObjectValue?, mockInfo: UtMockInfo): MockedObjectInfo {
         return value
             ?.let {
@@ -183,8 +187,8 @@ class Mocker(
     }
 
     /**
-     * Creates mocked instance of the [type] using mock info if it should be mocked by the mocker,
-     * otherwise returns null.
+     * Creates mocked instance (if it should be mocked by the mocker) of the [type] using [mockInfo]
+     * otherwise returns [NoMock].
      *
      * @see shouldMock
      */
@@ -194,8 +198,8 @@ class Mocker(
     }
 
     /**
-     * Creates mocked instance of the [type] using mock info. Unlike to [mock], it does not
-     * check anything and always returns the constructed mock.
+     * Creates mocked instance of the [type] using [mockInfo]
+     * it does not check anything and always returns the constructed mock.
      */
     fun forceMock(type: RefType, mockInfo: UtMockInfo): MockedObjectInfo {
         mockListenerController?.onShouldMock(strategy, mockInfo)

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -121,7 +121,6 @@ import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.ExecutableId
 import org.utbot.framework.plugin.api.FieldId
 import org.utbot.framework.plugin.api.MethodId
-import org.utbot.framework.plugin.api.SpringApplicationContext
 import org.utbot.framework.plugin.api.classId
 import org.utbot.framework.plugin.api.id
 import org.utbot.framework.plugin.api.util.executable

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -116,7 +116,7 @@ import org.utbot.framework.UtSettings
 import org.utbot.framework.UtSettings.maximizeCoverageUsingReflection
 import org.utbot.framework.UtSettings.preferredCexOption
 import org.utbot.framework.UtSettings.substituteStaticsWithSymbolicVariable
-import org.utbot.framework.plugin.api.ApplicationContext
+import org.utbot.framework.plugin.api.StandardApplicationContext
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.ExecutableId
 import org.utbot.framework.plugin.api.FieldId
@@ -240,7 +240,7 @@ class Traverser(
     internal val typeResolver: TypeResolver,
     private val globalGraph: InterProceduralUnitGraph,
     private val mocker: Mocker,
-    private val applicationContext: ApplicationContext?,
+    private val applicationContext: StandardApplicationContext?,
 ) : UtContextInitializer() {
 
     private val visitedStmts: MutableSet<Stmt> = mutableSetOf()

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -1385,7 +1385,7 @@ class Traverser(
 
             val mockedObject = mockedObjectInfo.value
             if (mockedObjectInfo is UnexpectedMock) {
-                error("Wrong mocker configuration, it has NO_MOCK stategy, but decided to mock $type object")
+                error("Wrong mocker configuration, it decided to mock $type object, although it is unexpected")
             }
 
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -277,8 +277,6 @@ class Traverser(
 
     internal val objectCounter = ObjectCounter(TypeRegistry.objectCounterInitialValue)
 
-
-
     private fun findNewAddr(insideStaticInitializer: Boolean): UtAddrExpression {
         val newAddr = objectCounter.createNewAddr()
         // return negative address for objects created inside static initializer
@@ -1387,7 +1385,7 @@ class Traverser(
 
             val mockedObject = mockedObjectInfo.value
             if (mockedObjectInfo is UnexpectedMock) {
-                queuedSymbolicStateUpdates += UtFalse.asHardConstraint()
+                error("Wrong mocker configuration, it has NO_MOCK stategy, but decided to mock $type object")
             }
 
 
@@ -1480,7 +1478,8 @@ class Traverser(
 
             val mockedObject = mockedObjectInfo.value ?: error("Mocked value cannot be null after force mock")
             if (mockedObjectInfo is UnexpectedMock) {
-                queuedSymbolicStateUpdates += UtFalse.asHardConstraint()
+                queuedSymbolicStateUpdates += nullEqualityConstraint.asHardConstraint()
+                return mockedObject
             }
 
             queuedSymbolicStateUpdates += MemoryUpdate(mockInfos = persistentListOf(MockInfoEnriched(mockInfo)))
@@ -2721,7 +2720,7 @@ class Traverser(
                         // TODO isMock????
                         InvocationTarget(mockedObject, method, constraints)
                     }
-                    is UnexpectedMock -> null
+                    is UnexpectedMock -> unreachableBranch("If it ever happens, it should be investigated")
                 }
             }
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -1385,9 +1385,8 @@ class Traverser(
 
             val mockedObject = mockedObjectInfo.value
             if (mockedObjectInfo is UnexpectedMock) {
-                error("Wrong mocker configuration, it decided to mock $type object, although it is unexpected")
+                queuedSymbolicStateUpdates += nullEqualityConstraint.asHardConstraint()
             }
-
 
             if (mockedObject != null) {
                 queuedSymbolicStateUpdates += MemoryUpdate(mockInfos = persistentListOf(MockInfoEnriched(mockInfo)))

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
@@ -105,7 +105,7 @@ class UtBotSymbolicEngine(
     dependencyPaths: String,
     val mockStrategy: MockStrategy = NO_MOCKS,
     chosenClassesToMockAlways: Set<ClassId>,
-    applicationContext: ApplicationContext?,
+    applicationContext: ApplicationContext,
     private val solverTimeoutInMillis: Int = checkSolverTimeoutMillis
 ) : UtContextInitializer() {
     private val graph = methodUnderTest.sootMethod.jimpleBody().apply {
@@ -129,7 +129,8 @@ class UtBotSymbolicEngine(
         classUnderTest,
         hierarchy,
         chosenClassesToMockAlways,
-        MockListenerController(controller)
+        MockListenerController(controller),
+        applicationContext = applicationContext,
     )
 
     fun attachMockListener(mockListener: MockListener) = mocker.mockListenerController?.attach(mockListener)

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
@@ -105,7 +105,7 @@ class UtBotSymbolicEngine(
     dependencyPaths: String,
     val mockStrategy: MockStrategy = NO_MOCKS,
     chosenClassesToMockAlways: Set<ClassId>,
-    applicationContext: ApplicationContext,
+    applicationContext: StandardApplicationContext,
     private val solverTimeoutInMillis: Int = checkSolverTimeoutMillis
 ) : UtContextInitializer() {
     private val graph = methodUnderTest.sootMethod.jimpleBody().apply {

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/util/mockListeners/ForceMockListener.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/util/mockListeners/ForceMockListener.kt
@@ -8,25 +8,17 @@ import org.utbot.framework.util.ConflictTriggers
 
 /**
  * Listener for mocker events in [org.utbot.engine.UtBotSymbolicEngine].
- * If forced mock happened, cancels the engine job.
  *
  * Supposed to be created only if Mockito is not installed.
  */
-class ForceMockListener private constructor(triggers: ConflictTriggers, private val shouldCancelJob: Boolean): MockListener(triggers) {
+class ForceMockListener private constructor(triggers: ConflictTriggers): MockListener(triggers) {
     override fun onShouldMock(controller: EngineController, strategy: MockStrategy, mockInfo: UtMockInfo) {
-        // If force mocking happened -- сancel engine job
-        if (shouldCancelJob) controller.job?.cancel(ForceMockCancellationException())
-
         triggers[Conflict.ForceMockHappened] = true
     }
 
     companion object {
-        fun create(
-            testCaseGenerator: TestCaseGenerator,
-            conflictTriggers: ConflictTriggers,
-            shouldCancelJob: Boolean = false,
-        ) : ForceMockListener {
-            val listener = ForceMockListener(conflictTriggers, shouldCancelJob)
+        fun create(testCaseGenerator: TestCaseGenerator, conflictTriggers: ConflictTriggers) : ForceMockListener {
+            val listener = ForceMockListener(conflictTriggers)
             testCaseGenerator.engineActions.add { engine -> engine.attachMockListener(listener) }
 
             return listener

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/util/mockListeners/ForceMockListener.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/util/mockListeners/ForceMockListener.kt
@@ -12,17 +12,21 @@ import org.utbot.framework.util.ConflictTriggers
  *
  * Supposed to be created only if Mockito is not installed.
  */
-class ForceMockListener private constructor(triggers: ConflictTriggers, private val cancelJob: Boolean): MockListener(triggers) {
+class ForceMockListener private constructor(triggers: ConflictTriggers, private val shouldCancelJob: Boolean): MockListener(triggers) {
     override fun onShouldMock(controller: EngineController, strategy: MockStrategy, mockInfo: UtMockInfo) {
         // If force mocking happened -- сancel engine job
-        if (cancelJob) controller.job?.cancel(ForceMockCancellationException())
+        if (shouldCancelJob) controller.job?.cancel(ForceMockCancellationException())
 
         triggers[Conflict.ForceMockHappened] = true
     }
 
     companion object {
-        fun create(testCaseGenerator: TestCaseGenerator, conflictTriggers: ConflictTriggers, cancelJob: Boolean = true) : ForceMockListener {
-            val listener = ForceMockListener(conflictTriggers, cancelJob)
+        fun create(
+            testCaseGenerator: TestCaseGenerator,
+            conflictTriggers: ConflictTriggers,
+            shouldCancelJob: Boolean = false,
+        ) : ForceMockListener {
+            val listener = ForceMockListener(conflictTriggers, shouldCancelJob)
             testCaseGenerator.engineActions.add { engine -> engine.attachMockListener(listener) }
 
             return listener

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/util/mockListeners/ForceStaticMockListener.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/util/mockListeners/ForceStaticMockListener.kt
@@ -16,21 +16,25 @@ import org.utbot.framework.util.ConflictTriggers
  *
  * Supposed to be created only if Mockito inline is not installed.
  */
-class ForceStaticMockListener private constructor(triggers: ConflictTriggers, private val cancelJob: Boolean): MockListener(triggers) {
+class ForceStaticMockListener private constructor(triggers: ConflictTriggers, private val shouldCancelJob: Boolean): MockListener(triggers) {
     override fun onShouldMock(controller: EngineController, strategy: MockStrategy, mockInfo: UtMockInfo) {
         if (mockInfo is UtNewInstanceMockInfo
             || mockInfo is UtStaticMethodMockInfo
             || mockInfo is UtStaticObjectMockInfo) {
             // If force static mocking happened -- сancel engine job
-            if (cancelJob) controller.job?.cancel(ForceStaticMockCancellationException())
+            if (shouldCancelJob) controller.job?.cancel(ForceStaticMockCancellationException())
 
             triggers[Conflict.ForceStaticMockHappened] = true
         }
     }
 
     companion object {
-        fun create(testCaseGenerator: TestCaseGenerator, conflictTriggers: ConflictTriggers, cancelJob: Boolean = true) : ForceStaticMockListener {
-            val listener = ForceStaticMockListener(conflictTriggers, cancelJob)
+        fun create(
+            testCaseGenerator: TestCaseGenerator,
+            conflictTriggers: ConflictTriggers,
+            shouldCancelJob: Boolean = false,
+        ) : ForceStaticMockListener {
+            val listener = ForceStaticMockListener(conflictTriggers, shouldCancelJob)
             testCaseGenerator.engineActions.add { engine -> engine.attachMockListener(listener) }
 
             return listener

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/util/mockListeners/ForceStaticMockListener.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/util/mockListeners/ForceStaticMockListener.kt
@@ -12,29 +12,17 @@ import org.utbot.framework.util.ConflictTriggers
 
 /**
  * Listener for mocker events in [org.utbot.engine.UtBotSymbolicEngine].
- * If forced static mock happened, cancels the engine job.
  *
  * Supposed to be created only if Mockito inline is not installed.
  */
-class ForceStaticMockListener private constructor(triggers: ConflictTriggers, private val shouldCancelJob: Boolean): MockListener(triggers) {
+class ForceStaticMockListener private constructor(triggers: ConflictTriggers): MockListener(triggers) {
     override fun onShouldMock(controller: EngineController, strategy: MockStrategy, mockInfo: UtMockInfo) {
-        if (mockInfo is UtNewInstanceMockInfo
-            || mockInfo is UtStaticMethodMockInfo
-            || mockInfo is UtStaticObjectMockInfo) {
-            // If force static mocking happened -- сancel engine job
-            if (shouldCancelJob) controller.job?.cancel(ForceStaticMockCancellationException())
-
             triggers[Conflict.ForceStaticMockHappened] = true
         }
-    }
 
     companion object {
-        fun create(
-            testCaseGenerator: TestCaseGenerator,
-            conflictTriggers: ConflictTriggers,
-            shouldCancelJob: Boolean = false,
-        ) : ForceStaticMockListener {
-            val listener = ForceStaticMockListener(conflictTriggers, shouldCancelJob)
+        fun create(testCaseGenerator: TestCaseGenerator, conflictTriggers: ConflictTriggers) : ForceStaticMockListener {
+            val listener = ForceStaticMockListener(conflictTriggers)
             testCaseGenerator.engineActions.add { engine -> engine.attachMockListener(listener) }
 
             return listener

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestCaseGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestCaseGenerator.kt
@@ -149,8 +149,8 @@ open class TestCaseGenerator(
         val method2errors = methods.associateWith { mutableMapOf<String, Int>() }
 
         val conflictTriggers = ConflictTriggers()
-        val forceMockListener = ForceMockListener.create(this, conflictTriggers, cancelJob = false)
-        val forceStaticMockListener = ForceStaticMockListener.create(this, conflictTriggers, cancelJob = false)
+        val forceMockListener = ForceMockListener.create(this, conflictTriggers)
+        val forceStaticMockListener = ForceStaticMockListener.create(this, conflictTriggers)
 
         runIgnoringCancellationException {
             runBlockingWithCancellationPredicate(isCanceled) {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestCaseGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestCaseGenerator.kt
@@ -61,7 +61,7 @@ open class TestCaseGenerator(
     val engineActions: MutableList<(UtBotSymbolicEngine) -> Unit> = mutableListOf(),
     val isCanceled: () -> Boolean = { false },
     val forceSootReload: Boolean = true,
-    val applicationContext: ApplicationContext = ApplicationContext(),
+    val applicationContext: StandardApplicationContext = StandardApplicationContext(),
 ) {
     private val logger: KLogger = KotlinLogging.logger {}
     private val timeoutLogger: KLogger = KotlinLogging.logger(logger.name + ".timeout")
@@ -257,7 +257,7 @@ open class TestCaseGenerator(
         method: ExecutableId,
         mockStrategyApi: MockStrategyApi,
         chosenClassesToMockAlways: Set<ClassId>,
-        applicationContext: ApplicationContext,
+        applicationContext: StandardApplicationContext,
         executionTimeEstimator: ExecutionTimeEstimator
     ): UtBotSymbolicEngine {
         logger.debug("Starting symbolic execution for $method  --$mockStrategyApi--")

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestCaseGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestCaseGenerator.kt
@@ -61,7 +61,7 @@ open class TestCaseGenerator(
     val engineActions: MutableList<(UtBotSymbolicEngine) -> Unit> = mutableListOf(),
     val isCanceled: () -> Boolean = { false },
     val forceSootReload: Boolean = true,
-    val applicationContext: ApplicationContext? = null,
+    val applicationContext: ApplicationContext = ApplicationContext(),
 ) {
     private val logger: KLogger = KotlinLogging.logger {}
     private val timeoutLogger: KLogger = KotlinLogging.logger(logger.name + ".timeout")
@@ -118,7 +118,7 @@ open class TestCaseGenerator(
                 method,
                 mockStrategy,
                 chosenClassesToMockAlways,
-                applicationContext = null,
+                applicationContext,
                 executionTimeEstimator,
             )
             engineActions.map { engine.apply(it) }
@@ -257,7 +257,7 @@ open class TestCaseGenerator(
         method: ExecutableId,
         mockStrategyApi: MockStrategyApi,
         chosenClassesToMockAlways: Set<ClassId>,
-        applicationContext: ApplicationContext?,
+        applicationContext: ApplicationContext,
         executionTimeEstimator: ExecutionTimeEstimator
     ): UtBotSymbolicEngine {
         logger.debug("Starting symbolic execution for $method  --$mockStrategyApi--")

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineProcessMain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineProcessMain.kt
@@ -80,7 +80,7 @@ private fun EngineProcessModel.setup(kryoHelper: KryoHelper, watchdog: IdleWatch
     watchdog.measureTimeForActiveCall(createTestGenerator, "Creating Test Generator") { params ->
         AnalyticsConfigureUtil.configureML()
         Instrumenter.adapter = RdInstrumenter(realProtocol.rdInstrumenterAdapter)
-        val applicationContext: ApplicationContext = kryoHelper.readObject(params.applicationContext)
+        val applicationContext: StandardApplicationContext = kryoHelper.readObject(params.applicationContext)
 
         testGenerator = TestCaseGenerator(buildDirs = params.buildDir.map { Paths.get(it) },
             classpath = params.classpath,
@@ -98,7 +98,7 @@ private fun EngineProcessModel.setup(kryoHelper: KryoHelper, watchdog: IdleWatch
         logger.debug().measureTime({ "starting generation for ${methods.size} methods, starting with ${methods.first()}" }) {
             val generateFlow = when (testGenerator.applicationContext) {
                 is SpringApplicationContext -> defaultSpringFlow(params.generationTimeout)
-                is ApplicationContext -> testFlow {
+                is StandardApplicationContext -> testFlow {
                     generationTimeout = params.generationTimeout
                     isSymbolicEngineEnabled = params.isSymbolicEngineEnabled
                     isFuzzingEnabled = params.isFuzzingEnabled

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineProcessMain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineProcessMain.kt
@@ -7,8 +7,6 @@ import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
 import org.utbot.analytics.AnalyticsConfigureUtil
 import org.utbot.common.*
-import org.utbot.engine.util.mockListeners.ForceMockListener
-import org.utbot.engine.util.mockListeners.ForceStaticMockListener
 import org.utbot.framework.codegen.*
 import org.utbot.framework.codegen.domain.HangingTestsTimeout
 import org.utbot.framework.codegen.domain.MockitoStaticMocking
@@ -26,7 +24,6 @@ import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.framework.plugin.api.util.method
 import org.utbot.framework.plugin.services.JdkInfo
 import org.utbot.framework.process.generated.*
-import org.utbot.framework.util.ConflictTriggers
 import org.utbot.instrumentation.instrumentation.instrumenter.Instrumenter
 import org.utbot.instrumentation.util.KryoHelper
 import org.utbot.rd.IdleWatchdog
@@ -99,19 +96,9 @@ private fun EngineProcessModel.setup(kryoHelper: KryoHelper, watchdog: IdleWatch
     watchdog.measureTimeForActiveCall(generate, "Generating tests") { params ->
         val methods: List<ExecutableId> = kryoHelper.readObject(params.methods)
         logger.debug().measureTime({ "starting generation for ${methods.size} methods, starting with ${methods.first()}" }) {
-            val mockFrameworkInstalled = params.mockInstalled
-            val conflictTriggers = ConflictTriggers(kryoHelper.readObject(params.conflictTriggers))
-            if (!mockFrameworkInstalled) {
-                ForceMockListener.create(testGenerator, conflictTriggers, shouldCancelJob = true)
-            }
-            val staticsMockingConfigured = params.staticsMockingIsConfigureda
-            if (!staticsMockingConfigured) {
-                ForceStaticMockListener.create(testGenerator, conflictTriggers, shouldCancelJob = true)
-            }
-
             val generateFlow = when (testGenerator.applicationContext) {
                 is SpringApplicationContext -> defaultSpringFlow(params.generationTimeout)
-                is EmptyApplicationContext -> testFlow {
+                is ApplicationContext -> testFlow {
                     generationTimeout = params.generationTimeout
                     isSymbolicEngineEnabled = params.isSymbolicEngineEnabled
                     isFuzzingEnabled = params.isFuzzingEnabled

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineProcessMain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineProcessMain.kt
@@ -102,11 +102,11 @@ private fun EngineProcessModel.setup(kryoHelper: KryoHelper, watchdog: IdleWatch
             val mockFrameworkInstalled = params.mockInstalled
             val conflictTriggers = ConflictTriggers(kryoHelper.readObject(params.conflictTriggers))
             if (!mockFrameworkInstalled) {
-                ForceMockListener.create(testGenerator, conflictTriggers, cancelJob = true)
+                ForceMockListener.create(testGenerator, conflictTriggers, shouldCancelJob = true)
             }
             val staticsMockingConfigured = params.staticsMockingIsConfigureda
             if (!staticsMockingConfigured) {
-                ForceStaticMockListener.create(testGenerator, conflictTriggers, cancelJob = true)
+                ForceStaticMockListener.create(testGenerator, conflictTriggers, shouldCancelJob = true)
             }
 
             val generateFlow = when (testGenerator.applicationContext) {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/process/generated/EngineProcessModel.Generated.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/process/generated/EngineProcessModel.Generated.kt
@@ -72,7 +72,7 @@ class EngineProcessModel private constructor(
         }
         
         
-        const val serializationHash = -4839464828913070560L
+        const val serializationHash = -120710112541549600L
         
     }
     override val serializersOwner: ISerializersOwner get() = EngineProcessModel
@@ -173,7 +173,7 @@ val IProtocol.engineProcessModel get() = getOrCreateExtension(EngineProcessModel
 
 
 /**
- * #### Generated from [EngineProcessModel.kt:102]
+ * #### Generated from [EngineProcessModel.kt:98]
  */
 data class FindMethodParamNamesArguments (
     val classId: ByteArray,
@@ -236,7 +236,7 @@ data class FindMethodParamNamesArguments (
 
 
 /**
- * #### Generated from [EngineProcessModel.kt:106]
+ * #### Generated from [EngineProcessModel.kt:102]
  */
 data class FindMethodParamNamesResult (
     val paramNames: ByteArray
@@ -293,7 +293,7 @@ data class FindMethodParamNamesResult (
 
 
 /**
- * #### Generated from [EngineProcessModel.kt:95]
+ * #### Generated from [EngineProcessModel.kt:91]
  */
 data class FindMethodsInClassMatchingSelectedArguments (
     val classId: ByteArray,
@@ -356,7 +356,7 @@ data class FindMethodsInClassMatchingSelectedArguments (
 
 
 /**
- * #### Generated from [EngineProcessModel.kt:99]
+ * #### Generated from [EngineProcessModel.kt:95]
  */
 data class FindMethodsInClassMatchingSelectedResult (
     val executableIds: ByteArray
@@ -416,9 +416,6 @@ data class FindMethodsInClassMatchingSelectedResult (
  * #### Generated from [EngineProcessModel.kt:44]
  */
 data class GenerateParams (
-    val mockInstalled: Boolean,
-    val staticsMockingIsConfigureda: Boolean,
-    val conflictTriggers: ByteArray,
     val methods: ByteArray,
     val mockStrategy: String,
     val chosenClassesToMockAlways: ByteArray,
@@ -436,9 +433,6 @@ data class GenerateParams (
         
         @Suppress("UNCHECKED_CAST")
         override fun read(ctx: SerializationCtx, buffer: AbstractBuffer): GenerateParams  {
-            val mockInstalled = buffer.readBool()
-            val staticsMockingIsConfigureda = buffer.readBool()
-            val conflictTriggers = buffer.readByteArray()
             val methods = buffer.readByteArray()
             val mockStrategy = buffer.readString()
             val chosenClassesToMockAlways = buffer.readByteArray()
@@ -448,13 +442,10 @@ data class GenerateParams (
             val isFuzzingEnabled = buffer.readBool()
             val fuzzingValue = buffer.readDouble()
             val searchDirectory = buffer.readString()
-            return GenerateParams(mockInstalled, staticsMockingIsConfigureda, conflictTriggers, methods, mockStrategy, chosenClassesToMockAlways, timeout, generationTimeout, isSymbolicEngineEnabled, isFuzzingEnabled, fuzzingValue, searchDirectory)
+            return GenerateParams(methods, mockStrategy, chosenClassesToMockAlways, timeout, generationTimeout, isSymbolicEngineEnabled, isFuzzingEnabled, fuzzingValue, searchDirectory)
         }
         
         override fun write(ctx: SerializationCtx, buffer: AbstractBuffer, value: GenerateParams)  {
-            buffer.writeBool(value.mockInstalled)
-            buffer.writeBool(value.staticsMockingIsConfigureda)
-            buffer.writeByteArray(value.conflictTriggers)
             buffer.writeByteArray(value.methods)
             buffer.writeString(value.mockStrategy)
             buffer.writeByteArray(value.chosenClassesToMockAlways)
@@ -479,9 +470,6 @@ data class GenerateParams (
         
         other as GenerateParams
         
-        if (mockInstalled != other.mockInstalled) return false
-        if (staticsMockingIsConfigureda != other.staticsMockingIsConfigureda) return false
-        if (!(conflictTriggers contentEquals other.conflictTriggers)) return false
         if (!(methods contentEquals other.methods)) return false
         if (mockStrategy != other.mockStrategy) return false
         if (!(chosenClassesToMockAlways contentEquals other.chosenClassesToMockAlways)) return false
@@ -497,9 +485,6 @@ data class GenerateParams (
     //hash code trait
     override fun hashCode(): Int  {
         var __r = 0
-        __r = __r*31 + mockInstalled.hashCode()
-        __r = __r*31 + staticsMockingIsConfigureda.hashCode()
-        __r = __r*31 + conflictTriggers.contentHashCode()
         __r = __r*31 + methods.contentHashCode()
         __r = __r*31 + mockStrategy.hashCode()
         __r = __r*31 + chosenClassesToMockAlways.contentHashCode()
@@ -515,9 +500,6 @@ data class GenerateParams (
     override fun print(printer: PrettyPrinter)  {
         printer.println("GenerateParams (")
         printer.indent {
-            print("mockInstalled = "); mockInstalled.print(printer); println()
-            print("staticsMockingIsConfigureda = "); staticsMockingIsConfigureda.print(printer); println()
-            print("conflictTriggers = "); conflictTriggers.print(printer); println()
             print("methods = "); methods.print(printer); println()
             print("mockStrategy = "); mockStrategy.print(printer); println()
             print("chosenClassesToMockAlways = "); chosenClassesToMockAlways.print(printer); println()
@@ -536,7 +518,7 @@ data class GenerateParams (
 
 
 /**
- * #### Generated from [EngineProcessModel.kt:62]
+ * #### Generated from [EngineProcessModel.kt:58]
  */
 data class GenerateResult (
     val notEmptyCases: Int,
@@ -599,7 +581,7 @@ data class GenerateResult (
 
 
 /**
- * #### Generated from [EngineProcessModel.kt:114]
+ * #### Generated from [EngineProcessModel.kt:110]
  */
 data class GenerateTestReportArgs (
     val eventLogMessage: String?,
@@ -692,7 +674,7 @@ data class GenerateTestReportArgs (
 
 
 /**
- * #### Generated from [EngineProcessModel.kt:123]
+ * #### Generated from [EngineProcessModel.kt:119]
  */
 data class GenerateTestReportResult (
     val notifyMessage: String,
@@ -824,7 +806,7 @@ data class JdkInfo (
 
 
 /**
- * #### Generated from [EngineProcessModel.kt:90]
+ * #### Generated from [EngineProcessModel.kt:86]
  */
 data class MethodDescription (
     val name: String,
@@ -893,7 +875,7 @@ data class MethodDescription (
 
 
 /**
- * #### Generated from [EngineProcessModel.kt:66]
+ * #### Generated from [EngineProcessModel.kt:62]
  */
 data class RenderParams (
     val testSetsId: Long,
@@ -1034,7 +1016,7 @@ data class RenderParams (
 
 
 /**
- * #### Generated from [EngineProcessModel.kt:83]
+ * #### Generated from [EngineProcessModel.kt:79]
  */
 data class RenderResult (
     val generatedCode: String,
@@ -1097,7 +1079,7 @@ data class RenderResult (
 
 
 /**
- * #### Generated from [EngineProcessModel.kt:87]
+ * #### Generated from [EngineProcessModel.kt:83]
  */
 data class SetupContextParams (
     val classpathForUrlsClassloader: List<String>
@@ -1235,7 +1217,7 @@ data class TestGeneratorParams (
 
 
 /**
- * #### Generated from [EngineProcessModel.kt:109]
+ * #### Generated from [EngineProcessModel.kt:105]
  */
 data class WriteSarifReportArguments (
     val testSetsId: Long,

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -26,7 +26,7 @@ import org.utbot.framework.CancellationStrategyType.NONE
 import org.utbot.framework.CancellationStrategyType.SAVE_PROCESSED_RESULTS
 import org.utbot.framework.UtSettings
 import org.utbot.framework.plugin.api.ClassId
-import org.utbot.framework.plugin.api.EmptyApplicationContext
+import org.utbot.framework.plugin.api.ApplicationContext
 import org.utbot.framework.plugin.api.JavaDocCommentStyle
 import org.utbot.framework.plugin.api.util.LockFile
 import org.utbot.framework.plugin.api.util.withStaticsSubstitutionRequired
@@ -170,7 +170,10 @@ object UtTestsDialogProcessor {
                             }.toMap()
                         }
 
-                        val applicationContext = EmptyApplicationContext
+                        val applicationContext = ApplicationContext(
+                            model.mockFramework.isInstalled,
+                            model.staticsMocking.isConfigured,
+                        )
                         // TODO: obtain bean definitions and other info from `utbot-spring-analyzer`
                         //SpringApplicationContext(beanQualifiedNames = emptyList())
 
@@ -249,8 +252,6 @@ object UtTestsDialogProcessor {
                                     .executeSynchronously()
 
                                 withStaticsSubstitutionRequired(true) {
-                                    val mockFrameworkInstalled = model.mockFramework.isInstalled
-
                                     val startTime = System.currentTimeMillis()
                                     val timerHandler =
                                         AppExecutorUtil.getAppScheduledExecutorService().scheduleWithFixedDelay({
@@ -266,8 +267,6 @@ object UtTestsDialogProcessor {
                                         }, 0, 500, TimeUnit.MILLISECONDS)
                                     try {
                                         val rdGenerateResult = process.generate(
-                                            mockFrameworkInstalled,
-                                            model.staticsMocking.isConfigured,
                                             model.conflictTriggers,
                                             methods,
                                             model.mockStrategy,

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -26,7 +26,7 @@ import org.utbot.framework.CancellationStrategyType.NONE
 import org.utbot.framework.CancellationStrategyType.SAVE_PROCESSED_RESULTS
 import org.utbot.framework.UtSettings
 import org.utbot.framework.plugin.api.ClassId
-import org.utbot.framework.plugin.api.ApplicationContext
+import org.utbot.framework.plugin.api.StandardApplicationContext
 import org.utbot.framework.plugin.api.JavaDocCommentStyle
 import org.utbot.framework.plugin.api.util.LockFile
 import org.utbot.framework.plugin.api.util.withStaticsSubstitutionRequired
@@ -170,7 +170,7 @@ object UtTestsDialogProcessor {
                             }.toMap()
                         }
 
-                        val applicationContext = ApplicationContext(
+                        val applicationContext = StandardApplicationContext(
                             model.mockFramework.isInstalled,
                             model.staticsMocking.isConfigured,
                         )

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -249,7 +249,7 @@ object UtTestsDialogProcessor {
                                     .executeSynchronously()
 
                                 withStaticsSubstitutionRequired(true) {
-                                    val mockFrameworkInstalled = model.mockFramework?.isInstalled ?: true
+                                    val mockFrameworkInstalled = model.mockFramework.isInstalled
 
                                     val startTime = System.currentTimeMillis()
                                     val timerHandler =

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/process/EngineProcess.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/process/EngineProcess.kt
@@ -252,8 +252,6 @@ class EngineProcess private constructor(val project: Project, private val classN
     }
 
     fun generate(
-        mockInstalled: Boolean,
-        staticsMockingIsConfigured: Boolean,
         conflictTriggers: ConflictTriggers,
         methods: List<ExecutableId>,
         mockStrategyApi: MockStrategyApi,
@@ -267,9 +265,6 @@ class EngineProcess private constructor(val project: Project, private val classN
     ): RdTestGenerationResult {
         assertReadAccessNotAllowed()
         val params = GenerateParams(
-            mockInstalled,
-            staticsMockingIsConfigured,
-            kryoHelper.writeObject(conflictTriggers.toMutableMap()),
             kryoHelper.writeObject(methods),
             mockStrategyApi.name,
             kryoHelper.writeObject(chosenClassesToMockAlways),

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/process/EngineProcess.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/process/EngineProcess.kt
@@ -10,10 +10,6 @@ import com.intellij.psi.impl.file.impl.JavaFileManager
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.refactoring.util.classMembers.MemberInfo
 import com.jetbrains.rd.util.ConcurrentHashMap
-import com.jetbrains.rd.util.ILoggerFactory
-import com.jetbrains.rd.util.Logger
-import com.jetbrains.rd.util.Statics
-import com.jetbrains.rd.util.lifetime.Lifetime
 import com.jetbrains.rd.util.lifetime.LifetimeDefinition
 import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
@@ -42,7 +38,6 @@ import org.utbot.rd.generated.SettingForResult
 import org.utbot.rd.generated.SettingsModel
 import org.utbot.rd.generated.settingsModel
 import org.utbot.rd.generated.synchronizationModel
-import org.utbot.rd.loggers.UtRdKLoggerFactory
 import org.utbot.rd.loggers.overrideDefaultRdLoggerFactoryWithKLogger
 import org.utbot.sarif.SourceFindingStrategy
 import java.io.File
@@ -188,7 +183,7 @@ class EngineProcess private constructor(val project: Project, private val classN
         classPath: String?,
         dependencyPaths: String,
         jdkInfo: JdkInfo,
-        applicationContext: ApplicationContext,
+        applicationContext: StandardApplicationContext,
         isCancelled: (Unit) -> Boolean
     ) {
         assertReadAccessNotAllowed()

--- a/utbot-rd/src/main/rdgen/org/utbot/rd/models/EngineProcessModel.kt
+++ b/utbot-rd/src/main/rdgen/org/utbot/rd/models/EngineProcessModel.kt
@@ -42,10 +42,6 @@ object EngineProcessModel : Ext(EngineProcessRoot) {
         field("applicationContext", array(PredefinedType.byte))
     }
     val generateParams = structdef {
-        // mocks
-        field("mockInstalled", PredefinedType.bool)
-        field("staticsMockingIsConfigureda", PredefinedType.bool)
-        field("conflictTriggers", array(PredefinedType.byte))
         // generate
         field("methods", array(PredefinedType.byte))
         field("mockStrategy", PredefinedType.string)

--- a/utbot-testing/src/main/kotlin/org/utbot/testing/TestSpecificTestCaseGenerator.kt
+++ b/utbot-testing/src/main/kotlin/org/utbot/testing/TestSpecificTestCaseGenerator.kt
@@ -57,8 +57,8 @@ class TestSpecificTestCaseGenerator(
         val mockAlwaysDefaults = Mocker.javaDefaultClasses.mapTo(mutableSetOf()) { it.id }
         val defaultTimeEstimator = ExecutionTimeEstimator(UtSettings.utBotGenerationTimeoutInMillis, 1)
 
-        val forceMockListener = ForceMockListener.create(this, conflictTriggers, cancelJob = false)
-        val forceStaticMockListener = ForceStaticMockListener.create(this, conflictTriggers, cancelJob = false)
+        val forceMockListener = ForceMockListener.create(this, conflictTriggers)
+        val forceStaticMockListener = ForceStaticMockListener.create(this, conflictTriggers)
 
         runBlocking {
             val controller = EngineController()


### PR DESCRIPTION
## Description

Fixes # ([1560](https://github.com/UnitTestBot/UTBotJava/issues/1560))

We need to stop symbolic execution if we called `forceMock` function and `Do not mock` strategy is used.
One of possible scenarios is when there are no implementations of an interface in project while `NO_MOCKS` strategy is selected.

To obtain this, some branch pruning is introduced.
Job cancellations are removed from mock listeners.

## How to test

### Automated tests

Corrected test:  `testMockInterfaceWithoutImplementorsWithNoMocksStrategy`
Added test: `testMockInterfaceWithoutImplementorsWithMockingStrategy`

### Manual tests

Scenario from issue.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.