### PR TITLE
Support separators in Spring Config Selection ComboBox

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -195,7 +195,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
     private val codegenLanguages = createComboBox(CodegenLanguage.values())
     private val testFrameworks = createComboBox(TestFramework.allItems.toTypedArray())
 
-    private val modelSpringConfigs = listOf(
+    private val modelSpringConfigs = setOf(
         null to listOf(NO_SPRING_CONFIGURATION_OPTION),
         "Java-based configurations" to model.getSortedSpringConfigurationClasses(),
         "XML-based configurations" to model.getSpringXMLConfigurationFiles()
@@ -242,7 +242,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
     }
 
     private fun <T> createComboBoxWithSeparatorsForSpringConfigs(
-        separatorToValues: List<Pair<T?, List<T>>>,
+        separatorToValues: Collection<Pair<T?, Collection<T>>>,
         width: Int = 300
     ): ComboBoxWithSeparators<T> {
         val comboBox = object : ComboBoxWithSeparators<T>() {}.apply {

--- a/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/models/BaseTestModel.kt
+++ b/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/models/BaseTestModel.kt
@@ -120,7 +120,8 @@ open class BaseTestsModel(
     }
 
     fun getSpringXMLConfigurationFiles(): List<String> {
-        val resourcesPaths = srcModule.getResourcesPaths()
+        val resourcesPaths =
+            listOf(testModule, srcModule).flatMapTo(mutableSetOf()) { it.getResourcesPaths() }
         val xmlFilePaths = resourcesPaths.flatMapTo(mutableListOf()) { path ->
             Files.list(path)
                 .asSequence()


### PR DESCRIPTION
## Description

New representation of Spring configuration option on UI: combobox is split into three parts (No configuration, Java-based configuration, XmlBasedConfiguration). Special UI item `ComboBoxWithSeparators` is used.

## How to test

### Automated tests

### Manual tests
Not relevant.

See the current stage:
![image](https://user-images.githubusercontent.com/54685068/229773004-76f7d0fc-1391-4c79-a287-edfebda87d03.png)
