### PR TITLE
Remove old fuzzer dependencies from JavaScript module

### DIFF
--- a/utbot-intellij-js/src/main/kotlin/org/utbot/intellij/plugin/language/js/CoverageModeButtons.kt
+++ b/utbot-intellij-js/src/main/kotlin/org/utbot/intellij/plugin/language/js/CoverageModeButtons.kt
@@ -1,8 +1,8 @@
 package org.utbot.intellij.plugin.language.js
 
-import service.CoverageMode
 import javax.swing.ButtonGroup
 import javax.swing.JRadioButton
+import service.coverage.CoverageMode
 
 object CoverageModeButtons {
 

--- a/utbot-intellij-js/src/main/kotlin/org/utbot/intellij/plugin/language/js/CoverageModeButtons.kt
+++ b/utbot-intellij-js/src/main/kotlin/org/utbot/intellij/plugin/language/js/CoverageModeButtons.kt
@@ -1,8 +1,8 @@
 package org.utbot.intellij.plugin.language.js
 
+import service.CoverageMode
 import javax.swing.ButtonGroup
 import javax.swing.JRadioButton
-import service.coverage.CoverageMode
 
 object CoverageModeButtons {
 

--- a/utbot-js/src/main/kotlin/api/JsTestGenerator.kt
+++ b/utbot-js/src/main/kotlin/api/JsTestGenerator.kt
@@ -8,6 +8,7 @@ import framework.api.js.util.isJsBasic
 import framework.api.js.util.jsErrorClassId
 import framework.api.js.util.jsUndefinedClassId
 import fuzzer.JsFeedback
+import fuzzer.JsFuzzedValue
 import fuzzer.JsFuzzingExecutionFeedback
 import fuzzer.JsMethodDescription
 import fuzzer.JsStatement
@@ -27,6 +28,7 @@ import org.utbot.framework.plugin.api.UtExecutionResult
 import org.utbot.framework.plugin.api.UtExecutionSuccess
 import org.utbot.framework.plugin.api.UtExplicitlyThrownException
 import org.utbot.framework.plugin.api.UtTimeoutException
+import org.utbot.fuzzer.UtFuzzedExecution
 import org.utbot.fuzzer.FuzzedValue
 import org.utbot.fuzzer.UtFuzzedExecution
 import org.utbot.fuzzing.Control
@@ -182,7 +184,7 @@ class JsTestGenerator(
     private fun getUtModelResult(
         execId: JsMethodId,
         resultData: ResultData,
-        fuzzedValues: List<FuzzedValue>
+        fuzzedValues: List<JsFuzzedValue>
     ): UtExecutionResult {
         if (resultData.isError && resultData.rawString == "Timeout") return UtTimeoutException(
             TimeoutException("  Timeout in generating test for ${
@@ -220,7 +222,7 @@ class JsTestGenerator(
             concreteValues = fuzzerVisitor.fuzzedConcreteValues,
             tracer = Trie(JsStatement::number)
         )
-        val collectedValues = mutableListOf<List<FuzzedValue>>()
+        val collectedValues = mutableListOf<List<JsFuzzedValue>>()
         // .location field gets us "jsFile:A:B", then we get A and B as ints
         val funcLocation = funcNode.firstChild!!.location.substringAfter("jsFile:")
             .split(":").map { it.toInt() }

--- a/utbot-js/src/main/kotlin/api/JsTestGenerator.kt
+++ b/utbot-js/src/main/kotlin/api/JsTestGenerator.kt
@@ -4,6 +4,8 @@ import codegen.JsCodeGenerator
 import com.google.javascript.rhino.Node
 import framework.api.js.JsClassId
 import framework.api.js.JsMethodId
+import framework.api.js.JsUtFuzzedExecution
+import framework.api.js.util.isExportable
 import framework.api.js.util.isJsBasic
 import framework.api.js.util.jsErrorClassId
 import framework.api.js.util.jsUndefinedClassId
@@ -218,7 +220,7 @@ class JsTestGenerator(
         val jsDescription = JsMethodDescription(
             name = funcNode.getAbstractFunctionName(),
             parameters = execId.parameters,
-            execId.classId,
+            classId = execId.classId,
             concreteValues = fuzzerVisitor.fuzzedConcreteValues,
             tracer = Trie(JsStatement::number)
         )
@@ -268,7 +270,7 @@ class JsTestGenerator(
                                 EnvironmentModels(thisObject, modelList, mapOf())
                             emit(
                                 JsValidExecution(
-                                    UtFuzzedExecution(
+                                    JsUtFuzzedExecution(
                                         stateBefore = initEnv,
                                         stateAfter = initEnv,
                                         result = result,

--- a/utbot-js/src/main/kotlin/api/JsTestGenerator.kt
+++ b/utbot-js/src/main/kotlin/api/JsTestGenerator.kt
@@ -5,7 +5,6 @@ import com.google.javascript.rhino.Node
 import framework.api.js.JsClassId
 import framework.api.js.JsMethodId
 import framework.api.js.JsUtFuzzedExecution
-import framework.api.js.util.isExportable
 import framework.api.js.util.isJsBasic
 import framework.api.js.util.jsErrorClassId
 import framework.api.js.util.jsUndefinedClassId
@@ -30,10 +29,8 @@ import org.utbot.framework.plugin.api.UtExecutionResult
 import org.utbot.framework.plugin.api.UtExecutionSuccess
 import org.utbot.framework.plugin.api.UtExplicitlyThrownException
 import org.utbot.framework.plugin.api.UtTimeoutException
-import org.utbot.fuzzer.UtFuzzedExecution
-import org.utbot.fuzzer.FuzzedValue
-import org.utbot.fuzzer.UtFuzzedExecution
 import org.utbot.fuzzing.Control
+import org.utbot.fuzzing.utils.Trie
 import parser.JsClassAstVisitor
 import parser.JsFunctionAstVisitor
 import parser.JsFuzzerAstVisitor
@@ -60,7 +57,6 @@ import utils.constructClass
 import utils.toJsAny
 import java.io.File
 import java.util.concurrent.CancellationException
-import org.utbot.fuzzing.utils.Trie
 
 private val logger = KotlinLogging.logger {}
 

--- a/utbot-js/src/main/kotlin/api/JsTestGenerator.kt
+++ b/utbot-js/src/main/kotlin/api/JsTestGenerator.kt
@@ -265,8 +265,8 @@ class JsTestGenerator(
                             return@runFuzzing JsFeedback(Control.PASS)
                         } else if (!currentlyCoveredStmts.containsAll(covData.additionalCoverage)) {
                             val (thisObject, modelList) = if (!funcNode.parent!!.isClassMembers) {
-                                null to params.map { it }
-                            } else params[0] to params.drop(1).map { it }
+                                null to params
+                            } else params[0] to params.drop(1)
                             val initEnv =
                                 EnvironmentModels(thisObject, modelList, mapOf())
                             emit(

--- a/utbot-js/src/main/kotlin/api/JsUtModelConstructor.kt
+++ b/utbot-js/src/main/kotlin/api/JsUtModelConstructor.kt
@@ -50,7 +50,7 @@ class JsUtModelConstructor : UtModelConstructorInterface {
         val values = (value as Map<String, Any>).values.map {
             construct(it, JsEmptyClassId())
         }
-        val id = JsIdProvider.get()
+        val id = JsIdProvider.createId()
         val instantiationCall = UtExecutableCallModel(null, constructor, values)
         return UtAssembleModel(
             id = id,

--- a/utbot-js/src/main/kotlin/api/JsUtModelConstructor.kt
+++ b/utbot-js/src/main/kotlin/api/JsUtModelConstructor.kt
@@ -7,16 +7,14 @@ import framework.api.js.JsPrimitiveModel
 import framework.api.js.JsUndefinedModel
 import framework.api.js.util.jsErrorClassId
 import framework.api.js.util.jsUndefinedClassId
+import fuzzer.JsIdProvider
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.UtAssembleModel
 import org.utbot.framework.plugin.api.UtExecutableCallModel
 import org.utbot.framework.plugin.api.UtModel
-import org.utbot.fuzzer.ReferencePreservingIntIdGenerator
 import org.utbot.instrumentation.instrumentation.execution.constructors.UtModelConstructorInterface
 
 class JsUtModelConstructor : UtModelConstructorInterface {
-
-    private val idGenerator = ReferencePreservingIntIdGenerator()
 
     // TODO SEVERE: Requires substantial expansion to other types
     @Suppress("NAME_SHADOWING")
@@ -52,7 +50,7 @@ class JsUtModelConstructor : UtModelConstructorInterface {
         val values = (value as Map<String, Any>).values.map {
             construct(it, JsEmptyClassId())
         }
-        val id = idGenerator.createId()
+        val id = JsIdProvider.get()
         val instantiationCall = UtExecutableCallModel(null, constructor, values)
         return UtAssembleModel(
             id = id,

--- a/utbot-js/src/main/kotlin/framework/api/js/JsApi.kt
+++ b/utbot-js/src/main/kotlin/framework/api/js/JsApi.kt
@@ -93,11 +93,7 @@ class JsConstructorId(
         get() = 0
 }
 
-class JsMultipleClassId(private val jsJoinedName: String) : JsClassId(jsJoinedName) {
-
-    val types: Sequence<JsClassId>
-        get() = jsJoinedName.split('|').map { JsClassId(it) }.asSequence()
-}
+class JsMultipleClassId(jsJoinedName: String) : JsClassId(jsJoinedName)
 
 open class JsUtModel(
     override val classId: JsClassId

--- a/utbot-js/src/main/kotlin/framework/api/js/JsUtFuzzedExecution.kt
+++ b/utbot-js/src/main/kotlin/framework/api/js/JsUtFuzzedExecution.kt
@@ -1,0 +1,11 @@
+package framework.api.js
+
+import org.utbot.framework.plugin.api.EnvironmentModels
+import org.utbot.framework.plugin.api.UtExecution
+import org.utbot.framework.plugin.api.UtExecutionResult
+
+class JsUtFuzzedExecution(
+    stateBefore: EnvironmentModels,
+    stateAfter: EnvironmentModels,
+    result: UtExecutionResult
+) : UtExecution(stateBefore, stateAfter, result, null, null, null, null)

--- a/utbot-js/src/main/kotlin/fuzzer/JsFuzzerApi.kt
+++ b/utbot-js/src/main/kotlin/fuzzer/JsFuzzerApi.kt
@@ -1,6 +1,7 @@
 package fuzzer
 
 import framework.api.js.JsClassId
+import framework.api.js.JsUtFuzzedExecution
 import framework.api.js.util.isClass
 import org.utbot.framework.plugin.api.UtTimeoutException
 import org.utbot.fuzzer.FuzzedConcreteValue
@@ -13,7 +14,7 @@ import org.utbot.fuzzing.Feedback
 import org.utbot.fuzzing.utils.Trie
 
 sealed interface JsFuzzingExecutionFeedback
-class JsValidExecution(val utFuzzedExecution: UtFuzzedExecution) : JsFuzzingExecutionFeedback
+class JsValidExecution(val utFuzzedExecution: JsUtFuzzedExecution) : JsFuzzingExecutionFeedback
 
 class JsTimeoutExecution(val utTimeout: UtTimeoutException) : JsFuzzingExecutionFeedback
 

--- a/utbot-js/src/main/kotlin/fuzzer/JsFuzzerApi.kt
+++ b/utbot-js/src/main/kotlin/fuzzer/JsFuzzerApi.kt
@@ -95,5 +95,5 @@ fun UtModel.fuzzed(block: JsFuzzedValue.() -> Unit = {}): JsFuzzedValue = JsFuzz
 object JsIdProvider {
     private var id = AtomicInteger(0)
 
-    fun get() = id.incrementAndGet()
+    fun createId() = id.incrementAndGet()
 }

--- a/utbot-js/src/main/kotlin/fuzzer/JsFuzzerApi.kt
+++ b/utbot-js/src/main/kotlin/fuzzer/JsFuzzerApi.kt
@@ -3,15 +3,14 @@ package fuzzer
 import framework.api.js.JsClassId
 import framework.api.js.JsUtFuzzedExecution
 import framework.api.js.util.isClass
+import org.utbot.framework.plugin.api.ClassId
+import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtTimeoutException
-import org.utbot.fuzzer.FuzzedConcreteValue
-import org.utbot.fuzzer.FuzzedValue
-import org.utbot.fuzzer.UtFuzzedExecution
-import org.utbot.fuzzer.UtFuzzedExecution
 import org.utbot.fuzzing.Control
 import org.utbot.fuzzing.Description
 import org.utbot.fuzzing.Feedback
 import org.utbot.fuzzing.utils.Trie
+import java.util.concurrent.atomic.AtomicInteger
 
 sealed interface JsFuzzingExecutionFeedback
 class JsValidExecution(val utFuzzedExecution: JsUtFuzzedExecution) : JsFuzzingExecutionFeedback

--- a/utbot-js/src/main/kotlin/fuzzer/JsFuzzerApi.kt
+++ b/utbot-js/src/main/kotlin/fuzzer/JsFuzzerApi.kt
@@ -40,28 +40,13 @@ class JsMethodDescription(
     )
 }
 
-class JsFeedback(
+data class JsFeedback(
     override val control: Control = Control.CONTINUE,
     val result: Trie.Node<JsStatement> = Trie.emptyNode()
-) : Feedback<JsClassId, JsFuzzedValue> {
-
-    override fun equals(other: Any?): Boolean {
-        val castOther = other as? JsFeedback
-        return control == castOther?.control
-    }
-
-    override fun hashCode(): Int {
-        return control.hashCode()
-    }
-}
+) : Feedback<JsClassId, UtModel>
 
 data class JsStatement(
     val number: Int
-)
-
-data class JsFuzzedValue(
-    val model: UtModel,
-    var summary: String? = null,
 )
 
 data class JsFuzzedConcreteValue(
@@ -89,8 +74,6 @@ enum class JsFuzzedContext {
         Unknown -> Unknown
     }
 }
-
-fun UtModel.fuzzed(block: JsFuzzedValue.() -> Unit = {}): JsFuzzedValue = JsFuzzedValue(this).apply(block)
 
 object JsIdProvider {
     private var id = AtomicInteger(0)

--- a/utbot-js/src/main/kotlin/fuzzer/JsFuzzerApi.kt
+++ b/utbot-js/src/main/kotlin/fuzzer/JsFuzzerApi.kt
@@ -93,7 +93,7 @@ enum class JsFuzzedContext {
 fun UtModel.fuzzed(block: JsFuzzedValue.() -> Unit = {}): JsFuzzedValue = JsFuzzedValue(this).apply(block)
 
 object JsIdProvider {
-    private var _id = AtomicInteger(0)
+    private var id = AtomicInteger(0)
 
-    fun get() = _id.incrementAndGet()
+    fun get() = id.incrementAndGet()
 }

--- a/utbot-js/src/main/kotlin/fuzzer/JsFuzzing.kt
+++ b/utbot-js/src/main/kotlin/fuzzer/JsFuzzing.kt
@@ -5,6 +5,7 @@ import fuzzer.providers.BoolValueProvider
 import fuzzer.providers.NumberValueProvider
 import fuzzer.providers.ObjectValueProvider
 import fuzzer.providers.StringValueProvider
+import org.utbot.framework.plugin.api.UtModel
 import org.utbot.fuzzing.Fuzzing
 import org.utbot.fuzzing.Seed
 import org.utbot.fuzzing.fuzz
@@ -17,10 +18,10 @@ fun defaultValueProviders() = listOf(
 )
 
 class JsFuzzing(
-    val exec: suspend (JsMethodDescription, List<JsFuzzedValue>) -> JsFeedback
-) : Fuzzing<JsClassId, JsFuzzedValue, JsMethodDescription, JsFeedback> {
+    val exec: suspend (JsMethodDescription, List<UtModel>) -> JsFeedback
+) : Fuzzing<JsClassId, UtModel, JsMethodDescription, JsFeedback> {
 
-    override fun generate(description: JsMethodDescription, type: JsClassId): Sequence<Seed<JsClassId, JsFuzzedValue>> {
+    override fun generate(description: JsMethodDescription, type: JsClassId): Sequence<Seed<JsClassId, UtModel>> {
         return defaultValueProviders().asSequence().flatMap { provider ->
             if (provider.accept(type)) {
                 provider.generate(description, type)
@@ -30,12 +31,12 @@ class JsFuzzing(
         }
     }
 
-    override suspend fun handle(description: JsMethodDescription, values: List<JsFuzzedValue>): JsFeedback {
+    override suspend fun handle(description: JsMethodDescription, values: List<UtModel>): JsFeedback {
         return exec(description, values)
     }
 }
 
 suspend fun runFuzzing(
     description: JsMethodDescription,
-    exec: suspend (JsMethodDescription, List<JsFuzzedValue>) -> JsFeedback
+    exec: suspend (JsMethodDescription, List<UtModel>) -> JsFeedback
 ) = JsFuzzing(exec).fuzz(description)

--- a/utbot-js/src/main/kotlin/fuzzer/JsFuzzing.kt
+++ b/utbot-js/src/main/kotlin/fuzzer/JsFuzzing.kt
@@ -3,12 +3,15 @@ package fuzzer
 import framework.api.js.JsClassId
 import fuzzer.providers.BoolValueProvider
 import fuzzer.providers.NumberValueProvider
+import fuzzer.providers.SetValueProvider
 import fuzzer.providers.ObjectValueProvider
 import fuzzer.providers.StringValueProvider
 import org.utbot.fuzzer.FuzzedValue
 import org.utbot.fuzzing.Fuzzing
 import org.utbot.fuzzing.Seed
 import org.utbot.fuzzing.fuzz
+import fuzzer.providers.ArrayValueProvider
+import fuzzer.providers.ObjectValueProvider
 
 fun defaultValueProviders() = listOf(
     BoolValueProvider,
@@ -18,10 +21,10 @@ fun defaultValueProviders() = listOf(
 )
 
 class JsFuzzing(
-    val exec: suspend (JsMethodDescription, List<FuzzedValue>) -> JsFeedback
-) : Fuzzing<JsClassId, FuzzedValue, JsMethodDescription, JsFeedback> {
+    val exec: suspend (JsMethodDescription, List<JsFuzzedValue>) -> JsFeedback
+) : Fuzzing<JsClassId, JsFuzzedValue, JsMethodDescription, JsFeedback> {
 
-    override fun generate(description: JsMethodDescription, type: JsClassId): Sequence<Seed<JsClassId, FuzzedValue>> {
+    override fun generate(description: JsMethodDescription, type: JsClassId): Sequence<Seed<JsClassId, JsFuzzedValue>> {
         return defaultValueProviders().asSequence().flatMap { provider ->
             if (provider.accept(type)) {
                 provider.generate(description, type)
@@ -31,12 +34,12 @@ class JsFuzzing(
         }
     }
 
-    override suspend fun handle(description: JsMethodDescription, values: List<FuzzedValue>): JsFeedback {
+    override suspend fun handle(description: JsMethodDescription, values: List<JsFuzzedValue>): JsFeedback {
         return exec(description, values)
     }
 }
 
 suspend fun runFuzzing(
     description: JsMethodDescription,
-    exec: suspend (JsMethodDescription, List<FuzzedValue>) -> JsFeedback
+    exec: suspend (JsMethodDescription, List<JsFuzzedValue>) -> JsFeedback
 ) = JsFuzzing(exec).fuzz(description)

--- a/utbot-js/src/main/kotlin/fuzzer/JsFuzzing.kt
+++ b/utbot-js/src/main/kotlin/fuzzer/JsFuzzing.kt
@@ -3,15 +3,11 @@ package fuzzer
 import framework.api.js.JsClassId
 import fuzzer.providers.BoolValueProvider
 import fuzzer.providers.NumberValueProvider
-import fuzzer.providers.SetValueProvider
 import fuzzer.providers.ObjectValueProvider
 import fuzzer.providers.StringValueProvider
-import org.utbot.fuzzer.FuzzedValue
 import org.utbot.fuzzing.Fuzzing
 import org.utbot.fuzzing.Seed
 import org.utbot.fuzzing.fuzz
-import fuzzer.providers.ArrayValueProvider
-import fuzzer.providers.ObjectValueProvider
 
 fun defaultValueProviders() = listOf(
     BoolValueProvider,

--- a/utbot-js/src/main/kotlin/fuzzer/providers/BoolValueProvider.kt
+++ b/utbot-js/src/main/kotlin/fuzzer/providers/BoolValueProvider.kt
@@ -1,34 +1,28 @@
 package fuzzer.providers
 
+
 import framework.api.js.JsClassId
 import framework.api.js.JsPrimitiveModel
 import framework.api.js.util.isJsBasic
-import fuzzer.JsFuzzedValue
 import fuzzer.JsMethodDescription
-import fuzzer.fuzzed
-
-
+import org.utbot.framework.plugin.api.UtModel
 import org.utbot.fuzzing.Seed
 import org.utbot.fuzzing.ValueProvider
 import org.utbot.fuzzing.seeds.Bool
 
-object BoolValueProvider : ValueProvider<JsClassId, JsFuzzedValue, JsMethodDescription> {
+object BoolValueProvider : ValueProvider<JsClassId, UtModel, JsMethodDescription> {
 
     override fun accept(type: JsClassId): Boolean {
         return type.isJsBasic
     }
 
-    override fun generate(description: JsMethodDescription, type: JsClassId): Sequence<Seed<JsClassId, JsFuzzedValue>> =
+    override fun generate(description: JsMethodDescription, type: JsClassId): Sequence<Seed<JsClassId, UtModel>> =
         sequence {
             yield(Seed.Known(Bool.TRUE()) {
-                JsPrimitiveModel(true).fuzzed {
-                    summary = "%var% = true"
-                }
+                JsPrimitiveModel(true)
             })
             yield(Seed.Known(Bool.FALSE()) {
-                JsPrimitiveModel(false).fuzzed {
-                    summary = "%var% = false"
-                }
+                JsPrimitiveModel(false)
             })
         }
 }

--- a/utbot-js/src/main/kotlin/fuzzer/providers/BoolValueProvider.kt
+++ b/utbot-js/src/main/kotlin/fuzzer/providers/BoolValueProvider.kt
@@ -3,20 +3,22 @@ package fuzzer.providers
 import framework.api.js.JsClassId
 import framework.api.js.JsPrimitiveModel
 import framework.api.js.util.isJsBasic
+import fuzzer.JsFuzzedValue
 import fuzzer.JsMethodDescription
-import org.utbot.fuzzer.FuzzedValue
-import org.utbot.fuzzer.providers.PrimitivesModelProvider.fuzzed
+import fuzzer.fuzzed
+
+
 import org.utbot.fuzzing.Seed
 import org.utbot.fuzzing.ValueProvider
 import org.utbot.fuzzing.seeds.Bool
 
-object BoolValueProvider : ValueProvider<JsClassId, FuzzedValue, JsMethodDescription> {
+object BoolValueProvider : ValueProvider<JsClassId, JsFuzzedValue, JsMethodDescription> {
 
     override fun accept(type: JsClassId): Boolean {
         return type.isJsBasic
     }
 
-    override fun generate(description: JsMethodDescription, type: JsClassId): Sequence<Seed<JsClassId, FuzzedValue>> =
+    override fun generate(description: JsMethodDescription, type: JsClassId): Sequence<Seed<JsClassId, JsFuzzedValue>> =
         sequence {
             yield(Seed.Known(Bool.TRUE()) {
                 JsPrimitiveModel(true).fuzzed {

--- a/utbot-js/src/main/kotlin/fuzzer/providers/NumberValueProvider.kt
+++ b/utbot-js/src/main/kotlin/fuzzer/providers/NumberValueProvider.kt
@@ -8,21 +8,20 @@ import fuzzer.JsFuzzedContext.GE
 import fuzzer.JsFuzzedContext.GT
 import fuzzer.JsFuzzedContext.LE
 import fuzzer.JsFuzzedContext.LT
-import fuzzer.JsFuzzedValue
 import fuzzer.JsMethodDescription
-import fuzzer.fuzzed
+import org.utbot.framework.plugin.api.UtModel
 import org.utbot.fuzzing.Seed
 import org.utbot.fuzzing.ValueProvider
 import org.utbot.fuzzing.seeds.DefaultFloatBound
 import org.utbot.fuzzing.seeds.IEEE754Value
 
-object NumberValueProvider : ValueProvider<JsClassId, JsFuzzedValue, JsMethodDescription> {
+object NumberValueProvider : ValueProvider<JsClassId, UtModel, JsMethodDescription> {
 
     override fun accept(type: JsClassId): Boolean {
         return type.isJsBasic
     }
 
-    override fun generate(description: JsMethodDescription, type: JsClassId): Sequence<Seed<JsClassId, JsFuzzedValue>> =
+    override fun generate(description: JsMethodDescription, type: JsClassId): Sequence<Seed<JsClassId, UtModel>> =
         sequence {
             description.concreteValues.forEach { (_, v, c) ->
                 if (v is Double) {
@@ -33,18 +32,14 @@ object NumberValueProvider : ValueProvider<JsClassId, JsFuzzedValue, JsMethodDes
                     }
 
                     yield(Seed.Known(IEEE754Value.fromValue(v)) { known ->
-                        JsPrimitiveModel(known.toDouble() + balance).fuzzed {
-                            summary = "%var% = ${known.toDouble() + balance}"
-                        }
+                        JsPrimitiveModel(known.toDouble() + balance)
                     })
                 }
             }
             DefaultFloatBound.values().forEach { bound ->
                 // All numbers in JavaScript are like Double in Java/Kotlin
                 yield(Seed.Known(bound(52, 11)) { known ->
-                    JsPrimitiveModel(known.toDouble()).fuzzed {
-                        summary = "%var% = ${known.toDouble()}"
-                    }
+                    JsPrimitiveModel(known.toDouble())
                 })
             }
         }

--- a/utbot-js/src/main/kotlin/fuzzer/providers/NumberValueProvider.kt
+++ b/utbot-js/src/main/kotlin/fuzzer/providers/NumberValueProvider.kt
@@ -3,26 +3,26 @@ package fuzzer.providers
 import framework.api.js.JsClassId
 import framework.api.js.JsPrimitiveModel
 import framework.api.js.util.isJsBasic
+import fuzzer.JsFuzzedContext.EQ
+import fuzzer.JsFuzzedContext.GE
+import fuzzer.JsFuzzedContext.GT
+import fuzzer.JsFuzzedContext.LE
+import fuzzer.JsFuzzedContext.LT
+import fuzzer.JsFuzzedValue
 import fuzzer.JsMethodDescription
-import org.utbot.fuzzer.FuzzedContext.Comparison.EQ
-import org.utbot.fuzzer.FuzzedContext.Comparison.GE
-import org.utbot.fuzzer.FuzzedContext.Comparison.GT
-import org.utbot.fuzzer.FuzzedContext.Comparison.LE
-import org.utbot.fuzzer.FuzzedContext.Comparison.LT
-import org.utbot.fuzzer.FuzzedValue
-import org.utbot.fuzzer.providers.PrimitivesModelProvider.fuzzed
+import fuzzer.fuzzed
 import org.utbot.fuzzing.Seed
 import org.utbot.fuzzing.ValueProvider
 import org.utbot.fuzzing.seeds.DefaultFloatBound
 import org.utbot.fuzzing.seeds.IEEE754Value
 
-object NumberValueProvider : ValueProvider<JsClassId, FuzzedValue, JsMethodDescription> {
+object NumberValueProvider : ValueProvider<JsClassId, JsFuzzedValue, JsMethodDescription> {
 
     override fun accept(type: JsClassId): Boolean {
         return type.isJsBasic
     }
 
-    override fun generate(description: JsMethodDescription, type: JsClassId): Sequence<Seed<JsClassId, FuzzedValue>> =
+    override fun generate(description: JsMethodDescription, type: JsClassId): Sequence<Seed<JsClassId, JsFuzzedValue>> =
         sequence {
             description.concreteValues.forEach { (_, v, c) ->
                 if (v is Double) {

--- a/utbot-js/src/main/kotlin/fuzzer/providers/ObjectValueProvider.kt
+++ b/utbot-js/src/main/kotlin/fuzzer/providers/ObjectValueProvider.kt
@@ -35,7 +35,7 @@ class ObjectValueProvider : ValueProvider<JsClassId, JsFuzzedValue, JsMethodDesc
     ): Seed.Recursive<JsClassId, JsFuzzedValue> {
         return Seed.Recursive(
             construct = Routine.Create(constructorId.parameters) { values ->
-                val id = JsIdProvider.get()
+                val id = JsIdProvider.createId()
                 UtAssembleModel(
                     id = id,
                     classId = classId,

--- a/utbot-js/src/main/kotlin/fuzzer/providers/ObjectValueProvider.kt
+++ b/utbot-js/src/main/kotlin/fuzzer/providers/ObjectValueProvider.kt
@@ -10,17 +10,12 @@ import fuzzer.fuzzed
 import org.utbot.framework.plugin.api.UtAssembleModel
 import org.utbot.framework.plugin.api.UtExecutableCallModel
 import org.utbot.framework.plugin.api.UtNullModel
-import org.utbot.fuzzer.FuzzedValue
-import org.utbot.fuzzer.ReferencePreservingIntIdGenerator
-import org.utbot.fuzzer.providers.ConstantsModelProvider.fuzzed
 import org.utbot.fuzzing.Routine
 import org.utbot.fuzzing.Seed
 import org.utbot.fuzzing.ValueProvider
 import org.utbot.fuzzing.utils.hex
 
 class ObjectValueProvider : ValueProvider<JsClassId, JsFuzzedValue, JsMethodDescription> {
-
-    private val idGenerator = ReferencePreservingIntIdGenerator()
 
     override fun accept(type: JsClassId): Boolean {
         return type.isClass
@@ -34,10 +29,13 @@ class ObjectValueProvider : ValueProvider<JsClassId, JsFuzzedValue, JsMethodDesc
         yield(createValue(type, constructor))
     }
 
-    private fun createValue(classId: JsClassId, constructorId: JsConstructorId): Seed.Recursive<JsClassId, JsFuzzedValue> {
+    private fun createValue(
+        classId: JsClassId,
+        constructorId: JsConstructorId
+    ): Seed.Recursive<JsClassId, JsFuzzedValue> {
         return Seed.Recursive(
             construct = Routine.Create(constructorId.parameters) { values ->
-                val id = idGenerator.createId()
+                val id = JsIdProvider.get()
                 UtAssembleModel(
                     id = id,
                     classId = classId,
@@ -48,7 +46,8 @@ class ObjectValueProvider : ValueProvider<JsClassId, JsFuzzedValue, JsMethodDesc
                         values.map { it.model }),
                     modificationsChainProvider = { mutableListOf() }
                 ).fuzzed {
-                    summary = "%var% = ${classId.simpleName}(${constructorId.parameters.joinToString { it.simpleName }})"
+                    summary =
+                        "%var% = ${classId.simpleName}(${constructorId.parameters.joinToString { it.simpleName }})"
                 }
             },
             modify = emptySequence(),

--- a/utbot-js/src/main/kotlin/fuzzer/providers/ObjectValueProvider.kt
+++ b/utbot-js/src/main/kotlin/fuzzer/providers/ObjectValueProvider.kt
@@ -3,19 +3,18 @@ package fuzzer.providers
 import framework.api.js.JsClassId
 import framework.api.js.JsConstructorId
 import framework.api.js.util.isClass
-import fuzzer.JsFuzzedValue
 import fuzzer.JsIdProvider
 import fuzzer.JsMethodDescription
-import fuzzer.fuzzed
 import org.utbot.framework.plugin.api.UtAssembleModel
 import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtNullModel
 import org.utbot.fuzzing.Routine
 import org.utbot.fuzzing.Seed
 import org.utbot.fuzzing.ValueProvider
 import org.utbot.fuzzing.utils.hex
 
-class ObjectValueProvider : ValueProvider<JsClassId, JsFuzzedValue, JsMethodDescription> {
+class ObjectValueProvider : ValueProvider<JsClassId, UtModel, JsMethodDescription> {
 
     override fun accept(type: JsClassId): Boolean {
         return type.isClass
@@ -32,7 +31,7 @@ class ObjectValueProvider : ValueProvider<JsClassId, JsFuzzedValue, JsMethodDesc
     private fun createValue(
         classId: JsClassId,
         constructorId: JsConstructorId
-    ): Seed.Recursive<JsClassId, JsFuzzedValue> {
+    ): Seed.Recursive<JsClassId, UtModel> {
         return Seed.Recursive(
             construct = Routine.Create(constructorId.parameters) { values ->
                 val id = JsIdProvider.createId()
@@ -43,18 +42,13 @@ class ObjectValueProvider : ValueProvider<JsClassId, JsFuzzedValue, JsMethodDesc
                     instantiationCall = UtExecutableCallModel(
                         null,
                         constructorId,
-                        values.map { it.model }),
+                        values.map { it }),
                     modificationsChainProvider = { mutableListOf() }
-                ).fuzzed {
-                    summary =
-                        "%var% = ${classId.simpleName}(${constructorId.parameters.joinToString { it.simpleName }})"
-                }
+                )
             },
             modify = emptySequence(),
             empty = Routine.Empty {
-                UtNullModel(classId).fuzzed {
-                    summary = "%var% = null"
-                }
+                UtNullModel(classId)
             }
         )
     }

--- a/utbot-js/src/main/kotlin/fuzzer/providers/ObjectValueProvider.kt
+++ b/utbot-js/src/main/kotlin/fuzzer/providers/ObjectValueProvider.kt
@@ -3,7 +3,10 @@ package fuzzer.providers
 import framework.api.js.JsClassId
 import framework.api.js.JsConstructorId
 import framework.api.js.util.isClass
+import fuzzer.JsFuzzedValue
+import fuzzer.JsIdProvider
 import fuzzer.JsMethodDescription
+import fuzzer.fuzzed
 import org.utbot.framework.plugin.api.UtAssembleModel
 import org.utbot.framework.plugin.api.UtExecutableCallModel
 import org.utbot.framework.plugin.api.UtNullModel
@@ -15,7 +18,7 @@ import org.utbot.fuzzing.Seed
 import org.utbot.fuzzing.ValueProvider
 import org.utbot.fuzzing.utils.hex
 
-class ObjectValueProvider : ValueProvider<JsClassId, FuzzedValue, JsMethodDescription> {
+class ObjectValueProvider : ValueProvider<JsClassId, JsFuzzedValue, JsMethodDescription> {
 
     private val idGenerator = ReferencePreservingIntIdGenerator()
 
@@ -31,7 +34,7 @@ class ObjectValueProvider : ValueProvider<JsClassId, FuzzedValue, JsMethodDescri
         yield(createValue(type, constructor))
     }
 
-    private fun createValue(classId: JsClassId, constructorId: JsConstructorId): Seed.Recursive<JsClassId, FuzzedValue> {
+    private fun createValue(classId: JsClassId, constructorId: JsConstructorId): Seed.Recursive<JsClassId, JsFuzzedValue> {
         return Seed.Recursive(
             construct = Routine.Create(constructorId.parameters) { values ->
                 val id = idGenerator.createId()

--- a/utbot-js/src/main/kotlin/fuzzer/providers/ObjectValueProvider.kt
+++ b/utbot-js/src/main/kotlin/fuzzer/providers/ObjectValueProvider.kt
@@ -42,7 +42,8 @@ class ObjectValueProvider : ValueProvider<JsClassId, UtModel, JsMethodDescriptio
                     instantiationCall = UtExecutableCallModel(
                         null,
                         constructorId,
-                        values.map { it }),
+                        values
+                    ),
                     modificationsChainProvider = { mutableListOf() }
                 )
             },

--- a/utbot-js/src/main/kotlin/fuzzer/providers/StringValueProvider.kt
+++ b/utbot-js/src/main/kotlin/fuzzer/providers/StringValueProvider.kt
@@ -4,14 +4,18 @@ import framework.api.js.JsClassId
 import framework.api.js.JsPrimitiveModel
 import framework.api.js.util.isJsBasic
 import framework.api.js.util.jsStringClassId
+import fuzzer.JsFuzzedValue
 import fuzzer.JsMethodDescription
+import fuzzer.fuzzed
+
+
 import org.utbot.fuzzer.FuzzedValue
 import org.utbot.fuzzer.providers.PrimitivesModelProvider.fuzzed
 import org.utbot.fuzzing.Seed
 import org.utbot.fuzzing.ValueProvider
 import org.utbot.fuzzing.seeds.StringValue
 
-object StringValueProvider : ValueProvider<JsClassId, FuzzedValue, JsMethodDescription> {
+object StringValueProvider : ValueProvider<JsClassId, JsFuzzedValue, JsMethodDescription> {
 
     override fun accept(type: JsClassId): Boolean {
         return type.isJsBasic
@@ -20,7 +24,7 @@ object StringValueProvider : ValueProvider<JsClassId, FuzzedValue, JsMethodDescr
     override fun generate(
         description: JsMethodDescription,
         type: JsClassId
-    ): Sequence<Seed<JsClassId, FuzzedValue>> = sequence {
+    ): Sequence<Seed<JsClassId, JsFuzzedValue>> = sequence {
         val constants = description.concreteValues.asSequence()
             .filter { it.classId == jsStringClassId }
         val values = constants

--- a/utbot-js/src/main/kotlin/fuzzer/providers/StringValueProvider.kt
+++ b/utbot-js/src/main/kotlin/fuzzer/providers/StringValueProvider.kt
@@ -7,10 +7,6 @@ import framework.api.js.util.jsStringClassId
 import fuzzer.JsFuzzedValue
 import fuzzer.JsMethodDescription
 import fuzzer.fuzzed
-
-
-import org.utbot.fuzzer.FuzzedValue
-import org.utbot.fuzzer.providers.PrimitivesModelProvider.fuzzed
 import org.utbot.fuzzing.Seed
 import org.utbot.fuzzing.ValueProvider
 import org.utbot.fuzzing.seeds.StringValue

--- a/utbot-js/src/main/kotlin/fuzzer/providers/StringValueProvider.kt
+++ b/utbot-js/src/main/kotlin/fuzzer/providers/StringValueProvider.kt
@@ -4,14 +4,13 @@ import framework.api.js.JsClassId
 import framework.api.js.JsPrimitiveModel
 import framework.api.js.util.isJsBasic
 import framework.api.js.util.jsStringClassId
-import fuzzer.JsFuzzedValue
 import fuzzer.JsMethodDescription
-import fuzzer.fuzzed
+import org.utbot.framework.plugin.api.UtModel
 import org.utbot.fuzzing.Seed
 import org.utbot.fuzzing.ValueProvider
 import org.utbot.fuzzing.seeds.StringValue
 
-object StringValueProvider : ValueProvider<JsClassId, JsFuzzedValue, JsMethodDescription> {
+object StringValueProvider : ValueProvider<JsClassId, UtModel, JsMethodDescription> {
 
     override fun accept(type: JsClassId): Boolean {
         return type.isJsBasic
@@ -20,7 +19,7 @@ object StringValueProvider : ValueProvider<JsClassId, JsFuzzedValue, JsMethodDes
     override fun generate(
         description: JsMethodDescription,
         type: JsClassId
-    ): Sequence<Seed<JsClassId, JsFuzzedValue>> = sequence {
+    ): Sequence<Seed<JsClassId, UtModel>> = sequence {
         val constants = description.concreteValues.asSequence()
             .filter { it.classId == jsStringClassId }
         val values = constants
@@ -28,9 +27,7 @@ object StringValueProvider : ValueProvider<JsClassId, JsFuzzedValue, JsMethodDes
                 sequenceOf("", "abc", "\n\t\n")
         values.forEach { value ->
             yield(Seed.Known(StringValue(value)) { known ->
-                JsPrimitiveModel(known.value).fuzzed {
-                    summary = "%var% = '${known.value}'"
-                }
+                JsPrimitiveModel(known.value)
             })
         }
     }

--- a/utbot-js/src/main/kotlin/parser/JsFuzzerAstVisitor.kt
+++ b/utbot-js/src/main/kotlin/parser/JsFuzzerAstVisitor.kt
@@ -5,6 +5,10 @@ import com.google.javascript.rhino.Node
 import framework.api.js.util.jsBooleanClassId
 import framework.api.js.util.jsDoubleClassId
 import framework.api.js.util.jsStringClassId
+import fuzzer.JsFuzzedConcreteValue
+import fuzzer.JsFuzzedContext
+
+
 import org.utbot.fuzzer.FuzzedConcreteValue
 import org.utbot.fuzzer.FuzzedContext
 import parser.JsParserUtils.getAnyValue
@@ -14,8 +18,8 @@ import parser.JsParserUtils.toFuzzedContextComparisonOrNull
 
 class JsFuzzerAstVisitor : IAstVisitor {
 
-    private var lastFuzzedOpGlobal: FuzzedContext = FuzzedContext.Unknown
-    val fuzzedConcreteValues = mutableSetOf<FuzzedConcreteValue>()
+    private var lastFuzzedOpGlobal: JsFuzzedContext = JsFuzzedContext.Unknown
+    val fuzzedConcreteValues = mutableSetOf<JsFuzzedConcreteValue>()
 
     override fun accept(rootNode: Node) {
         NodeUtil.visitPreOrder(rootNode) { node ->
@@ -25,8 +29,7 @@ class JsFuzzerAstVisitor : IAstVisitor {
                 currentFuzzedOp != null -> {
                     lastFuzzedOpGlobal = currentFuzzedOp
                     validateNode(node.getBinaryExprLeftOperand().getAnyValue())
-                    lastFuzzedOpGlobal = if (lastFuzzedOpGlobal is FuzzedContext.Comparison)
-                            (lastFuzzedOpGlobal as FuzzedContext.Comparison).reverse() else FuzzedContext.Unknown
+                    lastFuzzedOpGlobal = lastFuzzedOpGlobal.reverse()
                     validateNode(node.getBinaryExprRightOperand().getAnyValue())
                 }
             }
@@ -38,7 +41,7 @@ class JsFuzzerAstVisitor : IAstVisitor {
         when (value) {
             is String -> {
                 fuzzedConcreteValues.add(
-                    FuzzedConcreteValue(
+                    JsFuzzedConcreteValue(
                         jsStringClassId,
                         value.toString(),
                         lastFuzzedOpGlobal
@@ -48,7 +51,7 @@ class JsFuzzerAstVisitor : IAstVisitor {
 
             is Boolean -> {
                 fuzzedConcreteValues.add(
-                    FuzzedConcreteValue(
+                    JsFuzzedConcreteValue(
                         jsBooleanClassId,
                         value,
                         lastFuzzedOpGlobal
@@ -57,7 +60,7 @@ class JsFuzzerAstVisitor : IAstVisitor {
             }
 
             is Double -> {
-                fuzzedConcreteValues.add(FuzzedConcreteValue(jsDoubleClassId, value, lastFuzzedOpGlobal))
+                fuzzedConcreteValues.add(JsFuzzedConcreteValue(jsDoubleClassId, value, lastFuzzedOpGlobal))
             }
         }
     }

--- a/utbot-js/src/main/kotlin/parser/JsFuzzerAstVisitor.kt
+++ b/utbot-js/src/main/kotlin/parser/JsFuzzerAstVisitor.kt
@@ -1,5 +1,6 @@
 package parser
 
+
 import com.google.javascript.jscomp.NodeUtil
 import com.google.javascript.rhino.Node
 import framework.api.js.util.jsBooleanClassId
@@ -7,10 +8,6 @@ import framework.api.js.util.jsDoubleClassId
 import framework.api.js.util.jsStringClassId
 import fuzzer.JsFuzzedConcreteValue
 import fuzzer.JsFuzzedContext
-
-
-import org.utbot.fuzzer.FuzzedConcreteValue
-import org.utbot.fuzzer.FuzzedContext
 import parser.JsParserUtils.getAnyValue
 import parser.JsParserUtils.getBinaryExprLeftOperand
 import parser.JsParserUtils.getBinaryExprRightOperand

--- a/utbot-js/src/main/kotlin/parser/JsParserUtils.kt
+++ b/utbot-js/src/main/kotlin/parser/JsParserUtils.kt
@@ -4,9 +4,7 @@ import com.google.javascript.jscomp.Compiler
 import com.google.javascript.jscomp.SourceFile
 import com.google.javascript.rhino.Node
 import fuzzer.JsFuzzedContext
-import java.lang.IllegalStateException
 import parser.JsParserUtils.getMethodName
-import org.utbot.fuzzer.FuzzedContext
 
 // TODO: make methods more safe by checking the Node method is called on.
 // Used for .children() calls.

--- a/utbot-js/src/main/kotlin/parser/JsParserUtils.kt
+++ b/utbot-js/src/main/kotlin/parser/JsParserUtils.kt
@@ -3,8 +3,12 @@ package parser
 import com.google.javascript.jscomp.Compiler
 import com.google.javascript.jscomp.SourceFile
 import com.google.javascript.rhino.Node
+import fuzzer.JsFuzzedContext
+import java.lang.IllegalStateException
+import parser.JsParserUtils.getMethodName
 import org.utbot.fuzzer.FuzzedContext
 
+// TODO: make methods more safe by checking the Node method is called on.
 // Used for .children() calls.
 @Suppress("DEPRECATION")
 object JsParserUtils {
@@ -73,14 +77,14 @@ object JsParserUtils {
     /**
      * Called upon node with any kind of binary comparison token.
      */
-    fun Node.toFuzzedContextComparisonOrNull(): FuzzedContext.Comparison? = when {
-        this.isEQ -> FuzzedContext.Comparison.EQ
-        this.isNE -> FuzzedContext.Comparison.NE
-        this.token.name == "LT" -> FuzzedContext.Comparison.LT
-        this.token.name == "GT" -> FuzzedContext.Comparison.GT
-        this.token.name == "LE" -> FuzzedContext.Comparison.LE
-        this.token.name == "GE" -> FuzzedContext.Comparison.GE
-        this.token.name == "SHEQ" -> FuzzedContext.Comparison.EQ
+    fun Node.toFuzzedContextComparisonOrNull(): JsFuzzedContext? = when {
+        this.isEQ -> JsFuzzedContext.EQ
+        this.isNE -> JsFuzzedContext.NE
+        this.token.name == "LT" -> JsFuzzedContext.LT
+        this.token.name == "GT" -> JsFuzzedContext.GT
+        this.token.name == "LE" -> JsFuzzedContext.LE
+        this.token.name == "GE" -> JsFuzzedContext.GE
+        this.token.name == "SHEQ" -> JsFuzzedContext.EQ
         else -> null
     }
 

--- a/utbot-js/src/main/kotlin/service/CoverageServiceProvider.kt
+++ b/utbot-js/src/main/kotlin/service/CoverageServiceProvider.kt
@@ -8,16 +8,11 @@ import fuzzer.JsMethodDescription
 import org.utbot.framework.plugin.api.UtAssembleModel
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.util.isStatic
-import org.utbot.fuzzer.FuzzedValue
 import settings.JsTestGenerationSettings
 import settings.JsTestGenerationSettings.tempFileName
 import utils.CoverageData
 import utils.ResultData
 import java.util.regex.Pattern
-import org.utbot.framework.plugin.api.UtArrayModel
-import org.utbot.framework.plugin.api.UtExecutableCallModel
-import org.utbot.framework.plugin.api.UtNullModel
-import providers.imports.IImportsProvider
 
 class CoverageServiceProvider(
     private val context: ServiceContext,
@@ -174,11 +169,11 @@ fs.writeFileSync("$resFilePath$index.json", JSON.stringify(json$index))
         method: JsMethodId,
         containingClass: String?
     ): String {
-        val actualParams = description.thisInstance?.let{ fuzzedValue.drop(1) } ?: fuzzedValue
+        val actualParams = description.thisInstance?.let { fuzzedValue.drop(1) } ?: fuzzedValue
         val initClass = containingClass?.let {
             if (!method.isStatic) {
-                description.thisInstance?.let { fuzzedValue[0].model.toCallString() } ?:
-                "new ${JsTestGenerationSettings.fileUnderTestAliases}.${it}()"
+                description.thisInstance?.let { fuzzedValue[0].model.toCallString() }
+                    ?: "new ${JsTestGenerationSettings.fileUnderTestAliases}.${it}()"
             } else "${JsTestGenerationSettings.fileUnderTestAliases}.$it"
         } ?: JsTestGenerationSettings.fileUnderTestAliases
         var callString = "$initClass.${method.name}"

--- a/utbot-js/src/main/kotlin/service/CoverageServiceProvider.kt
+++ b/utbot-js/src/main/kotlin/service/CoverageServiceProvider.kt
@@ -3,6 +3,7 @@ package service
 import framework.api.js.JsMethodId
 import framework.api.js.JsPrimitiveModel
 import framework.api.js.util.isUndefined
+import fuzzer.JsFuzzedValue
 import fuzzer.JsMethodDescription
 import org.utbot.framework.plugin.api.UtAssembleModel
 import org.utbot.framework.plugin.api.UtModel
@@ -13,8 +14,11 @@ import settings.JsTestGenerationSettings.tempFileName
 import utils.CoverageData
 import utils.ResultData
 import java.util.regex.Pattern
+import org.utbot.framework.plugin.api.UtArrayModel
+import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtNullModel
+import providers.imports.IImportsProvider
 
-// TODO: Add "error" field in result json to not collide with "result" field upon error.
 class CoverageServiceProvider(
     private val context: ServiceContext,
     private val instrumentationService: InstrumentationService,
@@ -58,7 +62,7 @@ function check_value(value, json) {
     }
 
     fun get(
-        fuzzedValues: List<List<FuzzedValue>>,
+        fuzzedValues: List<List<JsFuzzedValue>>,
         execId: JsMethodId,
     ): Pair<List<CoverageData>, List<ResultData>> {
         return when (mode) {
@@ -75,7 +79,7 @@ function check_value(value, json) {
     }
 
     private fun runBasicCoverageAnalysis(
-        fuzzedValues: List<List<FuzzedValue>>,
+        fuzzedValues: List<List<JsFuzzedValue>>,
         execId: JsMethodId,
     ): Pair<List<CoverageData>, List<ResultData>> {
         val covFunName = instrumentationService.covFunName
@@ -99,7 +103,7 @@ function check_value(value, json) {
     }
 
     private fun runFastCoverageAnalysis(
-        fuzzedValues: List<List<FuzzedValue>>,
+        fuzzedValues: List<List<JsFuzzedValue>>,
         execId: JsMethodId,
     ): Pair<List<CoverageData>, List<ResultData>> {
         val covFunName = instrumentationService.covFunName
@@ -134,7 +138,7 @@ fs.writeFileSync("$resFilePath", JSON.stringify(json))
     }
 
     private fun makeStringForRunJs(
-        fuzzedValue: List<FuzzedValue>,
+        fuzzedValue: List<JsFuzzedValue>,
         method: JsMethodId,
         containingClass: String?,
         covFunName: String,
@@ -166,7 +170,7 @@ fs.writeFileSync("$resFilePath$index.json", JSON.stringify(json$index))
     }
 
     private fun makeCallFunctionString(
-        fuzzedValue: List<FuzzedValue>,
+        fuzzedValue: List<JsFuzzedValue>,
         method: JsMethodId,
         containingClass: String?
     ): String {

--- a/utbot-js/src/main/kotlin/service/CoverageServiceProvider.kt
+++ b/utbot-js/src/main/kotlin/service/CoverageServiceProvider.kt
@@ -3,7 +3,6 @@ package service
 import framework.api.js.JsMethodId
 import framework.api.js.JsPrimitiveModel
 import framework.api.js.util.isUndefined
-import fuzzer.JsFuzzedValue
 import fuzzer.JsMethodDescription
 import org.utbot.framework.plugin.api.UtAssembleModel
 import org.utbot.framework.plugin.api.UtModel
@@ -57,7 +56,7 @@ function check_value(value, json) {
     }
 
     fun get(
-        fuzzedValues: List<List<JsFuzzedValue>>,
+        fuzzedValues: List<List<UtModel>>,
         execId: JsMethodId,
     ): Pair<List<CoverageData>, List<ResultData>> {
         return when (mode) {
@@ -74,7 +73,7 @@ function check_value(value, json) {
     }
 
     private fun runBasicCoverageAnalysis(
-        fuzzedValues: List<List<JsFuzzedValue>>,
+        fuzzedValues: List<List<UtModel>>,
         execId: JsMethodId,
     ): Pair<List<CoverageData>, List<ResultData>> {
         val covFunName = instrumentationService.covFunName
@@ -98,7 +97,7 @@ function check_value(value, json) {
     }
 
     private fun runFastCoverageAnalysis(
-        fuzzedValues: List<List<JsFuzzedValue>>,
+        fuzzedValues: List<List<UtModel>>,
         execId: JsMethodId,
     ): Pair<List<CoverageData>, List<ResultData>> {
         val covFunName = instrumentationService.covFunName
@@ -133,7 +132,7 @@ fs.writeFileSync("$resFilePath", JSON.stringify(json))
     }
 
     private fun makeStringForRunJs(
-        fuzzedValue: List<JsFuzzedValue>,
+        fuzzedValue: List<UtModel>,
         method: JsMethodId,
         containingClass: String?,
         covFunName: String,
@@ -165,14 +164,14 @@ fs.writeFileSync("$resFilePath$index.json", JSON.stringify(json$index))
     }
 
     private fun makeCallFunctionString(
-        fuzzedValue: List<JsFuzzedValue>,
+        fuzzedValue: List<UtModel>,
         method: JsMethodId,
         containingClass: String?
     ): String {
         val actualParams = description.thisInstance?.let { fuzzedValue.drop(1) } ?: fuzzedValue
         val initClass = containingClass?.let {
             if (!method.isStatic) {
-                description.thisInstance?.let { fuzzedValue[0].model.toCallString() }
+                description.thisInstance?.let { fuzzedValue[0].toCallString() }
                     ?: "new ${JsTestGenerationSettings.fileUnderTestAliases}.${it}()"
             } else "${JsTestGenerationSettings.fileUnderTestAliases}.$it"
         } ?: JsTestGenerationSettings.fileUnderTestAliases
@@ -180,7 +179,7 @@ fs.writeFileSync("$resFilePath$index.json", JSON.stringify(json$index))
         callString += actualParams.joinToString(
             prefix = "(",
             postfix = ")",
-        ) { value -> value.model.toCallString() }
+        ) { value -> value.toCallString() }
         return callString
     }
 


### PR DESCRIPTION
## Description

Now `utbot-js` module depends on `utbot-fuzzing` and do not contain any imports from `org.utbot.fuzzer`

Fixes #1792 

## How to test

### Manual tests

Various scenarios have been tested. You can find the examples in the folder `/utbot-js/samples' and try to run UTBot.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.