### PR TITLE
Correctly handle randomizing of Seed.Recursive modifications

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
@@ -357,6 +357,12 @@ class UtBotSymbolicEngine(
             names,
             listOf(transform(ValueProvider.of(defaultValueProviders(defaultIdGenerator))))
         ) { thisInstance, descr, values ->
+            if (thisInstance?.model is UtNullModel) {
+                // We should not try to run concretely any models with null-this.
+                // But fuzzer does generate such values, because it can fail to generate any "good" values.
+                return@runJavaFuzzing BaseFeedback(Trie.emptyNode(), Control.PASS)
+            }
+
             val diff = until - System.currentTimeMillis()
             val thresholdMillisForFuzzingOperation = 0 // may be better use 10-20 millis as it might not be possible
             // to concretely execute that values because request to instrumentation process involves

--- a/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/utils/Functions.kt
+++ b/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/utils/Functions.kt
@@ -81,7 +81,7 @@ internal enum class BinaryFormat : (Int) -> Boolean {
     DOUBLE { override fun invoke(index: Int) = index % 16 == 0 && index != 0 },
 }
 
-internal fun <T> List<T>.transformIfNotEmpty(transform: List<T>.() -> List<T>): List<T> {
+internal fun <T> MutableList<T>.transformIfNotEmpty(transform: MutableList<T>.() -> List<T>): List<T> {
     return if (isNotEmpty()) transform() else this
 }
 

--- a/utbot-fuzzing/src/test/kotlin/org/utbot/fuzzing/FuzzerSmokeTest.kt
+++ b/utbot-fuzzing/src/test/kotlin/org/utbot/fuzzing/FuzzerSmokeTest.kt
@@ -27,12 +27,15 @@ class FuzzerSmokeTest {
 
     @Test
     fun `fuzzing throws an exception if no values generated for some type`() {
-        assertThrows<IllegalStateException> {
+        assertThrows<NoSeedValueException> {
             runBlocking {
                 var count = 0
                 runFuzzing<Unit, Unit, Description<Unit>, BaseFeedback<Unit, Unit, Unit>>(
-                    { _, _ -> sequenceOf() },
-                    Description(listOf(Unit))
+                    provider = { _, _ -> sequenceOf() },
+                    description = Description(listOf(Unit)),
+                    configuration = Configuration(
+                        generateEmptyCollectionsForMissedTypes = false
+                    )
                 ) { _, _ ->
                     count += 1
                     BaseFeedback(Unit, Control.STOP)


### PR DESCRIPTION
## Description

Fixes #1990

When fuzzer fails to generate any fields of an object, the object was set to `null`. To fix this now null-this values are ignored. Also, there's a non-optimal logic, when fuzzer try to fuzz values of modified fields first and only then choose a subset of those modifications. With this patch fuzzer choose subset of modifications in Seed.Recursive and only then will fuzz them.

## How to test

### Automated tests

All fuzzer tests should pass.

### Manual tests

Try an example from the issue. It should generate at least 1 trivial test.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.