### PR TITLE
Support Spring projects with main xml config in utbot-spring-analyzer

### DIFF
--- a/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/ApplicationRunner.kt
+++ b/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/ApplicationRunner.kt
@@ -4,6 +4,7 @@ import org.utbot.spring.analyzers.SpringApplicationAnalyzer
 import org.utbot.spring.data.ApplicationData
 import org.utbot.spring.utils.PathsUtils
 import java.io.File
+import java.net.URL
 
 /**
  * To run this app, arguments must be passed in the following way:
@@ -30,8 +31,7 @@ fun main(args: Array<String>) {
 
     val applicationData =
         ApplicationData(
-            applicationUrlArray = args[0].split(';').filter { it != PathsUtils.EMPTY_PATH }
-                .map { File(it).toURI().toURL() }.toTypedArray(),
+            applicationUrlArray = parseApplicationUrls(args[0]),
             configurationFile = args[1],
             propertyFilesPaths = args[2].split(";").filter { it != PathsUtils.EMPTY_PATH },
             xmlConfigurationPaths = args[3].split(";").filter { it != PathsUtils.EMPTY_PATH },
@@ -39,3 +39,10 @@ fun main(args: Array<String>) {
 
     SpringApplicationAnalyzer(applicationData).analyze()
 }
+
+fun parseApplicationUrls(urlString: String): Array<URL> =
+    urlString
+        .split(';')
+        .filter { it != PathsUtils.EMPTY_PATH }
+        .map { File(it).toURI().toURL() }
+        .toTypedArray()

--- a/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/ApplicationRunner.kt
+++ b/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/ApplicationRunner.kt
@@ -1,13 +1,14 @@
 package org.utbot.spring
 
 import org.utbot.spring.analyzers.SpringApplicationAnalyzer
+import org.utbot.spring.data.ApplicationData
 import org.utbot.spring.utils.PathsUtils
-import java.nio.file.Path
+import java.io.File
 
 /**
  * To run this app, arguments must be passed in the following way:
  * args[0] - classpath of current project
- * args[1] - fully qualified name of configuration class
+ * args[1] - fully qualified name of configuration class or main .xml configuration file path
  * args[2] - `.properties` file paths, separated via `;`, empty string if no files exist
  * args[3] - `.xml` configuration file paths
  *
@@ -18,17 +19,23 @@ fun main(args: Array<String>) {
 
     /* FOR EXAMPLE
     val arg0 = "/Users/kirillshishin/IdeaProjects/spring-starter-lesson-28/build/classes/java/main"
+
     val arg1 = "com.dmdev.spring.config.ApplicationConfiguration"
+    or
+    val arg1 = "/Users/kirillshishin/IdeaProjects/spring-starter-lesson-28/src/main/resources/application.xml"
+
     val arg2 = "/Users/kirillshishin/IdeaProjects/spring-starter-lesson-28/src/main/resources/application.properties;/Users/kirillshishin/IdeaProjects/spring-starter-lesson-28/src/main/resources/application-web.properties"
     val arg3 = "/Users/kirillshishin/IdeaProjects/spring-starter-lesson-28/src/main/resources/application.xml;/Users/kirillshishin/IdeaProjects/spring-starter-lesson-28/src/main/resources/application2.xml"
     */
 
-    val springApplicationAnalyzer = SpringApplicationAnalyzer(
-        applicationUrl = Path.of(args[0]).toUri().toURL(),
-        configurationClassFqn = args[1],
-        propertyFilesPaths = args[2].split(";").filter { it != PathsUtils.EMPTY_PATH },
-        xmlConfigurationPaths = args[3].split(";").filter { it != PathsUtils.EMPTY_PATH },
-    )
+    val applicationData =
+        ApplicationData(
+            applicationUrlArray = args[0].split(';').filter { it != PathsUtils.EMPTY_PATH }
+                .map { File(it).toURI().toURL() }.toTypedArray(),
+            configurationFile = args[1],
+            propertyFilesPaths = args[2].split(";").filter { it != PathsUtils.EMPTY_PATH },
+            xmlConfigurationPaths = args[3].split(";").filter { it != PathsUtils.EMPTY_PATH },
+        )
 
-    springApplicationAnalyzer.analyze()
+    SpringApplicationAnalyzer(applicationData).analyze()
 }

--- a/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/analyzers/SpringApplicationAnalyzer.kt
+++ b/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/analyzers/SpringApplicationAnalyzer.kt
@@ -2,9 +2,11 @@ package org.utbot.spring.analyzers
 
 import org.springframework.boot.builder.SpringApplicationBuilder
 import org.springframework.context.ApplicationContextException
+import org.utbot.spring.configurators.ApplicationConfigurationType
+import org.utbot.spring.configurators.ApplicationConfigurationType.JavaConfiguration
+import org.utbot.spring.configurators.ApplicationConfigurationType.XmlConfiguration
 import org.utbot.spring.configurators.ApplicationConfigurator
 import org.utbot.spring.data.ApplicationData
-import org.utbot.spring.utils.ExtensionUtils
 import org.utbot.spring.utils.FakeFileManager
 import java.io.File
 
@@ -17,21 +19,17 @@ class SpringApplicationAnalyzer(
             FakeFileManager(applicationData.propertyFilesPaths + applicationData.xmlConfigurationPaths)
         fakeFileManager.createTempFiles()
 
-        val app = SpringApplicationBuilder(SpringApplicationAnalyzer::class.java)
+        val applicationBuilder = SpringApplicationBuilder(SpringApplicationAnalyzer::class.java)
+        val applicationConfigurator = ApplicationConfigurator(applicationBuilder, applicationData)
 
-        val applicationConfigurator = ApplicationConfigurator(app, applicationData)
-        when (File(applicationData.configurationFile).extension) {
-            ExtensionUtils.XML -> {
-                applicationConfigurator.configureXmlBasedApplication()
-            }
-            else -> {
-                applicationConfigurator.configureJavaBasedApplication()
-            }
+        when (findConfigurationType(applicationData)) {
+            XmlConfiguration -> applicationConfigurator.configureXmlBasedApplication()
+            else -> applicationConfigurator.configureJavaBasedApplication()
         }
 
         try {
-            app.build()
-            app.run()
+            applicationBuilder.build()
+            applicationBuilder.run()
         } catch (e: ApplicationContextException) {
             // UtBotBeanFactoryPostProcessor destroys bean definitions
             // to prevent Spring application from actually starting and
@@ -39,6 +37,15 @@ class SpringApplicationAnalyzer(
             println("Bean analysis finished successfully")
         } finally {
             fakeFileManager.deleteTempFiles()
+        }
+    }
+
+    private fun findConfigurationType(applicationData: ApplicationData): ApplicationConfigurationType {
+        //TODO: support Spring Boot Applications here.
+        val fileExtension = File(applicationData.configurationFile).extension
+        return when (fileExtension) {
+            "xml" -> XmlConfiguration
+            else -> JavaConfiguration
         }
     }
 }

--- a/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/config/TestApplicationConfiguration.kt
+++ b/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/config/TestApplicationConfiguration.kt
@@ -3,9 +3,11 @@ package org.utbot.spring.config
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.ImportResource
 import org.utbot.spring.postProcessors.UtBotBeanFactoryPostProcessor
 
 @Configuration
+@ImportResource
 open class TestApplicationConfiguration {
 
     @Bean

--- a/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/configurators/ApplicationConfigurator.kt
+++ b/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/configurators/ApplicationConfigurator.kt
@@ -7,7 +7,7 @@ import org.utbot.spring.utils.ConfigurationManager
 import java.net.URLClassLoader
 
 open class ApplicationConfigurator(
-    private val app: SpringApplicationBuilder,
+    private val applicationBuilder: SpringApplicationBuilder,
     private val applicationData: ApplicationData
 ) {
     private val classLoader: ClassLoader = URLClassLoader(applicationData.applicationUrlArray)
@@ -37,8 +37,8 @@ open class ApplicationConfigurator(
         xmlFilesConfigurator.configure()
 
         for (prop in propertiesConfigurator.readProperties()) {
-            app.properties(prop)
+            applicationBuilder.properties(prop)
         }
-        app.sources(TestApplicationConfiguration::class.java, configurationClass)
+        applicationBuilder.sources(TestApplicationConfiguration::class.java, configurationClass)
     }
 }

--- a/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/configurators/ApplicationConfigurator.kt
+++ b/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/configurators/ApplicationConfigurator.kt
@@ -1,0 +1,44 @@
+package org.utbot.spring.configurators
+
+import org.springframework.boot.builder.SpringApplicationBuilder
+import org.utbot.spring.config.TestApplicationConfiguration
+import org.utbot.spring.data.ApplicationData
+import org.utbot.spring.utils.ConfigurationManager
+import java.net.URLClassLoader
+
+open class ApplicationConfigurator(
+    private val app: SpringApplicationBuilder,
+    private val applicationData: ApplicationData
+) {
+    private val classLoader: ClassLoader = URLClassLoader(applicationData.applicationUrlArray)
+
+    fun configureJavaBasedApplication() {
+        configureApplication(
+            configurationClass = classLoader.loadClass(applicationData.configurationFile),
+            xmlConfigurationPaths = applicationData.xmlConfigurationPaths
+        )
+    }
+
+    fun configureXmlBasedApplication() {
+        configureApplication(
+            configurationClass = TestApplicationConfiguration::class.java,
+            xmlConfigurationPaths = listOf(applicationData.configurationFile)
+        )
+    }
+
+    private fun configureApplication(configurationClass: Class<*>, xmlConfigurationPaths: List<String>) {
+
+        val configurationManager = ConfigurationManager(classLoader, configurationClass)
+
+        val xmlFilesConfigurator = XmlFilesConfigurator(xmlConfigurationPaths, configurationManager)
+        val propertiesConfigurator = PropertiesConfigurator(applicationData.propertyFilesPaths, configurationManager)
+
+        propertiesConfigurator.configure()
+        xmlFilesConfigurator.configure()
+
+        for (prop in propertiesConfigurator.readProperties()) {
+            app.properties(prop)
+        }
+        app.sources(TestApplicationConfiguration::class.java, configurationClass)
+    }
+}

--- a/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/configurators/ApplicationType.kt
+++ b/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/configurators/ApplicationType.kt
@@ -1,0 +1,10 @@
+package org.utbot.spring.configurators
+
+enum class ApplicationConfigurationType {
+
+    XmlConfiguration,
+
+    JavaConfiguration,
+
+    SpringBootConfiguration
+}

--- a/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/data/ApplicationData.kt
+++ b/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/data/ApplicationData.kt
@@ -1,0 +1,10 @@
+package org.utbot.spring.data
+
+import java.net.URL
+
+data class ApplicationData(
+    val applicationUrlArray: Array<URL>,
+    val configurationFile: String,
+    val propertyFilesPaths: List<String>,
+    val xmlConfigurationPaths: List<String>,
+)

--- a/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/utils/ExtensionUtils.kt
+++ b/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/utils/ExtensionUtils.kt
@@ -1,0 +1,5 @@
+package org.utbot.spring.utils
+
+object ExtensionUtils {
+    const val XML = "xml"
+}

--- a/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/utils/ExtensionUtils.kt
+++ b/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/utils/ExtensionUtils.kt
@@ -1,5 +1,0 @@
-package org.utbot.spring.utils
-
-object ExtensionUtils {
-    const val XML = "xml"
-}

--- a/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/utils/FakeFileManager.kt
+++ b/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/utils/FakeFileManager.kt
@@ -1,6 +1,5 @@
 package org.utbot.spring.utils
 
-import org.utbot.spring.utils.PathsUtils
 import java.io.File
 import java.io.IOException
 

--- a/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/utils/PathsUtils.kt
+++ b/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/utils/PathsUtils.kt
@@ -1,6 +1,5 @@
 package org.utbot.spring.utils
 
-import java.io.File
 import kotlin.io.path.Path
 
 object PathsUtils {


### PR DESCRIPTION
## Description

Some spring projects don't have a java configuration class. 
Such projects may have XML config as the main one. This is a common situation for old projects, as there were no alternative to xml that time.

Support for a project with such a config has been added.
It means that `utbot-spring-analyzer` can get and deal with not only the fully qualified name of Java configuration class, but xml one also.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.