### PR TITLE
Fix python state before / state after changes detection

### DIFF
--- a/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/constructor/tree/PythonCgMethodConstructor.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/constructor/tree/PythonCgMethodConstructor.kt
@@ -62,7 +62,7 @@ class PythonCgMethodConstructor(context: CgContext) : CgMethodConstructor(contex
                     val afterThisInstance = execution.stateAfter.thisInstance
                     val assertThisObject = emptyList<Pair<CgVariable, UtModel>>().toMutableList()
                     if (beforeThisInstance is PythonTreeModel && afterThisInstance is PythonTreeModel) {
-                        if (beforeThisInstance != afterThisInstance) {
+                        if (PythonTreeWrapper(beforeThisInstance.tree) != PythonTreeWrapper(afterThisInstance.tree)) {
                             thisInstance = thisInstance?.let {
                                 val newValue =
                                     if (it is CgPythonTree) {
@@ -91,7 +91,7 @@ class PythonCgMethodConstructor(context: CgContext) : CgMethodConstructor(contex
 
                         val afterValue = execution.stateAfter.parameters[index]
                         if (afterValue is PythonTreeModel && param is PythonTreeModel) {
-                            if (afterValue != param) {
+                            if (PythonTreeWrapper(afterValue.tree) != PythonTreeWrapper(param.tree)) {
                                 if (argument !is CgVariable) {
                                     argument = newVar(argument.type, name) {argument}
                                 }


### PR DESCRIPTION
## Description

After PR #1844 comparison algorithm of python objects had been changed but comparison in state before / state after differences detector hadn't been. I fixed it. 

Fixes #986

## How to test

### Manual tests

1. Write method which can change some class field or function which change one of the arguments. For example,
```python
class A:
    def __init__(self, x: int):
        self.x = x
    def inc(self):  # test me 
        self.x += 1
```
or
```python
def my_append(xs: list[int]):
    xs.append(1)
```
2. Generate tests
3. __Expected__: assertions for `x`-field and `xs`-argument have been created
```python
class TestA(unittest.TestCase):
    def test_inc(self):
        a = copyreg._reconstructor(samples.arithmetic.A, builtins.object, None)
        a.x = -170141183460469231731687303715884105728
        actual = a.inc()
        self.assertEqual(None, actual)
        
        actual_x = a.x
        expected_x = a.x
        self.assertEqual(expected_x, actual_x)
```
and
```python
class TestTopLevelFunctions(unittest.TestCase):
    def test_my_append(self):
        xs = [-170141183460469231731687303715884105728]
        actual = samples.arithmetic.my_append(xs)
        self.assertEqual(None, actual)

        self.assertEqual([-170141183460469231731687303715884105728, 1], xs)
```

## Self-check list

Check off the item if the statement is true. Hint: [x] is a marked item.

Please do not delete the list or its items.

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.