### PR TITLE
Fix empty member list for generate test action

### DIFF
--- a/utbot-intellij-js/src/main/kotlin/org/utbot/intellij/plugin/language/js/JsLanguageAssistant.kt
+++ b/utbot-intellij-js/src/main/kotlin/org/utbot/intellij/plugin/language/js/JsLanguageAssistant.kt
@@ -78,9 +78,19 @@ object JsLanguageAssistant : LanguageAssistant() {
                 file = file,
             )
         }
-        val memberInfos = generateMemberInfo(e.project!!, file.statements.filterIsInstance<JSFunction>())
-        val focusedMethodMI = memberInfos.find { member ->
+        var memberInfos = generateMemberInfo(e.project!!, file.statements.filterIsInstance<JSFunction>())
+        var focusedMethodMI = memberInfos.find { member ->
             member.member?.name == focusedMethod?.name
+        }
+        // TODO: generate tests for all classes, not only the first one
+        //  (currently not possible since breaks JsTestGenerator routine)
+        if (memberInfos.isEmpty()) {
+            memberInfos = generateMemberInfo(
+                e.project!!,
+                emptyList(),
+                file.statements.filterIsInstance<ES6Class>().first()
+            )
+            focusedMethodMI = memberInfos.first()
         }
         return PsiTargets(
             methods = memberInfos,


### PR DESCRIPTION
## Description

Now, when trying to run test generation from the context menu on a file containing a class, the methods of this class are displayed in the dialog box.

Fixes #1902 

## How to test

### Manual tests

Various scenarios have been tested. You can find the examples in the folder `/utbot-js/samples' and try to run UTBot.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.