### PR TITLE
Make loading Spring bean classes even more safe

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -1293,7 +1293,7 @@ class SpringApplicationContext(
                         // it is possible to have problems with classes loading.
                         when (e) {
                             is ClassNotFoundException, is NoClassDefFoundError, is IllegalAccessError ->
-                                logger.warn { "Failed to load bean class for $beanFqn" }
+                                logger.warn { "Failed to load bean class for $beanFqn (${e.message})" }
 
                             else -> throw e
                         }

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -8,6 +8,7 @@
 
 package org.utbot.framework.plugin.api
 
+import mu.KotlinLogging
 import org.utbot.common.FileUtil
 import org.utbot.common.isDefaultValue
 import org.utbot.common.withToStringThreadLocalReentrancyGuard
@@ -1270,6 +1271,10 @@ class SpringApplicationContext(
     private val shouldUseImplementors: Boolean,
 ): ApplicationContext(mockInstalled, staticsMockingIsConfigured) {
 
+    companion object {
+        private val logger = KotlinLogging.logger {}
+    }
+
     private var areInjectedClassesInitialized : Boolean = false
 
     // Classes representing concrete types that are actually used in Spring application
@@ -1283,10 +1288,15 @@ class SpringApplicationContext(
                             !beanClass.isLocalClass && (!beanClass.isMemberClass || beanClass.isStatic)) {
                             springInjectedClassesStorage += beanClass.id
                         }
-                    } catch (e: ClassNotFoundException) {
+                    } catch (e: Throwable) {
                         // For some Spring beans (e.g. with anonymous classes)
                         // it is possible to have problems with classes loading.
-                        continue
+                        when (e) {
+                            is ClassNotFoundException, is NoClassDefFoundError, is IllegalAccessError ->
+                                logger.warn { "Failed to load bean class for $beanFqn" }
+
+                            else -> throw e
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Description

Wraps class loading and `ClassId` instantiation to be even more safe for Spring beans

## How to test

### Manual tests

Can be tested on a big project with many different bean definitions or `@EnableAutoConfiguration` annotation on a selected `@Configuration` in a Spring Boot application. Symbolic engine should not fail and beans that failed to load should be logged in `rdEngineProcessLogs` (e.g. `org.springframework.boot.autoconfigure.jdbc.metadata.DataSourcePoolMetadataProvidersConfiguration$HikariPoolDataSourceMetadataProviderConfiguration$$Lambda$560/0x00000008011446e8`)

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.