### PR TITLE
Implement search for all @Configuration classes in Spring project

### DIFF
--- a/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/models/BaseTestModel.kt
+++ b/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/models/BaseTestModel.kt
@@ -1,15 +1,24 @@
 package org.utbot.intellij.plugin.models
 
 import com.intellij.openapi.module.Module
+import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.module.ModuleUtil
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.TestModuleProperties
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.newvfs.impl.FakeVirtualFile
+import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiClass
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.ProjectScope
+import com.intellij.psi.search.searches.AnnotatedElementsSearch
 import org.jetbrains.kotlin.idea.core.getPackage
 import org.jetbrains.kotlin.idea.util.projectStructure.allModules
+import org.jetbrains.kotlin.idea.util.rootManager
+import org.jetbrains.kotlin.idea.util.sourceRoot
 import org.utbot.framework.plugin.api.CodegenLanguage
 import org.utbot.intellij.plugin.ui.utils.ITestSourceRoot
+import org.utbot.intellij.plugin.ui.utils.getSortedTestRoots
 import org.utbot.intellij.plugin.ui.utils.isBuildWithGradle
 import org.utbot.intellij.plugin.ui.utils.suitableTestSourceRoots
 
@@ -53,6 +62,42 @@ open class BaseTestsModel(
     fun getAllTestSourceRoots() : MutableList<out ITestSourceRoot> {
         with(if (project.isBuildWithGradle) project.allModules() else potentialTestModules) {
             return this.flatMap { it.suitableTestSourceRoots().toList() }.toMutableList().distinct().toMutableList()
+        }
+    }
+
+    fun getSortedTestRoots(): MutableList<ITestSourceRoot> = getSortedTestRoots(
+        getAllTestSourceRoots(),
+        sourceRootHistory,
+        srcModule.rootManager.sourceRoots.map { file: VirtualFile -> file.toNioPath().toString() },
+        codegenLanguage
+    )
+
+    fun getSortedSpringConfigurationClasses(): List<PsiClass> {
+        val psiFacade = JavaPsiFacade.getInstance(project)
+        val testRootToIndex = getSortedTestRoots().withIndex().associate { (i, root) -> root.dir to i }
+
+        // not using `srcModule.testModules(project)` here because it returns
+        // test modules for dependencies of source module if no test roots are found
+        // for the source module itself, however we don't want to search for
+        // configurations there because they are unlikely to be of any use
+        val testModules = ModuleManager.getInstance(project).modules.filter { module ->
+            srcModule == TestModuleProperties.getInstance(module).productionModule
+        }
+
+        val searchScope = testModules.fold(GlobalSearchScope.moduleScope(srcModule)) { accScope, module ->
+            accScope.union(GlobalSearchScope.moduleScope(module))
+        }
+
+        return listOf(
+            "org.springframework.boot.test.context.TestConfiguration",
+            "org.springframework.context.annotation.Configuration"
+        ).mapNotNull {
+            psiFacade.findClass(it, ProjectScope.getLibrariesScope(project))
+        }.flatMap { annotation ->
+            AnnotatedElementsSearch
+                .searchPsiClasses(annotation, searchScope)
+                .findAll()
+                .sortedBy { testRootToIndex[it.containingFile.sourceRoot] ?: Int.MAX_VALUE }
         }
     }
 

--- a/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/models/BaseTestModel.kt
+++ b/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/models/BaseTestModel.kt
@@ -72,6 +72,21 @@ open class BaseTestsModel(
         codegenLanguage
     )
 
+    /**
+     * Searches for classes marked with `@Configuration` and `@TestConfiguration` annotations
+     * in source module and its test modules.
+     *
+     * Classes are sorted in the following order:
+     *   - Classes marked with `@TestConfiguration` annotation
+     *   - Classes marked with `@Configuration` annotation
+     *
+     * Inside one group classes are sorted by their roots in the following order:
+     *   - Classes from test roots
+     *   - Classes from source roots
+     *
+     * Classes from the test roots are additionally sorted by their roots
+     * in the order provided by [getSortedTestRoots]
+     */
     fun getSortedSpringConfigurationClasses(): List<PsiClass> {
         val psiFacade = JavaPsiFacade.getInstance(project)
         val testRootToIndex = getSortedTestRoots().withIndex().associate { (i, root) -> root.dir to i }

--- a/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/ui/components/TestFolderComboWithBrowseButton.kt
+++ b/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/ui/components/TestFolderComboWithBrowseButton.kt
@@ -17,12 +17,10 @@ import com.intellij.util.ui.UIUtil
 import java.io.File
 import javax.swing.DefaultComboBoxModel
 import javax.swing.JList
-import org.jetbrains.kotlin.idea.util.rootManager
 import org.utbot.common.PathUtil
 import org.utbot.intellij.plugin.models.BaseTestsModel
 import org.utbot.intellij.plugin.ui.utils.ITestSourceRoot
 import org.utbot.intellij.plugin.ui.utils.addDedicatedTestRoot
-import org.utbot.intellij.plugin.ui.utils.getSortedTestRoots
 import org.utbot.intellij.plugin.ui.utils.isBuildWithGradle
 
 private const val SET_TEST_FOLDER = "set test folder"
@@ -58,12 +56,7 @@ class TestFolderComboWithBrowseButton(private val model: BaseTestsModel) :
             }
         }
 
-        val testRoots = getSortedTestRoots(
-            model.getAllTestSourceRoots(),
-            model.sourceRootHistory,
-            model.srcModule.rootManager.sourceRoots.map { file: VirtualFile -> file.toNioPath().toString() },
-            model.codegenLanguage
-        )
+        val testRoots = model.getSortedTestRoots()
 
         // this method is blocked for Gradle, where multiple test modules can exist
         model.testModule.addDedicatedTestRoot(testRoots, model.codegenLanguage)


### PR DESCRIPTION
## Description

Fixes [#1921](https://github.com/UnitTestBot/UTBotJava/issues/1921)

Implemented `BaseTestsModel.getSortedSpringConfigurationClasses()` method that searches for classes marked with `@Configuration` and `@TestConfiguration` annotations in source module and its test modules.

Classes are sorted in the following order:
  - Classes marked with `@TestConfiguration` annotation
  - Classes marked with `@Configuration` annotation

Inside one group classes are sorted by their roots in the following order:
  - Classes from test roots
  - Classes from source roots

Classes from the test roots are additionally sorted by their roots in the order provided by `BaseTestsModel.getSortedTestRoots()`

## How to test

Standard regression checks on regression tests.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.