### PR TITLE
Fix utbot inspection on inner classes

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/sarif/DataClasses.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/sarif/DataClasses.kt
@@ -47,6 +47,9 @@ data class Sarif(
             .writerWithDefaultPrettyPrinter()
             .writeValueAsString(this)
 
+    operator fun plus(other: Sarif): Sarif =
+        this.copy(runs = this.runs + other.runs)
+
     @JsonIgnore
     fun getAllResults(): List<SarifResult> =
         runs.flatMap { it.results }

--- a/utbot-framework/src/main/kotlin/org/utbot/sarif/SarifReport.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/sarif/SarifReport.kt
@@ -29,7 +29,7 @@ class SarifReport(
          */
         fun mergeReports(reports: List<String>): String =
             reports.fold(Sarif.empty()) { sarif: Sarif, report: String ->
-                sarif.copy(runs = sarif.runs + Sarif.fromJson(report).runs)
+                sarif + Sarif.fromJson(report)
             }.toJson()
 
         /**

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/sarif/SarifReportIdea.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/sarif/SarifReportIdea.kt
@@ -44,8 +44,9 @@ object SarifReportIdea {
         IntelliJApiHelper.run(IntelliJApiHelper.Target.THREAD_POOL, indicator, "Save SARIF report for ${classId.name}") {
             try {
                 val sarifReportAsJson = proc.writeSarif(reportFilePath, testSetsId, generatedTestsCode, sourceFinding)
-                val sarifReport = Sarif.fromJson(sarifReportAsJson)
-                srcClassPathToSarifReport[srcClassPath] = sarifReport
+                val newSarifReport = Sarif.fromJson(sarifReportAsJson)
+                val oldSarifReport = srcClassPathToSarifReport[srcClassPath] ?: Sarif.empty()
+                srcClassPathToSarifReport[srcClassPath] = oldSarifReport + newSarifReport
             } catch (e: Exception) {
                 logger.error { e }
             } finally {


### PR DESCRIPTION
## Description

Fixes #1986

Merged all the SARIF reports for inner classes into one.

For the code below 

```Java
public class Main {
    public int len(String s) { return s.length(); }
}
class A {
    public int divide(int x) { return 1 / x; }
}
class B {
    public int index(int[] a, int i) { return a[i]; }
}
```

utbot displays all the results from inner classes on the Problems view:

![image](https://user-images.githubusercontent.com/54814796/226565325-ab05bd4e-a534-4cfe-80fc-dda1b7c61ef0.png)

## How to test

### Manual tests

Please, repeat the scenario from the issue #1986

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.