### PR TITLE
Some fixes in Python fuzzer logic

### DIFF
--- a/utbot-python/samples/easy_samples/field.py
+++ b/utbot-python/samples/easy_samples/field.py
@@ -1,0 +1,10 @@
+class NoTestsProblem:
+    def __init__(self):
+        self.board = []
+
+    def set_position(self, row, col, symbol):
+        self.board[row][col] = symbol
+        return symbol
+
+    def start(self):
+        self.set_position(1, 2, "O")

--- a/utbot-python/samples/easy_samples/general.py
+++ b/utbot-python/samples/easy_samples/general.py
@@ -2,7 +2,7 @@ import collections
 import heapq
 import typing
 from socket import socket
-from typing import List, Dict, Set, Optional
+from typing import List, Dict, Set, Optional, AbstractSet
 from dataclasses import dataclass
 import logging
 import datetime
@@ -94,7 +94,7 @@ def empty():
     return 1
 
 
-def id_(x):
+def id_(x: AbstractSet[int]):
     return x
 
 

--- a/utbot-python/src/main/kotlin/org/utbot/python/PythonEngine.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/PythonEngine.kt
@@ -11,6 +11,7 @@ import org.utbot.fuzzing.utils.Trie
 import org.utbot.python.evaluation.*
 import org.utbot.python.evaluation.serialiation.MemoryDump
 import org.utbot.python.evaluation.serialiation.toPythonTree
+import org.utbot.python.framework.api.python.PythonTree
 import org.utbot.python.framework.api.python.PythonTreeModel
 import org.utbot.python.framework.api.python.PythonTreeWrapper
 import org.utbot.python.fuzzing.*
@@ -259,6 +260,12 @@ class PythonEngine(
                             return@PythonFuzzing PythonFeedback(control = Control.STOP)
                         }
 
+                        if (arguments.any { PythonTree.containsFakeNode(it.tree) }) {
+                            logger.debug("FakeNode in Python model")
+                            emit(InvalidExecution(UtError("Bad input object", Throwable())))
+                            return@PythonFuzzing PythonFeedback(control = Control.PASS)
+                        }
+
                         val pair = Pair(description, arguments.map { PythonTreeWrapper(it.tree) })
                         val mem = cache.get(pair)
                         if (mem != null) {
@@ -278,7 +285,7 @@ class PythonEngine(
                         return@PythonFuzzing result.fuzzingPlatformFeedback
                     }.fuzz(pmd)
                 } catch (_: Exception) { // e.g. NoSeedValueException
-                    logger.info { "Cannot fuzz values for types: $parameters" }
+                    logger.info { "Cannot fuzz values for types: ${parameters.map { it.pythonTypeRepresentation() }}" }
                 }
             }
             manager.disconnect()

--- a/utbot-python/src/main/kotlin/org/utbot/python/PythonEngine.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/PythonEngine.kt
@@ -263,7 +263,7 @@ class PythonEngine(
                         if (arguments.any { PythonTree.containsFakeNode(it.tree) }) {
                             logger.debug("FakeNode in Python model")
                             emit(InvalidExecution(UtError("Bad input object", Throwable())))
-                            return@PythonFuzzing PythonFeedback(control = Control.PASS)
+                            return@PythonFuzzing PythonFeedback(control = Control.CONTINUE)
                         }
 
                         val pair = Pair(description, arguments.map { PythonTreeWrapper(it.tree) })

--- a/utbot-python/src/main/kotlin/org/utbot/python/PythonTestCaseGenerator.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/PythonTestCaseGenerator.kt
@@ -29,6 +29,7 @@ import org.utbot.python.utils.TimeoutMode
 import java.io.File
 
 private val logger = KotlinLogging.logger {}
+private const val RANDOM_TYPE_FREQUENCY = 6
 
 class PythonTestCaseGenerator(
     private val withMinimization: Boolean = true,
@@ -220,9 +221,11 @@ class PythonTestCaseGenerator(
                 originalDef.meta.name,
                 originalDef.meta.args.take(shortType.arguments.size)
             )
-            val additionalVars = originalDef.meta.args.drop(shortType.arguments.size).fold("") { acc, arg ->
-                acc + "\n" + "${arg.name}: ${pythonAnyType.pythonTypeRepresentation()}"  // TODO: better types
-            }
+            val additionalVars = originalDef.meta.args
+                .drop(shortType.arguments.size)
+                .joinToString(separator="\n", prefix="\n") { arg ->
+                    "${arg.name}: ${pythonAnyType.pythonTypeRepresentation()}"  // TODO: better types
+                }
             method.definition = PythonFunctionDefinition(shortMeta, shortType)
             val missingLines = methodHandler(method, typeStorage, coveredLines, errors, executions, null, firstUntil, additionalVars)
             method.definition = originalDef
@@ -294,7 +297,7 @@ class PythonTestCaseGenerator(
             ),
             mypyConfigFile,
             additionalVars,
-            randomTypeFrequency = 6
+            randomTypeFrequency = RANDOM_TYPE_FREQUENCY
         )
 
         runBlocking breaking@{

--- a/utbot-python/src/main/kotlin/org/utbot/python/PythonTestCaseGenerator.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/PythonTestCaseGenerator.kt
@@ -117,14 +117,21 @@ class PythonTestCaseGenerator(
         }.take(maxSubstitutions)
     }
 
-    fun generate(method: PythonMethod, until: Long): PythonTestSet {
-        storageForMypyMessages.clear()
+    private fun methodHandler(
+        method: PythonMethod,
+        typeStorage: PythonTypeStorage,
+        coveredLines: MutableSet<Int>,
+        errors: MutableList<UtError>,
+        executions: MutableList<UtExecution>,
+        initMissingLines: Set<Int>?,
+        until: Long,
+        additionalVars: String = ""
+    ): Set<Int>? {  // returns missing lines
         val limitManager = TestGenerationLimitManager(
             ExecutionWithTimeoutMode,
             until,
         )
-
-        val typeStorage = PythonTypeStorage.get(mypyStorage)
+        var missingLines = initMissingLines
 
         val (hintCollector, constantCollector) = constructCollectors(mypyStorage, typeStorage, method)
         val constants = constantCollector.result.map { (type, value) ->
@@ -132,13 +139,6 @@ class PythonTestCaseGenerator(
             PythonFuzzedConcreteValue(type, value)
         }
 
-        val executions = mutableListOf<UtExecution>()
-        val errors = mutableListOf<UtError>()
-        var missingLines: Set<Int>? = null
-        val coveredLines = mutableSetOf<Int>()
-        var generated = 0
-
-        logger.info("Start test generation for ${method.name}")
         substituteTypeParameters(method, typeStorage).forEach { newMethod ->
             inferAnnotations(
                 newMethod,
@@ -148,6 +148,7 @@ class PythonTestCaseGenerator(
                 mypyReportLine,
                 mypyConfigFile,
                 limitManager,
+                additionalVars
             ) { functionType ->
                 val args = (functionType as FunctionType).arguments
 
@@ -168,7 +169,6 @@ class PythonTestCaseGenerator(
                 val fuzzerCancellation = { isCancelled() || limitManager.isCancelled() }
 
                 engine.fuzzing(args, fuzzerCancellation, until).collect {
-                    generated += 1
                     when (it) {
                         is ValidExecution -> {
                             executions += it.utFuzzedExecution
@@ -195,6 +195,40 @@ class PythonTestCaseGenerator(
                 limitManager.restart()
                 feedback
             }
+        }
+        return missingLines
+    }
+
+    fun generate(method: PythonMethod, until: Long): PythonTestSet {
+        storageForMypyMessages.clear()
+
+        val typeStorage = PythonTypeStorage.get(mypyStorage)
+
+        val executions = mutableListOf<UtExecution>()
+        val errors = mutableListOf<UtError>()
+        val coveredLines = mutableSetOf<Int>()
+
+        logger.info("Start test generation for ${method.name}")
+        val meta = method.definition.type.pythonDescription() as PythonCallableTypeDescription
+        val argKinds = meta.argumentKinds
+        if (argKinds.any { it != PythonCallableTypeDescription.ArgKind.ARG_POS }) {
+            val now = System.currentTimeMillis()
+            val firstUntil = (until - now) / 2 + now
+            val originalDef = method.definition
+            val shortType = meta.removeNonPositionalArgs(originalDef.type)
+            val shortMeta = PythonFuncItemDescription(
+                originalDef.meta.name,
+                originalDef.meta.args.take(shortType.arguments.size)
+            )
+            val additionalVars = originalDef.meta.args.drop(shortType.arguments.size).fold("") { acc, arg ->
+                acc + "\n" + "${arg.name}: ${pythonAnyType.pythonTypeRepresentation()}"  // TODO: better types
+            }
+            method.definition = PythonFunctionDefinition(shortMeta, shortType)
+            val missingLines = methodHandler(method, typeStorage, coveredLines, errors, executions, null, firstUntil, additionalVars)
+            method.definition = originalDef
+            methodHandler(method, typeStorage, coveredLines, errors, executions, missingLines, until)
+        } else {
+            methodHandler(method, typeStorage, coveredLines, errors, executions, null, until)
         }
 
         logger.info("Collect all test executions for ${method.name}")
@@ -234,6 +268,7 @@ class PythonTestCaseGenerator(
         report: List<MypyReportLine>,
         mypyConfigFile: File,
         limitManager: TestGenerationLimitManager,
+        additionalVars: String,
         annotationHandler: suspend (Type) -> InferredTypeFeedback,
     ) {
         val namesInModule = mypyStorage.names
@@ -257,7 +292,8 @@ class PythonTestCaseGenerator(
                 getOffsetLine(sourceFileContent, method.ast.beginOffset),
                 getOffsetLine(sourceFileContent, method.ast.endOffset)
             ),
-            mypyConfigFile
+            mypyConfigFile,
+            additionalVars
         )
 
         runBlocking breaking@{

--- a/utbot-python/src/main/kotlin/org/utbot/python/PythonTestCaseGenerator.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/PythonTestCaseGenerator.kt
@@ -293,7 +293,8 @@ class PythonTestCaseGenerator(
                 getOffsetLine(sourceFileContent, method.ast.endOffset)
             ),
             mypyConfigFile,
-            additionalVars
+            additionalVars,
+            randomTypeFrequency = 6
         )
 
         runBlocking breaking@{

--- a/utbot-python/src/main/kotlin/org/utbot/python/code/CodeGen.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/code/CodeGen.kt
@@ -45,7 +45,8 @@ object PythonCodeGenerator {
         methodAnnotations: Map<String, Type>,
         directoriesForSysPath: Set<String>,
         moduleToImport: String,
-        namesInModule: Collection<String>
+        namesInModule: Collection<String>,
+        additionalVars: String
     ): String {
         val context = UtContext(this::class.java.classLoader)
         withUtContext(context) {
@@ -60,7 +61,8 @@ object PythonCodeGenerator {
                 methodAnnotations,
                 directoriesForSysPath,
                 moduleToImport,
-                namesInModule
+                namesInModule,
+                additionalVars
             )
         }
     }

--- a/utbot-python/src/main/kotlin/org/utbot/python/framework/api/python/PythonTree.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/framework/api/python/PythonTree.kt
@@ -26,6 +26,19 @@ object PythonTree {
         return tree.children.any { isRecursiveObjectDFS(it, visited) }
     }
 
+    fun containsFakeNode(tree: PythonTreeNode): Boolean {
+        return containsFakeNodeDFS(tree, mutableSetOf())
+    }
+
+    private fun containsFakeNodeDFS(tree: PythonTreeNode, visited: MutableSet<PythonTreeNode>): Boolean {
+        if (visited.contains(tree))
+            return false
+        if (tree is FakeNode)
+            return true
+        visited.add(tree)
+        return tree.children.any { containsFakeNodeDFS(it, visited) }
+    }
+
     open class PythonTreeNode(
         val id: Long,
         val type: PythonClassId,
@@ -68,6 +81,8 @@ object PythonTree {
         open fun diversity(): Int = // must be called only from PythonTreeWrapper!
             1 + children.fold(0) { acc, child -> acc + child.diversity() }
     }
+
+    object FakeNode: PythonTreeNode(0L, PythonClassId(""))
 
     class PrimitiveNode(
         id: Long,

--- a/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/PythonCodeGenerator.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/PythonCodeGenerator.kt
@@ -211,7 +211,8 @@ class PythonCodeGenerator(
         methodAnnotations: Map<String, Type>,
         directoriesForSysPath: Set<String>,
         moduleToImport: String,
-        namesInModule: Collection<String>
+        namesInModule: Collection<String>,
+        additionalVars: String
     ): String {
         val cgRendererContext = CgRendererContext.fromCgContext(context)
         val printer = CgPrinterImpl()
@@ -242,6 +243,8 @@ class PythonCodeGenerator(
 
         val mypyCheckCode = listOf(
             renderer.toString(),
+            "",
+            additionalVars,
             "",
             functionName,
         ) + method.codeAsString.split("\n").map { "    $it" }

--- a/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/PythonApi.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/PythonApi.kt
@@ -16,7 +16,9 @@ import org.utbot.fuzzing.utils.Trie
 import org.utbot.python.framework.api.python.PythonTree
 import org.utbot.python.fuzzing.provider.*
 import org.utbot.python.fuzzing.provider.utils.isAny
+import org.utbot.python.fuzzing.provider.utils.isConcreteType
 import org.utbot.python.newtyping.*
+import org.utbot.python.newtyping.general.DefaultSubstitutionProvider
 import org.utbot.python.newtyping.general.Type
 
 private val logger = KotlinLogging.logger {}
@@ -56,7 +58,7 @@ class PythonFuzzedValue(
     val summary: String? = null,
 )
 
-fun pythonDefaultValueProviders() = listOf(
+fun pythonDefaultValueProviders(typeStorage: PythonTypeStorage) = listOf(
     NoneValueProvider,
     BoolValueProvider,
     IntValueProvider,
@@ -73,7 +75,8 @@ fun pythonDefaultValueProviders() = listOf(
     BytearrayValueProvider,
     ReduceValueProvider,
     ConstantValueProvider,
-    TypeAliasValueProvider
+    TypeAliasValueProvider,
+    SubtypeValueProvider(typeStorage)
 )
 
 class PythonFuzzing(
@@ -81,28 +84,13 @@ class PythonFuzzing(
     val execute: suspend (description: PythonMethodDescription, values: List<PythonFuzzedValue>) -> PythonFeedback,
 ) : Fuzzing<Type, PythonFuzzedValue, PythonMethodDescription, PythonFeedback> {
 
-    private fun generateDefault(description: PythonMethodDescription, type: Type): Sequence<Seed<Type, PythonFuzzedValue>> {
-        var providers = emptyList<Seed<Type, PythonFuzzedValue>>().asSequence()
-        pythonDefaultValueProviders().asSequence().forEach { provider ->
+    private fun generateDefault(description: PythonMethodDescription, type: Type)= sequence<Seed<Type, PythonFuzzedValue>> {
+        pythonDefaultValueProviders(pythonTypeStorage).asSequence().forEach { provider ->
             if (provider.accept(type)) {
                 logger.debug { "Provider ${provider.javaClass.simpleName} accepts type ${type.pythonTypeRepresentation()}" }
-                providers += provider.generate(description, type)
+                yieldAll(provider.generate(description, type))
             }
         }
-        return providers
-    }
-
-    private fun generateSubtype(description: PythonMethodDescription, type: Type): Sequence<Seed<Type, PythonFuzzedValue>> {
-        var providers = emptyList<Seed<Type, PythonFuzzedValue>>().asSequence()
-        if (type.meta is PythonProtocolDescription || ((type.meta as? PythonConcreteCompositeTypeDescription)?.isAbstract == true)) {
-            val subtypes = pythonTypeStorage.allTypes.filter {
-                PythonSubtypeChecker.checkIfRightIsSubtypeOfLeft(type, it, pythonTypeStorage)
-            }
-            subtypes.forEach {
-                providers += generateDefault(description, it)
-            }
-        }
-        return providers
     }
 
     override fun generate(description: PythonMethodDescription, type: Type): Sequence<Seed<Type, PythonFuzzedValue>> {
@@ -112,7 +100,6 @@ class PythonFuzzing(
             logger.debug("Any does not have provider")
         } else {
             providers += generateDefault(description, type)
-            providers += generateSubtype(description, type)
         }
 
         return providers

--- a/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/PythonApi.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/PythonApi.kt
@@ -16,11 +16,8 @@ import org.utbot.fuzzing.utils.Trie
 import org.utbot.python.framework.api.python.PythonTree
 import org.utbot.python.fuzzing.provider.*
 import org.utbot.python.fuzzing.provider.utils.isAny
-import org.utbot.python.newtyping.PythonProtocolDescription
-import org.utbot.python.newtyping.PythonSubtypeChecker
-import org.utbot.python.newtyping.PythonTypeStorage
+import org.utbot.python.newtyping.*
 import org.utbot.python.newtyping.general.Type
-import org.utbot.python.newtyping.pythonTypeRepresentation
 
 private val logger = KotlinLogging.logger {}
 
@@ -97,7 +94,7 @@ class PythonFuzzing(
 
     private fun generateSubtype(description: PythonMethodDescription, type: Type): Sequence<Seed<Type, PythonFuzzedValue>> {
         var providers = emptyList<Seed<Type, PythonFuzzedValue>>().asSequence()
-        if (type.meta is PythonProtocolDescription) {
+        if (type.meta is PythonProtocolDescription || ((type.meta as? PythonConcreteCompositeTypeDescription)?.isAbstract == true)) {
             val subtypes = pythonTypeStorage.allTypes.filter {
                 PythonSubtypeChecker.checkIfRightIsSubtypeOfLeft(type, it, pythonTypeStorage)
             }

--- a/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/ReduceValueProvider.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/ReduceValueProvider.kt
@@ -30,7 +30,7 @@ object ReduceValueProvider : ValueProvider<Type, PythonFuzzedValue, PythonMethod
     override fun accept(type: Type): Boolean {
         val hasSupportedType =
             !unsupportedTypes.contains(type.pythonTypeName())
-        return hasSupportedType && type.meta is PythonConcreteCompositeTypeDescription // && (hasInit || hasNew)
+        return hasSupportedType && (type.meta as? PythonConcreteCompositeTypeDescription)?.isAbstract == false // && (hasInit || hasNew)
     }
 
     override fun generate(description: PythonMethodDescription, type: Type) = sequence {
@@ -100,12 +100,7 @@ object ReduceValueProvider : ValueProvider<Type, PythonFuzzedValue, PythonMethod
                 )
             },
             modify = modifications,
-            empty = Routine.Empty {
-                PythonFuzzedValue(
-                    PythonTree.fromObject(),
-                    "%var% = ${type.pythonTypeRepresentation()}"
-                )
-            }
+            empty = Routine.Empty { PythonFuzzedValue(PythonTree.FakeNode) }
         )
     }
 

--- a/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/ReduceValueProvider.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/ReduceValueProvider.kt
@@ -8,6 +8,7 @@ import org.utbot.python.framework.api.python.PythonTree
 import org.utbot.python.framework.api.python.util.toPythonRepr
 import org.utbot.python.fuzzing.PythonFuzzedValue
 import org.utbot.python.fuzzing.PythonMethodDescription
+import org.utbot.python.fuzzing.provider.utils.isConcreteType
 import org.utbot.python.newtyping.*
 import org.utbot.python.newtyping.general.FunctionType
 import org.utbot.python.newtyping.general.Type
@@ -30,7 +31,7 @@ object ReduceValueProvider : ValueProvider<Type, PythonFuzzedValue, PythonMethod
     override fun accept(type: Type): Boolean {
         val hasSupportedType =
             !unsupportedTypes.contains(type.pythonTypeName())
-        return hasSupportedType && (type.meta as? PythonConcreteCompositeTypeDescription)?.isAbstract == false // && (hasInit || hasNew)
+        return hasSupportedType && isConcreteType(type) // && (hasInit || hasNew)
     }
 
     override fun generate(description: PythonMethodDescription, type: Type) = sequence {

--- a/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/SubtypeValueProvider.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/SubtypeValueProvider.kt
@@ -1,0 +1,39 @@
+package org.utbot.python.fuzzing.provider
+
+import org.utbot.fuzzing.Routine
+import org.utbot.fuzzing.Seed
+import org.utbot.fuzzing.ValueProvider
+import org.utbot.python.framework.api.python.PythonTree
+import org.utbot.python.fuzzing.PythonFuzzedValue
+import org.utbot.python.fuzzing.PythonMethodDescription
+import org.utbot.python.fuzzing.provider.utils.isConcreteType
+import org.utbot.python.newtyping.*
+import org.utbot.python.newtyping.PythonSubtypeChecker.Companion.checkIfRightIsSubtypeOfLeft
+import org.utbot.python.newtyping.general.DefaultSubstitutionProvider
+import org.utbot.python.newtyping.general.Type
+
+class SubtypeValueProvider(
+    private val typeStorage: PythonTypeStorage
+) : ValueProvider<Type, PythonFuzzedValue, PythonMethodDescription> {
+    override fun accept(type: Type): Boolean {
+        return type.meta is PythonProtocolDescription ||
+                ((type.meta as? PythonConcreteCompositeTypeDescription)?.isAbstract == true)
+    }
+
+    private val concreteTypes = typeStorage.allTypes.filter {
+        isConcreteType(it) && it.pythonDescription().name.name.first() != '_'  // Don't substitute private classes
+    }.map {
+        DefaultSubstitutionProvider.substituteAll(it, it.parameters.map { pythonAnyType })
+    }
+
+    override fun generate(description: PythonMethodDescription, type: Type) = sequence {
+        val subtypes = concreteTypes.filter { checkIfRightIsSubtypeOfLeft(type, it, typeStorage) }
+        subtypes.forEach { subtype ->
+            yield(
+                Seed.Recursive(
+                construct = Routine.Create(listOf(subtype)) { v -> v.first() },
+                empty = Routine.Empty { PythonFuzzedValue(PythonTree.FakeNode) }
+            ))
+        }
+    }
+}

--- a/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/TypeAliasValueProvider.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/TypeAliasValueProvider.kt
@@ -21,12 +21,7 @@ object TypeAliasValueProvider : ValueProvider<Type, PythonFuzzedValue, PythonMet
         return sequenceOf(
             Seed.Recursive(
                 construct = Routine.Create(listOf(compositeType.members[0])) { v -> v.first() },
-                empty = Routine.Empty {
-                    PythonFuzzedValue(
-                        PythonTree.fromObject(),
-                        "%var% = ${type.pythonTypeRepresentation()}"
-                    )
-                }
+                empty = Routine.Empty { PythonFuzzedValue(PythonTree.FakeNode) }
             )
         )
     }

--- a/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/UnionValueProvider.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/UnionValueProvider.kt
@@ -21,10 +21,7 @@ object UnionValueProvider : ValueProvider<Type, PythonFuzzedValue, PythonMethodD
         params.forEach { unionParam ->
             yield(Seed.Recursive(
                 construct = Routine.Create(listOf(unionParam)) { v -> v.first() },
-                empty = Routine.Empty { PythonFuzzedValue(
-                    PythonTree.fromObject(),
-                    "%var% = ${unionParam.meta} from ${type.pythonTypeRepresentation()}",
-                )}
+                empty = Routine.Empty { PythonFuzzedValue(PythonTree.FakeNode) }
             ))
         }
     }

--- a/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/utils/ProviderUtils.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/utils/ProviderUtils.kt
@@ -5,6 +5,7 @@ import org.utbot.python.framework.api.python.PythonTree
 import org.utbot.python.fuzzing.PythonFuzzedValue
 import org.utbot.python.fuzzing.PythonMethodDescription
 import org.utbot.python.newtyping.PythonAnyTypeDescription
+import org.utbot.python.newtyping.PythonConcreteCompositeTypeDescription
 import org.utbot.python.newtyping.PythonSubtypeChecker
 import org.utbot.python.newtyping.general.Type
 
@@ -20,4 +21,8 @@ fun getSuitableConstantsFromCode(description: PythonMethodDescription, type: Typ
             Seed.Simple(PythonFuzzedValue(it))
         }
     }
+}
+
+fun isConcreteType(type: Type): Boolean {
+    return (type.meta as? PythonConcreteCompositeTypeDescription)?.isAbstract == false
 }

--- a/utbot-python/src/main/kotlin/org/utbot/python/newtyping/ast/test.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/newtyping/ast/test.kt
@@ -8,7 +8,7 @@ fun main() {
     val content = """
     class A:
         @decorator
-        def func(x):
+        def func(x, y = 1, *args, **kwargs):
             return 1
     """.trimIndent()
 

--- a/utbot-python/src/main/kotlin/org/utbot/python/newtyping/inference/TypeInferenceProcessor.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/newtyping/inference/TypeInferenceProcessor.kt
@@ -101,7 +101,8 @@ class TypeInferenceProcessor(
                     getOffsetLine(sourceFileContent, pythonMethod.ast.beginOffset),
                     getOffsetLine(sourceFileContent, pythonMethod.ast.endOffset)
                 ),
-                configFile
+                configFile,
+                ""
             )
 
             startingTypeInferenceAction()

--- a/utbot-python/src/main/kotlin/org/utbot/python/newtyping/inference/baseline/BaselineAlgorithm.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/newtyping/inference/baseline/BaselineAlgorithm.kt
@@ -31,7 +31,8 @@ class BaselineAlgorithm(
     private val moduleToImport: String,
     private val namesInModule: Collection<String>,
     private val initialErrorNumber: Int,
-    private val configFile: File
+    private val configFile: File,
+    private val additionalVars: String
 ) : TypeInferenceAlgorithm() {
     private val random = Random(0)
 
@@ -93,7 +94,8 @@ class BaselineAlgorithm(
             fileForMypyRuns,
             pythonPath,
             configFile,
-            initialErrorNumber
+            initialErrorNumber,
+            additionalVars
         )
     }
 

--- a/utbot-python/src/main/kotlin/org/utbot/python/newtyping/inference/baseline/BaselineAlgorithm.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/newtyping/inference/baseline/BaselineAlgorithm.kt
@@ -32,7 +32,8 @@ class BaselineAlgorithm(
     private val namesInModule: Collection<String>,
     private val initialErrorNumber: Int,
     private val configFile: File,
-    private val additionalVars: String
+    private val additionalVars: String,
+    private val randomTypeFrequency: Int = 0
 ) : TypeInferenceAlgorithm() {
     private val random = Random(0)
 
@@ -47,12 +48,25 @@ class BaselineAlgorithm(
         val fileForMypyRuns = TemporaryFileManager.assignTemporaryFile(tag = "mypy.py")
         var iterationCounter = 0
 
+        val simpleTypes = simplestTypes(storage)
+        val mixtureType = createPythonUnionType(simpleTypes)
+
         run breaking@ {
             while (states.isNotEmpty()) {
                 if (isCancelled())
                     return@breaking
                 logger.debug("State number: ${states.size}")
                 iterationCounter++
+
+                if (randomTypeFrequency > 0 && iterationCounter % randomTypeFrequency == 0) {
+                    val weights = states.map { 1.0 / (it.anyNodes.size * it.anyNodes.size + 1) }
+                    val state = weightedRandom(states, weights, random)
+                    val newState = expandState(state, storage, state.anyNodes.map { mixtureType })
+                    if (newState != null) {
+                        logger.info("Random type: ${newState.signature.pythonTypeRepresentation()}")
+                        annotationHandler(newState.signature)
+                    }
+                }
 
                 val state = chooseState(states)
                 val newState = expandState(state, storage)

--- a/utbot-python/src/main/kotlin/org/utbot/python/newtyping/inference/baseline/StateExpansion.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/newtyping/inference/baseline/StateExpansion.kt
@@ -12,6 +12,12 @@ fun expandState(state: BaselineAlgorithmState, typeStorage: PythonTypeStorage): 
     if (state.anyNodes.isEmpty())
         return null
     val types = state.candidateGraph.getNext() ?: return null
+    return expandState(state, typeStorage, types)
+}
+
+fun expandState(state: BaselineAlgorithmState, typeStorage: PythonTypeStorage, types: List<Type>): BaselineAlgorithmState? {
+    if (types.isEmpty())
+        return null
     val substitution = (state.anyNodes zip types).associate { it }
     return expandNodes(state, substitution, state.generalRating, typeStorage)
 }

--- a/utbot-python/src/main/kotlin/org/utbot/python/newtyping/inference/baseline/TypeCandidateGeneration.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/newtyping/inference/baseline/TypeCandidateGeneration.kt
@@ -158,6 +158,16 @@ fun createTypeRating(
     return TypeRating(scores)
 }
 
+fun simplestTypes(storage: PythonTypeStorage): List<Type> {
+    val int = storage.pythonInt
+    val listOfAny = DefaultSubstitutionProvider.substituteAll(storage.pythonList, listOf(pythonAnyType))
+    val str = storage.pythonStr
+    val bool = storage.pythonBool
+    val float = storage.pythonFloat
+    val dictOfAny = DefaultSubstitutionProvider.substituteAll(storage.pythonDict, listOf(pythonAnyType, pythonAnyType))
+    return listOf(int, listOfAny, str, bool, float, dictOfAny)
+}
+
 fun createGeneralTypeRating(hintCollectorResult: HintCollectorResult, storage: PythonTypeStorage): List<Type> {
     val allLowerBounds: MutableList<Type> = mutableListOf()
     val allUpperBounds: MutableList<Type> = mutableListOf()
@@ -170,13 +180,7 @@ fun createGeneralTypeRating(hintCollectorResult: HintCollectorResult, storage: P
             !typesAreEqual(it, pythonAnyType)
         })
     }
-    val int = storage.pythonInt
-    val listOfAny = DefaultSubstitutionProvider.substituteAll(storage.pythonList, listOf(pythonAnyType))
-    val str = storage.pythonStr
-    val bool = storage.pythonBool
-    val float = storage.pythonFloat
-    val dictOfAny = DefaultSubstitutionProvider.substituteAll(storage.pythonDict, listOf(pythonAnyType, pythonAnyType))
-    val prefix = listOf(int, listOfAny, str, bool, float, dictOfAny)
+    val prefix = simplestTypes(storage)
     val rating = createTypeRating(
         storage.simpleTypes.filter { !prefix.any { type -> typesAreEqual(type.getOrigin(), it) } },
         allLowerBounds,

--- a/utbot-python/src/main/kotlin/org/utbot/python/newtyping/mypy/RunMypy.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/newtyping/mypy/RunMypy.kt
@@ -83,10 +83,11 @@ fun setConfigFile(directoriesForSysPath: Set<String>): File {
             show_absolute_path = True
             cache_fine_grained = True
             check_untyped_defs = True
-            strict_optional = False
             disable_error_code = assignment,union-attr
             implicit_optional = True
+            strict_optional = False
             allow_redefinition = True
+            local_partial_types = True
             """.trimIndent()
     TemporaryFileManager.writeToAssignedFile(file, configContent)
     return file

--- a/utbot-python/src/main/kotlin/org/utbot/python/newtyping/mypy/RunMypy.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/newtyping/mypy/RunMypy.kt
@@ -100,13 +100,14 @@ fun checkSuggestedSignatureWithDMypy(
     fileForMypyCode: File,
     pythonPath: String,
     configFile: File,
-    initialErrorNumber: Int
+    initialErrorNumber: Int,
+    additionalVars: String
 ): Boolean {
     val annotationMap =
         (method.definition.meta.args.map { it.name } zip method.definition.type.arguments).associate {
             Pair(it.first, it.second)
         }
-    val mypyCode = generateMypyCheckCode(method, annotationMap, directoriesForSysPath, moduleToImport, namesInModule)
+    val mypyCode = generateMypyCheckCode(method, annotationMap, directoriesForSysPath, moduleToImport, namesInModule, additionalVars)
     // logger.debug(mypyCode)
     TemporaryFileManager.writeToAssignedFile(fileForMypyCode, mypyCode)
     val mypyOutput = checkWithDMypy(pythonPath, fileForMypyCode.canonicalPath, configFile)

--- a/utbot-python/src/main/kotlin/org/utbot/python/newtyping/mypy/RunMypy.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/newtyping/mypy/RunMypy.kt
@@ -86,6 +86,7 @@ fun setConfigFile(directoriesForSysPath: Set<String>): File {
             strict_optional = False
             disable_error_code = assignment,union-attr
             implicit_optional = True
+            allow_redefinition = True
             """.trimIndent()
     TemporaryFileManager.writeToAssignedFile(file, configContent)
     return file

--- a/utbot-python/src/test/kotlin/org/utbot/python/newtyping/PythonSubtypeCheckerTest.kt
+++ b/utbot-python/src/test/kotlin/org/utbot/python/newtyping/PythonSubtypeCheckerTest.kt
@@ -116,4 +116,16 @@ internal class PythonSubtypeCheckerTest {
         assertTrue(checkIfRightIsSubtypeOfLeft(tupleOfAny, tupleOfIntAndFloat, pythonTypeStorage))
         assertFalse(checkIfRightIsSubtypeOfLeft(tupleOfInt, tupleOfIntAndFloat, pythonTypeStorage))
     }
+
+    @Test
+    fun testAbstractSet() {
+        val abstractSet = storage.definitions["typing"]!!["AbstractSet"]!!.getUtBotType()
+        assertTrue((abstractSet.pythonDescription() as PythonConcreteCompositeTypeDescription).isAbstract)
+        val set = storage.definitions["builtins"]!!["set"]!!.getUtBotType()
+
+        val abstractSetOfAny = DefaultSubstitutionProvider.substituteByIndex(abstractSet, 0, pythonAnyType)
+        val setOfAny = DefaultSubstitutionProvider.substituteByIndex(set, 0, pythonAnyType)
+
+        assertTrue(checkIfRightIsSubtypeOfLeft(abstractSetOfAny, setOfAny, pythonTypeStorage))
+    }
 }


### PR DESCRIPTION
## Description

Changes:
- New logic for functions with default arguments: first try to fuzz only positional arguments, then all of them.
- Added new Python tree node: FakeNode (instead of Java `null`). If fuzzer provides object with this node, we don't start execution with this data.
- BaselineAlgorithm now provides random type each 6 iterations.
- Logic for abstract classes is now the same as for protocols.

## How to test

### Manual tests

Default arguments: https://github.com/TheAlgorithms/Python/blob/master/machine_learning/gradient_descent.py (function `_error`).

Random type: https://github.com/TheAlgorithms/Python/blob/master/data_structures/queue/circular_queue.py  (function `enqueue` of class `CircularQueue`). Mypy does not pass any types for `data` parameter, bacause it consideres `self.array` to be `list[None]`.

Test for abstract class:

```python
from typing import AbstractSet

def id_(x: AbstractSet[int]):
    return x
```

Generated output:
```python
import sys
sys.path.append(r'../../../utbot-python/samples/easy_samples')
import builtins
import general
import unittest


class TestTopLevelFunctions(unittest.TestCase):
    # region Test suites for executable general.id_
    
    # region FUZZER
    
    def test_id_(self):
        """
        x = builtins.set[typing.Any]
        """
        actual = general.id_(set())
        
        self.assertEqual(set(), actual)
    # endregion
    
    # endregion
```

## Self-check list

Check off the item if the statement is true. Hint: [x] is a marked item.

Please do not delete the list or its items.

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.