### PR TITLE
Fix false naming escaping in JavaScript 

### DIFF
--- a/utbot-js/src/main/kotlin/framework/codegen/model/constructor/visitor/CgJsRenderer.kt
+++ b/utbot-js/src/main/kotlin/framework/codegen/model/constructor/visitor/CgJsRenderer.kt
@@ -408,7 +408,7 @@ internal class CgJsRenderer(context: CgRendererContext, printer: CgPrinter = CgP
         print("${exception.name.escapeNamePossibleKeyword()}: ${exception.type}")
     }
 
-    override fun escapeNamePossibleKeywordImpl(s: String): String = ""
+    override fun escapeNamePossibleKeywordImpl(s: String): String = s
 
     override fun renderClassVisibility(classId: ClassId) {
         TODO("Not yet implemented")

--- a/utbot-js/src/main/kotlin/framework/codegen/model/constructor/visitor/CgJsRenderer.kt
+++ b/utbot-js/src/main/kotlin/framework/codegen/model/constructor/visitor/CgJsRenderer.kt
@@ -50,7 +50,6 @@ import org.utbot.framework.codegen.renderer.CgAbstractRenderer
 import org.utbot.framework.codegen.renderer.CgPrinter
 import org.utbot.framework.codegen.renderer.CgPrinterImpl
 import org.utbot.framework.codegen.renderer.CgRendererContext
-import org.utbot.framework.codegen.services.language.isLanguageKeyword
 import org.utbot.framework.plugin.api.BuiltinMethodId
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.TypeParameters
@@ -409,8 +408,7 @@ internal class CgJsRenderer(context: CgRendererContext, printer: CgPrinter = CgP
         print("${exception.name.escapeNamePossibleKeyword()}: ${exception.type}")
     }
 
-    override fun escapeNamePossibleKeywordImpl(s: String): String =
-        if (isLanguageKeyword(s, context.cgLanguageAssistant)) "`$s`" else s
+    override fun escapeNamePossibleKeywordImpl(s: String): String = ""
 
     override fun renderClassVisibility(classId: ClassId) {
         TODO("Not yet implemented")


### PR DESCRIPTION
## Description

Fixes #1940 

## How to test

### Manual tests

Various scenarios have been tested. You can find the examples in the folder `/utbot-js/samples' and try to run UTBot.

## Self-check list

Check off the item if the statement is true. Hint: [x] is a marked item.

Please do not delete the list or its items.

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.