### PR TITLE
Support profiles selection for Spring-guided test generation

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -252,7 +252,7 @@ object UtTestsDialogProcessor {
                                                     classpathForClassLoader,
                                                     approach.config,
                                                     fileStorage,
-                                                    profileExpression = null,
+                                                    model.profileExpression,
                                                 )
                                             }
                                         }

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/GenerateTestsModel.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/GenerateTestsModel.kt
@@ -55,6 +55,7 @@ class GenerateTestsModel(
     lateinit var commentStyle: JavaDocCommentStyle
 
     lateinit var typeReplacementApproach: TypeReplacementApproach
+    lateinit var profileExpression: String
 
     val conflictTriggers: ConflictTriggers = ConflictTriggers()
 

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -407,15 +407,13 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
                     )
                 }
                 indent {
-                    row {
-                        cell(JBLabel("Profile name(s):     "))
-                        cell(profileExpression)
+                    row("Profile name(s):") {
+                        cell(profileExpression).align(Align.FILL)
                         contextHelp(
                             "Profile name or expression like \"prod|web\" may be passed here.<br>" +
                                     "If expression is incorrect, default profile will be used"
                         )
-                    }
-                        .enabledIf(selectProfile.selected)
+                    }.enabledIf(selectProfile.selected)
                 }
             }
             row("Mocking strategy:") {


### PR DESCRIPTION
## Description

For Spring project, user may select that he would like to activate the selected profile only an type it's name (or names as logical expression). If user does not customize this setting, the default profile for selected config is used.

## How to test

### Manual tests

- Introduce a specific profile for test needs
- Verify that it is not activated for selected config by Spring
- Activate it in plugin UI
- Check that this profile is used for analysis

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual scenarios** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.