### PR TITLE
Avoid fully qualified names rendering in mockedConstruction

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/MockFrameworkManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/MockFrameworkManager.kt
@@ -289,7 +289,8 @@ private class MockitoStaticMocker(context: CgContext, private val mocker: Object
             mockConstructionInitializer.mockConstructionCall
         )
 
-        importIfNeeded(mockedConstructionContextClassId)
+        importIfNeeded(MockitoStaticMocking.mockedConstructionClassId)
+        importIfNeeded(classId)
 
         resources += mockedConstructionDeclaration
         +CgAssignment(mockedConstructionDeclaration.variable, mockConstructionInitializer.mockConstructionCall)
@@ -355,6 +356,9 @@ private class MockitoStaticMocker(context: CgContext, private val mocker: Object
             ).also {
                 resources += it
                 +CgAssignment(it.variable, classMockStaticCall)
+
+                importIfNeeded(MockitoStaticMocking.mockedStaticClassId)
+                importIfNeeded(classId)
             }
         }
 
@@ -437,6 +441,7 @@ private class MockitoStaticMocker(context: CgContext, private val mocker: Object
         )
 
         importIfNeeded(mockedConstructionContextClassId)
+        importIfNeeded(classId)
 
         return MockConstructionBlock(
             mockitoClassId[MockitoStaticMocking.mockConstructionMethodId](clazz, answersBlock),


### PR DESCRIPTION
## Description

Fixes https://github.com/UnitTestBot/UTBotJava/issues/2175

Fixes the requirement of `00429929` to avoid fully qualified names in generated code.
Avoid it for `MockedConstruction` and its context.

## How to test

### Automated tests

Standard utbot-samples pipeline as a set of regression checks.

### Manual tests

Not required

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.