### PR TITLE
Fix *test/resources* directory creation

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -153,7 +153,7 @@ import java.io.File
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.*
-import kotlin.io.path.exists
+import kotlin.io.path.notExists
 
 private const val RECENTS_KEY = "org.utbot.recents"
 
@@ -893,10 +893,10 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
         val mockitoExtensionsPath = "$testResourcesPath/$MOCKITO_EXTENSIONS_FOLDER".toPath()
         val mockitoMockMakerPath = "$mockitoExtensionsPath/$MOCKITO_MOCKMAKER_FILE_NAME".toPath()
 
-        if (!testResourcesPath.exists()) Files.createDirectory(testResourcesPath)
-        if (!mockitoExtensionsPath.exists()) Files.createDirectory(mockitoExtensionsPath)
+        if (testResourcesPath.notExists()) Files.createDirectories(testResourcesPath)
+        if (mockitoExtensionsPath.notExists()) Files.createDirectories(mockitoExtensionsPath)
 
-        if (!mockitoMockMakerPath.exists()) {
+        if (mockitoMockMakerPath.notExists()) {
             Files.createFile(mockitoMockMakerPath)
             Files.write(mockitoMockMakerPath, listOf(MOCKITO_EXTENSIONS_FILE_CONTENT))
         }


### PR DESCRIPTION
## Description

This PR fixes the crash when *test* directory is missing in project.

Fixes #2135

## How to test

### Automated tests

Manual testing only.
Reproduce the steps from the issue.