### PR TITLE
Use unique mocking statement if all cases are equal

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -1148,9 +1148,24 @@ class BuiltinConstructorId(
     }
 }
 
-open class TypeParameters(val parameters: List<ClassId> = emptyList())
+open class TypeParameters(val parameters: List<ClassId> = emptyList()) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
 
-class WildcardTypeParameter : TypeParameters(emptyList())
+        other as TypeParameters
+
+        if (parameters != other.parameters) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return parameters.hashCode()
+    }
+}
+
+object WildcardTypeParameter : TypeParameters(emptyList())
 
 /**
  * Describes the way to replace abstract types with concrete implementors.

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/CgElement.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/CgElement.kt
@@ -354,7 +354,7 @@ class CgMultipleArgsAnnotation(
     val arguments: MutableList<CgNamedAnnotationArgument>
 ) : CgAnnotation()
 
-class CgArrayAnnotationArgument(
+data class CgArrayAnnotationArgument(
     val values: List<CgExpression>
 ) : CgExpression {
     override val type: ClassId = objectArrayClassId // TODO: is this type correct?
@@ -373,7 +373,7 @@ interface CgStatement : CgElement
 
 sealed class CgComment : CgStatement
 
-class CgSingleLineComment(val comment: String) : CgComment()
+data class CgSingleLineComment(val comment: String) : CgComment()
 
 /**
  * A comment that consists of multiple lines.
@@ -388,19 +388,19 @@ sealed class CgAbstractMultilineComment : CgComment() {
 /**
  * Multiline comment where each line starts with ///
  */
-class CgTripleSlashMultilineComment(override val lines: List<String>) : CgAbstractMultilineComment()
+data class CgTripleSlashMultilineComment(override val lines: List<String>) : CgAbstractMultilineComment()
 
 /**
  * Classic Java multiline comment starting with &#47;* and ending with *&#47;
  */
-class CgMultilineComment(override val lines: List<String>) : CgAbstractMultilineComment() {
+data class CgMultilineComment(override val lines: List<String>) : CgAbstractMultilineComment() {
     constructor(line: String) : this(listOf(line))
 }
 
 //class CgDocumentationComment(val lines: List<String>) : CgComment {
 //    constructor(text: String?) : this(text?.split("\n") ?: listOf())
 //}
-class CgDocumentationComment(val lines: List<CgDocStatement>) : CgComment() {
+data class CgDocumentationComment(val lines: List<CgDocStatement>) : CgComment() {
     constructor(text: String?) : this(text?.split("\n")?.map { CgDocRegularStmt(it) }?.toList() ?: listOf())
 
     override fun equals(other: Any?): Boolean =
@@ -413,71 +413,54 @@ sealed class CgDocStatement : CgStatement { //todo is it really CgStatement or m
     abstract fun isEmpty(): Boolean
 }
 
-sealed class CgDocTagStatement(val content: List<CgDocStatement>) : CgDocStatement() {
+sealed class CgDocTagStatement : CgDocStatement() {
+    abstract val content: List<CgDocStatement>
+
     override fun isEmpty(): Boolean = content.all { it.isEmpty() }
 }
 
-class CgDocPreTagStatement(content: List<CgDocStatement>) : CgDocTagStatement(content) {
-    override fun equals(other: Any?): Boolean =
-        if (other is CgDocPreTagStatement) this.hashCode() == other.hashCode() else false
-
-    override fun hashCode(): Int = content.hashCode()
-}
+data class CgDocPreTagStatement(override val content: List<CgDocStatement>) : CgDocTagStatement()
 
 /**
  * Represents a type for statements containing custom JavaDoc tags.
  */
-data class CgCustomTagStatement(val statements: List<CgDocStatement>) : CgDocTagStatement(statements)
+data class CgCustomTagStatement(override val content: List<CgDocStatement>) : CgDocTagStatement()
 
-class CgDocCodeStmt(val stmt: String) : CgDocStatement() {
+data class CgDocCodeStmt(val stmt: String) : CgDocStatement() {
     override fun isEmpty(): Boolean = stmt.isEmpty()
-
-    override fun equals(other: Any?): Boolean =
-        if (other is CgDocCodeStmt) this.hashCode() == other.hashCode() else false
-
-    override fun hashCode(): Int = stmt.hashCode()
 }
 
-class CgDocRegularStmt(val stmt: String) : CgDocStatement() {
+data class CgDocRegularStmt(val stmt: String) : CgDocStatement() {
     override fun isEmpty(): Boolean = stmt.isEmpty()
-
-    override fun equals(other: Any?): Boolean =
-        if (other is CgDocRegularStmt) this.hashCode() == other.hashCode() else false
-
-    override fun hashCode(): Int = stmt.hashCode()
 }
 
 /**
  * Represents an element of a whole line of a multiline comment.
  */
-class CgDocRegularLineStmt(val stmt: String) : CgDocStatement() {
+data class CgDocRegularLineStmt(val stmt: String) : CgDocStatement() {
     override fun isEmpty(): Boolean = stmt.isEmpty()
-
-    override fun equals(other: Any?): Boolean =
-        if (other is CgDocRegularLineStmt) this.hashCode() == other.hashCode() else false
-
-    override fun hashCode(): Int = stmt.hashCode()
 }
 
 open class CgDocClassLinkStmt(val className: String) : CgDocStatement() {
     override fun isEmpty(): Boolean = className.isEmpty()
 
-    override fun equals(other: Any?): Boolean =
-        if (other is CgDocClassLinkStmt) this.hashCode() == other.hashCode() else false
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
 
-    override fun hashCode(): Int = className.hashCode()
-}
+        other as CgDocClassLinkStmt
 
-class CgDocMethodLinkStmt(val methodName: String, stmt: String) : CgDocClassLinkStmt(stmt) {
-    override fun equals(other: Any?): Boolean =
-        if (other is CgDocMethodLinkStmt) this.hashCode() == other.hashCode() else false
+        if (className != other.className) return false
+
+        return true
+    }
 
     override fun hashCode(): Int {
-        var result = super.hashCode()
-        result = 31 * result + methodName.hashCode()
-        return result
+        return className.hashCode()
     }
 }
+
+data class CgDocMethodLinkStmt(val methodName: String, val stmt: String) : CgDocClassLinkStmt(stmt)
 
 fun convertDocToCg(stmt: DocStatement): CgDocStatement {
     return when (stmt) {
@@ -487,7 +470,7 @@ fun convertDocToCg(stmt: DocStatement): CgDocStatement {
         }
         is DocCustomTagStatement -> {
             val stmts = stmt.content.map { convertDocToCg(it) }
-            CgCustomTagStatement(statements = stmts)
+            CgCustomTagStatement(content = stmts)
         }
         is DocRegularStmt -> CgDocRegularStmt(stmt = stmt.stmt)
         is DocRegularLineStmt -> CgDocRegularLineStmt(stmt = stmt.stmt)
@@ -499,7 +482,7 @@ fun convertDocToCg(stmt: DocStatement): CgDocStatement {
 
 // Anonymous function (lambda)
 
-class CgAnonymousFunction(
+data class CgAnonymousFunction(
     override val type: ClassId,
     val parameters: List<CgParameterDeclaration>,
     val body: List<CgStatement>
@@ -507,13 +490,13 @@ class CgAnonymousFunction(
 
 // Return statement
 
-class CgReturnStatement(val expression: CgExpression) : CgStatement
+data class CgReturnStatement(val expression: CgExpression) : CgStatement
 
 // Array element access
 
 // TODO: check nested array element access expressions e.g. a[0][1][2]
 // TODO in general it is not CgReferenceExpression because array element can have a primitive type
-class CgArrayElementAccess(val array: CgExpression, val index: CgExpression) : CgReferenceExpression {
+data class CgArrayElementAccess(val array: CgExpression, val index: CgExpression) : CgReferenceExpression {
     override val type: ClassId = array.type.elementClassId ?: objectClassId
 }
 
@@ -525,30 +508,30 @@ sealed class CgComparison : CgExpression {
     override val type: ClassId = booleanClassId
 }
 
-class CgLessThan(
+data class CgLessThan(
     override val left: CgExpression,
     override val right: CgExpression
 ) : CgComparison()
 
-class CgGreaterThan(
+data class CgGreaterThan(
     override val left: CgExpression,
     override val right: CgExpression
 ) : CgComparison()
 
-class CgEqualTo(
+data class CgEqualTo(
     override val left: CgExpression,
     override val right: CgExpression
 ) : CgComparison()
 
 // Increment and decrement
 
-class CgIncrement(val variable: CgVariable) : CgStatement
+data class CgIncrement(val variable: CgVariable) : CgStatement
 
-class CgDecrement(val variable: CgVariable) : CgStatement
+data class CgDecrement(val variable: CgVariable) : CgStatement
 
 // Inner block in method (keeps parent method fields visible)
 
-class CgInnerBlock(val statements: List<CgStatement>) : CgStatement
+data class CgInnerBlock(val statements: List<CgStatement>) : CgStatement
 
 // Try-catch
 
@@ -577,19 +560,19 @@ sealed class CgLoop : CgStatement {
     abstract val statements: List<CgStatement>
 }
 
-class CgForLoop(
+data class CgForLoop(
     val initialization: CgDeclaration,
     override val condition: CgExpression,
     val update: CgStatement,
     override val statements: List<CgStatement>
 ) : CgLoop()
 
-class CgWhileLoop(
+data class CgWhileLoop(
     override val condition: CgExpression,
     override val statements: List<CgStatement>
 ) : CgLoop()
 
-class CgDoWhileLoop(
+data class CgDoWhileLoop(
     override val condition: CgExpression,
     override val statements: List<CgStatement>
 ) : CgLoop()
@@ -599,7 +582,7 @@ class CgDoWhileLoop(
  * @property iterable represents iterable in foreach loop
  * @property statements represents statements in foreach loop
  */
-class CgForEachLoop(
+data class CgForEachLoop(
     override val condition: CgExpression,
     override val statements: List<CgStatement>,
     val iterable: CgReferenceExpression,
@@ -624,7 +607,7 @@ class CgDeclaration(
 
 // Variable assignment
 
-class CgAssignment(
+data class CgAssignment(
     val lValue: CgExpression,
     val rValue: CgExpression
 ) : CgStatement
@@ -644,7 +627,7 @@ interface CgReferenceExpression : CgExpression
  *
  * @property isSafetyCast shows if we should use "as?" instead of "as" in Kotlin code
  */
-class CgTypeCast(
+data class CgTypeCast(
     val targetType: ClassId,
     val expression: CgExpression,
     val isSafetyCast: Boolean = false,
@@ -655,7 +638,7 @@ class CgTypeCast(
 /**
  * Represents [java.lang.Class.isInstance] method.
  */
-class CgIsInstance(
+data class CgIsInstance(
     val classExpression: CgExpression,
     val value: CgExpression,
 ): CgExpression {
@@ -669,7 +652,7 @@ interface CgValue : CgReferenceExpression
 
 // This instance
 
-class CgThisInstance(override val type: ClassId) : CgValue
+data class CgThisInstance(override val type: ClassId) : CgValue
 
 // Variables
 
@@ -706,7 +689,7 @@ open class CgVariable(
  *
  * In Kotlin the difference is in addition of "!!" to the expression
  */
-class CgNotNullAssertion(val expression: CgExpression) : CgValue {
+data class CgNotNullAssertion(val expression: CgExpression) : CgValue {
     override val type: ClassId
         get() = when (val expressionType = expression.type) {
             is BuiltinClassId -> BuiltinClassId(
@@ -761,7 +744,7 @@ sealed class CgParameterKind {
 
 // Primitive and String literals
 
-class CgLiteral(override val type: ClassId, val value: Any?) : CgValue {
+data class CgLiteral(override val type: ClassId, val value: Any?) : CgValue {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
@@ -782,21 +765,27 @@ class CgLiteral(override val type: ClassId, val value: Any?) : CgValue {
 }
 
 // Runnable like this::toString or (new Object())::toString (non-static) or Random::nextRandomInt (static) etc
-abstract class CgRunnable(override val type: ClassId, val methodId: MethodId) : CgValue
+abstract class CgRunnable : CgValue {
+    abstract val methodId: MethodId
+}
 
 /**
  * [referenceExpression] is "this" in this::toString or (new Object()) in (new Object())::toString (non-static)
  */
-class CgNonStaticRunnable(
-    type: ClassId,
+data class CgNonStaticRunnable(
+    override val type: ClassId,
     val referenceExpression: CgReferenceExpression,
-    methodId: MethodId
-) : CgRunnable(type, methodId)
+    override val methodId: MethodId
+) : CgRunnable()
 
 /**
  * [classId] is Random is Random::nextRandomInt (static) etc
  */
-class CgStaticRunnable(type: ClassId, val classId: ClassId, methodId: MethodId) : CgRunnable(type, methodId)
+data class CgStaticRunnable(
+    override val type: ClassId,
+    val classId: ClassId,
+    override val methodId: MethodId,
+) : CgRunnable()
 
 // Array allocation
 
@@ -826,10 +815,10 @@ open class CgAllocateArray(type: ClassId, elementType: ClassId, val size: Int) :
 /**
  * Allocation of an array with initialization. For example: `new String[] {"a", "b", null}`.
  */
-class CgAllocateInitializedArray(val initializer: CgArrayInitializer) :
+data class CgAllocateInitializedArray(val initializer: CgArrayInitializer) :
     CgAllocateArray(initializer.arrayType, initializer.elementType, initializer.size)
 
-class CgArrayInitializer(val arrayType: ClassId, val elementType: ClassId, val values: List<CgExpression>) :
+data class CgArrayInitializer(val arrayType: ClassId, val elementType: ClassId, val values: List<CgExpression>) :
     CgExpression {
     val size: Int
         get() = values.size
@@ -841,7 +830,7 @@ class CgArrayInitializer(val arrayType: ClassId, val elementType: ClassId, val v
 
 // Spread operator (for Kotlin, empty for Java)
 
-class CgSpread(override val type: ClassId, val array: CgExpression) : CgExpression
+data class CgSpread(override val type: ClassId, val array: CgExpression) : CgExpression
 
 // Interpolated string
 // e.g. String.format() for Java, "${}" for Kotlin
@@ -867,12 +856,12 @@ abstract class CgAbstractFieldAccess : CgReferenceExpression {
         get() = fieldId.type
 }
 
-class CgFieldAccess(
+data class CgFieldAccess(
     val caller: CgExpression,
     override val fieldId: FieldId
 ) : CgAbstractFieldAccess()
 
-class CgStaticFieldAccess(
+data class CgStaticFieldAccess(
     override val fieldId: FieldId
 ) : CgAbstractFieldAccess() {
     val declaringClass: ClassId = fieldId.declaringClass
@@ -881,7 +870,7 @@ class CgStaticFieldAccess(
 
 // Conditional statements
 
-class CgIfStatement(
+data class CgIfStatement(
     val condition: CgExpression,
     val trueBranch: List<CgStatement>,
     val falseBranch: List<CgStatement>? = null // false branch may be absent
@@ -901,14 +890,14 @@ data class CgSwitchCase(
 
 // Binary logical operators
 
-class CgLogicalAnd(
+data class CgLogicalAnd(
     val left: CgExpression,
     val right: CgExpression
 ) : CgExpression {
     override val type: ClassId = booleanClassId
 }
 
-class CgLogicalOr(
+data class CgLogicalOr(
     val left: CgExpression,
     val right: CgExpression
 ) : CgExpression {
@@ -920,23 +909,25 @@ class CgLogicalOr(
 /**
  * @param variable represents an array variable
  */
-class CgGetLength(val variable: CgVariable) : CgExpression {
+data class CgGetLength(val variable: CgVariable) : CgExpression {
     override val type: ClassId = intClassId
 }
 
 // Acquisition of java or kotlin class, e.g. MyClass.class in Java, MyClass::class.java in Kotlin or MyClass::class for Kotlin classes
 
-sealed class CgGetClass(val classId: ClassId) : CgReferenceExpression {
+sealed class CgGetClass : CgReferenceExpression {
+    abstract val classId: ClassId
+
     override val type: ClassId = Class::class.id
 }
 
-class CgGetJavaClass(classId: ClassId) : CgGetClass(classId)
+data class CgGetJavaClass(override val classId: ClassId) : CgGetClass()
 
-class CgGetKotlinClass(classId: ClassId) : CgGetClass(classId)
+data class CgGetKotlinClass(override val classId: ClassId) : CgGetClass()
 
 // Executable calls
 
-class CgStatementExecutableCall(val call: CgExecutableCall) : CgStatement
+data class CgStatementExecutableCall(val call: CgExecutableCall) : CgStatement
 
 // TODO in general it is not CgReferenceExpression because returned value can have a primitive type
 //  (or no value can be returned)
@@ -946,7 +937,7 @@ abstract class CgExecutableCall : CgReferenceExpression {
     abstract val typeParameters: TypeParameters
 }
 
-class CgConstructorCall(
+data class CgConstructorCall(
     override val executableId: ConstructorId,
     override val arguments: List<CgExpression>,
     override val typeParameters: TypeParameters = TypeParameters()
@@ -954,7 +945,7 @@ class CgConstructorCall(
     override val type: ClassId = executableId.classId
 }
 
-class CgMethodCall(
+data class CgMethodCall(
     val caller: CgExpression?,
     override val executableId: MethodId,
     override val arguments: List<CgExpression>,
@@ -967,13 +958,13 @@ fun CgExecutableCall.toStatement(): CgStatementExecutableCall = CgStatementExecu
 
 // Throw statement
 
-class CgThrowStatement(
+data class CgThrowStatement(
     val exception: CgExpression
 ) : CgStatement
 
 // Empty line
 
-class CgEmptyLine : CgStatement
+object CgEmptyLine : CgStatement
 
 data class CgExceptionHandler(
     val exception: CgVariable,

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgAbstractRenderer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/renderer/CgAbstractRenderer.kt
@@ -353,9 +353,9 @@ abstract class CgAbstractRenderer(
     }
 
     override fun visit(element: CgCustomTagStatement) {
-        if (element.statements.all { it.isEmpty() }) return
+        if (element.content.all { it.isEmpty() }) return
 
-        element.statements.forEach { it.accept(this) }
+        element.content.forEach { it.accept(this) }
     }
 
     override fun visit(element: CgDocCodeStmt) {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/MockFrameworkManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/MockFrameworkManager.kt
@@ -372,7 +372,17 @@ private class MockitoStaticMocker(context: CgContext, private val mocker: Object
             mockAnswerStatements[index] = statements
         }
 
-        val answerValues = mockAnswerStatements.values
+        val answerValues = mockAnswerStatements.values.let {
+            val uniqueMockingStatements = it.distinct()
+
+            // If we have only one unique mocking statement, we do not need switch-case with all statements - we can
+            // use only this unique statement.
+            if (uniqueMockingStatements.size == 1) {
+                uniqueMockingStatements
+            } else {
+                it
+            }
+        }
         // If we have no more than one branch or all branches are empty,
         // it means we do not need this switch and mock counter itself at all.
         val atMostOneBranchOrAllEmpty = answerValues.size <= 1 || answerValues.all { statements -> statements.isEmpty() }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgStatementConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgStatementConstructor.kt
@@ -458,7 +458,7 @@ internal class CgStatementConstructorImpl(context: CgContext) :
         CgThrowStatement(exception()).also { currentBlock += it }
 
     override fun emptyLine() {
-        currentBlock += CgEmptyLine()
+        currentBlock += CgEmptyLine
     }
 
     /**

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/ConstructorUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/ConstructorUtils.kt
@@ -142,7 +142,7 @@ internal fun CgContextOwner.isUtil(method: MethodId): Boolean {
     return method in utilMethodProvider.utilMethodIds
 }
 
-val classCgClassId = CgClassId(Class::class.id, typeParameters = WildcardTypeParameter(), isNullable = false)
+val classCgClassId = CgClassId(Class::class.id, typeParameters = WildcardTypeParameter, isNullable = false)
 
 /**
  * A [MethodId] to add an item into [ArrayList].

--- a/utbot-js/src/main/kotlin/framework/codegen/model/constructor/tree/JsCgStatementConstructor.kt
+++ b/utbot-js/src/main/kotlin/framework/codegen/model/constructor/tree/JsCgStatementConstructor.kt
@@ -262,7 +262,7 @@ class JsCgStatementConstructor(context: CgContext) :
         CgThrowStatement(exception()).also { currentBlock += it }
 
     override fun emptyLine() {
-        currentBlock += CgEmptyLine()
+        currentBlock += CgEmptyLine
     }
 
     override fun emptyLineIfNeeded() {

--- a/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/constructor/tree/PythonCgStatementConstructor.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/constructor/tree/PythonCgStatementConstructor.kt
@@ -258,7 +258,7 @@ class PythonCgStatementConstructorImpl(context: CgContext) :
         CgThrowStatement(exception()).also { currentBlock += it }
 
     override fun emptyLine() {
-        currentBlock += CgEmptyLine()
+        currentBlock += CgEmptyLine
     }
 
     override fun emptyLineIfNeeded() {


### PR DESCRIPTION
If during the processing of `UtNewInstanceInstrumentation` we discovered, that all mocking statements are identical, we do not need to use them all and can just take only one unique statement.

Fixes #1983.

## How to test

### Automated tests

Common pipeline

### Manual tests

Checked with mentioned in the issue.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.