### PR TITLE
Optimize imports programmatically if UtBot is run as a plugin

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerationController.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/CodeGenerationController.kt
@@ -3,6 +3,7 @@ package org.utbot.intellij.plugin.generator
 import com.intellij.analysis.AnalysisScope
 import com.intellij.codeInsight.CodeInsightUtil
 import com.intellij.codeInsight.FileModificationService
+import com.intellij.codeInsight.actions.OptimizeImportsProcessor
 import com.intellij.ide.fileTemplates.FileTemplateManager
 import com.intellij.ide.fileTemplates.FileTemplateUtil
 import com.intellij.ide.fileTemplates.JavaTemplateUtil
@@ -781,6 +782,7 @@ object CodeGenerationController {
         }
 
         DumbService.getInstance(model.project).runWhenSmart {
+            OptimizeImportsProcessor(project, file).run()
             codeStyleManager.reformat(file)
             when (model.codegenLanguage) {
                 CodegenLanguage.JAVA -> {


### PR DESCRIPTION
## Description

Partially fixes # ([2033](https://github.com/UnitTestBot/UTBotJava/issues/2033))

We have an approach to optimize imports "manually" in generated code.

However, it is not perfect. For example, we have one implementation for two different tasks: to create a variable (involving all related actions like field setting) and to just create a variable declaration. It leads to useless imports in Spring projects, for example.

To improve this situation, we may also optimize imports programmatically.
It is not a perfect solution, because UtBot may also be run as a command line tool, but it allows to obtain significant improvement with minimal efforts and regression influence.

## How to test

### Automated tests

Standard utbot pipeline as a set of regression checks that generated code still compiles.

### Manual tests

Scenario from the issue

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.