### PR TITLE
Improve UtBotBeanFactoryPostProcessor to get more bean definitions

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -61,7 +61,6 @@ import org.utbot.framework.plugin.api.TypeReplacementMode.*
 import org.utbot.framework.plugin.api.util.allDeclaredFieldIds
 import org.utbot.framework.plugin.api.util.fieldId
 import org.utbot.framework.plugin.api.util.isSubtypeOf
-import org.utbot.framework.plugin.api.util.objectClassId
 import org.utbot.framework.plugin.api.util.utContext
 import org.utbot.framework.process.OpenModulesContainer
 import soot.SootField
@@ -1276,7 +1275,7 @@ class SpringApplicationContext(
     private val springInjectedClasses: Set<ClassId>
         get() {
             if (!areInjectedClassesInitialized) {
-                springInjectedClassesStorage += beanQualifiedNames
+                _springInjectedClasses += beanQualifiedNames
                     .map { fqn -> utContext.classLoader.loadClass(fqn) }
                     .filterNot { it.isAbstract || it.isInterface || it.isLocalClass || it.isMemberClass && !it.isStatic }
                     .mapTo(mutableSetOf()) { it.id }
@@ -1286,7 +1285,7 @@ class SpringApplicationContext(
                 areInjectedClassesInitialized = true
             }
 
-            return springInjectedClassesStorage
+            return _springInjectedClasses
         }
 
     // This is a service field to model the lazy behavior of [springInjectedClasses].
@@ -1294,7 +1293,7 @@ class SpringApplicationContext(
     //
     // Actually, we should just call [springInjectedClasses] with `by lazy`, but  we had problems
     // with a strange `kotlin.UNINITIALIZED_VALUE` in `speculativelyCannotProduceNullPointerException` method call.
-    private val springInjectedClassesStorage = mutableSetOf<ClassId>()
+    private val _springInjectedClasses = mutableSetOf<ClassId>()
 
     override val typeReplacementMode: TypeReplacementMode =
         if (shouldUseImplementors) KnownImplementor else NoImplementors

--- a/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/postProcessors/UtBotBeanFactoryPostProcessor.kt
+++ b/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/postProcessors/UtBotBeanFactoryPostProcessor.kt
@@ -28,27 +28,13 @@ object UtBotBeanFactoryPostProcessor : BeanFactoryPostProcessor, PriorityOrdered
         println("Finished post-processing bean factory in UtBot")
     }
 
-    private fun findBeanClassNames(beanFactory: ConfigurableListableBeanFactory): ArrayList<String> {
-        val beanClassNames = ArrayList<String>()
-        for (beanDefinitionName in beanFactory.beanDefinitionNames) {
-            val beanDefinition = beanFactory.getBeanDefinition(beanDefinitionName)
-
-            if (beanDefinition is AnnotatedBeanDefinition) {
-                val factoryMethodMetadata = beanDefinition.factoryMethodMetadata
-                if (factoryMethodMetadata != null) {
-                    beanClassNames.add(factoryMethodMetadata.returnTypeName)
-                }
-            } else {
-                var className = beanDefinition.beanClassName
-                if (className == null) {
-                    className = beanFactory.getBean(beanDefinitionName).javaClass.name
-                }
-                className?.let { beanClassNames.add(it) }
-            }
+    private fun findBeanClassNames(beanFactory: ConfigurableListableBeanFactory): List<String> =
+        beanFactory.beanDefinitionNames.map {
+            beanFactory.getBeanDefinition(it).beanClassName
+                // TODO: avoid getting bean and use methodName + declaringClass from previous implementation
+                //  and use it to find return type from PsiMethod return expressions in utbot main process.
+                ?: beanFactory.getBean(it)::class.java.name
         }
-
-        return beanClassNames
-    }
 
     private fun destroyBeanDefinitions(beanFactory: ConfigurableListableBeanFactory) {
         for (beanDefinitionName in beanFactory.beanDefinitionNames) {


### PR DESCRIPTION
## Description

UtBotBeanFactoryPostProcessor had some problems with situations like:

```java
@Bean
public MyInterface initBean() {
   return new MyInterfaceImpl();
}
```

Actual bean type to return is `MyInterfaceImpl`, but previous implementation returned `MyInterface`.

This version should be replaced with something that does not call `getBean` later. Some details are provided in `TODO` in code.


## How to test

Should not be tested as a separate feature, just as a part of 1st phase approach with selected configuration.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.