### PR TITLE
Enable Fuzzer in Spring no-config test generation

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestFlow.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestFlow.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.flattenConcat
 import kotlinx.coroutines.flow.flowOf
 import org.utbot.engine.UtBotSymbolicEngine
 import org.utbot.framework.UtSettings
+import org.utbot.framework.process.generated.GenerateParams
 
 /**
  * Constructs [TestFlow] for customization and creates flow producer.
@@ -27,11 +28,11 @@ fun defaultTestFlow(timeout: Long) = testFlow {
 /**
  * Creates default flow for Spring application.
  */
-fun defaultSpringFlow(timeout: Long) = testFlow {
+fun defaultSpringFlow(params: GenerateParams) = testFlow {
+    generationTimeout = params.generationTimeout
     isSymbolicEngineEnabled = true
-    generationTimeout = timeout
-    isFuzzingEnabled = false
-    fuzzingValue = 0.0
+    isFuzzingEnabled = params.isFuzzingEnabled
+    fuzzingValue = params.fuzzingValue
 }
 
 /**

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineProcessMain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineProcessMain.kt
@@ -1,8 +1,6 @@
 package org.utbot.framework.process
 
 import com.jetbrains.rd.framework.IProtocol
-import com.jetbrains.rd.util.Logger
-import com.jetbrains.rd.util.lifetime.Lifetime
 import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
 import org.utbot.analytics.AnalyticsConfigureUtil
@@ -31,9 +29,7 @@ import org.utbot.instrumentation.util.KryoHelper
 import org.utbot.rd.IdleWatchdog
 import org.utbot.rd.ClientProtocolBuilder
 import org.utbot.rd.RdSettingsContainerFactory
-import org.utbot.rd.findRdPort
 import org.utbot.rd.generated.settingsModel
-import org.utbot.rd.loggers.UtRdKLoggerFactory
 import org.utbot.rd.terminateOnException
 import org.utbot.sarif.RdSourceFindingStrategyFacade
 import org.utbot.sarif.SarifReport
@@ -113,7 +109,7 @@ private fun EngineProcessModel.setup(kryoHelper: KryoHelper, watchdog: IdleWatch
         val methods: List<ExecutableId> = kryoHelper.readObject(params.methods)
         logger.debug().measureTime({ "starting generation for ${methods.size} methods, starting with ${methods.first()}" }) {
             val generateFlow = when (testGenerator.applicationContext) {
-                is SpringApplicationContext -> defaultSpringFlow(params.generationTimeout)
+                is SpringApplicationContext -> defaultSpringFlow(params)
                 is ApplicationContext -> testFlow {
                     generationTimeout = params.generationTimeout
                     isSymbolicEngineEnabled = params.isSymbolicEngineEnabled

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -352,6 +352,10 @@ object UtTestsDialogProcessor {
                                             )
                                         }, 0, 500, TimeUnit.MILLISECONDS)
                                     try {
+                                        val useFuzzing = when (model.projectType) {
+                                            Spring -> model.typeReplacementApproach == DoNotReplace
+                                            else -> UtSettings.useFuzzing
+                                        }
                                         val rdGenerateResult = process.generate(
                                             model.conflictTriggers,
                                             methods,
@@ -360,7 +364,7 @@ object UtTestsDialogProcessor {
                                             model.timeout,
                                             model.timeout,
                                             true,
-                                            UtSettings.useFuzzing,
+                                            useFuzzing,
                                             project.service<Settings>().fuzzingValue,
                                             searchDirectory.pathString
                                         )


### PR DESCRIPTION
## Description

This PR allows using Fuzzer in Spring projects when user decided to generate tests with <ins>**no configuration**</ins>.

Fixes #2155