### PR TITLE
set-output command removed because of deprecation #1898

### DIFF
--- a/.github/workflows/build-and-run-tests-from-branch.yml
+++ b/.github/workflows/build-and-run-tests-from-branch.yml
@@ -65,8 +65,8 @@ jobs:
         run: |
           FRAMEWORK_TESTS=$(echo $(cat .github/workflows/framework-tests-matrix.json))
           COMBINED_PROJECTS=$(echo $(cat .github/workflows/combined-projects-matrix.json))
-          echo "::set-output name=framework-tests-matrix::$FRAMEWORK_TESTS"
-          echo "::set-output name=combined-projects-matrix::$COMBINED_PROJECTS"
+          echo "framework-tests-matrix=$FRAMEWORK_TESTS" >> $GITHUB_OUTPUT
+          echo "combined-projects-matrix=$COMBINED_PROJECTS" >> $GITHUB_OUTPUT
           echo $FRAMEWORK_TESTS
           echo $COMBINED_PROJECTS
   framework-tests:


### PR DESCRIPTION
## Description

Replace deprecated command `set-output`. Read more at the blog post: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Fixes #1898

## How to test

### Automated tests

Run pipeline

### Manual tests

Not applicable

## Self-check list

- [ ] check if branch workflow run finished well
