### PR TITLE
Added limit for number of executions

### DIFF
--- a/utbot-python/src/main/kotlin/org/utbot/python/PythonTestCaseGenerator.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/PythonTestCaseGenerator.kt
@@ -30,6 +30,7 @@ import java.io.File
 
 private val logger = KotlinLogging.logger {}
 private const val RANDOM_TYPE_FREQUENCY = 6
+private const val MAX_EXECUTIONS = 50000
 
 class PythonTestCaseGenerator(
     private val withMinimization: Boolean = true,
@@ -167,7 +168,9 @@ class PythonTestCaseGenerator(
 
                 var feedback: InferredTypeFeedback = SuccessFeedback
 
-                val fuzzerCancellation = { isCancelled() || limitManager.isCancelled() }
+                val fuzzerCancellation = {
+                    isCancelled() || limitManager.isCancelled() || (errors.size + executions.size) >= MAX_EXECUTIONS
+                }
 
                 engine.fuzzing(args, fuzzerCancellation, until).collect {
                     when (it) {


### PR DESCRIPTION
## Description

We sped up Python execution so much that test generation for the following function throwed `java.lang.OutOfMemoryError: Java heap space`:

```python
class Dummy:
    def propagate(self):
        return [self, self]
```

To fix this I set maximum of 50k executions.

## How to test

### Manual tests

See function from description.

## Self-check list

Check off the item if the statement is true. Hint: [x] is a marked item.

Please do not delete the list or its items.

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.