### PR TITLE
Use detected project type in Codegen

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
@@ -714,14 +714,24 @@ enum class ParametrizedTestSource(
 
 enum class ProjectType {
     /**
-     * Standard JVM application without DI frameworks.
+     * Standard JVM project without DI frameworks
      */
-    PURE_JVM,
+    PureJvm,
 
     /**
-     * Spring or Spring Boot application.
+     * Spring or Spring Boot project
      */
-    SPRING_APPLICATION,
+    Spring,
+
+    /**
+     * Python project
+     */
+    Python,
+
+    /**
+     * JavaScript project
+     */
+    JavaScript,
 }
 
 enum class TypeReplacementApproach {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/context/CgContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/context/CgContext.kt
@@ -22,6 +22,7 @@ import kotlinx.collections.immutable.PersistentSet
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.collections.immutable.persistentSetOf
+import org.utbot.framework.codegen.domain.ProjectType
 import org.utbot.framework.codegen.domain.models.CgMethodTestSet
 import org.utbot.framework.codegen.domain.builtin.TestClassUtilMethodProvider
 import org.utbot.framework.codegen.domain.builtin.UtilClassFileMethodProvider
@@ -66,8 +67,8 @@ interface CgContextOwner {
     // current class under test
     val classUnderTest: ClassId
 
-    // If test class is configured with Spring, we should do some extra analysis
-    val isSpringClass: Boolean
+    // If project under test is configured with Spring, we should do some extra analysis
+    val projectType: ProjectType
 
     // test class currently being generated (if series of nested classes is generated, it is the outermost one)
     val outerMostTestClass: ClassId
@@ -434,7 +435,7 @@ interface CgContextOwner {
  */
 data class CgContext(
     override val classUnderTest: ClassId,
-    override val isSpringClass: Boolean = false,
+    override val projectType: ProjectType,
     val generateUtilClassFile: Boolean = false,
     override var currentExecutable: ExecutableId? = null,
     override val collectedExceptions: MutableSet<ClassId> = mutableSetOf(),

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineProcessMain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineProcessMain.kt
@@ -12,6 +12,7 @@ import org.utbot.framework.codegen.domain.HangingTestsTimeout
 import org.utbot.framework.codegen.domain.MockitoStaticMocking
 import org.utbot.framework.codegen.domain.NoStaticMocking
 import org.utbot.framework.codegen.domain.ParametrizedTestSource
+import org.utbot.framework.codegen.domain.ProjectType
 import org.utbot.framework.codegen.domain.RuntimeExceptionTestsBehaviour
 import org.utbot.framework.codegen.domain.testFrameworkByName
 import org.utbot.framework.codegen.reports.TestsGenerationReport
@@ -135,6 +136,7 @@ private fun EngineProcessModel.setup(kryoHelper: KryoHelper, watchdog: IdleWatch
         val testSetsId: Long = params.testSetsId
         val codeGenerator = CodeGenerator(
             classUnderTest = classId,
+            projectType = ProjectType.valueOf(params.projectType),
             generateUtilClassFile = params.generateUtilClassFile,
             paramNames = kryoHelper.readObject(params.paramNames),
             testFramework = testFramework,

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/process/generated/EngineProcessModel.Generated.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/process/generated/EngineProcessModel.Generated.kt
@@ -72,7 +72,7 @@ class EngineProcessModel private constructor(
         }
         
         
-        const val serializationHash = -120710112541549600L
+        const val serializationHash = -2087034443345538396L
         
     }
     override val serializersOwner: ISerializersOwner get() = EngineProcessModel
@@ -173,7 +173,7 @@ val IProtocol.engineProcessModel get() = getOrCreateExtension(EngineProcessModel
 
 
 /**
- * #### Generated from [EngineProcessModel.kt:98]
+ * #### Generated from [EngineProcessModel.kt:99]
  */
 data class FindMethodParamNamesArguments (
     val classId: ByteArray,
@@ -236,7 +236,7 @@ data class FindMethodParamNamesArguments (
 
 
 /**
- * #### Generated from [EngineProcessModel.kt:102]
+ * #### Generated from [EngineProcessModel.kt:103]
  */
 data class FindMethodParamNamesResult (
     val paramNames: ByteArray
@@ -293,7 +293,7 @@ data class FindMethodParamNamesResult (
 
 
 /**
- * #### Generated from [EngineProcessModel.kt:91]
+ * #### Generated from [EngineProcessModel.kt:92]
  */
 data class FindMethodsInClassMatchingSelectedArguments (
     val classId: ByteArray,
@@ -356,7 +356,7 @@ data class FindMethodsInClassMatchingSelectedArguments (
 
 
 /**
- * #### Generated from [EngineProcessModel.kt:95]
+ * #### Generated from [EngineProcessModel.kt:96]
  */
 data class FindMethodsInClassMatchingSelectedResult (
     val executableIds: ByteArray
@@ -581,7 +581,7 @@ data class GenerateResult (
 
 
 /**
- * #### Generated from [EngineProcessModel.kt:110]
+ * #### Generated from [EngineProcessModel.kt:111]
  */
 data class GenerateTestReportArgs (
     val eventLogMessage: String?,
@@ -674,7 +674,7 @@ data class GenerateTestReportArgs (
 
 
 /**
- * #### Generated from [EngineProcessModel.kt:119]
+ * #### Generated from [EngineProcessModel.kt:120]
  */
 data class GenerateTestReportResult (
     val notifyMessage: String,
@@ -806,7 +806,7 @@ data class JdkInfo (
 
 
 /**
- * #### Generated from [EngineProcessModel.kt:86]
+ * #### Generated from [EngineProcessModel.kt:87]
  */
 data class MethodDescription (
     val name: String,
@@ -880,6 +880,7 @@ data class MethodDescription (
 data class RenderParams (
     val testSetsId: Long,
     val classUnderTest: ByteArray,
+    val projectType: String,
     val paramNames: ByteArray,
     val generateUtilClassFile: Boolean,
     val testFramework: String,
@@ -903,6 +904,7 @@ data class RenderParams (
         override fun read(ctx: SerializationCtx, buffer: AbstractBuffer): RenderParams  {
             val testSetsId = buffer.readLong()
             val classUnderTest = buffer.readByteArray()
+            val projectType = buffer.readString()
             val paramNames = buffer.readByteArray()
             val generateUtilClassFile = buffer.readBool()
             val testFramework = buffer.readString()
@@ -916,12 +918,13 @@ data class RenderParams (
             val hangingTestsTimeout = buffer.readLong()
             val enableTestsTimeout = buffer.readBool()
             val testClassPackageName = buffer.readString()
-            return RenderParams(testSetsId, classUnderTest, paramNames, generateUtilClassFile, testFramework, mockFramework, codegenLanguage, parameterizedTestSource, staticsMocking, forceStaticMocking, generateWarningsForStaticMocking, runtimeExceptionTestsBehaviour, hangingTestsTimeout, enableTestsTimeout, testClassPackageName)
+            return RenderParams(testSetsId, classUnderTest, projectType, paramNames, generateUtilClassFile, testFramework, mockFramework, codegenLanguage, parameterizedTestSource, staticsMocking, forceStaticMocking, generateWarningsForStaticMocking, runtimeExceptionTestsBehaviour, hangingTestsTimeout, enableTestsTimeout, testClassPackageName)
         }
         
         override fun write(ctx: SerializationCtx, buffer: AbstractBuffer, value: RenderParams)  {
             buffer.writeLong(value.testSetsId)
             buffer.writeByteArray(value.classUnderTest)
+            buffer.writeString(value.projectType)
             buffer.writeByteArray(value.paramNames)
             buffer.writeBool(value.generateUtilClassFile)
             buffer.writeString(value.testFramework)
@@ -952,6 +955,7 @@ data class RenderParams (
         
         if (testSetsId != other.testSetsId) return false
         if (!(classUnderTest contentEquals other.classUnderTest)) return false
+        if (projectType != other.projectType) return false
         if (!(paramNames contentEquals other.paramNames)) return false
         if (generateUtilClassFile != other.generateUtilClassFile) return false
         if (testFramework != other.testFramework) return false
@@ -973,6 +977,7 @@ data class RenderParams (
         var __r = 0
         __r = __r*31 + testSetsId.hashCode()
         __r = __r*31 + classUnderTest.contentHashCode()
+        __r = __r*31 + projectType.hashCode()
         __r = __r*31 + paramNames.contentHashCode()
         __r = __r*31 + generateUtilClassFile.hashCode()
         __r = __r*31 + testFramework.hashCode()
@@ -994,6 +999,7 @@ data class RenderParams (
         printer.indent {
             print("testSetsId = "); testSetsId.print(printer); println()
             print("classUnderTest = "); classUnderTest.print(printer); println()
+            print("projectType = "); projectType.print(printer); println()
             print("paramNames = "); paramNames.print(printer); println()
             print("generateUtilClassFile = "); generateUtilClassFile.print(printer); println()
             print("testFramework = "); testFramework.print(printer); println()
@@ -1016,7 +1022,7 @@ data class RenderParams (
 
 
 /**
- * #### Generated from [EngineProcessModel.kt:79]
+ * #### Generated from [EngineProcessModel.kt:80]
  */
 data class RenderResult (
     val generatedCode: String,
@@ -1079,7 +1085,7 @@ data class RenderResult (
 
 
 /**
- * #### Generated from [EngineProcessModel.kt:83]
+ * #### Generated from [EngineProcessModel.kt:84]
  */
 data class SetupContextParams (
     val classpathForUrlsClassloader: List<String>
@@ -1217,7 +1223,7 @@ data class TestGeneratorParams (
 
 
 /**
- * #### Generated from [EngineProcessModel.kt:105]
+ * #### Generated from [EngineProcessModel.kt:106]
  */
 data class WriteSarifReportArguments (
     val testSetsId: Long,

--- a/utbot-intellij-python/src/main/kotlin/org/utbot/intellij/plugin/language/python/PythonDialogWindow.kt
+++ b/utbot-intellij-python/src/main/kotlin/org/utbot/intellij/plugin/language/python/PythonDialogWindow.kt
@@ -15,6 +15,7 @@ import com.jetbrains.python.refactoring.classes.PyMemberInfoStorage
 import com.jetbrains.python.refactoring.classes.membersManager.PyMemberInfo
 import com.jetbrains.python.refactoring.classes.ui.PyMemberSelectionTable
 import org.utbot.framework.UtSettings
+import org.utbot.framework.codegen.domain.ProjectType
 import org.utbot.intellij.plugin.settings.Settings
 import java.awt.BorderLayout
 import java.util.concurrent.TimeUnit
@@ -171,6 +172,7 @@ class PythonDialogWindow(val model: PythonTestsModel) : DialogWrapper(model.proj
         model.testFramework = testFrameworks.item
         model.timeout = TimeUnit.SECONDS.toMillis(timeoutSpinnerForTotalTimeout.number.toLong())
         model.testSourceRootPath = testSourceFolderField.text
+        model.projectType = ProjectType.Python
 
         val settings = model.project.service<Settings>()
         with(settings) {

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerationController.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerationController.kt
@@ -8,7 +8,6 @@ import com.intellij.ide.fileTemplates.FileTemplateUtil
 import com.intellij.ide.fileTemplates.JavaTemplateUtil
 import com.intellij.ide.highlighter.JavaFileType
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.application.readAction
 import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.command.WriteCommandAction.runWriteCommandAction
@@ -686,6 +685,7 @@ object CodeGenerationController {
                 proc.render(
                     testSetsId,
                     classUnderTest,
+                    model.projectType,
                     paramNames.toMutableMap(),
                     generateUtilClassFile = true,
                     model.testFramework,

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -25,6 +25,7 @@ import org.utbot.framework.CancellationStrategyType.CANCEL_EVERYTHING
 import org.utbot.framework.CancellationStrategyType.NONE
 import org.utbot.framework.CancellationStrategyType.SAVE_PROCESSED_RESULTS
 import org.utbot.framework.UtSettings
+import org.utbot.framework.codegen.domain.ProjectType.*
 import org.utbot.framework.codegen.domain.ProjectType
 import org.utbot.framework.codegen.domain.TypeReplacementApproach
 import org.utbot.framework.plugin.api.ClassId
@@ -177,8 +178,10 @@ object UtTestsDialogProcessor {
                         val staticMockingConfigured = model.staticsMocking.isConfigured
 
                         val applicationContext = when (model.projectType) {
-                            ProjectType.PURE_JVM -> ApplicationContext(mockFrameworkInstalled, staticMockingConfigured)
-                            ProjectType.SPRING_APPLICATION -> {
+                            PureJvm,
+                            Python,
+                            JavaScript -> ApplicationContext(mockFrameworkInstalled, staticMockingConfigured)
+                            Spring -> {
                                 val shouldUseImplementors = when (model.typeReplacementApproach) {
                                     TypeReplacementApproach.DO_NOT_REPLACE -> false
                                     TypeReplacementApproach.REPLACE_IF_POSSIBLE -> true

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/GenerateTestsModel.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/GenerateTestsModel.kt
@@ -18,7 +18,6 @@ import com.intellij.refactoring.util.classMembers.MemberInfo
 import org.jetbrains.kotlin.psi.KtFile
 import org.utbot.framework.SummariesGenerationType
 import org.utbot.framework.UtSettings
-import org.utbot.framework.codegen.domain.ProjectType
 import org.utbot.framework.codegen.domain.TypeReplacementApproach
 import org.utbot.framework.plugin.api.JavaDocCommentStyle
 import org.utbot.framework.util.ConflictTriggers
@@ -42,8 +41,6 @@ class GenerateTestsModel(
 ) {
     override var sourceRootHistory = project.service<Settings>().sourceRootHistory
     override var codegenLanguage = project.service<Settings>().codegenLanguage
-
-    lateinit var projectType: ProjectType
 
     lateinit var testFramework: TestFramework
     lateinit var mockStrategy: MockStrategyApi

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/process/EngineProcess.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/process/EngineProcess.kt
@@ -278,6 +278,7 @@ class EngineProcess private constructor(val project: Project, private val classN
     fun render(
         testSetsId: Long,
         classUnderTest: ClassId,
+        projectType: ProjectType,
         paramNames: MutableMap<ExecutableId, List<String>>,
         generateUtilClassFile: Boolean,
         testFramework: TestFramework,
@@ -296,6 +297,7 @@ class EngineProcess private constructor(val project: Project, private val classN
         val params = RenderParams(
             testSetsId,
             kryoHelper.writeObject(classUnderTest),
+            projectType.toString(),
             kryoHelper.writeObject(paramNames),
             generateUtilClassFile,
             testFramework.id.lowercase(),

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -288,7 +288,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
                     null
                 )
             }
-            if (model.projectType == ProjectType.SPRING_APPLICATION) {
+            if (model.projectType == ProjectType.Spring) {
                 row("Spring configuration:") {
                     makePanelWithHelpTooltip(
                         springConfig,
@@ -1040,7 +1040,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
         val mockStrategyIsSupported = mockStrategies.item == MockStrategyApi.NO_MOCKS
 
         // We do not support PUT in Spring projects
-        val isSupportedProjectType = model.projectType == ProjectType.PURE_JVM
+        val isSupportedProjectType = model.projectType == ProjectType.PureJvm
         parametrizedTestSources.isEnabled =
             isSupportedProjectType && languageIsSupported && frameworkIsSupported && mockStrategyIsSupported
 
@@ -1076,7 +1076,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
 
     private fun updateSpringConfigurationEnabled() {
         // We check for > 1 because there is already extra-dummy NO_SPRING_CONFIGURATION_OPTION option
-        springConfig.isEnabled = model.projectType == ProjectType.SPRING_APPLICATION
+        springConfig.isEnabled = model.projectType == ProjectType.Spring
                 && modelSpringConfigs.size > 1
 
         if (!springConfig.isEnabled) {

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -247,9 +247,8 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
         DependencyInjectionFramework.allItems.forEach {
             it.isInstalled = findDependencyInjectionLibrary(model.project, model.testModule, it) != null
         }
-        model.projectType =
-            if (SpringBeans.isInstalled) ProjectType.SPRING_APPLICATION
-            else ProjectType.PURE_JVM
+        model.projectType = if (SpringBeans.isInstalled) ProjectType.Spring else ProjectType.PureJvm
+
         StaticsMocking.allItems.forEach {
             it.isConfigured = staticsMockingConfigured()
         }

--- a/utbot-js/src/main/kotlin/codegen/JsCodeGenerator.kt
+++ b/utbot-js/src/main/kotlin/codegen/JsCodeGenerator.kt
@@ -33,6 +33,7 @@ class JsCodeGenerator(
 ) {
     private var context: CgContext = CgContext(
         classUnderTest = classUnderTest,
+        projectType = ProjectType.JavaScript,
         paramNames = paramNames,
         testFramework = testFramework,
         mockFramework = MockFramework.MOCKITO,

--- a/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/PythonCodeGenerator.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/PythonCodeGenerator.kt
@@ -5,6 +5,7 @@ import org.utbot.framework.codegen.CodeGeneratorResult
 import org.utbot.framework.codegen.domain.ForceStaticMocking
 import org.utbot.framework.codegen.domain.HangingTestsTimeout
 import org.utbot.framework.codegen.domain.ParametrizedTestSource
+import org.utbot.framework.codegen.domain.ProjectType
 import org.utbot.framework.codegen.domain.RuntimeExceptionTestsBehaviour
 import org.utbot.framework.codegen.domain.StaticsMocking
 import org.utbot.framework.codegen.domain.TestFramework
@@ -42,7 +43,6 @@ import org.utbot.python.newtyping.pythonAnyType
 import org.utbot.python.newtyping.pythonModules
 import org.utbot.python.newtyping.pythonTypeRepresentation
 import org.utbot.python.framework.codegen.toPythonRawString
-import org.utbot.python.newtyping.pythonDescription
 import org.utbot.python.newtyping.pythonName
 
 class PythonCodeGenerator(
@@ -60,6 +60,7 @@ class PythonCodeGenerator(
     testClassPackageName: String = classUnderTest.packageName
 ) : CodeGenerator(
     classUnderTest = classUnderTest,
+    projectType = ProjectType.Python,
     paramNames = paramNames,
     generateUtilClassFile = true,
     testFramework = testFramework,

--- a/utbot-rd/src/main/rdgen/org/utbot/rd/models/EngineProcessModel.kt
+++ b/utbot-rd/src/main/rdgen/org/utbot/rd/models/EngineProcessModel.kt
@@ -62,6 +62,7 @@ object EngineProcessModel : Ext(EngineProcessRoot) {
     val renderParams = structdef {
         field("testSetsId", PredefinedType.long)
         field("classUnderTest", array(PredefinedType.byte))
+        field("projectType", PredefinedType.string)
         field("paramNames", array(PredefinedType.byte))
         field("generateUtilClassFile", PredefinedType.bool)
         field("testFramework", PredefinedType.string)

--- a/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/models/BaseTestModel.kt
+++ b/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/models/BaseTestModel.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.idea.refactoring.memberInfo.qualifiedClassNameForRen
 import org.jetbrains.kotlin.idea.util.projectStructure.allModules
 import org.jetbrains.kotlin.idea.util.rootManager
 import org.jetbrains.kotlin.idea.util.sourceRoot
+import org.utbot.framework.codegen.domain.ProjectType
 import org.utbot.framework.plugin.api.CodegenLanguage
 import org.utbot.intellij.plugin.ui.utils.ITestSourceRoot
 import org.utbot.intellij.plugin.ui.utils.getSortedTestRoots
@@ -40,6 +41,7 @@ open class BaseTestsModel(
     var testPackageName: String? = null
     open var sourceRootHistory : MutableList<String> = mutableListOf()
     open lateinit var codegenLanguage: CodegenLanguage
+    open lateinit var projectType: ProjectType
 
     fun setSourceRootAndFindTestModule(newTestSourceRoot: VirtualFile?) {
         requireNotNull(newTestSourceRoot)

--- a/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/models/BaseTestModel.kt
+++ b/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/models/BaseTestModel.kt
@@ -11,9 +11,7 @@ import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiClass
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.AnnotatedElementsSearch
-import com.intellij.util.containers.mapSmart
 import org.jetbrains.kotlin.idea.core.getPackage
-import org.jetbrains.kotlin.idea.refactoring.memberInfo.qualifiedClassNameForRendering
 import org.jetbrains.kotlin.idea.util.projectStructure.allModules
 import org.jetbrains.kotlin.idea.util.rootManager
 import org.jetbrains.kotlin.idea.util.sourceRoot


### PR DESCRIPTION
## Description

Before this PR, we had `isSpringClass` flag setted directly in `CgContext` to hack Codegen for Spring generation.
Currently, we define if project is Spring or not in `UtTestsDialogProcessor` and use obtained value in Codegen.

## How to test

Does not require standalone testing.
Just verify that for project without Spring there are no awful regressions.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.