### PR TITLE
Move action update to background thread

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/actions/GenerateTestsAction.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/actions/GenerateTestsAction.kt
@@ -1,5 +1,6 @@
 package org.utbot.intellij.plugin.ui.actions
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.components.service
@@ -19,6 +20,8 @@ class GenerateTestsAction : AnAction() {
             languageAssistant.update(e)
         }
     }
+
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
 
     private fun accessByProjectSettings(e: AnActionEvent): Boolean {
         val experimentalLanguageSetting = e.project?.service<Settings>()?.experimentalLanguagesSupport


### PR DESCRIPTION
## Description
Sometimes (first time when PSI is not yet fully initialized and cached) our action update takes hundreds of milliseconds.
So let's move updating to background thread with handy IntelliJ API

Fixes #2129


### Manual tests

Start samples project, go to Project View and try Shift+Alt+U on some "root" package. Dialog should appear queckly and with no exception (see the issue).

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.