### PR TITLE
Make tests on timeout generate method under test call for all test frameworks

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/TestFrameworkManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/TestFrameworkManager.kt
@@ -203,7 +203,14 @@ abstract class TestFrameworkManager(val context: CgContext)
 
     abstract fun passArgumentsToArgsVariable(argsVariable: CgVariable, argsArray: CgVariable, executionIndex: Int)
 
-    open fun expectTimeout(timeoutMs: Long, block: () -> Unit) {}
+    /**
+     * Most frameworks don't have special timeout assertion, so only tested
+     * method call is generated, while timeout is set using
+     * [timeout argument][timeoutArgumentName] of the test annotation
+     *
+     * @see setTestExecutionTimeout
+     */
+    open fun expectTimeout(timeoutMs: Long, block: () -> Unit): Unit = block()
 
     open fun setTestExecutionTimeout(timeoutMs: Long) {
         val timeout = CgNamedAnnotationArgument(


### PR DESCRIPTION
## Description

Fixes [#1933](https://github.com/UnitTestBot/UTBotJava/issues/1933)

Most frameworks don't have special timeout assertion, so in `expectTimeout` only tested method call is generated, while timeout is set using timeout argument of the test annotation in `setTestExecutionTimeout`

## How to test

### Manual tests

Generate tests for:
```
public void sleep() throws InterruptedException {
    Thread.sleep(5000);
}
```

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.