### PR TITLE
Set correct cgLanguageAssistant in EngineProcess codegen #1918

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/CodeGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/CodeGenerator.kt
@@ -36,7 +36,7 @@ open class CodeGenerator(
     forceStaticMocking: ForceStaticMocking = ForceStaticMocking.defaultItem,
     generateWarningsForStaticMocking: Boolean = true,
     codegenLanguage: CodegenLanguage = CodegenLanguage.defaultItem,
-    cgLanguageAssistant: CgLanguageAssistant = CgLanguageAssistant.getByCodegenLanguage(CodegenLanguage.defaultItem),
+    cgLanguageAssistant: CgLanguageAssistant = CgLanguageAssistant.getByCodegenLanguage(codegenLanguage),
     parameterizedTestSource: ParametrizedTestSource = ParametrizedTestSource.defaultItem,
     runtimeExceptionTestsBehaviour: RuntimeExceptionTestsBehaviour = RuntimeExceptionTestsBehaviour.defaultItem,
     hangingTestsTimeout: HangingTestsTimeout = HangingTestsTimeout(),

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineProcessMain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineProcessMain.kt
@@ -17,6 +17,7 @@ import org.utbot.framework.codegen.domain.ParametrizedTestSource
 import org.utbot.framework.codegen.domain.RuntimeExceptionTestsBehaviour
 import org.utbot.framework.codegen.domain.testFrameworkByName
 import org.utbot.framework.codegen.reports.TestsGenerationReport
+import org.utbot.framework.codegen.services.language.CgLanguageAssistant
 import org.utbot.framework.plugin.api.*
 import org.utbot.framework.plugin.api.MethodDescription
 import org.utbot.framework.plugin.api.util.UtContext
@@ -152,6 +153,7 @@ private fun EngineProcessModel.setup(kryoHelper: KryoHelper, watchdog: IdleWatch
             testFramework = testFramework,
             mockFramework = MockFramework.valueOf(params.mockFramework),
             codegenLanguage = CodegenLanguage.valueOf(params.codegenLanguage),
+            cgLanguageAssistant = CgLanguageAssistant.getByCodegenLanguage(CodegenLanguage.valueOf(params.codegenLanguage)),
             parameterizedTestSource = ParametrizedTestSource.valueOf(params.parameterizedTestSource),
             staticsMocking = staticMocking,
             forceStaticMocking = kryoHelper.readObject(params.forceStaticMocking),


### PR DESCRIPTION
## Description

After adding `cgLanguageAssistant` property to `CodeGenerator`, it was `JavaCgLanguageAssistant` by default, so anyone who constructs `CodeGenerator` should set the correct value in constructor. However, this was not done for codegenerator instance in `EngineProcessMain`, which lead to UtBot action always using Java for codegeneration. This PR sets this parameter correctly in `EngineProcessMain` and also changes the default value of property to default assistant for passed codegen language.

Fixes #1918 

## How to test

### Manual tests

Just launch UtBot action with "Generated test language" = "Kotlin" on any class, and check that the generated tests is written in Kotlin.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.