### PR TITLE
Correct annotations in TestNg and cleanup code

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
@@ -277,17 +277,17 @@ object TestNg : TestFramework(id = "TestNG",displayName = "TestNG") {
         simpleName = "Test"
     )
 
-    override val beforeMethod = "@${mainPackage}.BeforeMethod"
-    override val beforeMethodFqn = "${mainPackage}.BeforeMethod"
+    override val beforeMethod = "@$mainPackage.BeforeMethod"
+    override val beforeMethodFqn = "$mainPackage.BeforeMethod"
     override val beforeMethodId = BuiltinClassId(
-        canonicalName = "${mainPackage}.BeforeMethod",
+        canonicalName = "$mainPackage.annotations.BeforeMethod",
         simpleName = "BeforeMethod"
     )
 
-    override val afterMethod = "@${mainPackage}.AfterMethod"
-    override val afterMethodFqn = "${mainPackage}.AfterMethod"
+    override val afterMethod = "@$mainPackage.AfterMethod"
+    override val afterMethodFqn = "$mainPackage.AfterMethod"
     override val afterMethodId = BuiltinClassId(
-        canonicalName = "${mainPackage}.AfterMethod",
+        canonicalName = "$mainPackage.annotations.AfterMethod",
         simpleName = "AfterMethod"
     )
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
@@ -181,21 +181,11 @@ abstract class TestFramework(
     abstract val assertionsClass: ClassId
     abstract val arraysAssertionsClass: ClassId
     abstract val kotlinFailureAssertionsClass: ClassId
-    abstract val testAnnotation: String
     abstract val testAnnotationId: ClassId
-    abstract val testAnnotationFqn: String
-    abstract val beforeMethod: String
     abstract val beforeMethodId: ClassId
-    abstract val beforeMethodFqn: String
-    abstract val afterMethod: String
     abstract val afterMethodId: ClassId
-    abstract val afterMethodFqn: String
-    abstract val parameterizedTestAnnotation: String
     abstract val parameterizedTestAnnotationId: ClassId
-    abstract val parameterizedTestAnnotationFqn: String
-    abstract val methodSourceAnnotation: String
     abstract val methodSourceAnnotationId: ClassId
-    abstract val methodSourceAnnotationFqn: String
     abstract val nestedClassesShouldBeStatic: Boolean
     abstract val argListClassId: ClassId
 
@@ -270,31 +260,20 @@ abstract class TestFramework(
 object TestNg : TestFramework(id = "TestNG",displayName = "TestNG") {
     override val mainPackage: String = TEST_NG_PACKAGE
 
-    override val testAnnotation: String = "@$mainPackage.Test"
-    override val testAnnotationFqn: String = "$mainPackage.Test"
     override val testAnnotationId: ClassId = BuiltinClassId(
         canonicalName = "$mainPackage.annotations.Test",
         simpleName = "Test"
     )
 
-    override val beforeMethod = "@$mainPackage.BeforeMethod"
-    override val beforeMethodFqn = "$mainPackage.BeforeMethod"
     override val beforeMethodId = BuiltinClassId(
         canonicalName = "$mainPackage.annotations.BeforeMethod",
         simpleName = "BeforeMethod"
     )
 
-    override val afterMethod = "@$mainPackage.AfterMethod"
-    override val afterMethodFqn = "$mainPackage.AfterMethod"
     override val afterMethodId = BuiltinClassId(
         canonicalName = "$mainPackage.annotations.AfterMethod",
         simpleName = "AfterMethod"
     )
-
-    override val parameterizedTestAnnotation: String = "@$mainPackage.Test"
-    override val parameterizedTestAnnotationFqn: String = "@$mainPackage.Test"
-    override val methodSourceAnnotation: String = "@$mainPackage.DataProvider"
-    override val methodSourceAnnotationFqn: String = "@$mainPackage.DataProvider"
 
     internal const val testXmlName: String = "testng.xml"
 
@@ -393,35 +372,20 @@ object Junit4 : TestFramework(id = "JUnit4",displayName = "JUnit 4") {
 
     override val mainPackage: String = JUNIT4_PACKAGE
 
-    override val testAnnotation = "@$mainPackage.Test"
-    override val testAnnotationFqn: String = "$mainPackage.Test"
     override val testAnnotationId = BuiltinClassId(
         canonicalName = "$mainPackage.Test",
         simpleName = "Test"
     )
 
-    override val beforeMethod = "@$mainPackage.Before"
-    override val beforeMethodFqn = "$mainPackage.Before"
     override val beforeMethodId = BuiltinClassId(
         canonicalName = "$mainPackage.Before",
         simpleName = "Before"
     )
 
-    override val afterMethod = "@$mainPackage.After"
-    override val afterMethodFqn = "$mainPackage.After"
     override val afterMethodId = BuiltinClassId(
         canonicalName = "$mainPackage.After",
         simpleName = "After"
     )
-
-    override val parameterizedTestAnnotation
-        get() = parametrizedTestsNotSupportedError
-    override val parameterizedTestAnnotationFqn
-        get() = parametrizedTestsNotSupportedError
-    override val methodSourceAnnotation
-        get() = parametrizedTestsNotSupportedError
-    override val methodSourceAnnotationFqn
-        get() = parametrizedTestsNotSupportedError
 
     override val parameterizedTestAnnotationId = voidClassId
     override val methodSourceAnnotationId = voidClassId
@@ -468,31 +432,20 @@ object Junit4 : TestFramework(id = "JUnit4",displayName = "JUnit 4") {
 object Junit5 : TestFramework(id = "JUnit5", displayName = "JUnit 5") {
     override val mainPackage: String = JUNIT5_PACKAGE
 
-    override val testAnnotation = "@$mainPackage.Test"
-    override val testAnnotationFqn: String = "$mainPackage.Test"
     override val testAnnotationId = BuiltinClassId(
         canonicalName = "$JUNIT5_PACKAGE.Test",
         simpleName = "Test"
     )
 
-    override val beforeMethod = "@${mainPackage}.BeforeEach"
-    override val beforeMethodFqn = "${mainPackage}.BeforeEach"
     override val beforeMethodId = BuiltinClassId(
         canonicalName = "${mainPackage}.BeforeEach",
         simpleName = "BeforeEach"
     )
 
-    override val afterMethod = "@${mainPackage}.AfterEach"
-    override val afterMethodFqn = "${mainPackage}.AfterEach"
     override val afterMethodId = BuiltinClassId(
         canonicalName = "${mainPackage}.AfterEach",
         simpleName = "AfterEach"
     )
-
-    override val parameterizedTestAnnotation = "$JUNIT5_PARAMETERIZED_PACKAGE.ParameterizedTest"
-    override val parameterizedTestAnnotationFqn: String = "$JUNIT5_PARAMETERIZED_PACKAGE.ParameterizedTest"
-    override val methodSourceAnnotation: String = "$JUNIT5_PARAMETERIZED_PACKAGE.provider.MethodSource"
-    override val methodSourceAnnotationFqn: String = "$JUNIT5_PARAMETERIZED_PACKAGE.provider.MethodSource"
 
     val executableClassId = BuiltinClassId(
         canonicalName = "$JUNIT5_PACKAGE.function.Executable",

--- a/utbot-js/src/main/kotlin/framework/codegen/JsDomain.kt
+++ b/utbot-js/src/main/kotlin/framework/codegen/JsDomain.kt
@@ -16,25 +16,9 @@ object Mocha : TestFramework(id = "Mocha", displayName = "Mocha") {
     override val assertionsClass = jsUndefinedClassId
     override val arraysAssertionsClass = jsUndefinedClassId
     override val kotlinFailureAssertionsClass: ClassId = jsUndefinedClassId
-    override val testAnnotation = ""
-    override val testAnnotationFqn = ""
 
-    override val beforeMethod: String = ""
     override val beforeMethodId: ClassId = jsUndefinedClassId
-    override val beforeMethodFqn: String = ""
-
-    override val afterMethod: String = ""
     override val afterMethodId: ClassId = jsUndefinedClassId
-    override val afterMethodFqn: String = ""
-
-    override val parameterizedTestAnnotation: String
-        get() = throw UnsupportedOperationException("Parameterized tests are not supported for Mocha")
-    override val parameterizedTestAnnotationFqn: String
-        get() = throw UnsupportedOperationException("Parameterized tests are not supported for Mocha")
-    override val methodSourceAnnotation: String
-        get() = throw UnsupportedOperationException("Parameterized tests are not supported for Mocha")
-    override val methodSourceAnnotationFqn: String
-        get() = throw UnsupportedOperationException("Parameterized tests are not supported for Mocha")
 
     override val nestedClassesShouldBeStatic: Boolean
         get() = false

--- a/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/PythonDomain.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/PythonDomain.kt
@@ -16,28 +16,18 @@ object Pytest : TestFramework(displayName = "pytest", id = "pytest") {
     override val assertionsClass: ClassId = pythonNoneClassId
     override val arraysAssertionsClass: ClassId = assertionsClass
     override val kotlinFailureAssertionsClass: ClassId = assertionsClass
-    override val testAnnotation: String
-        get() = TODO("Not yet implemented")
+
     override val testAnnotationId: ClassId = BuiltinClassId(
         canonicalName = "pytest",
         simpleName = "Tests"
     )
-    override val testAnnotationFqn: String = ""
 
-    override val beforeMethod: String = ""
     override val beforeMethodId: ClassId = pythonAnyClassId
-    override val beforeMethodFqn: String = ""
 
-    override val afterMethod: String = ""
     override val afterMethodId: ClassId = pythonAnyClassId
-    override val afterMethodFqn: String = ""
 
-    override val parameterizedTestAnnotation: String = ""
     override val parameterizedTestAnnotationId: ClassId = pythonAnyClassId
-    override val parameterizedTestAnnotationFqn: String = ""
-    override val methodSourceAnnotation: String = ""
     override val methodSourceAnnotationId: ClassId = pythonAnyClassId
-    override val methodSourceAnnotationFqn: String = ""
     override val nestedClassesShouldBeStatic: Boolean = false
     override val argListClassId: ClassId = pythonAnyClassId
 
@@ -67,27 +57,17 @@ object Unittest : TestFramework(displayName = "Unittest", id = "Unittest") {
     override val assertionsClass: ClassId = PythonClassId("self")
     override val arraysAssertionsClass: ClassId = assertionsClass
     override val kotlinFailureAssertionsClass: ClassId = assertionsClass
-    override val testAnnotation: String = ""
     override val testAnnotationId: ClassId = BuiltinClassId(
         canonicalName = "Unittest",
         simpleName = "Tests"
     )
-    override val testAnnotationFqn: String = "unittest"
 
-    override val beforeMethod: String = ""
     override val beforeMethodId: ClassId = pythonAnyClassId
-    override val beforeMethodFqn: String = ""
 
-    override val afterMethod: String = ""
     override val afterMethodId: ClassId = pythonAnyClassId
-    override val afterMethodFqn: String = ""
 
-    override val parameterizedTestAnnotation: String = ""
     override val parameterizedTestAnnotationId: ClassId = pythonAnyClassId
-    override val parameterizedTestAnnotationFqn: String = ""
-    override val methodSourceAnnotation: String = ""
     override val methodSourceAnnotationId: ClassId = pythonAnyClassId
-    override val methodSourceAnnotationFqn: String = ""
     override val nestedClassesShouldBeStatic: Boolean = false
     override val argListClassId: ClassId = pythonAnyClassId
 


### PR DESCRIPTION
## Description

There are two commits here:
- first commit corrects fully qualified name for TestNg annotations `BeforeMethod` and `AfterMethod`
- second commit removes unused legacy variables from `TestFramework` and it's inheritors


## How to test

### Manual tests

Check that tests are generated properly for Spring project using TestNg.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.