### PR TITLE
Improve the appearance of paths in Spring Config Selection ComboBox

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -192,6 +192,9 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
     private val codegenLanguages = createComboBox(CodegenLanguage.values())
     private val testFrameworks = createComboBox(TestFramework.allItems.toTypedArray())
 
+    private val javaConfigurationHelper = SpringConfigurationsHelper(".")
+    private val xmlConfigurationHelper = SpringConfigurationsHelper(File.separator)
+
     private val springConfig = createComboBoxWithSeparatorsForSpringConfigs(shortenConfigurationNames())
 
     private val mockStrategies = createComboBox(MockStrategyApi.values())
@@ -217,10 +220,6 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
         staticsMocking to null,
         parametrizedTestSources to null
     )
-
-
-    private val javaConfigurationHelper = SpringConfigurationsHelper(".")
-    private val xmlConfigurationHelper = SpringConfigurationsHelper(File.separator)
 
     private fun shortenConfigurationNames(): Set<Pair<String?, Collection<String>>> {
         val shortenedSortedSpringConfigurationClasses =

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/SpringConfigurationsHelper.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/SpringConfigurationsHelper.kt
@@ -1,0 +1,91 @@
+package org.utbot.intellij.plugin.util
+
+/**
+ * Getting from spring Configuration Classes and Spring XML Configuration Files shortened paths
+ *
+ * How is this done:
+ * - Parent directories are appended to the file name until the path becomes unique
+ *
+ *  Example:
+ *  - [["config.web.WebConfig", "config.web2.WebConfig", "config.web.AnotherConfig"]] ->
+ *  [["web.WebConfig", "web2.WebConfig", "AnotherConfig"]]
+ */
+object SpringConfigurationsHelper {
+
+    private var separator = ""
+
+    data class PathData(private var shortenedPath: String) {
+
+        private val pathConstructor: MutableList<String> = shortenedPath.split(separator).toMutableList()
+
+        init {
+            try {
+                shortenedPath = pathConstructor.last()
+                pathConstructor.removeLast()
+            } catch (e: Exception) {
+                println("Path [$shortenedPath] can't be extended")
+            }
+        }
+
+        fun getShortenedPath() = shortenedPath
+
+        fun addPathParentDir(): Boolean {
+            return try {
+                shortenedPath = pathConstructor.last() + separator + shortenedPath
+                pathConstructor.removeLast()
+                true
+            } catch (e: Exception) {
+                println("Path [$shortenedPath] can't be extended")
+                false
+            }
+        }
+    }
+
+    private fun preparePathsData(
+        paths: Set<String>,
+        pathsData: MutableList<PathData>,
+        pathsDataMap: MutableMap<String, PathData>
+    ) {
+        for (path in paths) {
+            pathsDataMap[path] = PathData(path)
+        }
+        pathsData.addAll(pathsDataMap.values)
+    }
+
+    private fun getMinimizedPaths(pathDataMap: MutableMap<String, PathData>): Set<String> {
+        val shortenedPaths = mutableSetOf<String>()
+        for (elem in pathDataMap.values) {
+            shortenedPaths.add(elem.getShortenedPath())
+        }
+        return shortenedPaths.toSet()
+    }
+
+    fun shortenSpringConfigNames(paths: Set<String>, separator: String): Set<String> {
+        SpringConfigurationsHelper.separator = separator
+
+        val pathsDataMap = mutableMapOf<String, PathData>()
+        var pathsData = mutableListOf<PathData>()
+
+        preparePathsData(paths, pathsData, pathsDataMap)
+
+        while (pathsData.size != pathsData.distinct().size) {
+            pathsData = pathsData.sortedBy { it.getShortenedPath() }.toMutableList()
+            for (ind in pathsData.indices) {
+                val curShortenedPath = pathsData[ind].getShortenedPath()
+
+                var maxIndWithSamePath = ind
+                while (maxIndWithSamePath < pathsData.size) {
+                    if (pathsData[maxIndWithSamePath].getShortenedPath() == curShortenedPath) maxIndWithSamePath++
+                    else break
+                }
+
+                if (ind == maxIndWithSamePath - 1) continue
+                for (i in ind until maxIndWithSamePath) {
+                    if (!pathsData[i].addPathParentDir()) return paths
+                }
+                break
+            }
+        }
+        return getMinimizedPaths(pathsDataMap)
+    }
+}

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/SpringConfigurationsHelper.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/SpringConfigurationsHelper.kt
@@ -46,10 +46,12 @@ class SpringConfigurationsHelper(val separator: String) {
         fullNames.forEach { nameToInfo[it] = NameInfo(it) }
         var nameInfoCollection = nameToInfo.values
 
-        while (nameInfoCollection.size != nameInfoCollection.distinct().size) {
+        // this cycle continues until all shortenedNames become unique
+        while (nameInfoCollection.size != nameInfoCollection.distinctBy { it.shortenedName }.size) {
             nameInfoCollection = nameInfoCollection.sortedBy { it.shortenedName }.toMutableList()
 
-            for (index in nameInfoCollection.indices) {
+            var index = 0
+            while(index < nameInfoCollection.size){
                 val curShortenedPath = nameInfoCollection[index].shortenedName
 
                 // here we search a block of shortened paths that are equivalent
@@ -64,8 +66,9 @@ class SpringConfigurationsHelper(val separator: String) {
                     }
                 }
 
-                //if the size of this block is one, we should not enlarge it
+                // if the size of this block is one, we should not enlarge it
                 if (index == maxIndexWithSamePath - 1) {
+                    index++
                     continue
                 }
 
@@ -75,6 +78,9 @@ class SpringConfigurationsHelper(val separator: String) {
                         return collectShortenedNames()
                     }
                 }
+
+                // after enlarging the block, we proceed to search for the next block
+                index = maxIndexWithSamePath
             }
         }
 

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/SpringConfigurationsHelper.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/util/SpringConfigurationsHelper.kt
@@ -1,14 +1,17 @@
 package org.utbot.intellij.plugin.util
 
 /**
- * Getting from spring Configuration Classes and Spring XML Configuration Files shortened paths
+ * This class is a converter between full Spring configuration names and shortened versions.
  *
- * How is this done:
- * - Parent directories are appended to the file name until the path becomes unique
+ * Shortened versions are represented on UI.
+ * Full names are used in further analysis in utbot-spring-analyzer.
  *
- *  Example:
- *  - [["config.web.WebConfig", "config.web2.WebConfig", "config.web.AnotherConfig"]] ->
- *  [["web.WebConfig", "web2.WebConfig", "AnotherConfig"]]
+ * The idea of this implementation is to append parent directories to the file name until all names become unique.
+ *
+ * Example:
+ * - [["config.web.WebConfig", "config.web2.WebConfig", "config.web.AnotherConfig"]]
+ * ->
+ * [["web.WebConfig", "web2.WebConfig", "AnotherConfig"]]
  */
 class SpringConfigurationsHelper(val separator: String) {
 


### PR DESCRIPTION
## Description

Fixes https://github.com/UnitTestBot/UTBotJava/issues/2079

Now the paths to the Spring Config Selection Combobox have become shorter. 

Added functions that shorten paths.
How is this done: parent directories are appended to the file name until the path becomes unique

#### Example:
>["config.web.WebConfig", "config.web2.WebConfig", "config.web.AnotherConfig"] ->["web.WebConfig", "web2.WebConfig", "AnotherConfig"]

<img width="528" alt="image" src="https://user-images.githubusercontent.com/73890886/229939855-83d2f909-b347-466b-9dac-726cd4a1c131.png">

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.