### PR TITLE
Add cached executions filtration

### DIFF
--- a/utbot-python/src/main/kotlin/org/utbot/python/PythonEngine.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/PythonEngine.kt
@@ -224,6 +224,9 @@ class PythonEngine(
                                 is InvalidExecution -> {
                                     PythonExecutionResult(result, PythonFeedback(control = Control.CONTINUE))
                                 }
+                                is CachedExecutionFeedback -> {
+                                    PythonExecutionResult(result, PythonFeedback(control = Control.PASS))
+                                }
                             }
                         }
                     }
@@ -270,12 +273,11 @@ class PythonEngine(
                         val mem = cache.get(pair)
                         if (mem != null) {
                             logger.debug("Repeat in fuzzing")
-                            emit(mem.fuzzingExecutionFeedback)
+                            emit(CachedExecutionFeedback(mem.fuzzingExecutionFeedback))
                             return@PythonFuzzing mem.fuzzingPlatformFeedback
                         }
                         val result = fuzzingResultHandler(description, arguments)
                         if (result == null) {  // timeout
-                            logger.info { "Fuzzing process was interrupted by timeout" }
                             manager.disconnect()
                             return@PythonFuzzing PythonFeedback(control = Control.STOP)
                         }

--- a/utbot-python/src/main/kotlin/org/utbot/python/PythonEngine.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/PythonEngine.kt
@@ -216,15 +216,10 @@ class PythonEngine(
                                         PythonFeedback(control = Control.CONTINUE, result = trieNode)
                                     )
                                 }
-
-                                is ArgumentsTypeErrorFeedback, is TypeErrorFeedback -> {
-                                    PythonExecutionResult(result, PythonFeedback(control = Control.PASS))
-                                }
-
                                 is InvalidExecution -> {
                                     PythonExecutionResult(result, PythonFeedback(control = Control.CONTINUE))
                                 }
-                                is CachedExecutionFeedback -> {
+                                else -> {
                                     PythonExecutionResult(result, PythonFeedback(control = Control.PASS))
                                 }
                             }
@@ -265,7 +260,7 @@ class PythonEngine(
 
                         if (arguments.any { PythonTree.containsFakeNode(it.tree) }) {
                             logger.debug("FakeNode in Python model")
-                            emit(InvalidExecution(UtError("Bad input object", Throwable())))
+                            emit(FakeNodeFeedback)
                             return@PythonFuzzing PythonFeedback(control = Control.CONTINUE)
                         }
 

--- a/utbot-python/src/main/kotlin/org/utbot/python/PythonTestCaseGenerator.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/PythonTestCaseGenerator.kt
@@ -200,6 +200,9 @@ class PythonTestCaseGenerator(
                                 }
                             }
                         }
+                        is FakeNodeFeedback -> {
+                           limitManager.addFakeNodeExecutions()
+                        }
                     }
                     limitManager.missedLines = missingLines?.size
                 }

--- a/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/PythonApi.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/PythonApi.kt
@@ -16,9 +16,7 @@ import org.utbot.fuzzing.utils.Trie
 import org.utbot.python.framework.api.python.PythonTree
 import org.utbot.python.fuzzing.provider.*
 import org.utbot.python.fuzzing.provider.utils.isAny
-import org.utbot.python.fuzzing.provider.utils.isConcreteType
 import org.utbot.python.newtyping.*
-import org.utbot.python.newtyping.general.DefaultSubstitutionProvider
 import org.utbot.python.newtyping.general.Type
 
 private val logger = KotlinLogging.logger {}
@@ -42,6 +40,7 @@ class ValidExecution(val utFuzzedExecution: UtFuzzedExecution): FuzzingExecution
 class InvalidExecution(val utError: UtError): FuzzingExecutionFeedback
 class TypeErrorFeedback(val message: String) : FuzzingExecutionFeedback
 class ArgumentsTypeErrorFeedback(val message: String) : FuzzingExecutionFeedback
+class CachedExecutionFeedback(val cachedFeedback: FuzzingExecutionFeedback) : FuzzingExecutionFeedback
 
 data class PythonExecutionResult(
     val fuzzingExecutionFeedback: FuzzingExecutionFeedback,

--- a/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/PythonApi.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/PythonApi.kt
@@ -41,6 +41,7 @@ class InvalidExecution(val utError: UtError): FuzzingExecutionFeedback
 class TypeErrorFeedback(val message: String) : FuzzingExecutionFeedback
 class ArgumentsTypeErrorFeedback(val message: String) : FuzzingExecutionFeedback
 class CachedExecutionFeedback(val cachedFeedback: FuzzingExecutionFeedback) : FuzzingExecutionFeedback
+object FakeNodeFeedback : FuzzingExecutionFeedback
 
 data class PythonExecutionResult(
     val fuzzingExecutionFeedback: FuzzingExecutionFeedback,

--- a/utbot-python/src/main/kotlin/org/utbot/python/utils/TestGenerationLimitManager.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/utils/TestGenerationLimitManager.kt
@@ -1,7 +1,5 @@
 package org.utbot.python.utils
 
-import kotlin.math.min
-
 class TestGenerationLimitManager(
     // global settings
     var mode: LimitManagerMode,
@@ -10,18 +8,15 @@ class TestGenerationLimitManager(
     // local settings: one type inference iteration
     var executions: Int = 150,
     var invalidExecutions: Int = 10,
-    var additionalExecutions: Int = 5,
     var missedLines: Int? = null,
 ) {
     private val initExecution = executions
     private val initInvalidExecutions = invalidExecutions
-    private val initAdditionalExecutions = additionalExecutions
     private val initMissedLines = missedLines
 
     fun restart() {
         executions = initExecution
         invalidExecutions = initInvalidExecutions
-        additionalExecutions = initAdditionalExecutions
         missedLines = initMissedLines
     }
 
@@ -56,10 +51,7 @@ object TimeoutMode : LimitManagerMode {
 
 object ExecutionMode : LimitManagerMode {
     override fun isCancelled(manager: TestGenerationLimitManager): Boolean {
-        if (manager.invalidExecutions <= 0 || manager.executions <= 0) {
-            return min(manager.invalidExecutions, 0) + min(manager.executions, 0) + manager.additionalExecutions <= 0
-        }
-        return false
+        return manager.invalidExecutions <= 0 || manager.executions <= 0
     }
 }
 

--- a/utbot-python/src/main/kotlin/org/utbot/python/utils/TestGenerationLimitManager.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/utils/TestGenerationLimitManager.kt
@@ -8,15 +8,18 @@ class TestGenerationLimitManager(
     // local settings: one type inference iteration
     var executions: Int = 150,
     var invalidExecutions: Int = 10,
+    var fakeNodeExecutions: Int = 20,
     var missedLines: Int? = null,
 ) {
     private val initExecution = executions
     private val initInvalidExecutions = invalidExecutions
+    private val initFakeNodeExecutions = fakeNodeExecutions
     private val initMissedLines = missedLines
 
     fun restart() {
         executions = initExecution
         invalidExecutions = initInvalidExecutions
+        fakeNodeExecutions = initFakeNodeExecutions
         missedLines = initMissedLines
     }
 
@@ -26,6 +29,10 @@ class TestGenerationLimitManager(
 
     fun addInvalidExecution() {
         invalidExecutions -= 1
+    }
+
+    fun addFakeNodeExecutions() {
+        fakeNodeExecutions -= 1
     }
 
     fun isCancelled(): Boolean {
@@ -51,7 +58,7 @@ object TimeoutMode : LimitManagerMode {
 
 object ExecutionMode : LimitManagerMode {
     override fun isCancelled(manager: TestGenerationLimitManager): Boolean {
-        return manager.invalidExecutions <= 0 || manager.executions <= 0
+        return manager.invalidExecutions <= 0 || manager.executions <= 0 || manager.fakeNodeExecutions <= 0
     }
 }
 


### PR DESCRIPTION
## Description

Added new `CachedFeedback` which we can filter and do not collect to executions but save to `limitManager`.

Now when we get `OutOfMemoryError` we will stop process and render generated tests. 

Also added a new counter in `limitManager` for fuzzed objects with `FakeNode`-s

Fixes #1928

## How to test

### Manual tests

For methods without arguments (exclude `self`) in empty class we can fuzz only one execution. Now we should to save only one execution and use memory only for one execution. 

Try to generate tests with a large timeout:
```python
class Dummy:
    def propagate(self):
        return [self, self]
```

__Expected__: one successfully generated test without memory error

## Self-check list

Check off the item if the statement is true. Hint: [x] is a marked item.

Please do not delete the list or its items.

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.