### PR TITLE
Stop logging useless trace to `LoggerModel.setup`

### DIFF
--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/rd/InstrumentedProcess.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/rd/InstrumentedProcess.kt
@@ -33,7 +33,6 @@ import org.utbot.rd.terminateOnException
 import java.io.File
 
 private val logger = KotlinLogging.logger { }
-private val rdLogger = UtRdKLogger(logger, "")
 
 private const val UTBOT_INSTRUMENTATION = "utbot-instrumentation"
 private const val INSTRUMENTATION_LIB = "lib"
@@ -136,7 +135,7 @@ class InstrumentedProcess private constructor(
             logger.trace("rd process started")
 
             val proc = InstrumentedProcess(classLoader, rdProcess)
-            proc.loggerModel.setup(rdLogger, proc.lifetime)
+            proc.loggerModel.setup(logger, proc.lifetime)
 
             proc.lifetime.onTermination {
                 logger.trace { "process is terminating" }

--- a/utbot-rd/src/main/kotlin/org/utbot/rd/loggers/UtRdKLogger.kt
+++ b/utbot-rd/src/main/kotlin/org/utbot/rd/loggers/UtRdKLogger.kt
@@ -6,7 +6,11 @@ import mu.KLogger
 /**
  * Adapter from RD Logger to KLogger
  */
-class UtRdKLogger(private val realLogger: KLogger, val category: String) : Logger {
+class UtRdKLogger(
+    private val realLogger: KLogger,
+    val category: String,
+    private val logTraceOnError: Boolean = true
+) : Logger {
     val logLevel: LogLevel
         get() {
             return when {
@@ -24,7 +28,11 @@ class UtRdKLogger(private val realLogger: KLogger, val category: String) : Logge
     }
 
     private fun format(level: LogLevel, message: Any?, throwable: Throwable?): String {
-        val throwableToPrint = if (level < LogLevel.Error) throwable else throwable ?: Exception("No exception was actually thrown, this exception is used purely to log trace")
+        val throwableToPrint =
+            if (logTraceOnError && level >= LogLevel.Error)
+                throwable ?: Exception("No exception was actually thrown, this exception is used purely to log trace")
+            else
+                throwable
         val rdCategory = if (category.isNotEmpty()) "RdCategory: ${category.substringAfterLast('.').padEnd(25)} | " else ""
         return "$rdCategory${message?.toString() ?: ""} ${throwableToPrint?.getThrowableText()?.let { "| $it" } ?: ""}"
     }

--- a/utbot-rd/src/main/kotlin/org/utbot/rd/loggers/UtRdLogUtil.kt
+++ b/utbot-rd/src/main/kotlin/org/utbot/rd/loggers/UtRdLogUtil.kt
@@ -26,7 +26,10 @@ fun overrideDefaultRdLoggerFactoryWithKLogger(logger: KLogger) {
     }
 }
 
-fun LoggerModel.setup(rdLogger: UtRdKLogger, processLifetime: Lifetime) {
+fun LoggerModel.setup(logger: KLogger, processLifetime: Lifetime) {
+    // we do not log trace on error here because it's a job of clint-side process logger
+    // server-side process logger can only log trace of where it was set up from which isn't particularly useful
+    val rdLogger = UtRdKLogger(logger, "", logTraceOnError = false)
     // currently we do not specify log level for different categories
     // though it is possible with some additional map on categories -> consider performance
     // this logLevel is obtained from KotlinLogger

--- a/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/process/SpringAnalyzerProcess.kt
+++ b/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/process/SpringAnalyzerProcess.kt
@@ -37,7 +37,6 @@ private const val SPRING_ANALYZER_JAR_PATH = "lib/$SPRING_ANALYZER_JAR_FILENAME"
 private const val UNKNOWN_MODIFICATION_TIME = 0L
 
 private val logger = KotlinLogging.logger {}
-private val rdLogger = UtRdKLogger(logger, "")
 
 private var classpathArgs = listOf<String>()
 
@@ -106,7 +105,7 @@ class SpringAnalyzerProcess private constructor(
                 }
                 rdProcess.awaitProcessReady()
                 val proc = SpringAnalyzerProcess(rdProcess)
-                proc.loggerModel.setup(rdLogger, proc.lifetime)
+                proc.loggerModel.setup(logger, proc.lifetime)
                 return proc
             }
     }


### PR DESCRIPTION
## Description

Fixes #2179 

Stop logging trace on error in server-side process logger because it's already done in a clint-side process logger

## How to test

### Manual tests

Make spring analyzer process (or instrumented process) log an error, for instance, by using malformed XML Spring config. There should be no trace like this in logs:
```
| java.lang.Exception: No exception was actually thrown, this exception is used purely to log trace
	at org.utbot.rd.loggers.UtRdKLogger.format(UtRdKLogger.kt:33)
	at org.utbot.rd.loggers.UtRdKLogger.log(UtRdKLogger.kt:44)
	at org.utbot.rd.loggers.UtRdLogUtilKt$setup$1.invoke(UtRdLogUtil.kt:41)
	at org.utbot.rd.loggers.UtRdLogUtilKt$setup$1.invoke(UtRdLogUtil.kt:38)
	at com.jetbrains.rd.util.reactive.Signal.fire(Signal.kt:32)
	at com.jetbrains.rd.framework.impl.RdSignal.onWireReceived(RdSignal.kt:42)
	at com.jetbrains.rd.framework.MessageBroker$invoke$2$2.invoke(MessageBroker.kt:57)
	at com.jetbrains.rd.framework.MessageBroker$invoke$2$2.invoke(MessageBroker.kt:56)
	at com.jetbrains.rd.framework.impl.ProtocolContexts.readMessageContextAndInvoke(ProtocolContexts.kt:148)
	at com.jetbrains.rd.framework.MessageBroker$invoke$2.invoke(MessageBroker.kt:56)
	at com.jetbrains.rd.framework.MessageBroker$invoke$2.invoke(MessageBroker.kt:54)
	at com.jetbrains.rd.util.threading.SingleThreadSchedulerBase.queue$lambda-3(SingleThreadScheduler.kt:41)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.