### PR TITLE
Add RunReadAction wrapper for slow Spring operation

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -236,11 +236,13 @@ object UtTestsDialogProcessor {
                                         when (val approach = model.typeReplacementApproach) {
                                             DoNotReplace -> emptyList()
                                             is ReplaceIfPossible -> {
-                                                val contentRoots = listOfNotNull(
-                                                    model.srcModule,
-                                                    springConfigClass?.module
-                                                ).distinct().flatMap { module ->
-                                                    ModuleRootManager.getInstance(module).contentRoots.toList()
+                                                val contentRoots = runReadAction {
+                                                    listOfNotNull(
+                                                        model.srcModule,
+                                                        springConfigClass?.module
+                                                    ).distinct().flatMap { module ->
+                                                        ModuleRootManager.getInstance(module).contentRoots.toList()
+                                                    }
                                                 }
                                                 process.getSpringBeanQualifiedNames(
                                                     classpathForClassLoader,


### PR DESCRIPTION
## Description

Use `runReadAction` in `Generate tests` background task to get `contentRoots`

## How to test

### Manual tests

Generate tests for any spring project (for example, pet-clinic)

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.