### PR TITLE
Broken action for Project View multi-selection in IDEA 2022.3 

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/language/JavaLanguage.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/language/JavaLanguage.kt
@@ -109,7 +109,7 @@ object JvmLanguageAssistant : LanguageAssistant() {
                     }
                 }
             } else {
-                val someSelection = e.getData(PlatformDataKeys.SELECTED_ITEMS)?: return null
+                val someSelection = e.getData(PlatformDataKeys.PSI_ELEMENT_ARRAY)?: return null
                 someSelection.forEach {
                     when(it) {
                         is PsiFileSystemItem  -> srcClasses += getAllClasses(project, arrayOf(it.virtualFile))

--- a/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/language/agnostic/LanguageAssistant.kt
+++ b/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/language/agnostic/LanguageAssistant.kt
@@ -45,7 +45,7 @@ abstract class LanguageAssistant {
                         element.containingFile?.let { getLanguageFromFile(it) }
                     }
                     else -> {
-                        val someSelection = e.getData(PlatformDataKeys.SELECTED_ITEMS)?: return null
+                        val someSelection = e.getData(PlatformDataKeys.PSI_ELEMENT_ARRAY)?: return null
                         someSelection.firstNotNullOfOrNull {
                             when(it) {
                                 is PsiFileSystemItem -> findLanguageRecursively(project, arrayOf(it.virtualFile))


### PR DESCRIPTION
## Description
PSI_ELEMENT_ARRAY key should be used (it also works in previous IntelliJ API versions)

## How to test

### Manual tests

Using plugin with IDEA 2022.3 select several files in Project View, press our shourtcut: nothing happens.

## Self-check list

Check off the item if the statement is true. Hint: [x] is a marked item.

Please do not delete the list or its items.

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.