### PR TITLE
Added a test with a path diversion because of jdk statics

### DIFF
--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/stdlib/JavaIOFileInputStreamCheckTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/stdlib/JavaIOFileInputStreamCheckTest.kt
@@ -11,7 +11,7 @@ import org.utbot.testing.CodeGeneration
 import org.utbot.testing.DoNotCalculate
 import org.utbot.testing.UtValueTestCaseChecker
 
-class JavaIOFileInputStreamCheckTest : UtValueTestCaseChecker(
+internal class JavaIOFileInputStreamCheckTest : UtValueTestCaseChecker(
     testClass = JavaIOFileInputStreamCheck::class,
     testCodeGeneration = true,
     pipelines = listOf(

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/stdlib/JavaIOFileInputStreamCheckTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/stdlib/JavaIOFileInputStreamCheckTest.kt
@@ -11,7 +11,7 @@ import org.utbot.testing.CodeGeneration
 import org.utbot.testing.DoNotCalculate
 import org.utbot.testing.UtValueTestCaseChecker
 
-internal class JavaIOFileInputStreamCheckTest : UtValueTestCaseChecker(
+class JavaIOFileInputStreamCheckTest : UtValueTestCaseChecker(
     testClass = JavaIOFileInputStreamCheck::class,
     testCodeGeneration = true,
     pipelines = listOf(

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/stdlib/StaticsPathDiversionTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/stdlib/StaticsPathDiversionTest.kt
@@ -1,0 +1,39 @@
+package org.utbot.examples.stdlib
+
+import org.junit.jupiter.api.Test
+import org.utbot.framework.plugin.api.CodegenLanguage
+import org.utbot.framework.plugin.api.util.id
+import org.utbot.testcheckers.ge
+import org.utbot.testcheckers.withoutConcrete
+import org.utbot.testing.AtLeast
+import org.utbot.testing.Compilation
+import org.utbot.testing.UtValueTestCaseChecker
+
+class StaticsPathDiversionTest : UtValueTestCaseChecker(
+    testClass = StaticsPathDiversion::class,
+    testCodeGeneration = true,
+    pipelines = listOf(
+        TestLastStage(CodegenLanguage.JAVA, Compilation), // See the comment for the testJavaIOFile
+        TestLastStage(CodegenLanguage.KOTLIN, Compilation),  // See the comment for the testJavaIOFile
+    )
+) {
+    @Test
+    fun testJavaIOFile() {
+        // TODO Here we have a path diversion example - the static field `java.io.File#separator` is considered as not meaningful,
+        //  so it is not passed to the concrete execution because of absence in the `stateBefore` models.
+        //  So, the symbolic engine has 2 results - true and false, as expected, but the concrete executor may produce 1 or 2,
+        //  depending on the model for the argument of the MUT produced by the solver.
+        //  Such diversion was predicted to some extent - see `org.utbot.common.WorkaroundReason.IGNORE_STATICS_FROM_TRUSTED_LIBRARIES`
+        //  and the corresponding issue https://github.com/UnitTestBot/UTBotJava/issues/716
+        withoutConcrete {
+            check(
+                StaticsPathDiversion::separatorEquality,
+                ge(2), // We cannot guarantee the exact number of branches without minimization
+                { _, r -> r == true },
+                { _, r -> r == false },
+                additionalMockAlwaysClasses = setOf(java.io.File::class.id), // From the use-case
+                coverage = AtLeast(78)
+            )
+        }
+    }
+}

--- a/utbot-framework-test/src/test/kotlin/org/utbot/examples/stdlib/StaticsPathDiversionTest.kt
+++ b/utbot-framework-test/src/test/kotlin/org/utbot/examples/stdlib/StaticsPathDiversionTest.kt
@@ -1,23 +1,24 @@
 package org.utbot.examples.stdlib
 
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.utbot.framework.plugin.api.CodegenLanguage
 import org.utbot.framework.plugin.api.util.id
 import org.utbot.testcheckers.ge
-import org.utbot.testcheckers.withoutConcrete
-import org.utbot.testing.AtLeast
-import org.utbot.testing.Compilation
+import org.utbot.testing.FullWithAssumptions
 import org.utbot.testing.UtValueTestCaseChecker
+import java.io.File
 
-class StaticsPathDiversionTest : UtValueTestCaseChecker(
+internal class StaticsPathDiversionTest : UtValueTestCaseChecker(
     testClass = StaticsPathDiversion::class,
     testCodeGeneration = true,
     pipelines = listOf(
-        TestLastStage(CodegenLanguage.JAVA, Compilation), // See the comment for the testJavaIOFile
-        TestLastStage(CodegenLanguage.KOTLIN, Compilation),  // See the comment for the testJavaIOFile
+        TestLastStage(CodegenLanguage.JAVA),
+        TestLastStage(CodegenLanguage.KOTLIN)
     )
 ) {
     @Test
+    @Disabled("See https://github.com/UnitTestBot/UTBotJava/issues/716")
     fun testJavaIOFile() {
         // TODO Here we have a path diversion example - the static field `java.io.File#separator` is considered as not meaningful,
         //  so it is not passed to the concrete execution because of absence in the `stateBefore` models.
@@ -25,15 +26,16 @@ class StaticsPathDiversionTest : UtValueTestCaseChecker(
         //  depending on the model for the argument of the MUT produced by the solver.
         //  Such diversion was predicted to some extent - see `org.utbot.common.WorkaroundReason.IGNORE_STATICS_FROM_TRUSTED_LIBRARIES`
         //  and the corresponding issue https://github.com/UnitTestBot/UTBotJava/issues/716
-        withoutConcrete {
-            check(
-                StaticsPathDiversion::separatorEquality,
-                ge(2), // We cannot guarantee the exact number of branches without minimization
-                { _, r -> r == true },
-                { _, r -> r == false },
-                additionalMockAlwaysClasses = setOf(java.io.File::class.id), // From the use-case
-                coverage = AtLeast(78)
-            )
-        }
+        check(
+            StaticsPathDiversion::separatorEquality,
+            ge(2), // We cannot guarantee the exact number of branches without minimization
+
+            // In the matchers below we check that the symbolic does not change the static field `File.separator` - we should
+            // change the parameter, not the static field
+            { s, separator -> separator == File.separator && s == separator },
+            { s, separator -> separator == File.separator && s != separator },
+            additionalMockAlwaysClasses = setOf(java.io.File::class.id), // From the use-case
+            coverage = FullWithAssumptions(assumeCallsNumber = 1)
+        )
     }
 }

--- a/utbot-sample/src/main/java/org/utbot/examples/stdlib/StaticsPathDiversion.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/stdlib/StaticsPathDiversion.java
@@ -1,0 +1,20 @@
+package org.utbot.examples.stdlib;
+
+import org.utbot.api.mock.UtMock;
+
+import java.io.File;
+
+public class StaticsPathDiversion {
+    @SuppressWarnings("RedundantIfStatement")
+    public boolean separatorEquality(String s) {
+        // Ignore this case to make sure we will have not more than 2 executions even without minimization
+        UtMock.assume(s != null);
+
+        // We use if-else here instead of a simple return to get executions for both return values - true and false
+        if (File.separator.equals(s)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/utbot-sample/src/main/java/org/utbot/examples/stdlib/StaticsPathDiversion.java
+++ b/utbot-sample/src/main/java/org/utbot/examples/stdlib/StaticsPathDiversion.java
@@ -5,16 +5,17 @@ import org.utbot.api.mock.UtMock;
 import java.io.File;
 
 public class StaticsPathDiversion {
-    @SuppressWarnings("RedundantIfStatement")
-    public boolean separatorEquality(String s) {
+    @SuppressWarnings({"IfStatementWithIdenticalBranches"})
+    // In this test we check that the symbolic engine does not change the static field `File.separator`
+    public String separatorEquality(String s) {
         // Ignore this case to make sure we will have not more than 2 executions even without minimization
         UtMock.assume(s != null);
 
-        // We use if-else here instead of a simple return to get executions for both return values - true and false
+        // We use if-else here instead of a simple return to get executions for both return values
         if (File.separator.equals(s)) {
-            return true;
+            return File.separator;
         } else {
-            return false;
+            return File.separator;
         }
     }
 }


### PR DESCRIPTION
## Description

As described in #716, we have predicted a possible coverage regression because of not setting static fields from trusted libraries (JDK, for example). So, in this PR a test was added that demonstrates such a regression.

## How to test

### Automated tests

`org.utbot.examples.stdlib.StaticsPathDiversionTest`.

### Manual tests

Not applicable.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.