### PR TITLE
Enlarge ModelId in codegen with testSetId

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
@@ -780,13 +780,16 @@ object SpringBoot : DependencyInjectionFramework(
 /**
  * Extended id of [UtModel], unique for whole test set.
  *
- * Allows to distinguish models from different executions,
- * even if they have the same value of `UtModel.id`.
+ * Allows distinguishing models from different executions and test sets,
+ * even if they have the same value of `UtModel.id` that is allowed.
  */
-data class ModelId(
+data class ModelId private constructor(
     private val id: Int?,
     private val executionId: Int,
-)
-
-fun UtModel.withExecutionId(executionId: Int = -1) = ModelId(this.idOrNull(), executionId)
+    private val testSetId: Int,
+) {
+    companion object {
+        fun create(model: UtModel, executionId: Int = -1, testSetId: Int = -1) = ModelId(model.idOrNull(), executionId, testSetId)
+    }
+}
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/context/CgContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/context/CgContext.kt
@@ -30,7 +30,6 @@ import org.utbot.framework.codegen.domain.builtin.UtilClassFileMethodProvider
 import org.utbot.framework.codegen.domain.builtin.UtilMethodProvider
 import org.utbot.framework.codegen.domain.models.SimpleTestClassModel
 import org.utbot.framework.codegen.domain.models.CgParameterKind
-import org.utbot.framework.codegen.domain.withExecutionId
 import org.utbot.framework.codegen.services.access.Block
 import org.utbot.framework.codegen.tree.EnvironmentFieldStateCache
 import org.utbot.framework.codegen.tree.importIfNeeded
@@ -571,7 +570,7 @@ data class CgContext(
         }
     }
 
-    override fun getIdByModel(model: UtModel): ModelId = modelIds.getOrPut(model) { model.withExecutionId() }
+    override fun getIdByModel(model: UtModel): ModelId = modelIds.getOrPut(model) { ModelId.create(model) }
 
     private fun createClassIdForNestedClass(testClassModel: SimpleTestClassModel): ClassId {
         val simpleName = "${testClassModel.classUnderTest.simpleName}Test"


### PR DESCRIPTION
## Description

We would like to have the unique identifier of the `UtModel` in terms of code generator. 
It has already been introduced and called `ModelId`. 
However, `id` and `executableId` is not enough: we should also keep `testSetId` in it.

## How to test

Standalone testing is not required, just as a part of Spring 1st phase.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.