### PR TITLE
Avoid incorrect warning about the Destination package

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineProcessMain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineProcessMain.kt
@@ -273,7 +273,7 @@ private fun processInitialWarnings(report: TestsGenerationReport, params: Genera
 }
 
 private fun destinationWarningMessage(testPackageName: String?, classUnderTestPackageName: String): String? {
-    return if (classUnderTestPackageName != testPackageName) {
+    return if (!testPackageName.isNullOrEmpty() && classUnderTestPackageName != testPackageName) {
         """
             Warning: Destination package $testPackageName does not match package of the class $classUnderTestPackageName.
             This may cause unnecessary usage of reflection for protected or package-private fields and methods access.


### PR DESCRIPTION
## Description
Actually we don't show textfield to specify result package for tests. Thus in model is't just an empty string. The fix don't procude the warning in case of empty string.

Fixes #1915


### Manual tests

See the steps from #1915, actually the issue should appear always when you generate tests.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.