### PR TITLE
Fix NPE when generated fuzzer class is package-private

### DIFF
--- a/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzing/providers/Objects.kt
+++ b/utbot-fuzzers/src/main/kotlin/org/utbot/fuzzing/providers/Objects.kt
@@ -186,7 +186,7 @@ internal fun isAccessible(member: Member, packageName: String?): Boolean {
 
 internal fun isAccessible(clazz: Class<*>, packageName: String?): Boolean {
     return Modifier.isPublic(clazz.modifiers) ||
-            (packageName != null && isNotPrivateOrProtected(clazz.modifiers) && clazz.declaringClass.`package`?.name == packageName)
+            (packageName != null && isNotPrivateOrProtected(clazz.modifiers) && clazz.`package`?.name == packageName)
 }
 
 private fun isNotPrivateOrProtected(modifiers: Int): Boolean {


### PR DESCRIPTION
## Description

Fixes #2001

The NPE occurred for every type that is package-private. This fixes the problem by removing excess `declaringClass` call.

## How to test

### Automated tests

There's no implementation at the moment but there's a [task ](https://github.com/UnitTestBot/UTBotJava/issues/2004)to do it.

### Manual tests

The example from the issued must work.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.