### PR TITLE
Go. Use coverage to stop fuzzing and speed up fuzzing

### DIFF
--- a/utbot-go/src/main/kotlin/org/utbot/go/GoEngine.kt
+++ b/utbot-go/src/main/kotlin/org/utbot/go/GoEngine.kt
@@ -3,172 +3,75 @@ package org.utbot.go
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import mu.KotlinLogging
-import org.utbot.framework.plugin.api.TimeoutException
 import org.utbot.fuzzing.BaseFeedback
 import org.utbot.fuzzing.Control
 import org.utbot.fuzzing.utils.Trie
-import org.utbot.go.api.*
-import org.utbot.go.imports.GoImportsResolver
-import org.utbot.go.logic.EachExecutionTimeoutsMillisConfig
-import org.utbot.go.util.executeCommandByNewProcessOrFailWithoutWaiting
+import org.utbot.go.api.GoUtExecutionResult
+import org.utbot.go.api.GoUtFunction
+import org.utbot.go.api.GoUtFuzzedFunction
+import org.utbot.go.api.GoUtPanicFailure
+import org.utbot.go.framework.api.go.GoPackage
 import org.utbot.go.worker.GoWorker
-import org.utbot.go.worker.GoWorkerCodeGenerationHelper
 import org.utbot.go.worker.convertRawExecutionResultToExecutionResult
-import java.io.File
-import java.io.InputStreamReader
-import java.net.ServerSocket
-import java.net.SocketTimeoutException
-import java.util.concurrent.TimeUnit
 
 val logger = KotlinLogging.logger {}
 
 class GoEngine(
+    private val worker: GoWorker,
     private val functionUnderTest: GoUtFunction,
-    private val sourceFile: GoUtFile,
+    private val aliases: Map<GoPackage, String?>,
     private val intSize: Int,
-    private val goExecutableAbsolutePath: String,
-    private val eachExecutionTimeoutsMillisConfig: EachExecutionTimeoutsMillisConfig,
+    private val eachExecutionTimeoutMillis: Long,
     private val timeoutExceededOrIsCanceled: () -> Boolean,
-    private val timeoutMillis: Long = 10000
 ) {
 
     fun fuzzing(): Flow<Pair<GoUtFuzzedFunction, GoUtExecutionResult>> = flow {
         var attempts = 0
         val attemptsLimit = Int.MAX_VALUE
-        ServerSocket(0).use { serverSocket ->
-            var fileToExecute: File? = null
-            var fileWithModifiedFunction: File? = null
-            try {
-                // creating files for worker
-                val types = functionUnderTest.parameters.map { it.type }
-                val imports = GoImportsResolver.resolveImportsBasedOnTypes(
-                    types,
-                    functionUnderTest.sourcePackage,
-                    GoWorkerCodeGenerationHelper.alwaysRequiredImports
-                )
-                fileToExecute = GoWorkerCodeGenerationHelper.createFileToExecute(
-                    sourceFile,
-                    functionUnderTest,
-                    eachExecutionTimeoutsMillisConfig,
-                    serverSocket.localPort,
-                    imports
-                )
-                fileWithModifiedFunction = GoWorkerCodeGenerationHelper.createFileWithModifiedFunction(
-                    sourceFile, functionUnderTest
-                )
-
-                // starting worker process
-                val testFunctionName = GoWorkerCodeGenerationHelper.workerTestFunctionName
-                val command = listOf(
-                    goExecutableAbsolutePath, "test", "-run", testFunctionName
-                )
-                val sourceFileDir = File(sourceFile.absoluteDirectoryPath)
-                val processStartTime = System.currentTimeMillis()
-                val process = executeCommandByNewProcessOrFailWithoutWaiting(command, sourceFileDir)
-
-                try {
-                    // connecting to worker
-                    logger.debug { "Trying to connect to worker" }
-                    val workerSocket = try {
-                        serverSocket.soTimeout = timeoutMillis.toInt()
-                        serverSocket.accept()
-                    } catch (e: SocketTimeoutException) {
-                        val processHasExited = process.waitFor(timeoutMillis, TimeUnit.MILLISECONDS)
-                        if (processHasExited) {
-                            val processOutput = InputStreamReader(process.inputStream).readText()
-                            throw TimeoutException("Timeout exceeded: Worker not connected. Process output: $processOutput")
-                        } else {
-                            process.destroy()
-                        }
-                        throw TimeoutException("Timeout exceeded: Worker not connected")
-                    }
-                    val worker = GoWorker(workerSocket, functionUnderTest)
-                    logger.debug { "Worker connected - completed in ${System.currentTimeMillis() - processStartTime} ms" }
-
-                    // fuzzing
-                    if (functionUnderTest.parameters.isEmpty()) {
-                        worker.sendFuzzedParametersValues(emptyList(), emptyMap())
-                        val rawExecutionResult = worker.receiveRawExecutionResult()
-                        val executionResult = convertRawExecutionResultToExecutionResult(
-                            rawExecutionResult,
-                            functionUnderTest.resultTypes,
-                            intSize,
-                            eachExecutionTimeoutsMillisConfig[functionUnderTest],
-                        )
-                        val fuzzedFunction = GoUtFuzzedFunction(functionUnderTest, emptyList())
-                        emit(fuzzedFunction to executionResult)
-                    } else {
-                        val notCoveredLines = (1..functionUnderTest.numberOfAllStatements).toMutableSet()
-                        val aliases = imports.filter { it.alias != null }.associate { it.goPackage to it.alias }
-                        runGoFuzzing(functionUnderTest, intSize) { description, values ->
-                            if (timeoutExceededOrIsCanceled() || notCoveredLines.isEmpty()) {
-                                return@runGoFuzzing BaseFeedback(result = Trie.emptyNode(), control = Control.STOP)
-                            }
-                            val fuzzedFunction = GoUtFuzzedFunction(functionUnderTest, values)
-                            worker.sendFuzzedParametersValues(values, aliases)
-                            val rawExecutionResult = worker.receiveRawExecutionResult()
-                            val executionResult = convertRawExecutionResultToExecutionResult(
-                                rawExecutionResult,
-                                functionUnderTest.resultTypes,
-                                intSize,
-                                eachExecutionTimeoutsMillisConfig[functionUnderTest],
-                            )
-                            if (executionResult.trace.isEmpty()) {
-                                logger.error { "Coverage is empty for [${functionUnderTest.name}] with $values}" }
-                                if (executionResult is GoUtPanicFailure) {
-                                    logger.error { "Execution completed with panic: ${executionResult.panicValue}" }
-                                }
-                                return@runGoFuzzing BaseFeedback(result = Trie.emptyNode(), control = Control.PASS)
-                            }
-                            val trieNode = description.tracer.add(executionResult.trace.map { GoInstruction(it) })
-                            if (trieNode.count > 1) {
-                                if (++attempts >= attemptsLimit) {
-                                    return@runGoFuzzing BaseFeedback(result = Trie.emptyNode(), control = Control.STOP)
-                                }
-                                return@runGoFuzzing BaseFeedback(result = trieNode, control = Control.CONTINUE)
-                            }
-                            if (notCoveredLines.removeAll(executionResult.trace.toSet())) {
-                                emit(fuzzedFunction to executionResult)
-                            }
-                            BaseFeedback(result = trieNode, control = Control.CONTINUE)
-                        }
-                        workerSocket.close()
-                        val processHasExited = process.waitFor(timeoutMillis, TimeUnit.MILLISECONDS)
-                        if (!processHasExited) {
-                            process.destroy()
-                            throw TimeoutException("Timeout exceeded: Worker didn't finish")
-                        }
-                        val exitCode = process.exitValue()
-                        if (exitCode != 0) {
-                            val processOutput = InputStreamReader(process.inputStream).readText()
-                            throw RuntimeException(
-                                StringBuilder()
-                                    .append("Execution of ${"function [${functionUnderTest.name}] from $sourceFile"} in child process failed with non-zero exit code = $exitCode: ")
-                                    .appendLine()
-                                    .append(processOutput).toString()
-                            )
-                        }
-                    }
-                } catch (e: Exception) {
-                    val processHasExited = process.waitFor(timeoutMillis, TimeUnit.MILLISECONDS)
-                    if (!processHasExited) {
-                        process.destroy()
-                        throw TimeoutException("Timeout exceeded: Worker didn't finish")
-                    }
-                    val exitCode = process.exitValue()
-                    if (exitCode != 0) {
-                        val processOutput = InputStreamReader(process.inputStream).readText()
-                        throw RuntimeException(
-                            StringBuilder()
-                                .append("Execution of ${"function [${functionUnderTest.name}] from $sourceFile"} in child process failed with non-zero exit code = $exitCode: ")
-                                .appendLine()
-                                .append(processOutput).toString()
-                        )
-                    }
+        if (functionUnderTest.parameters.isEmpty()) {
+            worker.sendFuzzedParametersValues(functionUnderTest, emptyList(), emptyMap())
+            val rawExecutionResult = worker.receiveRawExecutionResult()
+            val executionResult = convertRawExecutionResultToExecutionResult(
+                rawExecutionResult,
+                functionUnderTest.resultTypes,
+                intSize,
+                eachExecutionTimeoutMillis,
+            )
+            val fuzzedFunction = GoUtFuzzedFunction(functionUnderTest, emptyList())
+            emit(fuzzedFunction to executionResult)
+        } else {
+            val notCoveredLines = (1..functionUnderTest.numberOfAllStatements).toMutableSet()
+            runGoFuzzing(functionUnderTest, intSize) { description, values ->
+                if (timeoutExceededOrIsCanceled() || notCoveredLines.isEmpty()) {
+                    return@runGoFuzzing BaseFeedback(result = Trie.emptyNode(), control = Control.STOP)
                 }
-            } finally {
-                fileToExecute?.delete()
-                fileWithModifiedFunction?.delete()
+                val fuzzedFunction = GoUtFuzzedFunction(functionUnderTest, values)
+                worker.sendFuzzedParametersValues(functionUnderTest, values, aliases)
+                val rawExecutionResult = worker.receiveRawExecutionResult()
+                val executionResult = convertRawExecutionResultToExecutionResult(
+                    rawExecutionResult,
+                    functionUnderTest.resultTypes,
+                    intSize,
+                    eachExecutionTimeoutMillis,
+                )
+                if (executionResult.trace.isEmpty()) {
+                    logger.error { "Coverage is empty for [${functionUnderTest.name}] with $values}" }
+                    if (executionResult is GoUtPanicFailure) {
+                        logger.error { "Execution completed with panic: ${executionResult.panicValue}" }
+                    }
+                    return@runGoFuzzing BaseFeedback(result = Trie.emptyNode(), control = Control.PASS)
+                }
+                val trieNode = description.tracer.add(executionResult.trace.map { GoInstruction(it) })
+                if (trieNode.count > 1) {
+                    if (++attempts >= attemptsLimit) {
+                        return@runGoFuzzing BaseFeedback(result = Trie.emptyNode(), control = Control.STOP)
+                    }
+                    return@runGoFuzzing BaseFeedback(result = trieNode, control = Control.CONTINUE)
+                }
+                if (notCoveredLines.removeAll(executionResult.trace.toSet())) {
+                    emit(fuzzedFunction to executionResult)
+                }
+                BaseFeedback(result = trieNode, control = Control.CONTINUE)
             }
         }
     }

--- a/utbot-go/src/main/kotlin/org/utbot/go/logic/AbstractGoUtTestsGenerationController.kt
+++ b/utbot-go/src/main/kotlin/org/utbot/go/logic/AbstractGoUtTestsGenerationController.kt
@@ -23,7 +23,7 @@ abstract class AbstractGoUtTestsGenerationController {
         val numOfFunctions = analysisResults.values
             .map { it.functions.size }
             .reduce { acc, numOfFunctions -> acc + numOfFunctions }
-        val functionTimeoutStepMillis = testsGenerationConfig.allExecutionTimeoutsMillisConfig / numOfFunctions
+        val functionTimeoutStepMillis = testsGenerationConfig.allFunctionExecutionTimeoutMillis / numOfFunctions
         var startTimeMillis = System.currentTimeMillis()
         val testCasesBySourceFiles = analysisResults.mapValues { (sourceFile, analysisResult) ->
             val functions = analysisResult.functions
@@ -33,7 +33,7 @@ abstract class AbstractGoUtTestsGenerationController {
                 functions,
                 intSize,
                 testsGenerationConfig.goExecutableAbsolutePath,
-                testsGenerationConfig.eachExecutionTimeoutsMillisConfig
+                testsGenerationConfig.eachFunctionExecutionTimeoutMillis
             ) { index -> isCanceled() || System.currentTimeMillis() - (startTimeMillis + (index + 1) * functionTimeoutStepMillis) > 0 }
                 .also {
                     startTimeMillis += functionTimeoutStepMillis * functions.size

--- a/utbot-go/src/main/kotlin/org/utbot/go/logic/GoTestCasesGenerator.kt
+++ b/utbot-go/src/main/kotlin/org/utbot/go/logic/GoTestCasesGenerator.kt
@@ -3,10 +3,21 @@ package org.utbot.go.logic
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
+import org.utbot.framework.plugin.api.TimeoutException
 import org.utbot.go.GoEngine
 import org.utbot.go.api.GoUtFile
 import org.utbot.go.api.GoUtFunction
 import org.utbot.go.api.GoUtFuzzedFunctionTestCase
+import org.utbot.go.imports.GoImportsResolver
+import org.utbot.go.util.executeCommandByNewProcessOrFailWithoutWaiting
+import org.utbot.go.worker.GoWorker
+import org.utbot.go.worker.GoWorkerCodeGenerationHelper
+import java.io.File
+import java.io.InputStreamReader
+import java.net.ServerSocket
+import java.net.SocketException
+import java.net.SocketTimeoutException
+import java.util.concurrent.TimeUnit
 import kotlin.system.measureTimeMillis
 
 val logger = KotlinLogging.logger {}
@@ -18,30 +29,126 @@ object GoTestCasesGenerator {
         functions: List<GoUtFunction>,
         intSize: Int,
         goExecutableAbsolutePath: String,
-        eachExecutionTimeoutsMillisConfig: EachExecutionTimeoutsMillisConfig,
-        timeoutExceededOrIsCanceled: (index: Int) -> Boolean
+        eachExecutionTimeoutMillis: Long,
+        connectionTimeoutMillis: Long = 10000,
+        endOfWorkerExecutionTimeout: Long = 1000,
+        timeoutExceededOrIsCanceled: (index: Int) -> Boolean = { false },
     ): List<GoUtFuzzedFunctionTestCase> = runBlocking {
-        return@runBlocking functions.flatMapIndexed { index, function ->
-            val testCases = mutableListOf<GoUtFuzzedFunctionTestCase>()
-            if (timeoutExceededOrIsCanceled(index)) return@flatMapIndexed testCases
-            val engine = GoEngine(
-                function,
-                sourceFile,
-                intSize,
-                goExecutableAbsolutePath,
-                eachExecutionTimeoutsMillisConfig,
-                { timeoutExceededOrIsCanceled(index) }
-            )
-            logger.info { "Fuzzing for function [${function.name}] - started" }
-            val totalFuzzingTime = measureTimeMillis {
-                engine.fuzzing().catch {
-                    logger.error { "Error in flow: ${it.message}" }
-                }.collect { (fuzzedFunction, executionResult) ->
-                    testCases.add(GoUtFuzzedFunctionTestCase(fuzzedFunction, executionResult))
+        ServerSocket(0).use { serverSocket ->
+            val allTestCases = mutableListOf<GoUtFuzzedFunctionTestCase>()
+            var fileToExecute: File? = null
+            var fileWithModifiedFunctions: File? = null
+            try {
+                // creating files for worker
+                val types = functions.flatMap { it.parameters }.map { it.type }
+                val imports = GoImportsResolver.resolveImportsBasedOnTypes(
+                    types,
+                    sourceFile.sourcePackage,
+                    GoWorkerCodeGenerationHelper.alwaysRequiredImports
+                )
+                val aliases = imports.filter { it.alias != null }.associate { it.goPackage to it.alias }
+                fileToExecute = GoWorkerCodeGenerationHelper.createFileToExecute(
+                    sourceFile,
+                    functions,
+                    eachExecutionTimeoutMillis,
+                    serverSocket.localPort,
+                    imports
+                )
+                fileWithModifiedFunctions = GoWorkerCodeGenerationHelper.createFileWithModifiedFunctions(
+                    sourceFile, functions
+                )
+
+                // starting worker process
+                val testFunctionName = GoWorkerCodeGenerationHelper.workerTestFunctionName
+                val command = listOf(
+                    goExecutableAbsolutePath, "test", "-run", testFunctionName
+                )
+                val sourceFileDir = File(sourceFile.absoluteDirectoryPath)
+                val processStartTime = System.currentTimeMillis()
+                val process = executeCommandByNewProcessOrFailWithoutWaiting(command, sourceFileDir)
+
+                try {
+                    // connecting to worker
+                    logger.debug { "Trying to connect to worker" }
+                    val workerSocket = try {
+                        serverSocket.soTimeout = connectionTimeoutMillis.toInt()
+                        serverSocket.accept()
+                    } catch (e: SocketTimeoutException) {
+                        val processHasExited = process.waitFor(endOfWorkerExecutionTimeout, TimeUnit.MILLISECONDS)
+                        if (processHasExited) {
+                            val processOutput = InputStreamReader(process.inputStream).readText()
+                            throw TimeoutException("Timeout exceeded: Worker not connected. Process output: $processOutput")
+                        } else {
+                            process.destroy()
+                        }
+                        throw TimeoutException("Timeout exceeded: Worker not connected")
+                    }
+                    val worker = GoWorker(workerSocket, sourceFile.sourcePackage)
+                    logger.debug { "Worker connected - completed in ${System.currentTimeMillis() - processStartTime} ms" }
+                    functions.forEachIndexed { index, function ->
+                        if (timeoutExceededOrIsCanceled(index)) return@forEachIndexed
+                        val testCases = mutableListOf<GoUtFuzzedFunctionTestCase>()
+                        val engine = GoEngine(
+                            worker,
+                            function,
+                            aliases,
+                            intSize,
+                            eachExecutionTimeoutMillis
+                        ) { timeoutExceededOrIsCanceled(index) }
+                        logger.info { "Fuzzing for function [${function.name}] - started" }
+                        val totalFuzzingTime = measureTimeMillis {
+                            engine.fuzzing().catch {
+                                logger.error { "Error in flow: ${it.message}" }
+                            }.collect { (fuzzedFunction, executionResult) ->
+                                testCases.add(GoUtFuzzedFunctionTestCase(fuzzedFunction, executionResult))
+                            }
+                        }
+                        logger.info { "Fuzzing for function [${function.name}] - completed in $totalFuzzingTime ms. Generated ${testCases.size} test cases" }
+                        allTestCases += testCases
+                    }
+                    workerSocket.close()
+                    val processHasExited = process.waitFor(endOfWorkerExecutionTimeout, TimeUnit.MILLISECONDS)
+                    if (!processHasExited) {
+                        process.destroy()
+                        throw TimeoutException("Timeout exceeded: Worker didn't finish")
+                    }
+                    val exitCode = process.exitValue()
+                    if (exitCode != 0) {
+                        val processOutput = InputStreamReader(process.inputStream).readText()
+                        throw RuntimeException(
+                            StringBuilder()
+                                .append("Execution of functions from $sourceFile in child process failed with non-zero exit code = $exitCode: ")
+                                .appendLine()
+                                .append(processOutput).toString()
+                        )
+                    }
+                } catch (e: TimeoutException) {
+                    logger.error { e.message }
+                } catch (e: RuntimeException) {
+                    logger.error { e.message }
+                } catch (e: SocketException) {
+                    val processHasExited = process.waitFor(endOfWorkerExecutionTimeout, TimeUnit.MILLISECONDS)
+                    if (!processHasExited) {
+                        process.destroy()
+                        logger.error { "Timeout exceeded: Worker didn't finish" }
+                    }
+                    val exitCode = process.exitValue()
+                    if (exitCode != 0) {
+                        val processOutput = InputStreamReader(process.inputStream).readText()
+                        logger.error {
+                            StringBuilder()
+                                .append("Execution of functions from $sourceFile in child process failed with non-zero exit code = $exitCode: ")
+                                .appendLine()
+                                .append(processOutput).toString()
+                        }
+                    }
+
                 }
+            } finally {
+                fileToExecute?.delete()
+                fileWithModifiedFunctions?.delete()
             }
-            logger.info { "Fuzzing for function [${function.name}] - completed in $totalFuzzingTime ms. Generated ${testCases.size} test cases" }
-            testCases
+            return@runBlocking allTestCases
         }
     }
 }

--- a/utbot-go/src/main/kotlin/org/utbot/go/logic/GoTestCasesGenerator.kt
+++ b/utbot-go/src/main/kotlin/org/utbot/go/logic/GoTestCasesGenerator.kt
@@ -31,7 +31,7 @@ object GoTestCasesGenerator {
         goExecutableAbsolutePath: String,
         eachExecutionTimeoutMillis: Long,
         connectionTimeoutMillis: Long = 10000,
-        endOfWorkerExecutionTimeout: Long = 1000,
+        endOfWorkerExecutionTimeout: Long = 5000,
         timeoutExceededOrIsCanceled: (index: Int) -> Boolean = { false },
     ): List<GoUtFuzzedFunctionTestCase> = runBlocking {
         ServerSocket(0).use { serverSocket ->

--- a/utbot-go/src/main/kotlin/org/utbot/go/logic/GoUtTestsGenerationConfig.kt
+++ b/utbot-go/src/main/kotlin/org/utbot/go/logic/GoUtTestsGenerationConfig.kt
@@ -1,25 +1,13 @@
 package org.utbot.go.logic
 
-import org.utbot.go.api.GoUtFunction
-
-data class EachExecutionTimeoutsMillisConfig(private val eachFunctionExecutionTimeoutMillis: Long) {
-    @Suppress("UNUSED_PARAMETER") // TODO: support finer tuning
-    operator fun get(function: GoUtFunction): Long = eachFunctionExecutionTimeoutMillis
-}
-
 class GoUtTestsGenerationConfig(
     val goExecutableAbsolutePath: String,
-    eachFunctionExecutionTimeoutMillis: Long,
-    allFunctionExecutionTimeoutMillis: Long
+    val eachFunctionExecutionTimeoutMillis: Long,
+    val allFunctionExecutionTimeoutMillis: Long
 ) {
 
     companion object Constants {
         const val DEFAULT_ALL_EXECUTION_TIMEOUT_MILLIS: Long = 60000
         const val DEFAULT_EACH_EXECUTION_TIMEOUT_MILLIS: Long = 1000
     }
-
-    val eachExecutionTimeoutsMillisConfig: EachExecutionTimeoutsMillisConfig =
-        EachExecutionTimeoutsMillisConfig(eachFunctionExecutionTimeoutMillis)
-
-    val allExecutionTimeoutsMillisConfig: Long = allFunctionExecutionTimeoutMillis
 }

--- a/utbot-go/src/main/kotlin/org/utbot/go/worker/GoWorker.kt
+++ b/utbot-go/src/main/kotlin/org/utbot/go/worker/GoWorker.kt
@@ -14,14 +14,24 @@ import java.net.Socket
 
 class GoWorker(
     socket: Socket,
-    val function: GoUtFunction
+    private val goPackage: GoPackage
 ) {
     private val reader: BufferedReader = BufferedReader(InputStreamReader(socket.getInputStream()))
     private val writer: BufferedWriter = BufferedWriter(OutputStreamWriter(socket.getOutputStream()))
 
-    fun sendFuzzedParametersValues(parameters: List<GoUtModel>, aliases: Map<GoPackage, String?>) {
-        val rawValues = parameters.map { it.convertToRawValue(function.sourcePackage, aliases) }
-        val json = convertObjectToJsonString(rawValues)
+    data class TestInput(
+        val functionName: String,
+        val arguments: List<RawValue>
+    )
+
+    fun sendFuzzedParametersValues(
+        function: GoUtFunction,
+        arguments: List<GoUtModel>,
+        aliases: Map<GoPackage, String?>
+    ) {
+        val rawValues = arguments.map { it.convertToRawValue(goPackage, aliases) }
+        val testCase = TestInput(function.modifiedName, rawValues)
+        val json = convertObjectToJsonString(testCase)
         writer.write(json)
         writer.flush()
     }

--- a/utbot-go/src/main/resources/go_source_code_analyzer/function_modifier.go
+++ b/utbot-go/src/main/resources/go_source_code_analyzer/function_modifier.go
@@ -12,6 +12,8 @@ type FunctionModifier struct {
 
 func (v *FunctionModifier) Visit(node ast.Node) ast.Visitor {
 	switch n := node.(type) {
+	case *ast.FuncDecl:
+		n.Doc = nil
 	case *ast.BlockStmt:
 		if n == nil {
 			n = &ast.BlockStmt{}


### PR DESCRIPTION
## Description

* Stop fuzzing after reaching 100% coverage. The remaining time is given to the next function
* Add new test only if it covers new lines
* Run all function in one process

Fixes #1806
Fixes #1810

## How to test

### Manual tests

Test on `utbot-go/go-samples/simple/samples.go` and `utbot-go/go-samples/simple/supported_types.go` files.

## Self-check list

Check off the item if the statement is true. Hint: [x] is a marked item.

Please do not delete the list or its items.

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.