### PR TITLE
Fix casts in overflow checking function

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/math/OverflowAsErrorTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/math/OverflowAsErrorTest.kt
@@ -70,6 +70,22 @@ internal class OverflowAsErrorTest : UtValueTestCaseChecker(
     }
 
     @Test
+    fun testByteWithIntOverflow() {
+        withTreatingOverflowAsError {
+            checkWithException(
+                OverflowExamples::byteWithIntOverflow,
+                eq(2),
+                { x, y, r ->
+                    runCatching {
+                        Math.addExact(x.toInt(), y)
+                    }.isFailure && r.isException<OverflowDetectionError>()
+                },
+                { x, y, r -> Math.addExact(x.toInt(), y).toByte() == r.getOrThrow() }
+            )
+        }
+    }
+
+    @Test
     fun testByteSubOverflow() {
         withTreatingOverflowAsError {
             checkWithException(

--- a/utbot-sample/src/main/java/org/utbot/examples/math/OverflowExamples.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/math/OverflowExamples.java
@@ -4,6 +4,9 @@ public class OverflowExamples {
     public byte byteAddOverflow(byte x, byte y) {
         return (byte) (x + y);
     }
+    public byte byteWithIntOverflow(byte x, int y) {
+        return (byte) (x + y);
+    }
     public byte byteMulOverflow(byte x, byte y) {
         return (byte) (x * y);
     }


### PR DESCRIPTION
## Fix the wrong way to cast primitive values in the function related to overflowing checks

## Description

Added an explicit cast for arguments of the check function. They were wrapped into a primitive value that didn't change their symbolic type. That led to an error where we process primitive values of different sorts.

Fixes #2022 

## How to test

### Automated tests

`org.utbot.examples.math.OverflowAsErrorTest#testByteWithIntOverflow`

### Manual tests

I tested the example from the issue and a similar one. Note that an example from the issue doesn't contain overflow since `+` casts both operands to an int type, therefore, since the second one is a constant and the first one is a byte value, an integer overflow can never occur. If we transform the second value into a symbolic value, we'll find an overflow error.

![image](https://user-images.githubusercontent.com/31047452/227218626-1aeea34a-53da-47f6-8fa3-58046e511b77.png)

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.