### PR TITLE
Fallback to no configuration mode when spring-analyzer crushes

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -252,7 +252,7 @@ object UtTestsDialogProcessor {
                                                 )
                                             }
                                         }
-                                    val shouldUseImplementors = model.typeReplacementApproach is ReplaceIfPossible
+                                    val shouldUseImplementors = beanQualifiedNames.isNotEmpty()
 
                                     SpringApplicationContext(
                                         mockFrameworkInstalled,


### PR DESCRIPTION
## Description

Fallback to no configuration mode when spring-analyzer crushes, exception is logged to engine process logs

## How to test

### Manual tests

Generate tests for Spring project using an invalid configuration (for instance, xml config with invalid syntax)

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.