### PR TITLE
Suggest named classes instead of anonymous nested ones

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/language/JavaLanguage.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/language/JavaLanguage.kt
@@ -64,7 +64,7 @@ object JvmLanguageAssistant : LanguageAssistant() {
             val psiElementHandler = PsiElementHandler.makePsiElementHandler(file)
 
             if (psiElementHandler.isCreateTestActionAvailable(element)) {
-                val srcClass = psiElementHandler.containingClass(element) ?: return null
+                val srcClass = psiElementHandler.identifiedContainingClass(element) ?: return null
                 val srcSourceRoot = srcClass.getSourceRoot() ?: return null
                 val srcMembers = srcClass.extractFirstLevelMembers(false)
                 val focusedMethod = focusedMethodOrNull(element, srcMembers, psiElementHandler)
@@ -94,7 +94,7 @@ object JvmLanguageAssistant : LanguageAssistant() {
                 val psiElementHandler = PsiElementHandler.makePsiElementHandler(file)
 
                 if (psiElementHandler.isCreateTestActionAvailable(element)) {
-                    psiElementHandler.containingClass(element)?.let {
+                    psiElementHandler.identifiedContainingClass(element)?.let {
                         srcClasses += setOf(it)
                         extractMembersFromSrcClasses = true
                         val memberInfoList = runReadAction<List<MemberInfo>> {
@@ -146,6 +146,11 @@ object JvmLanguageAssistant : LanguageAssistant() {
             return Triple(srcClasses.toSet(), selectedMethods.toSet(), extractMembersFromSrcClasses)
         }
         return null
+    }
+
+    private fun PsiElementHandler.identifiedContainingClass(element: PsiElement): PsiClass? {
+        val clazz = containingClass(element)
+        return if (clazz is PsiAnonymousClass) PsiTreeUtil.getParentOfType(clazz, PsiClass::class.java) else clazz
     }
 
     /**


### PR DESCRIPTION
## Description

Fixes #1025
As nested anonymouse classes is badly accessible for testing, let's suggest outer "identified" classes to avoid exceptions and eventually cover with tests what we really can.

## How to test

### Manual tests

See the issue, the example https://github.com/UnitTestBot/UTBotJava/issues/1025#issuecomment-1262215825

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.