### PR TITLE
kotlin.Streams.toList clashes with java.util.stream.Stream#toList whe…

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/stream/BaseStreamExampleTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/stream/BaseStreamExampleTest.kt
@@ -17,7 +17,7 @@ import org.utbot.testing.ignoreExecutionsNumber
 import org.utbot.testing.isException
 import java.util.Optional
 import java.util.stream.Stream
-import kotlin.streams.toList
+import org.utbot.testing.asList
 
 // TODO 1 instruction is always uncovered https://github.com/UnitTestBot/UTBotJava/issues/193
 // TODO failed Kotlin compilation (generics) JIRA:1332
@@ -35,7 +35,7 @@ class BaseStreamExampleTest : UtValueTestCaseChecker(
             check(
                 BaseStreamExample::returningStreamAsParameterExample,
                 eq(1),
-                { s, r -> s != null && s.toList() == r!!.toList() },
+                { s, r -> s != null && s.asList() == r!!.asList() },
                 coverage = FullWithAssumptions(assumeCallsNumber = 1)
             )
         }

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/stream/StreamsAsMethodResultExampleTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/stream/StreamsAsMethodResultExampleTest.kt
@@ -9,6 +9,7 @@ import org.utbot.testing.FullWithAssumptions
 import org.utbot.testing.UtValueTestCaseChecker
 import org.utbot.testing.isException
 import kotlin.streams.toList
+import org.utbot.testing.asList
 
 // TODO 1 instruction is always uncovered https://github.com/UnitTestBot/UTBotJava/issues/193
 // TODO failed Kotlin compilation (generics) JIRA:1332
@@ -25,8 +26,8 @@ class StreamsAsMethodResultExampleTest : UtValueTestCaseChecker(
         check(
             StreamsAsMethodResultExample::returningStreamExample,
             eq(2),
-            { c, r -> c.isEmpty() && c == r!!.toList() },
-            { c, r -> c.isNotEmpty() && c == r!!.toList() },
+            { c, r -> c.isEmpty() && c == r!!.asList() },
+            { c, r -> c.isNotEmpty() && c == r!!.asList() },
             coverage = FullWithAssumptions(assumeCallsNumber = 1)
         )
     }

--- a/utbot-testing/src/main/kotlin/org/utbot/testing/UtValueTestCaseChecker.kt
+++ b/utbot-testing/src/main/kotlin/org/utbot/testing/UtValueTestCaseChecker.kt
@@ -47,6 +47,8 @@ import org.utbot.testcheckers.ExecutionsNumberMatcher
 import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.util.stream.Collectors
+import java.util.stream.Stream
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KFunction0
@@ -2041,3 +2043,8 @@ inline fun <reified T> withSettingsFromTestFrameworkConfiguration(
         TestCodeGeneratorPipeline.currentTestFrameworkConfiguration = previousConfig
     }
 }
+
+/**
+ * Avoid conflict with java.util.stream.Stream.toList (available since Java 16 only)
+ */
+fun <T> Stream<T>.asList(): List<T> = collect(Collectors.toList<T>())


### PR DESCRIPTION
…n both project and Gradle are under Java 17


Feel free to apply more labels to your PR, e.g.: _lang-java_, _priority-minor_, _spec-performance_

## Title Fix broken code 

Previously used kotlin.Streams.toList now clashes with java.util.stream.Stream#toList (that is available since Java 16 only).
As we declare compatibility with old versions of Java we cannot use java.util.stream.Stream#toList
New "asList" methods were added locally to avoid the conflict.

## Self-check list

Check off the item if the statement is true. Hint: [x] is a marked item.

Please do not delete the list or its items.

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.