### PR TITLE
Rider plugin bugfixes

### DIFF
--- a/utbot-rider/src/dotnet/UtBot/UtBot/GenerateUnitTestElementProvider.cs
+++ b/utbot-rider/src/dotnet/UtBot/UtBot/GenerateUnitTestElementProvider.cs
@@ -6,7 +6,6 @@ using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp;
 using JetBrains.ReSharper.Psi.Resolve;
 using JetBrains.ReSharper.Psi.Tree;
-using JetBrains.Util;
 
 namespace UtBot;
 
@@ -18,7 +17,7 @@ internal class TimeoutGeneratorOption : IGeneratorOption
     public IReadOnlyList<string> GetPossibleValues() => new string[] { };
 
     public bool IsValidValue(string value) =>
-        value.IsNullOrEmpty() || (int.TryParse(value, out var intValue) && intValue > 0);
+        int.TryParse(value, out var intValue) && intValue > 0;
 
     public string ID => Id;
 

--- a/utbot-rider/src/dotnet/UtBot/UtBot/Utils/DotNetVersionUtils.cs
+++ b/utbot-rider/src/dotnet/UtBot/UtBot/Utils/DotNetVersionUtils.cs
@@ -78,13 +78,12 @@ internal class DotNetVersionUtils
         return new(defaultTfm, true);
     }
 
-    // TODO: is there a case when --list-runtimes is not available, but runtime is installed?
     private static bool GetCanRunVSharp(string workingDir)
     {
         var sdksInfo = RunProcess(new ProcessStartInfo
         {
             FileName = "dotnet",
-            Arguments = "--list-runtimes",
+            Arguments = "--list-sdks",
             WorkingDirectory = workingDir
         });
 
@@ -93,7 +92,7 @@ internal class DotNetVersionUtils
             return false;
         }
 
-        var matches = Regex.Matches(sdksInfo, @"\.(\S+)\.App (\d+)\.(\d+)\.(\d+)");
+        var matches = Regex.Matches(sdksInfo, @"(\d+)\.(\d+)\.(\d+)");
 
         if (matches.Count < 1)
         {
@@ -102,12 +101,7 @@ internal class DotNetVersionUtils
 
         for (var i = 0; i < matches.Count; ++i)
         {
-            if (matches[i].Groups[1].Value == "AspNetCore")
-            {
-                continue;
-            }
-
-            if (!int.TryParse(matches[i].Groups[2].Value, out var majorVersion))
+            if (!int.TryParse(matches[i].Groups[1].Value, out var majorVersion))
             {
                 continue;
             }

--- a/utbot-rider/src/dotnet/UtBot/UtBot/Utils/Notifications.cs
+++ b/utbot-rider/src/dotnet/UtBot/UtBot/Utils/Notifications.cs
@@ -60,8 +60,6 @@ internal class Notifications
         bool closeAfterExecution = true,
         UserNotificationCommand command = null)
     {
-        _logger.Error(message: body);
-
         ShowNotification(
             NotificationSeverity.CRITICAL,
             Title,

--- a/utbot-rider/src/dotnet/UtBot/UtBot/Utils/ProjectPublisher.cs
+++ b/utbot-rider/src/dotnet/UtBot/UtBot/Utils/ProjectPublisher.cs
@@ -30,7 +30,7 @@ public class ProjectPublisher
             var name = $"Publish::{project.Name}";
             Directory.CreateDirectory(outputDir.FullPath);
             var projectName = project.ProjectFileLocation.Name;
-            var rid = RuntimeInformation.RuntimeIdentifier;
+            var architecture = GetArchitecture();
             var tfm = config.TargetFrameworkId.TryGetShortIdentifier();
             var command = config.TargetFrameworkId.IsNetFramework ? "build" : "publish";
 
@@ -43,7 +43,7 @@ public class ProjectPublisher
             {
                 FileName = "dotnet",
                 Arguments =
-                    $"{command} \"{projectName}\" --sc -c {config.Name} -r {rid} -o {outputDir.FullPath} -f {tfm}",
+                    $"{command} \"{projectName}\" --sc -c {config.Name} -a {architecture} -o {outputDir.FullPath} -f {tfm}",
                 WorkingDirectory = project.ProjectFileLocation.Directory.FullPath,
                 RedirectStandardError = true,
                 RedirectStandardOutput = true
@@ -79,5 +79,20 @@ public class ProjectPublisher
         {
             publishLifetimeDef.Terminate();
         }
+    }
+
+    private string GetArchitecture()
+    {
+        var arch = RuntimeInformation.OSArchitecture;
+        return arch switch
+        {
+            Architecture.X86 => "x86",
+            Architecture.X64 => "x64",
+            Architecture.Arm => "arm",
+            Architecture.Arm64 => "arm64",
+            Architecture.Wasm or Architecture.S390x =>
+                throw new InvalidOperationException($"Unsupported architecture: {arch}"),
+            _ => throw new ArgumentOutOfRangeException()
+        };
     }
 }


### PR DESCRIPTION
- Check for installed .NET SDKs instead of runtimes, as they are necessary for publish
- Remove logging from popup notification method
- Fix RPC timeout for test generation
- Use -a flag instead of -r in Publisher because incorrect RIDs appeared