### PR TITLE
Set MockStrategy default value properly in Spring projects

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -1365,6 +1365,11 @@ enum class MockStrategyApi(
     companion object : CodeGenerationSettingBox {
         override val defaultItem = OTHER_PACKAGES
         override val allItems: List<MockStrategyApi> = values().toList()
+
+        // Mock strategy gains more meaning in Spring Projects.
+        // We use OTHER_CLASSES strategy as default one in `No configuration` mode
+        // and as unique acceptable in other modes (combined with type replacement).
+        val springDefaultItem = OTHER_CLASSES
     }
 }
 

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -712,7 +712,11 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
         cbSpecifyTestPackage.isEnabled = model.srcClasses.all { cl -> cl.packageName.isNotEmpty() }
 
         val settings = model.project.service<Settings>()
-        mockStrategies.item = settings.mockStrategy
+
+        mockStrategies.item = when (model.projectType) {
+            ProjectType.Spring -> MockStrategyApi.springDefaultItem
+            else ->    settings.mockStrategy
+        }
         staticsMocking.isSelected = settings.staticsMocking == MockitoStaticMocking
         parametrizedTestSources.isSelected = settings.parametrizedTestSource == ParametrizedTestSource.PARAMETRIZE
 
@@ -1025,13 +1029,14 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
         springConfig.addActionListener { _ ->
             val isSpringConfigSelected = springConfig.item != NO_SPRING_CONFIGURATION_OPTION
             if (isSpringConfigSelected) {
-                // Here mock strategy gains more meaning in Spring Projects.
-                // We use OTHER_CLASSES strategy combined with type replacement being enabled.
-                mockStrategies.item = MockStrategyApi.OTHER_CLASSES
+                mockStrategies.item = MockStrategyApi.springDefaultItem
                 mockStrategies.isEnabled = false
                 updateMockStrategyListForConfigGuidedTypeReplacements()
             } else {
-                mockStrategies.item = MockStrategyApi.defaultItem
+                mockStrategies.item = when (model.projectType) {
+                    ProjectType.Spring -> MockStrategyApi.springDefaultItem
+                    else -> MockStrategyApi.defaultItem
+                }
                 mockStrategies.isEnabled = true
                 updateMockStrategyList()
             }


### PR DESCRIPTION
## Description

MockStrategy default strategy is `other packages`.

In Spring applications, the behavior is different:
- In `No configuration` mode, default value is `other classes`
- in other modes, default and suggested only value is `other classes`

## How to test

### Manual tests

UI manual regression.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.