### PR TITLE
Fix activation of UTBot action for JavaScript files

### DIFF
--- a/utbot-intellij-js/src/main/kotlin/org/utbot/intellij/plugin/language/js/JsDialogProcessor.kt
+++ b/utbot-intellij-js/src/main/kotlin/org/utbot/intellij/plugin/language/js/JsDialogProcessor.kt
@@ -23,16 +23,15 @@ import org.jetbrains.kotlin.idea.util.application.invokeLater
 import org.jetbrains.kotlin.idea.util.application.runReadAction
 import org.jetbrains.kotlin.idea.util.application.runWriteAction
 import org.jetbrains.kotlin.konan.file.File
+import org.utbot.framework.plugin.api.TimeoutException
 import org.utbot.intellij.plugin.ui.utils.showErrorDialogLater
 import org.utbot.intellij.plugin.ui.utils.testModules
 import settings.JsDynamicSettings
 import settings.JsExportsSettings.endComment
 import settings.JsExportsSettings.startComment
-import settings.JsPackagesSettings.mochaData
-import settings.JsPackagesSettings.nycData
-import settings.JsPackagesSettings.ternData
 import settings.JsTestGenerationSettings.dummyClassName
-import settings.PackageData
+import settings.PackageDataService
+import settings.jsPackagesList
 import utils.JsCmdExec
 import utils.OsProvider
 import java.io.IOException
@@ -47,7 +46,7 @@ object JsDialogProcessor {
         fileMethods: Set<JSMemberInfo>,
         focusedMethod: JSMemberInfo?,
         containingFilePath: String,
-        editor: Editor,
+        editor: Editor?,
         file: JSFile
     ) {
         val model =
@@ -64,48 +63,50 @@ object JsDialogProcessor {
                     createDialog(model)?.let { dialogWindow ->
                         if (!dialogWindow.showAndGet()) return@invokeLater
                         // Since Tern.js accesses containing file, sync with file system required before test generation.
-                        runWriteAction {
-                            with(FileDocumentManager.getInstance()) {
-                                saveDocument(editor.document)
+                        editor?.let {
+                            runWriteAction {
+                                with(FileDocumentManager.getInstance()) {
+                                    saveDocument(editor.document)
+                                }
                             }
                         }
-                        createTests(dialogWindow.model, containingFilePath, editor)
+                        createTests(
+                            dialogWindow.model,
+                            containingFilePath,
+                            editor,
+                            dialogWindow.model.file.getContent()
+                        )
                     }
                 }
             }
         }).queue()
     }
 
-    private fun findNodeAndNPM(): Pair<String, String>? =
-        try {
-            val pathToNode = NodeJsLocalInterpreterManager.getInstance()
-                .interpreters.first().interpreterSystemIndependentPath
-            val (_, errorText) = JsCmdExec.runCommand(
-                shouldWait = true,
-                cmd = arrayOf("\"${pathToNode}\"", "-v")
-            )
-            if (errorText.isNotEmpty()) throw NoSuchElementException()
-            val pathToNPM =
-                pathToNode.substringBeforeLast("/") + "/" + "npm" + OsProvider.getProviderByOs().npmPackagePostfix
-            pathToNode to pathToNPM
-        } catch (e: NoSuchElementException) {
-            Messages.showErrorDialog(
-                "Node.js interpreter is not found in IDEA settings.\n" +
-                        "Please set it in Settings > Languages & Frameworks > Node.js",
-                "Requirement Error"
-            )
-            logger.error { "Node.js interpreter was not found in IDEA settings." }
-            null
-        } catch (e: IOException) {
-            Messages.showErrorDialog(
-                "Node.js interpreter path is corrupted in IDEA settings.\n" +
-                        "Please check Settings > Languages & Frameworks > Node.js",
-                "Requirement Error"
-            )
-            logger.error { "Node.js interpreter path is corrupted in IDEA settings." }
-            null
-        }
-
+    private fun findNodeAndNPM(): Pair<String, String>? = try {
+        val pathToNode =
+            NodeJsLocalInterpreterManager.getInstance().interpreters.first().interpreterSystemIndependentPath
+        val (_, errorText) = JsCmdExec.runCommand(
+            shouldWait = true, cmd = arrayOf("\"${pathToNode}\"", "-v")
+        )
+        if (errorText.isNotEmpty()) throw NoSuchElementException()
+        val pathToNPM =
+            pathToNode.substringBeforeLast("/") + "/" + "npm" + OsProvider.getProviderByOs().npmPackagePostfix
+        pathToNode to pathToNPM
+    } catch (e: NoSuchElementException) {
+        Messages.showErrorDialog(
+            "Node.js interpreter is not found in IDEA settings.\n" + "Please set it in Settings > Languages & Frameworks > Node.js",
+            "Requirement Error"
+        )
+        logger.error { "Node.js interpreter was not found in IDEA settings." }
+        null
+    } catch (e: IOException) {
+        Messages.showErrorDialog(
+            "Node.js interpreter path is corrupted in IDEA settings.\n" + "Please check Settings > Languages & Frameworks > Node.js",
+            "Requirement Error"
+        )
+        logger.error { "Node.js interpreter path is corrupted in IDEA settings." }
+        null
+    }
 
     private fun createJsTestModel(
         project: Project,
@@ -138,7 +139,6 @@ object JsDialogProcessor {
             this.pathToNode = pathToNode
             this.pathToNPM = pathToNPM
         }
-
     }
 
     private fun createDialog(jsTestsModel: JsTestsModel?) = jsTestsModel?.let { JsDialogWindow(it) }
@@ -150,7 +150,7 @@ object JsDialogProcessor {
         }
     }
 
-    private fun createTests(model: JsTestsModel, containingFilePath: String, editor: Editor) {
+    private fun createTests(model: JsTestsModel, containingFilePath: String, editor: Editor?, contents: String) {
         val normalizedContainingFilePath = containingFilePath.replace(File.separator, "/")
         (object : Task.Backgroundable(model.project, "Generate tests") {
             override fun run(indicator: ProgressIndicator) {
@@ -159,10 +159,9 @@ object JsDialogProcessor {
                 val testDir = PsiDirectoryFactory.getInstance(project).createDirectory(
                     model.testSourceRoot!!
                 )
-                val testFileName = normalizedContainingFilePath.substringAfterLast("/")
-                    .replace(Regex(".js"), "Test.js")
+                val testFileName = normalizedContainingFilePath.substringAfterLast("/").replace(Regex(".js"), "Test.js")
                 val testGenerator = JsTestGenerator(
-                    fileText = editor.document.text,
+                    fileText = contents,
                     sourceFilePath = normalizedContainingFilePath,
                     projectPath = model.project.basePath?.replace(File.separator, "/")
                         ?: throw IllegalStateException("Can't access project path."),
@@ -176,7 +175,9 @@ object JsDialogProcessor {
                         if (name == dummyClassName) null else name
                     },
                     outputFilePath = "${testDir.virtualFile.path}/$testFileName".replace(File.separator, "/"),
-                    exportsManager = partialApplication(JsDialogProcessor::manageExports, editor, project),
+                    exportsManager = partialApplication(
+                        JsDialogProcessor::manageExports, editor, project, model
+                    ),
                     settings = JsDynamicSettings(
                         pathToNode = model.pathToNode,
                         pathToNYC = model.pathToNYC,
@@ -184,8 +185,7 @@ object JsDialogProcessor {
                         timeout = model.timeout,
                         coverageMode = model.coverageMode
                     ),
-                    isCancelled = { indicator.isCanceled }
-                )
+                    isCancelled = { indicator.isCanceled })
 
                 indicator.fraction = indicator.fraction.coerceAtLeast(0.9)
                 indicator.text = "Generate code for tests"
@@ -193,11 +193,9 @@ object JsDialogProcessor {
                 val generatedCode = testGenerator.run()
                 invokeLater {
                     runWriteAction {
-                        val testPsiFile =
-                            testDir.findFile(testFileName) ?: PsiFileFactory.getInstance(project)
-                                .createFileFromText(testFileName, JsLanguageAssistant.jsLanguage, generatedCode)
-                        val testFileEditor =
-                            CodeInsightUtil.positionCursor(project, testPsiFile, testPsiFile)
+                        val testPsiFile = testDir.findFile(testFileName) ?: PsiFileFactory.getInstance(project)
+                            .createFileFromText(testFileName, JsLanguageAssistant.jsLanguage, generatedCode)
+                        val testFileEditor = CodeInsightUtil.positionCursor(project, testPsiFile, testPsiFile)
                         unblockDocument(project, testFileEditor.document)
                         testFileEditor.document.setText(generatedCode)
                         unblockDocument(project, testFileEditor.document)
@@ -208,57 +206,59 @@ object JsDialogProcessor {
         }).queue()
     }
 
-    private fun <A, B, C> partialApplication(f: (A, B, C) -> Unit, a: A, b: B): (C) -> Unit {
-        return { c: C -> f(a, b, c) }
+    private fun <A, B, C, D, E> partialApplication(f: (A, B, C, D, E) -> Unit, a: A, b: B, c: C): (D, E) -> Unit {
+        return { d: D, e: E -> f(a, b, c, d, e) }
     }
 
-    private fun manageExports(editor: Editor, project: Project, exports: List<String>) {
+    private fun JSFile.getContent(): String = this.viewProvider.contents.toString()
+
+    private fun manageExports(
+        editor: Editor?, project: Project, model: JsTestsModel, exports: List<String>, swappedText: (String?) -> String
+    ) {
         AppExecutorUtil.getAppExecutorService().submit {
             invokeLater {
-                val exportSection = exports.joinToString("\n") { "exports.$it = $it" }
-                val fileText = editor.document.text
+                val fileText = model.file.getContent()
                 when {
-                    fileText.contains(exportSection) -> {}
-
-                    fileText.contains(startComment) && !fileText.contains(exportSection) -> {
+                    fileText.contains(startComment) -> {
                         val regex = Regex("$startComment((\\r\\n|\\n|\\r|.)*)$endComment")
                         regex.find(fileText)?.groups?.get(1)?.value?.let { existingSection ->
-                            val exportRegex = Regex("exports[.](.*) =")
-                            val existingExports = existingSection.split("\n").filter { it.contains(exportRegex) }
-                            val existingExportsSet = existingExports.map { rawLine ->
-                                exportRegex.find(rawLine)?.groups?.get(1)?.value ?: throw IllegalStateException()
-                            }.toSet()
-                            val resultSet = existingExportsSet + exports.toSet()
-                            val resSection = resultSet.joinToString("\n") { "exports.$it = $it" }
-                            val swappedText = fileText.replace(existingSection, "\n$resSection\n")
-                            runWriteAction {
-                                with(editor.document) {
-                                    unblockDocument(project, this)
-                                    setText(swappedText)
-                                    unblockDocument(project, this)
+                            val newText = swappedText(existingSection)
+                            editor?.let {
+                                runWriteAction {
+                                    with(editor.document) {
+                                        unblockDocument(project, this)
+                                        setText(newText)
+                                        unblockDocument(project, this)
+                                    }
+                                    with(FileDocumentManager.getInstance()) {
+                                        saveDocument(editor.document)
+                                    }
                                 }
-                                with(FileDocumentManager.getInstance()) {
-                                    saveDocument(editor.document)
-                                }
+                            } ?: run {
+                                File(model.containingFilePath).writeText(newText)
                             }
                         }
                     }
 
                     else -> {
                         val line = buildString {
-                            append("\n$startComment\n")
-                            append(exportSection)
-                            append("\n$endComment")
+                            append("\n$startComment")
+                            append(swappedText(null))
+                            append(endComment)
                         }
-                        runWriteAction {
-                            with(editor.document) {
-                                unblockDocument(project, this)
-                                setText(fileText + line)
-                                unblockDocument(project, this)
+                        editor?.let {
+                            runWriteAction {
+                                with(editor.document) {
+                                    unblockDocument(project, this)
+                                    setText(fileText + line)
+                                    unblockDocument(project, this)
+                                }
+                                with(FileDocumentManager.getInstance()) {
+                                    saveDocument(editor.document)
+                                }
                             }
-                            with(FileDocumentManager.getInstance()) {
-                                saveDocument(editor.document)
-                            }
+                        } ?: run {
+                            File(model.containingFilePath).writeText(fileText + line)
                         }
                     }
                 }
@@ -267,45 +267,47 @@ object JsDialogProcessor {
     }
 }
 
-fun checkAndInstallRequirement(
-    project: Project,
-    pathToNPM: String,
-    requirement: PackageData,
-) {
-    if (!requirement.findPackageByNpm(project.basePath!!, pathToNPM)) {
-        installMissingRequirement(project, pathToNPM, requirement)
-    }
-}
-
-private fun installMissingRequirement(
-    project: Project,
-    pathToNPM: String,
-    requirement: PackageData,
-) {
+private fun PackageDataService.checkAndInstallRequirements(project: Project): Boolean {
+    val missingPackages = jsPackagesList.filterNot { this.findPackage(it) }
+    if (missingPackages.isEmpty()) return true
     val message = """
-            Requirement is not installed:
-            ${requirement.packageName}
-            Install it?
+            Requirements are not installed:
+            ${missingPackages.joinToString { it.packageName }}
+            Install them?
         """.trimIndent()
     val result = Messages.showOkCancelDialog(
-        project,
-        message,
-        "Requirement Missmatch Error",
-        "Install",
-        "Cancel",
-        null
+        project, message, "Requirements Missmatch Error", "Install", "Cancel", null
     )
 
     if (result == Messages.CANCEL)
-        return
+        return false
 
-    val (_, errorText) = requirement.installPackage(project.basePath!!, pathToNPM)
-
-    if (errorText.isNotEmpty()) {
+    try {
+        val (_, errorText) = this.installMissingPackages(missingPackages)
+        if (errorText.isNotEmpty()) {
+            showErrorDialogLater(
+                project,
+                "Requirements installing failed with some reason:\n${errorText}",
+                "Requirement installation error"
+            )
+            return false
+        }
+        return true
+    } catch (_: TimeoutException) {
         showErrorDialogLater(
             project,
-            "Requirements installing failed with some reason:\n${errorText}",
-            "Requirements error"
+            """
+                Requirements installing failed due to the exceeded waiting time for the installation, check your internet connection.
+                
+                Try to install missing npm packages manually:
+            ${
+                missingPackages.joinToString(separator = "\n") {
+                    "> npm install ${it.npmListFlag} ${it.packageName}"
+                }
+            }
+            """.trimIndent(),
+            "Requirement installation error"
         )
+        return false
     }
 }

--- a/utbot-intellij-js/src/main/kotlin/org/utbot/intellij/plugin/language/js/JsDialogProcessor.kt
+++ b/utbot-intellij-js/src/main/kotlin/org/utbot/intellij/plugin/language/js/JsDialogProcessor.kt
@@ -34,6 +34,7 @@ import settings.PackageDataService
 import settings.jsPackagesList
 import utils.JsCmdExec
 import utils.OsProvider
+import java.io.IOException
 
 private val logger = KotlinLogging.logger {}
 

--- a/utbot-intellij-js/src/main/kotlin/org/utbot/intellij/plugin/language/js/JsLanguageAssistant.kt
+++ b/utbot-intellij-js/src/main/kotlin/org/utbot/intellij/plugin/language/js/JsLanguageAssistant.kt
@@ -29,7 +29,7 @@ object JsLanguageAssistant : LanguageAssistant() {
         val focusedMethod: JSMemberInfo?,
         val module: Module,
         val containingFilePath: String,
-        val editor: Editor,
+        val editor: Editor?,
         val file: JSFile
     )
 
@@ -53,11 +53,15 @@ object JsLanguageAssistant : LanguageAssistant() {
 
     private fun getPsiTargets(e: AnActionEvent): PsiTargets? {
         e.project ?: return null
-        val virtualFile = (e.getData(CommonDataKeys.VIRTUAL_FILE) ?: return null).path
-        val editor = e.getData(CommonDataKeys.EDITOR) ?: return null
+        val editor = e.getData(CommonDataKeys.EDITOR)
         val file = e.getData(CommonDataKeys.PSI_FILE) as? JSFile ?: return null
-        val element = findPsiElement(file, editor) ?: return null
+        val element = if (editor != null) {
+            findPsiElement(file, editor) ?: return null
+        } else {
+            e.getData(CommonDataKeys.PSI_ELEMENT) ?: return null
+        }
         val module = element.module ?: return null
+        val virtualFile = (e.getData(CommonDataKeys.VIRTUAL_FILE) ?: return null).path
         val focusedMethod = getContainingMethod(element)
         containingClass(element)?.let {
             val methods = it.functions


### PR DESCRIPTION
## Description

When `Experimental language support` is turned on in UTBot settings, the UTBot action is enabled in context menu for JS-files.

Fixes #1883 

## How to test

### Manual tests

Various scenarios have been tested. You can find the examples in the folder `/utbot-js/samples' and try to run UTBot.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.