### PR TITLE
Make spring-analyzer bean post processor distinguish 3 kinds of beans: @Component-like beans, @Bean-like beans, and XML-like beans

### DIFF
--- a/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/postProcessors/UtBotBeanFactoryPostProcessor.kt
+++ b/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/postProcessors/UtBotBeanFactoryPostProcessor.kt
@@ -4,6 +4,7 @@ import com.jetbrains.rd.util.getLogger
 import com.jetbrains.rd.util.info
 import com.jetbrains.rd.util.warn
 import org.springframework.beans.factory.BeanCreationException
+import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
 import org.springframework.beans.factory.support.BeanDefinitionRegistry
@@ -30,16 +31,37 @@ object UtBotBeanFactoryPostProcessor : BeanFactoryPostProcessor, PriorityOrdered
         throw UtBotSpringShutdownException("Finished post-processing bean factory in UtBot", beanQualifiedNames)
     }
 
-    private fun findBeanClassNames(beanFactory: ConfigurableListableBeanFactory): List<String> {
-        return beanFactory.beanDefinitionNames.mapNotNull {
-            try {
-                beanFactory.getBeanDefinition(it).beanClassName ?: beanFactory.getBean(it).javaClass.name
+    private fun findBeanClassNames(beanFactory: ConfigurableListableBeanFactory): List<String> =
+        beanFactory.beanDefinitionNames
+            .mapNotNull { getBeanFqn(beanFactory, it) }
+            .filterNot { it.startsWith("org.utbot.spring") }
+            .distinct()
+
+    private fun getBeanFqn(beanFactory: ConfigurableListableBeanFactory, beanName: String): String? {
+        val beanDefinition = beanFactory.getBeanDefinition(beanName)
+        return if (beanDefinition is AnnotatedBeanDefinition) {
+            if (beanDefinition.factoryMethodMetadata == null) {
+                // there's no factoryMethod so bean is defined with @Component-like annotation rather than @Bean annotation
+                // same approach isn't applicable for @Bean beans, because for them, it returns name of @Configuration class
+                beanDefinition.metadata.className.also { fqn ->
+                    logger.info { "Got $fqn as metadata.className for @Component-like bean: $beanName" }
+                }
+            } else try {
+                // TODO to avoid side effects, determine beanClassName without getting bean by analyzing method
+                //  defining bean, for example, by finding all its return statements and determining their common type
+                //  NOTE: do not simply use return type from method signature because it may be an interface type
+                beanFactory.getBean(beanName)::class.java.name.also { fqn ->
+                    logger.info { "Got $fqn as runtime type for @Bean-like bean: $beanName" }
+                }
             } catch (e: BeanCreationException) {
-                logger.warn { "Failed to get bean: $it" }
+                logger.warn { "Failed to get bean: $beanName" }
                 null
             }
-        }.filterNot { it.startsWith("org.utbot.spring") }
-         .distinct()
+        } else {
+            beanDefinition.beanClassName.also { fqn ->
+                logger.info { "Got $fqn as beanClassName for XML-like bean: $beanName" }
+            }
+        }
     }
 
     private fun destroyBeanDefinitions(beanFactory: ConfigurableListableBeanFactory) {


### PR DESCRIPTION
## Description

Make it so 3 main kinds of beans are treated separately when it comes to determining their type:
- For `@Component`-like beans we can get the type by simply looking at the annotated class
- For `@Bean`-like beans we have to analyze the method defining bean (for now, we actually run it)
- For XML-like beans we can use `beanClassName`

This pull request is relevant because the approach used earlier failed for `@Bean`-like beans defined with a static method. It returned type of the `@Configuration` class defining the bean instead of type of the bean itself . For instance, in the following example for bean `beanLogBeanFactoryPostProcessor` we got `WebConfiguration` as its type instead of `LogBeanFactoryPostProcessor`.

```Java
@Configuration
public class WebConfiguration {
    @Bean
    public static LogBeanFactoryPostProcessor beanLogBeanFactoryPostProcessor() {
        return new LogBeanFactoryPostProcessor();
    }
}
```

## How to test

### Manual tests

Generate tests for Spring projects using all 3 kinds of beans.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.