### PR TITLE
Specify explicit foreground color for "GotItMessage"

### DIFF
--- a/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/ui/Notifications.kt
+++ b/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/ui/Notifications.kt
@@ -18,6 +18,7 @@ import com.intellij.openapi.wm.WindowManager
 import com.intellij.ui.GotItMessage
 import com.intellij.ui.awt.RelativePoint
 import com.intellij.util.ui.JBFont
+import com.intellij.util.ui.UIUtil
 import java.awt.Point
 import javax.swing.event.HyperlinkEvent
 import mu.KotlinLogging
@@ -201,7 +202,7 @@ object GotItTooltipActivity : StartupActivity {
                 .getKeyboardShortcut("org.utbot.intellij.plugin.ui.actions.GenerateTestsAction")?:return@invokeLater
             val shortcutText = KeymapUtil.getShortcutText(shortcut)
             val message = GotItMessage.createMessage("UnitTestBot is ready!",
-                "<div style=\"font-size:${JBFont.label().biggerOn(2.toFloat()).size}pt;\">" +
+                "<div style=\"font-size:${JBFont.label().biggerOn(2.toFloat()).size}pt;color:#${UIUtil.colorToHex(UIUtil.getLabelForeground())};\">" +
                         "You can get test coverage for methods, Java classes,<br>and even for whole source roots<br> with <b>$shortcutText</b></div>")
             message.setCallback { PropertiesComponent.getInstance().setValue(KEY, true) }
             WindowManager.getInstance().getFrame(project)?.rootPane?.let {


### PR DESCRIPTION

## Description

"Got it message" appears unreadable under light themes in new IDEA UI, the fix is to specify foreground color explicitly.

## Self-check list


- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.