### PR TITLE
Fix traversing concrete types in NoImplementors mode

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -1245,12 +1245,15 @@ class SpringApplicationContext(
      * if there is the unique implementor in bean definitions.
      */
     override fun replaceTypeIfNeeded(type: RefType): ClassId? =
-        if (type.sootClass.isInterface || type.sootClass.isAbstract) {
+        if (type.isAbstractType) {
             springInjectedClasses.singleOrNull { it.isSubtypeOf(type.id) }
         } else {
             null
         }
 }
+
+val RefType.isAbstractType
+ get() = this.sootClass.isAbstract || this.sootClass.isInterface
 
 interface CodeGenerationSettingItem {
     val id: String

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -126,6 +126,7 @@ import org.utbot.framework.plugin.api.TypeReplacementMode.KnownImplementor
 import org.utbot.framework.plugin.api.TypeReplacementMode.NoImplementors
 import org.utbot.framework.plugin.api.classId
 import org.utbot.framework.plugin.api.id
+import org.utbot.framework.plugin.api.isAbstractType
 import org.utbot.framework.plugin.api.util.executable
 import org.utbot.framework.plugin.api.util.findFieldByIdOrNull
 import org.utbot.framework.plugin.api.util.jField
@@ -1517,7 +1518,7 @@ class Traverser(
             // Mocking can be impossible here as there are no guaranties that `mockInfoGenerator` is instantiated.
             KnownImplementor,
             NoImplementors -> {
-                if (!type.sootClass.isAbstract && !type.sootClass.isInterface) {
+                if (!type.isAbstractType) {
                     findConcreteImplementation(addr, type, typeHardConstraint)
                 }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -1369,6 +1369,8 @@ class Traverser(
         traverseException(current, symException)
     }
 
+    private val nullEqualityConstraint = mkEq(addr, nullObjectAddr)
+
     // TODO: HACK violation of encapsulation
     fun createObject(
         addr: UtAddrExpression,
@@ -1398,8 +1400,6 @@ class Traverser(
 
             return ObjectValue(typeStorage, addr)
         }
-
-        val nullEqualityConstraint = mkEq(addr, nullObjectAddr)
 
         if (mockInfoGenerator != null) {
             val mockInfo = mockInfoGenerator.generate(addr)
@@ -1507,7 +1507,9 @@ class Traverser(
         val concreteImplementation = when (applicationContext.typeReplacementMode) {
             AnyImplementor -> findConcreteImplementation(addr, type, typeHardConstraint)
 
-            // If our type is not abstract, we should just still use concrete implementation that represents itself
+            // If our type is not abstract, both in `KnownImplementors` and `NoImplementors` mode,
+            // we should just still use concrete implementation that represents itself
+            //
             // Otherwise:
             // In case of `KnownImplementor` mode we should have already tried to replace type using `replaceTypeIfNeeded`.
             // However, this replacement attempt might be unsuccessful even if some possible concrete types are present.
@@ -1539,7 +1541,6 @@ class Traverser(
         type: RefType,
         typeHardConstraint: HardConstraint,
     ): Concrete? {
-        val nullEqualityConstraint = mkEq(addr, nullObjectAddr)
         val isMockConstraint = mkEq(typeRegistry.isMock(addr), UtFalse)
 
         queuedSymbolicStateUpdates += typeHardConstraint
@@ -1556,8 +1557,6 @@ class Traverser(
         type: RefType,
         mockInfoGenerator: UtMockInfoGenerator,
     ): ObjectValue {
-        val nullEqualityConstraint = mkEq(addr, nullObjectAddr)
-
         val mockInfo = mockInfoGenerator.generate(addr)
         val mockedObjectInfo = mocker.forceMock(type, mockInfoGenerator.generate(addr))
 


### PR DESCRIPTION
## Description

Corrects the behavior of `Traverser` in `NoImplementors` mode if type of creating object is concrete itself.
We may just use concrete implementation here.

## How to test

Should not be tested standalone.
Inaccessible in current `main`.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.