### PR TITLE
Removed redundant switch-case in mocks in case of only one branch

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/MockFrameworkManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/MockFrameworkManager.kt
@@ -22,7 +22,6 @@ import org.utbot.framework.codegen.domain.context.CgContext
 import org.utbot.framework.codegen.domain.context.CgContextOwner
 import org.utbot.framework.codegen.domain.models.CgAnonymousFunction
 import org.utbot.framework.codegen.domain.models.CgAssignment
-import org.utbot.framework.codegen.domain.models.CgBreakStatement
 import org.utbot.framework.codegen.domain.models.CgConstructorCall
 import org.utbot.framework.codegen.domain.models.CgDeclaration
 import org.utbot.framework.codegen.domain.models.CgExecutableCall
@@ -69,7 +68,6 @@ import org.utbot.framework.plugin.api.util.intClassId
 import org.utbot.framework.plugin.api.util.longClassId
 import org.utbot.framework.plugin.api.util.shortClassId
 import org.utbot.framework.plugin.api.util.voidClassId
-import java.util.Locale
 
 abstract class CgVariableConstructorComponent(val context: CgContext) :
         CgContextOwner by context,
@@ -337,7 +335,7 @@ private class MockitoStaticMocker(context: CgContext, private val mocker: Object
         val mockParameter = variableConstructor.declareParameter(
             classId,
             nameGenerator.variableName(
-                classId.simpleName.replaceFirstChar { it.lowercase(Locale.getDefault()) },
+                classId,
                 isMock = true
             )
         )


### PR DESCRIPTION
## Description

If we have only one branch in mocking new instances - i.e., we consider only the first invocation of executables - we do not need a switch-case and corresponding counter for labels.

Fixes #1878.

## How to test

### Automated tests

Common pipeline.

### Manual tests

Mentioned in the corresponding issue.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.