### PR TITLE
Call `doNothing` from mockito in tests for method calls returning void

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/builtin/MockitoBuiltins.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/builtin/MockitoBuiltins.kt
@@ -35,6 +35,11 @@ internal val ongoingStubbingClassId = BuiltinClassId(
     simpleName = "OngoingStubbing",
 )
 
+internal val stubberClassId = BuiltinClassId(
+    canonicalName = "org.mockito.stubbing.Stubber",
+    simpleName = "Stubber"
+)
+
 internal val answerClassId = BuiltinClassId(
     canonicalName = "org.mockito.stubbing.Answer",
     simpleName = "Answer",
@@ -81,6 +86,18 @@ internal val thenReturnMethodId = builtinMethodId(
     name = "thenReturn",
     returnType = ongoingStubbingClassId,
     arguments = arrayOf(objectClassId)
+)
+
+internal val doNothingMethodId = builtinStaticMethodId(
+    classId = mockitoClassId,
+    name = "doNothing",
+    returnType = stubberClassId,
+)
+
+internal val whenStubberMethodId = builtinMethodId(
+    classId = stubberClassId,
+    name = "when",
+    returnType = objectClassId,
 )
 
 // TODO: for this method and other static methods implement some utils that allow calling

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/builtin/MockitoBuiltins.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/builtin/MockitoBuiltins.kt
@@ -40,6 +40,14 @@ internal val stubberClassId = BuiltinClassId(
     simpleName = "Stubber"
 )
 
+// We wrap an Object classId in BuiltinClassId
+// in order to deal with [CgExpression.canBeReceiverOf]
+// when we want to call ANY method on an object.
+internal val genericObjectClassId = BuiltinClassId(
+    canonicalName = "java.lang.Object",
+    simpleName = "Object"
+)
+
 internal val answerClassId = BuiltinClassId(
     canonicalName = "org.mockito.stubbing.Answer",
     simpleName = "Answer",
@@ -97,7 +105,7 @@ internal val doNothingMethodId = builtinStaticMethodId(
 internal val whenStubberMethodId = builtinMethodId(
     classId = stubberClassId,
     name = "when",
-    returnType = stubberClassId,
+    returnType = genericObjectClassId,
     arguments = arrayOf(objectClassId)
 )
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/builtin/MockitoBuiltins.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/builtin/MockitoBuiltins.kt
@@ -97,7 +97,8 @@ internal val doNothingMethodId = builtinStaticMethodId(
 internal val whenStubberMethodId = builtinMethodId(
     classId = stubberClassId,
     name = "when",
-    returnType = objectClassId,
+    returnType = stubberClassId,
+    arguments = arrayOf(objectClassId)
 )
 
 // TODO: for this method and other static methods implement some utils that allow calling

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/access/CgCallableAccessManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/access/CgCallableAccessManager.kt
@@ -9,8 +9,8 @@ import org.utbot.framework.codegen.domain.builtin.getMethodId
 import org.utbot.framework.codegen.domain.builtin.getTargetException
 import org.utbot.framework.codegen.domain.builtin.invoke
 import org.utbot.framework.codegen.domain.builtin.newInstance
+import org.utbot.framework.codegen.domain.builtin.genericObjectClassId
 import org.utbot.framework.codegen.domain.builtin.setAccessible
-import org.utbot.framework.codegen.domain.builtin.stubberClassId
 import org.utbot.framework.codegen.domain.context.CgContext
 import org.utbot.framework.codegen.domain.context.CgContextOwner
 import org.utbot.framework.codegen.domain.models.CgAllocateArray
@@ -191,24 +191,24 @@ internal class CgCallableAccessManagerImpl(val context: CgContext) : CgCallableA
 
     private infix fun CgExpression.canBeReceiverOf(executable: MethodId): Boolean =
         when {
-            // method of the current test class can be called on its 'this' instance
+            // this executable can be called on its 'this' instance
             currentTestClass == executable.classId && this isThisInstanceOf currentTestClass -> true
 
-            // method of the current test class can be called on an object of this class or any of its subtypes
+            // this executable can be called on an object of this class or any of its subtypes
             this.type isSubtypeOf executable.classId -> true
 
-            // method of the current test class can be called on builtin type
-            this.type in builtinCallersWithoutReflection -> true
+            // this executable can be called on builtin type
+            this.type is BuiltinClassId && this.type in builtinCallersWithoutReflection -> true
 
             else -> false
         }
 
-    // Fore some builtin types do not having [ClassId] we need to clarify
-    // that it is allowed to call their methods without reflection.
+    // For some builtin types we need to clarify
+    // that it is allowed to call an executable without reflection.
     //
     // This approach is used, for example, to render the constructions with stubs
     // like `doNothing().when(entityManagerMock).persist(any())`.
-    private val builtinCallersWithoutReflection = setOf<ClassId>(stubberClassId)
+    private val builtinCallersWithoutReflection = setOf(genericObjectClassId)
 
     /**
      * For Kotlin extension functions, real caller is one of the arguments in JVM method (and declaration class is omitted),

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/MockFrameworkManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/MockFrameworkManager.kt
@@ -201,7 +201,9 @@ private class MockitoMocker(context: CgContext) : ObjectMocker(context) {
                     // Sometimes void methods are called explicitly, e.g. annotated with @Mock fields in Spring test classes.
                     // We would like to mark that this field is used and must not be removed from test class.
                     // Without `doNothing` call Intellij Idea suggests removing this field as unused.
-                    is MethodId -> mockitoClassId[doNothingMethodId]()[whenStubberMethodId](mockObject)[executable](*matchers)
+                    is MethodId -> {
+                        +mockitoClassId[doNothingMethodId]()[whenStubberMethodId](mockObject)[executable](*matchers)
+                    }
                     else -> error("Only MethodId and ConstructorId was expected to appear in simple mocker but got $executable")
                 }
             } else {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/MockFrameworkManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/MockFrameworkManager.kt
@@ -202,6 +202,8 @@ private class MockitoMocker(context: CgContext) : ObjectMocker(context) {
                     // We would like to mark that this field is used and must not be removed from test class.
                     // Without `doNothing` call Intellij Idea suggests removing this field as unused.
                     is MethodId -> {
+                        // We allow [stubberClassId] to be a receiver of [executable].
+                        // See [CgExpression.canBeReceiverOf]
                         +mockitoClassId[doNothingMethodId]()[whenStubberMethodId](mockObject)[executable](*matchers)
                     }
                     else -> error("Only MethodId and ConstructorId was expected to appear in simple mocker but got $executable")

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/MockFrameworkManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/MockFrameworkManager.kt
@@ -13,11 +13,13 @@ import org.utbot.framework.codegen.domain.builtin.anyLong
 import org.utbot.framework.codegen.domain.builtin.anyOfClass
 import org.utbot.framework.codegen.domain.builtin.anyShort
 import org.utbot.framework.codegen.domain.builtin.argumentMatchersClassId
+import org.utbot.framework.codegen.domain.builtin.doNothingMethodId
 import org.utbot.framework.codegen.domain.builtin.mockMethodId
 import org.utbot.framework.codegen.domain.builtin.mockedConstructionContextClassId
 import org.utbot.framework.codegen.domain.builtin.mockitoClassId
 import org.utbot.framework.codegen.domain.builtin.thenReturnMethodId
 import org.utbot.framework.codegen.domain.builtin.whenMethodId
+import org.utbot.framework.codegen.domain.builtin.whenStubberMethodId
 import org.utbot.framework.codegen.domain.context.CgContext
 import org.utbot.framework.codegen.domain.context.CgContextOwner
 import org.utbot.framework.codegen.domain.models.CgAnonymousFunction
@@ -190,28 +192,37 @@ private class MockitoMocker(context: CgContext) : ObjectMocker(context) {
 
     fun mockForVariable(model: UtCompositeModel, mockObject: CgVariable) {
         for ((executable, values) in model.mocks) {
-            // void method
+            val matchers = mockitoArgumentMatchersFor(executable)
+
             if (executable.returnType == voidClassId) {
-                // void methods on mocks do nothing by default
-                continue
-            }
-
-            when (executable) {
-                is MethodId -> {
-                    if (executable.parameters.any { !it.isAccessibleFrom(testClassPackageName) }) {
-                        error("Cannot mock method $executable with not accessible parameters" )
-                    }
-
-                    val matchers = mockitoArgumentMatchersFor(executable)
-                    if (!executable.isAccessibleFrom(testClassPackageName)) {
-                        error("Cannot mock method $executable as it is not accessible from package $testClassPackageName")
-                    }
-
-                    val results = values.map { variableConstructor.getOrCreateVariable(it) }.toTypedArray()
-                    `when`(mockObject[executable](*matchers)).thenReturn(executable.returnType, *results)
+                when (executable) {
+                    // All constructors are considered like void methods, but it is proposed to be changed to test constructors better.
+                    is ConstructorId -> continue
+                    // Sometimes void methods are called explicitly, e.g. annotated with @Mock fields in Spring test classes.
+                    // We would like to mark that this field is used and must not be removed from test class.
+                    // Without `doNothing` call Intellij Idea suggests removing this field as unused.
+                    is MethodId -> mockitoClassId[doNothingMethodId]()[whenStubberMethodId](mockObject)[executable](*matchers)
+                    else -> error("Only MethodId and ConstructorId was expected to appear in simple mocker but got $executable")
                 }
-                else -> error("ConstructorId was not expected to appear in simple mocker but got $executable")
+            } else {
+                when (executable) {
+                    is MethodId -> {
+                        if (executable.parameters.any { !it.isAccessibleFrom(testClassPackageName) }) {
+                            error("Cannot mock method $executable with not accessible parameters" )
+                        }
+
+                        if (!executable.isAccessibleFrom(testClassPackageName)) {
+                            error("Cannot mock method $executable as it is not accessible from package $testClassPackageName")
+                        }
+
+                        val results = values.map { variableConstructor.getOrCreateVariable(it) }.toTypedArray()
+                        `when`(mockObject[executable](*matchers)).thenReturn(executable.returnType, *results)
+                    }
+                    else -> error("Only MethodId was expected to appear in simple mocker but got $executable")
+                }
             }
+
+
         }
     }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/MockFrameworkManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/MockFrameworkManager.kt
@@ -202,8 +202,6 @@ private class MockitoMocker(context: CgContext) : ObjectMocker(context) {
                     // We would like to mark that this field is used and must not be removed from test class.
                     // Without `doNothing` call Intellij Idea suggests removing this field as unused.
                     is MethodId -> {
-                        // We allow [stubberClassId] to be a receiver of [executable].
-                        // See [CgExpression.canBeReceiverOf]
                         +mockitoClassId[doNothingMethodId]()[whenStubberMethodId](mockObject)[executable](*matchers)
                     }
                     else -> error("Only MethodId and ConstructorId was expected to appear in simple mocker but got $executable")


### PR DESCRIPTION
## Description

Consider the following code 

```java
private EntityManager em;

public void add(User user) {
        em.persist(user);
    }
```

Test code looks as follows:

```java
@InjectMocks
  public UserDaoImp userDaoImp;

  @Mock
  public EntityManager entityManagerMock;

public void testAdd_EntityManagerPersist() {
      userDaoImp.add(null);
  }
```

It is better to see

```java
public void testAdd_EntityManagerPersist() {
        doNothing().when(entityManagerMock).persist(any());
        userDaoImp.add(null);
    }
```

as `entityManagerMock` variable is considered to be unused by Idea that suggests to remove it. However, variable is useful, test will fail without it.

## How to test

Should not be tested as a standalone functionality, just as a part of Spring 1st phase full testing

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.