### PR TITLE
Add Spring-specific options to UI

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
@@ -712,7 +712,7 @@ enum class ParametrizedTestSource(
     }
 }
 
-enum class ApplicationType {
+enum class ProjectType {
     /**
      * Standard JVM application without DI frameworks.
      */

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -25,7 +25,7 @@ import org.utbot.framework.CancellationStrategyType.CANCEL_EVERYTHING
 import org.utbot.framework.CancellationStrategyType.NONE
 import org.utbot.framework.CancellationStrategyType.SAVE_PROCESSED_RESULTS
 import org.utbot.framework.UtSettings
-import org.utbot.framework.codegen.domain.ApplicationType
+import org.utbot.framework.codegen.domain.ProjectType
 import org.utbot.framework.codegen.domain.TypeReplacementApproach
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.ApplicationContext
@@ -176,9 +176,9 @@ object UtTestsDialogProcessor {
                         val mockFrameworkInstalled = model.mockFramework.isInstalled
                         val staticMockingConfigured = model.staticsMocking.isConfigured
 
-                        val applicationContext = when (model.applicationType) {
-                            ApplicationType.PURE_JVM -> ApplicationContext(mockFrameworkInstalled, staticMockingConfigured)
-                            ApplicationType.SPRING_APPLICATION -> {
+                        val applicationContext = when (model.projectType) {
+                            ProjectType.PURE_JVM -> ApplicationContext(mockFrameworkInstalled, staticMockingConfigured)
+                            ProjectType.SPRING_APPLICATION -> {
                                 val shouldUseImplementors = when (model.typeReplacementApproach) {
                                     TypeReplacementApproach.DO_NOT_REPLACE -> false
                                     TypeReplacementApproach.REPLACE_IF_POSSIBLE -> true

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/GenerateTestsModel.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/GenerateTestsModel.kt
@@ -18,7 +18,7 @@ import com.intellij.refactoring.util.classMembers.MemberInfo
 import org.jetbrains.kotlin.psi.KtFile
 import org.utbot.framework.SummariesGenerationType
 import org.utbot.framework.UtSettings
-import org.utbot.framework.codegen.domain.ApplicationType
+import org.utbot.framework.codegen.domain.ProjectType
 import org.utbot.framework.codegen.domain.TypeReplacementApproach
 import org.utbot.framework.plugin.api.JavaDocCommentStyle
 import org.utbot.framework.util.ConflictTriggers
@@ -43,7 +43,7 @@ class GenerateTestsModel(
     override var sourceRootHistory = project.service<Settings>().sourceRootHistory
     override var codegenLanguage = project.service<Settings>().codegenLanguage
 
-    lateinit var applicationType: ApplicationType
+    lateinit var projectType: ProjectType
 
     lateinit var testFramework: TestFramework
     lateinit var mockStrategy: MockStrategyApi

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/SettingsWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/SettingsWindow.kt
@@ -217,7 +217,7 @@ class SettingsWindow(val project: Project) {
                 )
                 .constraints(CCFlags.growX)
                 .component.apply {
-                    toolTipText = "<html><body>While fuzzer \"guesses\" the values to enter as much execution paths as possible, symbolic executor tries to \"deduce\" them. Choose the proportion of generation time allocated for each of these methods within Test generation timeout</body></html>"
+                    toolTipText = "<html><body>While fuzzer \"guesses\" the values to enter as much execution paths as possible, symbolic executor tries to \"deduce\" them. Choose the proportion of generation time allocated for each of these methods within Test generation timeout. The slide has no effect for Spring Projects.</body></html>"
                     addChangeListener {
                         fuzzLabel.text = "Fuzzing " + "%.0f %%".format(100.0 * (granularity - value) / granularity)
                         symLabel.text = "%.0f %%".format(100.0 * value / granularity) + " Symbolic execution"

--- a/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/models/BaseTestModel.kt
+++ b/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/models/BaseTestModel.kt
@@ -10,10 +10,10 @@ import com.intellij.openapi.vfs.newvfs.impl.FakeVirtualFile
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiClass
 import com.intellij.psi.search.GlobalSearchScope
-import com.intellij.psi.search.ProjectScope
 import com.intellij.psi.search.searches.AnnotatedElementsSearch
+import com.intellij.util.containers.mapSmart
 import org.jetbrains.kotlin.idea.core.getPackage
-import org.jetbrains.kotlin.idea.search.allScope
+import org.jetbrains.kotlin.idea.refactoring.memberInfo.qualifiedClassNameForRendering
 import org.jetbrains.kotlin.idea.util.projectStructure.allModules
 import org.jetbrains.kotlin.idea.util.rootManager
 import org.jetbrains.kotlin.idea.util.sourceRoot
@@ -82,7 +82,7 @@ open class BaseTestsModel(
      *      - firstly, from test source roots (in the order provided by [getSortedTestRoots])
      *      - after that, from source roots
      */
-    fun getSortedSpringConfigurationClasses(): List<PsiClass> {
+    fun getSortedSpringConfigurationClasses(): List<String> {
         val testRootToIndex = getSortedTestRoots().withIndex().associate { (i, root) -> root.dir to i }
 
         // Not using `srcModule.testModules(project)` here because it returns
@@ -108,7 +108,7 @@ open class BaseTestsModel(
                 .searchPsiClasses(annotation, searchScope)
                 .findAll()
                 .sortedBy { testRootToIndex[it.containingFile.sourceRoot] ?: Int.MAX_VALUE }
-        }
+        }.mapNotNull { it.qualifiedName }
     }
 
     fun updateSourceRootHistory(path: String) {


### PR DESCRIPTION
## Description

This PR adds Spring-specific options to UI like ability to choose the configuration.
See the following screenshots:
![image](https://user-images.githubusercontent.com/54685068/226342524-08d0b14f-16d6-4ca3-b50b-13e6e4f978cd.png)
![image](https://user-images.githubusercontent.com/54685068/226347788-f80e7300-c1f8-4258-be8a-f312fc94f398.png)
![image](https://user-images.githubusercontent.com/54685068/226347814-70847c22-1f04-465d-b5ee-de531bbf766b.png)


## How to test

### Automated tests

### Manual tests

Open Action Menu in Spring Project.