### PR TITLE
Go. Maps support

### DIFF
--- a/utbot-go/go-samples/simple/samples_go_ut_test.go
+++ b/utbot-go/go-samples/simple/samples_go_ut_test.go
@@ -92,23 +92,23 @@ func TestIsIdentityByUtGoFuzzer3(t *testing.T) {
 }
 
 func TestBinaryWithNonNilErrorByUtGoFuzzer1(t *testing.T) {
-	actualVal, actualErr := Binary([]int{1}, 2, 0, -1)
+	actualVal, actualErr := Binary(nil, 2, 0, -1)
 
 	assertMultiple := assert.New(t)
 	assertMultiple.Equal(-1, actualVal)
 	assertMultiple.ErrorContains(actualErr, "target not found in array")
 }
 
-func TestBinaryByUtGoFuzzer2(t *testing.T) {
-	actualVal, actualErr := Binary([]int{9223372036854775807, -1, -1, -1, -1}, 9223372036854775807, 0, 1)
+func TestBinaryWithNonNilErrorByUtGoFuzzer2(t *testing.T) {
+	actualVal, actualErr := Binary([]int{1, 1, 0}, 2, 1, 1)
 
 	assertMultiple := assert.New(t)
-	assertMultiple.Equal(0, actualVal)
-	assertMultiple.Nil(actualErr)
+	assertMultiple.Equal(-1, actualVal)
+	assertMultiple.ErrorContains(actualErr, "target not found in array")
 }
 
 func TestBinaryWithNonNilErrorByUtGoFuzzer3(t *testing.T) {
-	actualVal, actualErr := Binary([]int{1, 17592186044417, 257, 1125899906842625}, -9223372036854775808, 1, 2)
+	actualVal, actualErr := Binary([]int{1, 1, 0}, -9214364837600034814, 1, 1)
 
 	assertMultiple := assert.New(t)
 	assertMultiple.Equal(-1, actualVal)
@@ -116,15 +116,15 @@ func TestBinaryWithNonNilErrorByUtGoFuzzer3(t *testing.T) {
 }
 
 func TestBinaryWithNonNilErrorByUtGoFuzzer4(t *testing.T) {
-	actualVal, actualErr := Binary([]int{-1, -1, -1, -1, 9223372036854775807}, 9223372036854775807, 0, 1)
+	actualVal, actualErr := Binary([]int{9223372036854775807, 9223372036854775807, 1, 9223372036854775807, -9223372036854775808}, 9223372036854775807, -1, 1)
 
 	assertMultiple := assert.New(t)
-	assertMultiple.Equal(-1, actualVal)
-	assertMultiple.ErrorContains(actualErr, "target not found in array")
+	assertMultiple.Equal(0, actualVal)
+	assertMultiple.Nil(actualErr)
 }
 
 func TestBinaryPanicsByUtGoFuzzer(t *testing.T) {
-	assert.PanicsWithError(t, "runtime error: index out of range [-4611686018427387905]", func() { Binary([]int{1}, 2, -9223372036854775808, -1) })
+	assert.PanicsWithError(t, "runtime error: index out of range [-4611686018427387905]", func() { Binary(nil, 2, -9223372036854775808, -1) })
 }
 
 func TestStringSearchByUtGoFuzzer1(t *testing.T) {

--- a/utbot-go/go-samples/simple/supported_types.go
+++ b/utbot-go/go-samples/simple/supported_types.go
@@ -262,3 +262,29 @@ type S struct {
 func StructWithFieldsOfNamedTypes(s S) S {
 	return s
 }
+
+func Map(table map[string]int) map[string]int {
+	return table
+}
+
+func MapOfStructures(table map[Structure]Structure) map[Structure]Structure {
+	return table
+}
+
+func MapOfSliceOfInt(table map[string][]int) map[string][]int {
+	return table
+}
+
+func MapOfNamedType(table map[int]Type) map[int]Type {
+	return table
+}
+
+func MapOfNamedSlice(table map[uint]NS) map[uint]NS {
+	return table
+}
+
+type NM map[string]NA
+
+func NamedMap(n NM) NM {
+	return n
+}

--- a/utbot-go/go-samples/simple/supported_types_go_ut_test.go
+++ b/utbot-go/go-samples/simple/supported_types_go_ut_test.go
@@ -108,27 +108,27 @@ func TestUintPtrByUtGoFuzzer(t *testing.T) {
 }
 
 func TestFloat32ByUtGoFuzzer(t *testing.T) {
-	actualVal := Float32(0.24053639)
+	actualVal := Float32(0.59754527)
 
-	assert.Equal(t, float32(0.24053639), actualVal)
+	assert.Equal(t, float32(0.59754527), actualVal)
 }
 
 func TestFloat64ByUtGoFuzzer(t *testing.T) {
-	actualVal := Float64(0.6063452159973596)
+	actualVal := Float64(0.7815346320453048)
 
-	assert.Equal(t, 0.6063452159973596, actualVal)
+	assert.Equal(t, 0.7815346320453048, actualVal)
 }
 
 func TestComplex64ByUtGoFuzzer(t *testing.T) {
-	actualVal := Complex64(complex(0.30905056, 0.30905056))
+	actualVal := Complex64(complex(0.25277615, 0.25277615))
 
-	assert.Equal(t, complex(float32(0.30905056), float32(0.30905056)), actualVal)
+	assert.Equal(t, complex(float32(0.25277615), float32(0.25277615)), actualVal)
 }
 
 func TestComplex128ByUtGoFuzzer(t *testing.T) {
-	actualVal := Complex128(complex(0.5504370051176339, 0.5504370051176339))
+	actualVal := Complex128(complex(0.3851891847407185, 0.3851891847407185))
 
-	assert.Equal(t, complex(0.5504370051176339, 0.5504370051176339), actualVal)
+	assert.Equal(t, complex(0.3851891847407185, 0.3851891847407185), actualVal)
 }
 
 func TestByteByUtGoFuzzer(t *testing.T) {
@@ -210,12 +210,12 @@ func TestArrayOfArrayOfStructsByUtGoFuzzer(t *testing.T) {
 }
 
 func TestArrayOfSliceOfUintByUtGoFuzzer(t *testing.T) {
-	actualVal := ArrayOfSliceOfUint([5][]uint{{}, {}, {}, {}, {}})
+	actualVal := ArrayOfSliceOfUint([5][]uint{nil, nil, nil, nil, nil})
 
-	assert.Equal(t, [5][]uint{{}, {}, {}, {}, {}}, actualVal)
+	assert.Equal(t, [5][]uint{nil, nil, nil, nil, nil}, actualVal)
 }
 
-func TestReturnErrorOrNilByUtGoFuzzer1(t *testing.T) {
+func TestReturnErrorOrNilWithNonNilErrorByUtGoFuzzer1(t *testing.T) {
 	actualErr := returnErrorOrNil(0)
 
 	assert.Nil(t, actualErr)
@@ -240,21 +240,21 @@ func TestExternalStructWithAliasByUtGoFuzzer(t *testing.T) {
 }
 
 func TestSliceOfIntByUtGoFuzzer(t *testing.T) {
-	actualVal := SliceOfInt([]int{-1})
+	actualVal := SliceOfInt(nil)
 
-	assert.Equal(t, []int{-1}, actualVal)
+	assert.Nil(t, actualVal)
 }
 
 func TestSliceOfUintPtrByUtGoFuzzer(t *testing.T) {
-	actualVal := SliceOfUintPtr([]uintptr{0})
+	actualVal := SliceOfUintPtr(nil)
 
-	assert.Equal(t, []uintptr{0}, actualVal)
+	assert.Nil(t, actualVal)
 }
 
 func TestSliceOfStringByUtGoFuzzer(t *testing.T) {
-	actualVal := SliceOfString([]string{"hello"})
+	actualVal := SliceOfString(nil)
 
-	assert.Equal(t, []string{"hello"}, actualVal)
+	assert.Nil(t, actualVal)
 }
 
 func TestSliceOfStructsByUtGoFuzzer(t *testing.T) {
@@ -270,15 +270,15 @@ func TestSliceOfStructsWithNanByUtGoFuzzer(t *testing.T) {
 }
 
 func TestSliceOfSliceOfByteByUtGoFuzzer(t *testing.T) {
-	actualVal := SliceOfSliceOfByte([][]byte{{}})
+	actualVal := SliceOfSliceOfByte([][]byte{nil})
 
-	assert.Equal(t, [][]byte{{}}, actualVal)
+	assert.Equal(t, [][]byte{nil}, actualVal)
 }
 
 func TestSliceOfSliceOfStructsByUtGoFuzzer(t *testing.T) {
-	actualVal := SliceOfSliceOfStructs([][]Structure{{}})
+	actualVal := SliceOfSliceOfStructs([][]Structure{nil})
 
-	assert.Equal(t, [][]Structure{{}}, actualVal)
+	assert.Equal(t, [][]Structure{nil}, actualVal)
 }
 
 func TestSliceOfArrayOfIntByUtGoFuzzer(t *testing.T) {
@@ -294,7 +294,7 @@ func TestExportedStructWithEmbeddedUnexportedStructByUtGoFuzzer(t *testing.T) {
 }
 
 func TestNamedTypeByUtGoFuzzer(t *testing.T) {
-	actualVal := NamedType(Type(0))
+	actualVal := NamedType(0)
 
 	assert.Equal(t, Type(0), actualVal)
 }
@@ -324,13 +324,49 @@ func TestNamedArrayByUtGoFuzzer(t *testing.T) {
 }
 
 func TestNamedSliceByUtGoFuzzer(t *testing.T) {
-	actualVal := NamedSlice(NS{-1, 9223372036854775807, 9223372036854775807, 1, 9223372036854775807})
+	actualVal := NamedSlice(NS(nil))
 
-	assert.Equal(t, NS{-1, 9223372036854775807, 9223372036854775807, 1, 9223372036854775807}, actualVal)
+	assert.Nil(t, actualVal)
 }
 
 func TestStructWithFieldsOfNamedTypesByUtGoFuzzer(t *testing.T) {
-	actualVal := StructWithFieldsOfNamedTypes(S{T: T{{0, 0, 0, 0, 0}, {0, 0, 0, 0, 0}, {0, 0, 0, 0, 0}, {0, 0, 0, 0, 0}, {0, 0, 0, 0, 0}}, NS: NS{9223372036854775807, 1, 0, -9223372036854775808, 9223372036854775807}})
+	actualVal := StructWithFieldsOfNamedTypes(S{T: T{{0, 0, 0, 0, 0}, {0, 0, 0, 0, 0}, {0, 0, 0, 0, 0}, {0, 0, 0, 0, 0}, {0, 0, 0, 0, 0}}, NS: NS(nil)})
 
-	assert.Equal(t, S{T: T{{0, 0, 0, 0, 0}, {0, 0, 0, 0, 0}, {0, 0, 0, 0, 0}, {0, 0, 0, 0, 0}, {0, 0, 0, 0, 0}}, NS: NS{9223372036854775807, 1, 0, -9223372036854775808, 9223372036854775807}}, actualVal)
+	assert.Equal(t, S{T: T{{0, 0, 0, 0, 0}, {0, 0, 0, 0, 0}, {0, 0, 0, 0, 0}, {0, 0, 0, 0, 0}, {0, 0, 0, 0, 0}}, NS: NS(nil)}, actualVal)
+}
+
+func TestMapByUtGoFuzzer(t *testing.T) {
+	actualVal := Map(nil)
+
+	assert.Nil(t, actualVal)
+}
+
+func TestMapOfStructuresByUtGoFuzzer(t *testing.T) {
+	actualVal := MapOfStructures(map[Structure]Structure{Structure{}: {}})
+
+	assert.Equal(t, map[Structure]Structure{Structure{}: {}}, actualVal)
+}
+
+func TestMapOfSliceOfIntByUtGoFuzzer(t *testing.T) {
+	actualVal := MapOfSliceOfInt(map[string][]int{"hello": {}})
+
+	assert.Equal(t, map[string][]int{"hello": {}}, actualVal)
+}
+
+func TestMapOfNamedTypeByUtGoFuzzer(t *testing.T) {
+	actualVal := MapOfNamedType(map[int]Type{-1: 255})
+
+	assert.Equal(t, map[int]Type{-1: 255}, actualVal)
+}
+
+func TestMapOfNamedSliceByUtGoFuzzer(t *testing.T) {
+	actualVal := MapOfNamedSlice(nil)
+
+	assert.Nil(t, actualVal)
+}
+
+func TestNamedMapByUtGoFuzzer(t *testing.T) {
+	actualVal := NamedMap(NM(nil))
+
+	assert.Nil(t, actualVal)
 }

--- a/utbot-go/src/main/kotlin/org/utbot/go/GoLanguage.kt
+++ b/utbot-go/src/main/kotlin/org/utbot/go/GoLanguage.kt
@@ -12,6 +12,7 @@ fun goDefaultValueProviders() = listOf(
     GoPrimitivesValueProvider,
     GoArrayValueProvider,
     GoSliceValueProvider,
+    GoMapValueProvider,
     GoStructValueProvider,
     GoConstantValueProvider,
     GoNamedValueProvider,

--- a/utbot-go/src/main/kotlin/org/utbot/go/api/GoTypesApi.kt
+++ b/utbot-go/src/main/kotlin/org/utbot/go/api/GoTypesApi.kt
@@ -82,6 +82,27 @@ class GoSliceTypeId(
     override fun hashCode(): Int = elementTypeId.hashCode()
 }
 
+class GoMapTypeId(
+    name: String, val keyTypeId: GoTypeId, elementTypeId: GoTypeId,
+) : GoTypeId(name, elementTypeId = elementTypeId) {
+    override val canonicalName: String = "map[${keyTypeId.canonicalName}]${elementTypeId.canonicalName}"
+
+    override fun getRelativeName(destinationPackage: GoPackage, aliases: Map<GoPackage, String?>): String {
+        val keyType = keyTypeId.getRelativeName(destinationPackage, aliases)
+        val elementType = elementTypeId!!.getRelativeName(destinationPackage, aliases)
+        return "map[$keyType]$elementType"
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is GoMapTypeId) return false
+
+        return keyTypeId == other.keyTypeId && elementTypeId == other.elementTypeId
+    }
+
+    override fun hashCode(): Int = 31 * keyTypeId.hashCode() + elementTypeId.hashCode()
+}
+
 class GoInterfaceTypeId(name: String) : GoTypeId(name) {
     override val canonicalName: String = name
 

--- a/utbot-go/src/main/kotlin/org/utbot/go/api/util/GoUtModelsApiUtil.kt
+++ b/utbot-go/src/main/kotlin/org/utbot/go/api/util/GoUtModelsApiUtil.kt
@@ -41,6 +41,17 @@ fun GoUtModel.convertToRawValue(destinationPackage: GoPackage, aliases: Map<GoPa
             model.getElements().map { it.convertToRawValue(destinationPackage, aliases) }
         )
 
+        is GoUtMapModel -> MapValue(
+            model.typeId.getRelativeName(destinationPackage, aliases),
+            model.typeId.keyTypeId.getRelativeName(destinationPackage, aliases),
+            model.typeId.elementTypeId!!.getRelativeName(destinationPackage, aliases),
+            model.value.entries.map {
+                val key = it.key.convertToRawValue(destinationPackage, aliases)
+                val value = it.value.convertToRawValue(destinationPackage, aliases)
+                MapValue.KeyValue(key, value)
+            }
+        )
+
         is GoUtStructModel -> StructValue(
             model.typeId.getRelativeName(destinationPackage, aliases),
             model.value.map {

--- a/utbot-go/src/main/kotlin/org/utbot/go/fuzzer/providers/GoMapValueProvider.kt
+++ b/utbot-go/src/main/kotlin/org/utbot/go/fuzzer/providers/GoMapValueProvider.kt
@@ -1,0 +1,39 @@
+package org.utbot.go.fuzzer.providers
+
+import org.utbot.fuzzing.Routine
+import org.utbot.fuzzing.Seed
+import org.utbot.fuzzing.ValueProvider
+import org.utbot.go.GoDescription
+import org.utbot.go.api.GoMapTypeId
+import org.utbot.go.api.GoUtMapModel
+import org.utbot.go.framework.api.go.GoTypeId
+import org.utbot.go.framework.api.go.GoUtModel
+
+object GoMapValueProvider : ValueProvider<GoTypeId, GoUtModel, GoDescription> {
+    override fun accept(type: GoTypeId): Boolean = type is GoMapTypeId
+
+    override fun generate(description: GoDescription, type: GoTypeId): Sequence<Seed<GoTypeId, GoUtModel>> =
+        sequence {
+            type.let { it as GoMapTypeId }.also { mapType ->
+                yield(
+                    Seed.Collection(
+                        construct = Routine.Collection {
+                            GoUtMapModel(
+                                value = mutableMapOf(),
+                                typeId = mapType
+                            )
+                        },
+                        modify = Routine.ForEach(
+                            listOf(
+                                mapType.keyTypeId,
+                                mapType.elementTypeId!!
+                            )
+                        ) { self, _, values ->
+                            val model = self as GoUtMapModel
+                            model.value[values[0]] = values[1]
+                        }
+                    )
+                )
+            }
+        }
+}

--- a/utbot-go/src/main/kotlin/org/utbot/go/fuzzer/providers/GoNilValueProvider.kt
+++ b/utbot-go/src/main/kotlin/org/utbot/go/fuzzer/providers/GoNilValueProvider.kt
@@ -3,13 +3,14 @@ package org.utbot.go.fuzzer.providers
 import org.utbot.fuzzing.Seed
 import org.utbot.fuzzing.ValueProvider
 import org.utbot.go.GoDescription
+import org.utbot.go.api.GoMapTypeId
 import org.utbot.go.api.GoSliceTypeId
 import org.utbot.go.api.GoUtNilModel
 import org.utbot.go.framework.api.go.GoTypeId
 import org.utbot.go.framework.api.go.GoUtModel
 
 object GoNilValueProvider : ValueProvider<GoTypeId, GoUtModel, GoDescription> {
-    override fun accept(type: GoTypeId): Boolean = type is GoSliceTypeId
+    override fun accept(type: GoTypeId): Boolean = type is GoSliceTypeId || type is GoMapTypeId
 
     override fun generate(description: GoDescription, type: GoTypeId): Sequence<Seed<GoTypeId, GoUtModel>> =
         sequenceOf(Seed.Simple(GoUtNilModel(type)))

--- a/utbot-go/src/main/kotlin/org/utbot/go/gocodeanalyzer/AnalysisResults.kt
+++ b/utbot-go/src/main/kotlin/org/utbot/go/gocodeanalyzer/AnalysisResults.kt
@@ -54,6 +54,18 @@ data class AnalyzedSliceType(
     )
 }
 
+data class AnalyzedMapType(
+    override val name: String,
+    val keyType: AnalyzedType,
+    val elementType: AnalyzedType,
+) : AnalyzedType(name) {
+    override fun toGoTypeId(): GoTypeId = GoMapTypeId(
+        name = name,
+        keyTypeId = keyType.toGoTypeId(),
+        elementTypeId = elementType.toGoTypeId(),
+    )
+}
+
 data class AnalyzedInterfaceType(
     override val name: String,
 ) : AnalyzedType(name) {
@@ -85,7 +97,7 @@ class AnalyzedTypeAdapter : TypeAdapter<AnalyzedType> {
         return when {
             typeName == "interface{}" -> AnalyzedInterfaceType::class
             typeName == "struct{}" -> AnalyzedStructType::class
-            typeName.startsWith("map[") -> error("Map type not yet supported")
+            typeName.startsWith("map[") -> AnalyzedMapType::class
             typeName.startsWith("[]") -> AnalyzedSliceType::class
             typeName.startsWith("[") -> AnalyzedArrayType::class
             goPrimitives.map { it.name }.contains(typeName) -> AnalyzedPrimitiveType::class

--- a/utbot-go/src/main/kotlin/org/utbot/go/worker/GoCodeTemplates.kt
+++ b/utbot-go/src/main/kotlin/org/utbot/go/worker/GoCodeTemplates.kt
@@ -579,7 +579,7 @@ object GoCodeTemplates {
         		elem := v.Type().Elem()
         		elementType := elem.String()
         		typeName := fmt.Sprintf("[]%s", elementType)
-        		sliceElementValues := make([]__RawValue__, v.Len())
+        		sliceElementValues := make([]__RawValue__, 0, v.Len())
         		for i := 0; i < v.Len(); i++ {
         			sliceElementValue, err := __convertReflectValueToRawValue__(v.Index(i))
         			if err != nil {

--- a/utbot-go/src/main/kotlin/org/utbot/go/worker/GoCodeTemplates.kt
+++ b/utbot-go/src/main/kotlin/org/utbot/go/worker/GoCodeTemplates.kt
@@ -7,6 +7,15 @@ import org.utbot.go.simplecodegeneration.GoUtModelToCodeConverter
 
 object GoCodeTemplates {
 
+    private val errorMessages = """
+        var (
+        	ErrParsingValue                  = "failed to parse %s value: %s"
+        	ErrStringToReflectTypeFailure    = "failed to convert '%s' to reflect.Type: %s"
+        	ErrRawValueToReflectValueFailure = "failed to convert RawValue to reflect.Value: %s"
+        	ErrReflectValueToRawValueFailure = "failed to convert reflect.Value to RawValue: %s"
+        )
+    """.trimIndent()
+
     private val testInputStruct = """
         type __TestInput__ struct {
         	FunctionName string                   `json:"functionName"`
@@ -34,113 +43,153 @@ object GoCodeTemplates {
         	switch v.Type {
         	case "bool":
         		value, err := strconv.ParseBool(v.Value)
-        		__checkErrorAndExit__(err)
+        		if err != nil {
+        			return reflect.Value{}, fmt.Errorf(ErrParsingValue, v.Type, err)
+        		}
 
         		return reflect.ValueOf(value), nil
         	case "int":
         		value, err := strconv.Atoi(v.Value)
-        		__checkErrorAndExit__(err)
+        		if err != nil {
+        			return reflect.Value{}, fmt.Errorf(ErrParsingValue, v.Type, err)
+        		}
 
         		return reflect.ValueOf(value), nil
         	case "int8":
         		value, err := strconv.ParseInt(v.Value, 10, 8)
-        		__checkErrorAndExit__(err)
+        		if err != nil {
+        			return reflect.Value{}, fmt.Errorf(ErrParsingValue, v.Type, err)
+        		}
 
         		return reflect.ValueOf(int8(value)), nil
         	case "int16":
         		value, err := strconv.ParseInt(v.Value, 10, 16)
-        		__checkErrorAndExit__(err)
+        		if err != nil {
+        			return reflect.Value{}, fmt.Errorf(ErrParsingValue, v.Type, err)
+        		}
 
         		return reflect.ValueOf(int16(value)), nil
         	case "int32":
         		value, err := strconv.ParseInt(v.Value, 10, 32)
-        		__checkErrorAndExit__(err)
+        		if err != nil {
+        			return reflect.Value{}, fmt.Errorf(ErrParsingValue, v.Type, err)
+        		}
 
         		return reflect.ValueOf(int32(value)), nil
         	case "rune":
         		value, err := strconv.ParseInt(v.Value, 10, 32)
-        		__checkErrorAndExit__(err)
+        		if err != nil {
+        			return reflect.Value{}, fmt.Errorf(ErrParsingValue, v.Type, err)
+        		}
 
         		return reflect.ValueOf(rune(value)), nil
         	case "int64":
         		value, err := strconv.ParseInt(v.Value, 10, 64)
-        		__checkErrorAndExit__(err)
+        		if err != nil {
+        			return reflect.Value{}, fmt.Errorf(ErrParsingValue, v.Type, err)
+        		}
 
         		return reflect.ValueOf(value), nil
         	case "byte":
         		value, err := strconv.ParseUint(v.Value, 10, 8)
-        		__checkErrorAndExit__(err)
+        		if err != nil {
+        			return reflect.Value{}, fmt.Errorf(ErrParsingValue, v.Type, err)
+        		}
 
         		return reflect.ValueOf(byte(value)), nil
         	case "uint":
         		value, err := strconv.ParseUint(v.Value, 10, strconv.IntSize)
-        		__checkErrorAndExit__(err)
+        		if err != nil {
+        			return reflect.Value{}, fmt.Errorf(ErrParsingValue, v.Type, err)
+        		}
 
         		return reflect.ValueOf(uint(value)), nil
         	case "uint8":
         		value, err := strconv.ParseUint(v.Value, 10, 8)
-        		__checkErrorAndExit__(err)
+        		if err != nil {
+        			return reflect.Value{}, fmt.Errorf(ErrParsingValue, v.Type, err)
+        		}
 
         		return reflect.ValueOf(uint8(value)), nil
         	case "uint16":
         		value, err := strconv.ParseUint(v.Value, 10, 16)
-        		__checkErrorAndExit__(err)
+        		if err != nil {
+        			return reflect.Value{}, fmt.Errorf(ErrParsingValue, v.Type, err)
+        		}
 
         		return reflect.ValueOf(uint16(value)), nil
         	case "uint32":
         		value, err := strconv.ParseUint(v.Value, 10, 32)
-        		__checkErrorAndExit__(err)
+        		if err != nil {
+        			return reflect.Value{}, fmt.Errorf(ErrParsingValue, v.Type, err)
+        		}
 
         		return reflect.ValueOf(uint32(value)), nil
         	case "uint64":
         		value, err := strconv.ParseUint(v.Value, 10, 64)
-        		__checkErrorAndExit__(err)
+        		if err != nil {
+        			return reflect.Value{}, fmt.Errorf(ErrParsingValue, v.Type, err)
+        		}
 
         		return reflect.ValueOf(value), nil
         	case "float32":
         		value, err := strconv.ParseFloat(v.Value, 32)
-        		__checkErrorAndExit__(err)
+        		if err != nil {
+        			return reflect.Value{}, fmt.Errorf(ErrParsingValue, v.Type, err)
+        		}
 
         		return reflect.ValueOf(float32(value)), nil
         	case "float64":
         		value, err := strconv.ParseFloat(v.Value, 64)
-        		__checkErrorAndExit__(err)
+        		if err != nil {
+        			return reflect.Value{}, fmt.Errorf(ErrParsingValue, v.Type, err)
+        		}
 
         		return reflect.ValueOf(value), nil
         	case "complex64":
-        		splittedValue := strings.Split(v.Value, complexPartsDelimiter)
-        		if len(splittedValue) != 2 {
-        			return reflect.Value{}, fmt.Errorf("not correct complex64 value")
+        		splitValue := strings.Split(v.Value, complexPartsDelimiter)
+        		if len(splitValue) != 2 {
+        			return reflect.Value{}, fmt.Errorf("not correct complex64 value: %s", v.Value)
         		}
-        		realPart, err := strconv.ParseFloat(splittedValue[0], 32)
-        		__checkErrorAndExit__(err)
+        		realPart, err := strconv.ParseFloat(splitValue[0], 32)
+        		if err != nil {
+        			return reflect.Value{}, fmt.Errorf(ErrParsingValue, v.Type, err)
+        		}
 
-        		imaginaryPart, err := strconv.ParseFloat(splittedValue[1], 32)
-        		__checkErrorAndExit__(err)
+        		imaginaryPart, err := strconv.ParseFloat(splitValue[1], 32)
+        		if err != nil {
+        			return reflect.Value{}, fmt.Errorf(ErrParsingValue, v.Type, err)
+        		}
 
         		return reflect.ValueOf(complex(float32(realPart), float32(imaginaryPart))), nil
         	case "complex128":
-        		splittedValue := strings.Split(v.Value, complexPartsDelimiter)
-        		if len(splittedValue) != 2 {
-        			return reflect.Value{}, fmt.Errorf("not correct complex128 value")
+        		splitValue := strings.Split(v.Value, complexPartsDelimiter)
+        		if len(splitValue) != 2 {
+        			return reflect.Value{}, fmt.Errorf("not correct complex128 value: %s", v.Value)
         		}
 
-        		realPart, err := strconv.ParseFloat(splittedValue[0], 64)
-        		__checkErrorAndExit__(err)
+        		realPart, err := strconv.ParseFloat(splitValue[0], 64)
+        		if err != nil {
+        			return reflect.Value{}, fmt.Errorf(ErrParsingValue, v.Type, err)
+        		}
 
-        		imaginaryPart, err := strconv.ParseFloat(splittedValue[1], 64)
-        		__checkErrorAndExit__(err)
+        		imaginaryPart, err := strconv.ParseFloat(splitValue[1], 64)
+        		if err != nil {
+        			return reflect.Value{}, fmt.Errorf(ErrParsingValue, v.Type, err)
+        		}
 
         		return reflect.ValueOf(complex(realPart, imaginaryPart)), nil
         	case "string":
         		return reflect.ValueOf(v.Value), nil
         	case "uintptr":
         		value, err := strconv.ParseUint(v.Value, 10, strconv.IntSize)
-        		__checkErrorAndExit__(err)
+        		if err != nil {
+        			return reflect.Value{}, fmt.Errorf(ErrParsingValue, v.Type, err)
+        		}
 
         		return reflect.ValueOf(uintptr(value)), nil
         	}
-        	return reflect.Value{}, fmt.Errorf("primitive type '%s' is not supported", v.Type)
+        	return reflect.Value{}, fmt.Errorf("unsupported primitive type: '%s'", v.Type)
         }
     """.trimIndent()
 
@@ -162,7 +211,9 @@ object GoCodeTemplates {
     private val structValueToReflectValueMethod = """
         func (v __StructValue__) __toReflectValue__() (reflect.Value, error) {
         	structType, err := __convertStringToReflectType__(v.Type)
-        	__checkErrorAndExit__(err)
+        	if err != nil {
+        		return reflect.Value{}, fmt.Errorf(ErrStringToReflectTypeFailure, v.Type, err)
+        	}
 
         	structPtr := reflect.New(structType)
 
@@ -170,8 +221,10 @@ object GoCodeTemplates {
         		field := structPtr.Elem().FieldByName(f.Name)
 
         		reflectValue, err := f.Value.__toReflectValue__()
-        		__checkErrorAndExit__(err)
-        		
+        		if err != nil {
+        			return reflect.Value{}, fmt.Errorf(ErrRawValueToReflectValueFailure, err)
+        		}
+
         		if field.Type().Kind() == reflect.Uintptr {
         			reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().SetUint(reflectValue.Uint())
         		} else {
@@ -195,7 +248,9 @@ object GoCodeTemplates {
     private val arrayValueToReflectValueMethod = """
         func (v __ArrayValue__) __toReflectValue__() (reflect.Value, error) {
         	elementType, err := __convertStringToReflectType__(v.ElementType)
-        	__checkErrorAndExit__(err)
+        	if err != nil {
+        		return reflect.Value{}, fmt.Errorf(ErrStringToReflectTypeFailure, v.ElementType, err)
+        	}
 
         	arrayType := reflect.ArrayOf(v.Length, elementType)
         	arrayPtr := reflect.New(arrayType)
@@ -204,7 +259,9 @@ object GoCodeTemplates {
         		element := arrayPtr.Elem().Index(i)
 
         		reflectValue, err := v.Value[i].__toReflectValue__()
-        		__checkErrorAndExit__(err)
+        		if err != nil {
+        			return reflect.Value{}, fmt.Errorf(ErrRawValueToReflectValueFailure, err)
+        		}
 
         		element.Set(reflectValue)
         	}
@@ -225,7 +282,9 @@ object GoCodeTemplates {
     private val sliceValueToReflectValueMethod = """
         func (v __SliceValue__) __toReflectValue__() (reflect.Value, error) {
         	elementType, err := __convertStringToReflectType__(v.ElementType)
-        	__checkErrorAndExit__(err)
+        	if err != nil {
+        		return reflect.Value{}, fmt.Errorf(ErrStringToReflectTypeFailure, v.ElementType, err)
+        	}
 
         	sliceType := reflect.SliceOf(elementType)
         	slice := reflect.MakeSlice(sliceType, v.Length, v.Length)
@@ -236,7 +295,9 @@ object GoCodeTemplates {
         		element := slicePtr.Elem().Index(i)
 
         		reflectValue, err := v.Value[i].__toReflectValue__()
-        		__checkErrorAndExit__(err)
+        		if err != nil {
+        			return reflect.Value{}, fmt.Errorf(ErrRawValueToReflectValueFailure, err)
+        		}
 
         		element.Set(reflectValue)
         	}
@@ -254,7 +315,9 @@ object GoCodeTemplates {
     private val nilValueToReflectValueMethod = """
         func (v __NilValue__) __toReflectValue__() (reflect.Value, error) {
         	typ, err := __convertStringToReflectType__(v.Type)
-        	__checkErrorAndExit__(err)
+        	if err != nil {
+        		return reflect.Value{}, fmt.Errorf(ErrStringToReflectTypeFailure, v.Type, err)
+        	}
 
         	return reflect.Zero(typ), nil
         }
@@ -270,10 +333,14 @@ object GoCodeTemplates {
     private val namedValueToReflectValueMethod = """
         func (v __NamedValue__) __toReflectValue__() (reflect.Value, error) {
         	value, err := v.Value.__toReflectValue__()
-        	__checkErrorAndExit__(err)
+        	if err != nil {
+        		return reflect.Value{}, fmt.Errorf(ErrRawValueToReflectValueFailure, err)
+        	}
 
         	typ, err := __convertStringToReflectType__(v.Type)
-        	__checkErrorAndExit__(err)
+        	if err != nil {
+        		return reflect.Value{}, fmt.Errorf(ErrStringToReflectTypeFailure, v.Type, err)
+        	}
 
         	return value.Convert(typ), nil
         }
@@ -300,7 +367,7 @@ object GoCodeTemplates {
 
         		res, err := __convertStringToReflectType__(typeName[index+1:])
         		if err != nil {
-        			return nil, err
+        			return nil, fmt.Errorf("not correct type name '%s'", typeName)
         		}
 
         		result = reflect.SliceOf(res)
@@ -318,7 +385,7 @@ object GoCodeTemplates {
 
         		res, err := __convertStringToReflectType__(typeName[index+1:])
         		if err != nil {
-        			return nil, err
+        			return nil, fmt.Errorf(ErrStringToReflectTypeFailure, typeName[index+1:], err)
         		}
 
         		result = reflect.ArrayOf(length, res)
@@ -393,11 +460,17 @@ object GoCodeTemplates {
         }
     """.trimIndent()
 
-    private val checkErrorFunction = """
-        func __checkErrorAndExit__(err error) {
+    private val convertReflectValueOfDefinedTypeToRawValueFunction = """
+        func __convertReflectValueOfDefinedTypeToRawValue__(v reflect.Value) (__RawValue__, error) {
+        	value, err := __convertReflectValueOfPredeclaredOrNotDefinedTypeToRawValue__(v)
         	if err != nil {
-        		log.Fatal(err)
+        		return nil, fmt.Errorf(ErrReflectValueToRawValueFailure, err)
         	}
+
+        	return __NamedValue__{
+        		Type:  v.Type().Name(),
+        		Value: value,
+        	}, nil
         }
     """.trimIndent()
 
@@ -419,55 +492,56 @@ object GoCodeTemplates {
         }
     """.trimIndent()
 
-    private val convertReflectValueToRawValueFunction = """
-        //goland:noinspection GoPreferNilSlice
-        func __convertReflectValueToRawValue__(valueOfRes reflect.Value) (__RawValue__, error) {
+    private val convertReflectValueOfPredeclaredOrNotDefinedTypeToRawValueFunction = """
+        func __convertReflectValueOfPredeclaredOrNotDefinedTypeToRawValue__(v reflect.Value) (__RawValue__, error) {
         	const outputComplexPartsDelimiter = "@"
 
-        	switch valueOfRes.Kind() {
+        	switch v.Kind() {
         	case reflect.Bool:
         		return __PrimitiveValue__{
-        			Type:  valueOfRes.Kind().String(),
-        			Value: fmt.Sprintf("%#v", valueOfRes.Bool()),
+        			Type:  v.Kind().String(),
+        			Value: fmt.Sprintf("%#v", v.Bool()),
         		}, nil
         	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
         		return __PrimitiveValue__{
-        			Type:  valueOfRes.Kind().String(),
-        			Value: fmt.Sprintf("%#v", valueOfRes.Int()),
+        			Type:  v.Kind().String(),
+        			Value: fmt.Sprintf("%#v", v.Int()),
         		}, nil
         	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
         		return __PrimitiveValue__{
-        			Type:  valueOfRes.Kind().String(),
-        			Value: fmt.Sprintf("%v", valueOfRes.Uint()),
+        			Type:  v.Kind().String(),
+        			Value: fmt.Sprintf("%v", v.Uint()),
         		}, nil
         	case reflect.Float32, reflect.Float64:
         		return __PrimitiveValue__{
-        			Type:  valueOfRes.Kind().String(),
-        			Value: __convertFloat64ValueToString__(valueOfRes.Float()),
+        			Type:  v.Kind().String(),
+        			Value: __convertFloat64ValueToString__(v.Float()),
         		}, nil
         	case reflect.Complex64, reflect.Complex128:
-        		value := valueOfRes.Complex()
+        		value := v.Complex()
         		realPartString := __convertFloat64ValueToString__(real(value))
         		imagPartString := __convertFloat64ValueToString__(imag(value))
         		return __PrimitiveValue__{
-        			Type:  valueOfRes.Kind().String(),
+        			Type:  v.Kind().String(),
         			Value: fmt.Sprintf("%v%v%v", realPartString, outputComplexPartsDelimiter, imagPartString),
         		}, nil
         	case reflect.String:
         		return __PrimitiveValue__{
         			Type:  reflect.String.String(),
-        			Value: fmt.Sprintf("%v", valueOfRes.String()),
+        			Value: fmt.Sprintf("%v", v.String()),
         		}, nil
         	case reflect.Struct:
-        		fields := reflect.VisibleFields(valueOfRes.Type())
-        		resultValues := make([]__FieldValue__, 0, valueOfRes.NumField())
+        		fields := reflect.VisibleFields(v.Type())
+        		resultValues := make([]__FieldValue__, 0, v.NumField())
         		for _, field := range fields {
         			if len(field.Index) != 1 {
         				continue
         			}
 
-        			res, err := __convertReflectValueToRawValue__(valueOfRes.FieldByName(field.Name))
-        			__checkErrorAndExit__(err)
+        			res, err := __convertReflectValueToRawValue__(v.FieldByName(field.Name))
+        			if err != nil {
+        				return nil, fmt.Errorf(ErrReflectValueToRawValueFailure, err)
+        			}
 
         			resultValues = append(resultValues, __FieldValue__{
         				Name:       field.Name,
@@ -476,16 +550,18 @@ object GoCodeTemplates {
         			})
         		}
         		return __StructValue__{
-        			Type:  valueOfRes.Type().String(),
+        			Type:  "struct{}",
         			Value: resultValues,
         		}, nil
         	case reflect.Array:
-        		elem := valueOfRes.Type().Elem()
+        		elem := v.Type().Elem()
         		elementType := elem.String()
-        		arrayElementValues := []__RawValue__{}
-        		for i := 0; i < valueOfRes.Len(); i++ {
-        			arrayElementValue, err := __convertReflectValueToRawValue__(valueOfRes.Index(i))
-        			__checkErrorAndExit__(err)
+        		arrayElementValues := make([]__RawValue__, 0, v.Len())
+        		for i := 0; i < v.Len(); i++ {
+        			arrayElementValue, err := __convertReflectValueToRawValue__(v.Index(i))
+        			if err != nil {
+        				return nil, fmt.Errorf(ErrReflectValueToRawValueFailure, err)
+        			}
 
         			arrayElementValues = append(arrayElementValues, arrayElementValue)
         		}
@@ -497,42 +573,61 @@ object GoCodeTemplates {
         			Value:       arrayElementValues,
         		}, nil
         	case reflect.Slice:
-        		if valueOfRes.IsNil() {
-        			return nil, nil
+        		if v.IsNil() {
+        			return __NilValue__{Type: "nil"}, nil
         		}
-        		elem := valueOfRes.Type().Elem()
+        		elem := v.Type().Elem()
         		elementType := elem.String()
-        		sliceElementValues := []__RawValue__{}
-        		for i := 0; i < valueOfRes.Len(); i++ {
-        			sliceElementValue, err := __convertReflectValueToRawValue__(valueOfRes.Index(i))
-        			__checkErrorAndExit__(err)
+        		typeName := fmt.Sprintf("[]%s", elementType)
+        		sliceElementValues := make([]__RawValue__, v.Len())
+        		for i := 0; i < v.Len(); i++ {
+        			sliceElementValue, err := __convertReflectValueToRawValue__(v.Index(i))
+        			if err != nil {
+        				return nil, fmt.Errorf(ErrReflectValueToRawValueFailure, err)
+        			}
 
         			sliceElementValues = append(sliceElementValues, sliceElementValue)
         		}
         		length := len(sliceElementValues)
         		return __SliceValue__{
-        			Type:        fmt.Sprintf("[]%s", elementType),
+        			Type:        typeName,
         			ElementType: elementType,
         			Length:      length,
         			Value:       sliceElementValues,
         		}, nil
         	case reflect.Interface:
-        		if valueOfRes.Interface() == nil {
-        			return nil, nil
+        		if v.Interface() == nil {
+        			return __NilValue__{Type: "nil"}, nil
         		}
-        		if e, ok := valueOfRes.Interface().(error); ok {
-        			return __convertReflectValueToRawValue__(reflect.ValueOf(e.Error()))
+        		if e, ok := v.Interface().(error); ok {
+        			value, err := __convertReflectValueToRawValue__(reflect.ValueOf(e.Error()))
+        			if err != nil {
+        				return nil, fmt.Errorf(ErrReflectValueToRawValueFailure, err)
+        			}
+        			return __NamedValue__{
+        				Type:  "error",
+        				Value: value,
+        			}, nil
         		}
-        		return nil, errors.New("unsupported result type: " + valueOfRes.Type().String())
+        		return nil, fmt.Errorf("unsupported result type: %s", v.Type().String())
         	default:
-        		return nil, errors.New("unsupported result type: " + valueOfRes.Type().String())
+        		return nil, fmt.Errorf("unsupported result type: %s", v.Type().String())
         	}
+        }
+    """.trimIndent()
+
+    private val convertReflectValueToRawValueFunction = """
+        func __convertReflectValueToRawValue__(v reflect.Value) (__RawValue__, error) {
+        	if v.Type().PkgPath() != "" {
+        		return __convertReflectValueOfDefinedTypeToRawValue__(v)
+        	}
+        	return __convertReflectValueOfPredeclaredOrNotDefinedTypeToRawValue__(v)
         }
     """.trimIndent()
 
     private fun executeFunctionFunction(maxTraceLength: Int) = """
         func __executeFunction__(
-        	timeout time.Duration, arguments []reflect.Value, wrappedFunction func([]reflect.Value) []__RawValue__,
+        	function reflect.Value, arguments []reflect.Value, timeout time.Duration,
         ) __RawExecutionResult__ {
         	ctxWithTimeout, cancel := context.WithTimeout(context.Background(), timeout)
         	defer cancel()
@@ -562,7 +657,10 @@ object GoCodeTemplates {
         				} else {
         					resultValue, err = __convertReflectValueToRawValue__(reflect.ValueOf(panicMessage))
         				}
-        				__checkErrorAndExit__(err)
+        				if err != nil {
+        					_, _ = fmt.Fprint(os.Stderr, ErrReflectValueToRawValueFailure, err)
+        					os.Exit(1)
+        				}
 
         				executionResult.PanicMessage = &__RawPanicMessage__{
         					RawResultValue:  resultValue,
@@ -574,7 +672,11 @@ object GoCodeTemplates {
         		}()
 
         		argumentsWithTrace := append(arguments, reflect.ValueOf(&trace))
-        		resultValues := wrappedFunction(argumentsWithTrace)
+        		resultValues, err := __wrapResultValues__(function.Call(argumentsWithTrace))
+        		if err != nil {
+        			_, _ = fmt.Fprintf(os.Stderr, "Failed to wrap result values: %s", err)
+        			os.Exit(1)
+        		}
         		executionResult.RawResultValues = resultValues
         		panicked = false
         	}()
@@ -594,63 +696,67 @@ object GoCodeTemplates {
     """.trimIndent()
 
     private val wrapResultValuesForWorkerFunction = """
-        //goland:noinspection GoPreferNilSlice
-        func __wrapResultValuesForUtBotGoWorker__(values []reflect.Value) []__RawValue__ {
-        	rawValues := []__RawValue__{}
+        func __wrapResultValues__(values []reflect.Value) ([]__RawValue__, error) {
+        	rawValues := make([]__RawValue__, 0, len(values))
         	for _, value := range values {
         		resultValue, err := __convertReflectValueToRawValue__(value)
-        		__checkErrorAndExit__(err)
+        		if err != nil {
+        			return nil, fmt.Errorf(ErrReflectValueToRawValueFailure, err)
+        		}
 
         		rawValues = append(rawValues, resultValue)
         	}
-        	return rawValues
+        	return rawValues, nil
         }
     """.trimIndent()
 
     private val convertRawValuesToReflectValuesFunction = """
-        //goland:noinspection GoPreferNilSlice
-        func __convertRawValuesToReflectValues__(values []__RawValue__) []reflect.Value {
-        	parameters := []reflect.Value{}
+        func __convertRawValuesToReflectValues__(values []__RawValue__) ([]reflect.Value, error) {
+        	parameters := make([]reflect.Value, 0, len(values))
 
         	for _, value := range values {
         		reflectValue, err := value.__toReflectValue__()
-        		__checkErrorAndExit__(err)
+        		if err != nil {
+        			return nil, fmt.Errorf("failed to convert RawValue %s to reflect.Value: %s", value, err)
+        		}
 
         		parameters = append(parameters, reflectValue)
         	}
 
-        	return parameters
+        	return parameters, nil
         }
     """.trimIndent()
 
     private val parseJsonToFunctionNameAndRawValuesFunction = """
-        //goland:noinspection GoPreferNilSlice
-        func __parseJsonToFunctionNameAndRawValues__(decoder *json.Decoder) (string, []__RawValue__, error) {
+        func __parseTestInput__(decoder *json.Decoder) (funcName string, rawValues []__RawValue__, err error) {
         	var testInput __TestInput__
-        	err := decoder.Decode(&testInput)
-        	if err == io.EOF {
-        		return "", nil, err
+        	err = decoder.Decode(&testInput)
+        	if err != nil {
+        		return
         	}
-        	__checkErrorAndExit__(err)
 
-        	result := make([]__RawValue__, 0)
+        	funcName = testInput.FunctionName
+        	rawValues = make([]__RawValue__, 0, 10)
         	for _, arg := range testInput.Arguments {
-        		rawValue, err := __convertParsedJsonToRawValue__(arg, "")
-        		__checkErrorAndExit__(err)
+        		var rawValue __RawValue__
 
-        		result = append(result, rawValue)
+        		rawValue, err = __parseRawValue__(arg, "")
+        		if err != nil {
+        			return "", nil, fmt.Errorf("failed to parse argument %s of function %s: %s", arg, funcName, err)
+        		}
+
+        		rawValues = append(rawValues, rawValue)
         	}
 
-        	return testInput.FunctionName, result, nil
+        	return
         }
     """.trimIndent()
 
     private val convertParsedJsonToRawValueFunction = """
-        //goland:noinspection GoPreferNilSlice
-        func __convertParsedJsonToRawValue__(rawValue map[string]interface{}, name string) (__RawValue__, error) {
+        func __parseRawValue__(rawValue map[string]interface{}, name string) (__RawValue__, error) {
         	typeName, ok := rawValue["type"]
         	if !ok {
-        		return nil, fmt.Errorf("every rawValue must contain field 'type'")
+        		return nil, fmt.Errorf("every RawValue must contain field 'type'")
         	}
         	typeNameStr, ok := typeName.(string)
         	if !ok {
@@ -670,13 +776,15 @@ object GoCodeTemplates {
 
         		value, ok := v.([]interface{})
         		if !ok {
-        			return nil, fmt.Errorf("structValue field 'value' must be array")
+        			return nil, fmt.Errorf("StructValue field 'value' must be array")
         		}
 
-        		values := []__FieldValue__{}
+        		values := make([]__FieldValue__, 0, len(value))
         		for _, v := range value {
-        			nextValue, err := __convertParsedJsonToFieldValue__(v.(map[string]interface{}))
-        			__checkErrorAndExit__(err)
+        			nextValue, err := __parseFieldValue__(v.(map[string]interface{}))
+        			if err != nil {
+        				return nil, fmt.Errorf("failed to parse field %s of struct: %s", v, err)
+        			}
 
         			values = append(values, nextValue)
         		}
@@ -690,30 +798,32 @@ object GoCodeTemplates {
         	case strings.HasPrefix(typeNameStr, "[]"):
         		elementType, ok := rawValue["elementType"]
         		if !ok {
-        			return nil, fmt.Errorf("sliceValue must contain field 'elementType'")
+        			return nil, fmt.Errorf("SliceValue must contain field 'elementType'")
         		}
         		elementTypeStr, ok := elementType.(string)
         		if !ok {
-        			return nil, fmt.Errorf("sliceValue field 'elementType' must be string")
+        			return nil, fmt.Errorf("SliceValue field 'elementType' must be string")
         		}
 
         		if _, ok := rawValue["length"]; !ok {
-        			return nil, fmt.Errorf("sliceValue must contain field 'length'")
+        			return nil, fmt.Errorf("SliceValue must contain field 'length'")
         		}
         		length, ok := rawValue["length"].(float64)
         		if !ok {
-        			return nil, fmt.Errorf("sliceValue field 'length' must be float64")
+        			return nil, fmt.Errorf("SliceValue field 'length' must be float64")
         		}
 
         		value, ok := v.([]interface{})
         		if !ok || len(value) != int(length) {
-        			return nil, fmt.Errorf("sliceValue field 'value' must be array of length %d", int(length))
+        			return nil, fmt.Errorf("SliceValue field 'value' must be array of length %d", int(length))
         		}
 
-        		values := []__RawValue__{}
-        		for _, v := range value {
-        			nextValue, err := __convertParsedJsonToRawValue__(v.(map[string]interface{}), "")
-        			__checkErrorAndExit__(err)
+        		values := make([]__RawValue__, 0, len(value))
+        		for i, v := range value {
+        			nextValue, err := __parseRawValue__(v.(map[string]interface{}), "")
+        			if err != nil {
+        				return nil, fmt.Errorf("failed to parse %d slice element: %s", i, err)
+        			}
 
         			values = append(values, nextValue)
         		}
@@ -727,30 +837,32 @@ object GoCodeTemplates {
         	case strings.HasPrefix(typeNameStr, "["):
         		elementType, ok := rawValue["elementType"]
         		if !ok {
-        			return nil, fmt.Errorf("arrayValue must contain field 'elementType")
+        			return nil, fmt.Errorf("ArrayValue must contain field 'elementType")
         		}
         		elementTypeStr, ok := elementType.(string)
         		if !ok {
-        			return nil, fmt.Errorf("arrayValue field 'elementType' must be string")
+        			return nil, fmt.Errorf("ArrayValue field 'elementType' must be string")
         		}
 
         		if _, ok := rawValue["length"]; !ok {
-        			return nil, fmt.Errorf("arrayValue must contain field 'length'")
+        			return nil, fmt.Errorf("ArrayValue must contain field 'length'")
         		}
         		length, ok := rawValue["length"].(float64)
         		if !ok {
-        			return nil, fmt.Errorf("arrayValue field 'length' must be float64")
+        			return nil, fmt.Errorf("ArrayValue field 'length' must be float64")
         		}
 
         		value, ok := v.([]interface{})
         		if !ok || len(value) != int(length) {
-        			return nil, fmt.Errorf("arrayValue field 'value' must be array of length %d", int(length))
+        			return nil, fmt.Errorf("ArrayValue field 'value' must be array of length %d", int(length))
         		}
 
-        		values := []__RawValue__{}
-        		for _, v := range value {
-        			nextValue, err := __convertParsedJsonToRawValue__(v.(map[string]interface{}), "")
-        			__checkErrorAndExit__(err)
+        		values := make([]__RawValue__, 0, len(value))
+        		for i, v := range value {
+        			nextValue, err := __parseRawValue__(v.(map[string]interface{}), "")
+        			if err != nil {
+        				return nil, fmt.Errorf("failed to parse %d array element: %s", i, err)
+        			}
 
         			values = append(values, nextValue)
         		}
@@ -766,7 +878,7 @@ object GoCodeTemplates {
         		case "bool", "rune", "int", "int8", "int16", "int32", "int64", "byte", "uint", "uint8", "uint16", "uint32", "uint64", "float32", "float64", "complex64", "complex128", "string", "uintptr":
         			value, ok := v.(string)
         			if !ok {
-        				return nil, fmt.Errorf("primitiveValue field 'value' must be string")
+        				return nil, fmt.Errorf("PrimitiveValue field 'value' must be string")
         			}
 
         			return __PrimitiveValue__{
@@ -774,8 +886,10 @@ object GoCodeTemplates {
         				Value: value,
         			}, nil
         		default: // named type
-        			value, err := __convertParsedJsonToRawValue__(v.(map[string]interface{}), typeNameStr)
-        			__checkErrorAndExit__(err)
+        			value, err := __parseRawValue__(v.(map[string]interface{}), typeNameStr)
+        			if err != nil {
+        				return nil, fmt.Errorf("failed to parse of NamedValue with type %s: %s", typeNameStr, err)
+        			}
 
         			return __NamedValue__{
         				Type:  typeNameStr,
@@ -787,30 +901,32 @@ object GoCodeTemplates {
     """.trimIndent()
 
     private val convertParsedJsonToFieldValueFunction = """
-        func __convertParsedJsonToFieldValue__(p map[string]interface{}) (__FieldValue__, error) {
+        func __parseFieldValue__(p map[string]interface{}) (__FieldValue__, error) {
         	name, ok := p["name"]
         	if !ok {
-        		return __FieldValue__{}, fmt.Errorf("fieldValue must contain field 'name'")
+        		return __FieldValue__{}, fmt.Errorf("FieldValue must contain field 'name'")
         	}
         	nameStr, ok := name.(string)
         	if !ok {
-        		return __FieldValue__{}, fmt.Errorf("fieldValue 'name' must be string")
+        		return __FieldValue__{}, fmt.Errorf("FieldValue 'name' must be string")
+        	}
+
+        	if _, ok := p["value"]; !ok {
+        		return __FieldValue__{}, fmt.Errorf("FieldValue must contain field 'value'")
+        	}
+        	value, err := __parseRawValue__(p["value"].(map[string]interface{}), "")
+        	if err != nil {
+        		return __FieldValue__{}, err
         	}
 
         	isExported, ok := p["isExported"]
         	if !ok {
-        		return __FieldValue__{}, fmt.Errorf("fieldValue must contain field 'isExported'")
+        		return __FieldValue__{}, fmt.Errorf("FieldValue must contain field 'isExported'")
         	}
         	isExportedBool, ok := isExported.(bool)
         	if !ok {
-        		return __FieldValue__{}, fmt.Errorf("fieldValue 'isExported' must be bool")
+        		return __FieldValue__{}, fmt.Errorf("FieldValue 'isExported' must be bool")
         	}
-
-        	if _, ok := p["value"]; !ok {
-        		return __FieldValue__{}, fmt.Errorf("fieldValue must contain field 'value'")
-        	}
-        	value, err := __convertParsedJsonToRawValue__(p["value"].(map[string]interface{}), "")
-        	__checkErrorAndExit__(err)
 
         	return __FieldValue__{
         		Name:       nameStr,
@@ -826,6 +942,7 @@ object GoCodeTemplates {
         aliases: Map<GoPackage, String?>,
         maxTraceLength: Int,
     ) = listOf(
+        errorMessages,
         testInputStruct,
         rawValueInterface,
         primitiveValueStruct,
@@ -844,8 +961,9 @@ object GoCodeTemplates {
         convertStringToReflectType(namedTypes, destinationPackage, aliases),
         panicMessageStruct,
         rawExecutionResultStruct,
-        checkErrorFunction,
+        convertReflectValueOfDefinedTypeToRawValueFunction,
         convertFloat64ValueToStringFunction,
+        convertReflectValueOfPredeclaredOrNotDefinedTypeToRawValueFunction,
         convertReflectValueToRawValueFunction,
         executeFunctionFunction(maxTraceLength),
         wrapResultValuesForWorkerFunction,

--- a/utbot-go/src/main/kotlin/org/utbot/go/worker/GoWorkerCodeGenerationHelper.kt
+++ b/utbot-go/src/main/kotlin/org/utbot/go/worker/GoWorkerCodeGenerationHelper.kt
@@ -14,11 +14,10 @@ internal object GoWorkerCodeGenerationHelper {
 
     val alwaysRequiredImports = setOf(
         GoPackage("io", "io"),
+        GoPackage("os", "os"),
         GoPackage("context", "context"),
         GoPackage("json", "encoding/json"),
-        GoPackage("errors", "errors"),
         GoPackage("fmt", "fmt"),
-        GoPackage("log", "log"),
         GoPackage("math", "math"),
         GoPackage("net", "net"),
         GoPackage("reflect", "reflect"),
@@ -122,24 +121,40 @@ internal object GoWorkerCodeGenerationHelper {
         return """
             func $workerTestFunctionName(t *testing.T) {
             	con, err := net.Dial("tcp", ":$port")
-            	__checkErrorAndExit__(err)
+            	if err != nil {
+            		_, _ = fmt.Fprintf(os.Stderr, "Connection to server failed: %s", err)
+            		os.Exit(1)
+            	}
 
             	defer func() {
-            		err := con.Close()
+            		err = con.Close()
             		if err != nil {
-            			__checkErrorAndExit__(err)
+            			_, _ = fmt.Fprintf(os.Stderr, "Closing connection failed: %s", err)
+            			os.Exit(1)
             		}
             	}()
 
             	jsonDecoder := json.NewDecoder(con)
             	for {
-            		funcName, rawValues, err := __parseJsonToFunctionNameAndRawValues__(jsonDecoder)
+            		var (
+            			funcName  string
+            			rawValues []__RawValue__
+            		)
+            		funcName, rawValues, err = __parseTestInput__(jsonDecoder)
             		if err == io.EOF {
             			break
             		}
-            		__checkErrorAndExit__(err)
+            		if err != nil {
+            			_, _ = fmt.Fprintf(os.Stderr, "Failed to parse test input: %s", err)
+            			os.Exit(1)
+            		}
 
-            		arguments := __convertRawValuesToReflectValues__(rawValues)
+            		var arguments []reflect.Value
+            		arguments, err = __convertRawValuesToReflectValues__(rawValues)
+            		if err != nil {
+            			_, _ = fmt.Fprintf(os.Stderr, "Failed to convert slice of RawValue to slice of reflect.Value: %s", err)
+            			os.Exit(1)
+            		}
 
             		var function reflect.Value
             		switch funcName {
@@ -149,21 +164,30 @@ internal object GoWorkerCodeGenerationHelper {
             }
         }
             		default:
-            			panic(fmt.Sprintf("no function with that name: %s", funcName))
+            			_, _ = fmt.Fprintf(os.Stderr, "Function %s not found", funcName)
+            			os.Exit(1)
             		}
 
-            		executionResult := __executeFunction__($eachExecutionTimeoutMillis*time.Millisecond, arguments, func(arguments []reflect.Value) []__RawValue__ {
-            			return __wrapResultValuesForUtBotGoWorker__(function.Call(arguments))
-            		})
+            		executionResult := __executeFunction__(function, arguments, $eachExecutionTimeoutMillis*time.Millisecond)
 
-            		jsonBytes, toJsonErr := json.MarshalIndent(executionResult, "", "  ")
-            		__checkErrorAndExit__(toJsonErr)
+            		var jsonBytes []byte
+            		jsonBytes, err = json.Marshal(executionResult)
+            		if err != nil {
+            			_, _ = fmt.Fprintf(os.Stderr, "Failed to serialize execution result to json: %s", err)
+            			os.Exit(1)
+            		}
 
             		_, err = con.Write([]byte(strconv.Itoa(len(jsonBytes)) + "\n"))
-            		__checkErrorAndExit__(err)
+            		if err != nil {
+            			_, _ = fmt.Fprintf(os.Stderr, "Failed to send length of execution result: %s", err)
+            			os.Exit(1)
+            		}
 
             		_, err = con.Write(jsonBytes)
-            		__checkErrorAndExit__(err)
+            		if err != nil {
+            			_, _ = fmt.Fprintf(os.Stderr, "Failed to send execution result: %s", err)
+            			os.Exit(1)
+            		}
             	}
             }
         """.trimIndent()

--- a/utbot-go/src/main/kotlin/org/utbot/go/worker/RawExecutionResults.kt
+++ b/utbot-go/src/main/kotlin/org/utbot/go/worker/RawExecutionResults.kt
@@ -73,7 +73,7 @@ data class RawPanicMessage(
 
 data class RawExecutionResult(
     val timeoutExceeded: Boolean,
-    val rawResultValues: List<RawValue?>,
+    val rawResultValues: List<RawValue>,
     val panicMessage: RawPanicMessage?,
     val trace: List<Int>
 )
@@ -109,7 +109,7 @@ fun convertRawExecutionResultToExecutionResult(
     }
     var executedWithNonNilErrorString = false
     val resultValues = rawExecutionResult.rawResultValues.zip(functionResultTypes).map { (rawResultValue, resultType) ->
-        if (resultType.implementsError && rawResultValue != null) {
+        if (resultType.implementsError) {
             executedWithNonNilErrorString = true
         }
         createGoUtModelFromRawValue(rawResultValue, resultType, intSize)
@@ -122,7 +122,7 @@ fun convertRawExecutionResultToExecutionResult(
 }
 
 private fun createGoUtModelFromRawValue(
-    rawValue: RawValue?, typeId: GoTypeId, intSize: Int
+    rawValue: RawValue, typeId: GoTypeId, intSize: Int
 ): GoUtModel = if (rawValue is NilValue) {
     GoUtNilModel(typeId)
 } else {

--- a/utbot-go/src/main/resources/go_source_code_analyzer/analysis_results.go
+++ b/utbot-go/src/main/resources/go_source_code_analyzer/analysis_results.go
@@ -77,6 +77,16 @@ type AnalyzedFunctionParameter struct {
 	Type AnalyzedType `json:"type"`
 }
 
+type AnalyzedMapType struct {
+	Name        string       `json:"name"`
+	KeyType     AnalyzedType `json:"keyType"`
+	ElementType AnalyzedType `json:"elementType"`
+}
+
+func (t AnalyzedMapType) GetName() string {
+	return t.Name
+}
+
 type AnalyzedFunction struct {
 	Name                                string                      `json:"name"`
 	ModifiedName                        string                      `json:"modifiedName"`


### PR DESCRIPTION
## Description

* Deleted RawValue method `checkIsEqualTypes`
* Refactored the Go code
* Added logging of the number of function executions
* Added support for maps

## How to test

### Manual tests

```Go
type Structure struct {
	int
	int8
	int16
	int32
	int64
	uint
	uint8
	uint16
	uint32
	uint64
	uintptr
	float32
	float64
	complex64
	complex128
	byte
	rune
	string
	bool
}

type Type byte

type NA [5]uintptr

type NS []int

func Map(table map[string]int) map[string]int {
	return table
}

func MapOfStructures(table map[Structure]Structure) map[Structure]Structure {
	return table
}

func MapOfSliceOfInt(table map[string][]int) map[string][]int {
	return table
}

func MapOfNamedType(table map[int]Type) map[int]Type {
	return table
}

func MapOfNamedSlice(table map[uint]NS) map[uint]NS {
	return table
}

type NM map[string]NA

func NamedMap(n NM) NM {
	return n
}

```

## Self-check list

Check off the item if the statement is true. Hint: [x] is a marked item.

Please do not delete the list or its items.

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.