### PR TITLE
Fix package.json search for JavaScript

### DIFF
--- a/utbot-js/src/main/kotlin/service/PackageJsonService.kt
+++ b/utbot-js/src/main/kotlin/service/PackageJsonService.kt
@@ -19,16 +19,16 @@ class PackageJsonService(
 ) {
 
     fun findClosestConfig(): PackageJson {
-        var currDir = File(filePathToInference.substringBeforeLast("/"))
+        var currDir = File(filePathToInference)
         do {
+            currDir = currDir.parentFile
             val matchingFiles: Array<File> = currDir.listFiles(
                 FilenameFilter { _, name ->
                     return@FilenameFilter name == "package.json"
                 }
             ) ?: throw IllegalStateException("Error occurred while scanning file system")
             if (matchingFiles.isNotEmpty()) return parseConfig(matchingFiles.first())
-            currDir = currDir.parentFile
-        } while (currDir.path != projectPath)
+        } while (currDir.path.replace("\\", "/") != projectPath)
         return PackageJson.defaultConfig
     }
 


### PR DESCRIPTION
## Description

When the plugin has been reinstalled with IDEA restart and project clean & experimental languages support enabled, the action called for the JS file works properly.

Fixes #1947 

## How to test

### Manual tests

Follow this steps:
* Install plugin
* Reinstall plugin with IDEA restart
* Clean project, make sure that utbot_settings.xml is deleted after deinstallation of previously installed plugin
* Turn on experimental languages support
* Find the examples in the folder `/utbot-js/samples' and try to run UTBot.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.