### PR TITLE
Fix broken AndroidProjectInfo.requiresAnroidModel() in new API

### DIFF
--- a/utbot-android-studio/src/main/kotlin/org/androidstudio/plugin/util/UtAndroidGradleJavaProjectModelModifierWrapper.kt
+++ b/utbot-android-studio/src/main/kotlin/org/androidstudio/plugin/util/UtAndroidGradleJavaProjectModelModifierWrapper.kt
@@ -1,6 +1,7 @@
 package org.androidstudio.plugin.util
 
-import com.android.tools.idea.project.AndroidProjectInfo
+import com.android.tools.idea.model.AndroidModel
+import com.intellij.facet.ProjectFacetManager
 import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.module.Module
@@ -10,6 +11,7 @@ import com.intellij.openapi.roots.ExternalLibraryDescriptor
 import com.intellij.openapi.roots.impl.IdeaProjectModelModifier
 import com.intellij.openapi.roots.libraries.Library
 import com.intellij.pom.java.LanguageLevel
+import org.jetbrains.android.facet.AndroidFacet
 import org.jetbrains.concurrency.Promise
 
 /*
@@ -55,6 +57,7 @@ class UtAndroidGradleJavaProjectModelModifierWrapper(val project: Project): Idea
             return false
         }
 
-        return AndroidProjectInfo.getInstance(project).requiresAndroidModel()
+        return ProjectFacetManager.getInstance(project).getFacets(AndroidFacet.ID).stream()
+            .anyMatch { AndroidModel.isRequired(it) }
     }
 }


### PR DESCRIPTION
## Description

Actually required method was inlined to our code

Fixes #1949 

## How to test

### Manual tests

See the issue, adding new library (JUnit/Mockito etc.) shouldn't fail.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.