### PR TITLE
Disable flaky test in summaries

### DIFF
--- a/utbot-summary-tests/src/test/kotlin/math/SummaryOfMathTest.kt
+++ b/utbot-summary-tests/src/test/kotlin/math/SummaryOfMathTest.kt
@@ -18,7 +18,7 @@ class SummaryOfMathTest : SummaryTestCaseGeneratorTest(
     Stats::class,
 ) {
     @Test
-    @Disabled
+    @Disabled("Test fails, https://github.com/UnitTestBot/UTBotJava/issues/826")
     fun testOfInts() {
         val summary1 = "Test calls {@link guava.examples.math.StatsAccumulator#addAll(int[])},\n" +
                 "    there it triggers recursion of addAll once, \n" +
@@ -86,6 +86,7 @@ class SummaryOfMathTest : SummaryTestCaseGeneratorTest(
     }
 
     @Test
+    @Disabled("Test is flaky, https://github.com/UnitTestBot/UTBotJava/issues/826")
     fun testOfDoubles() {
         val summary1 = "Test calls {@link guava.examples.math.StatsAccumulator#addAll(double[])},\n" +
                 "    there it triggers recursion of addAll once, \n" +


### PR DESCRIPTION
## Description

There are two problems with `SummaryOfMathTest`

- they are ugly
- they are flaky

Finally, I decided to agree with Alexey Zinoviev and disable them.
There is a known issue https://github.com/UnitTestBot/UTBotJava/issues/826 to enable them.

## How to test

Testing is not required

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.