### PR TITLE
Fix unwanted fields in test class for Spring

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/builders/SpringTestClassModelBuilder.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/builders/SpringTestClassModelBuilder.kt
@@ -101,8 +101,10 @@ class SpringTestClassModelBuilder(val context: CgContext): TestClassModelBuilder
                 }
             }
             is UtCompositeModel -> {
+                // Here we traverse fields only.
+                // Traversing mocks as well will result in wrong models playing
+                // a role of class fields with @Mock annotation.
                 currentModel.fields.values.forEach { collectRecursively(it, allModels) }
-                currentModel.mocks.values.asSequence().flatten().forEach { collectRecursively(it, allModels) }
             }
             is UtAssembleModel -> {
                 currentModel.origin?.let { collectRecursively(it, allModels) }


### PR DESCRIPTION
## Description

There were unwanted fields with **@Mock** annotation because we were collecting everything from models, including fields and mocks. But there is no need for collecting mocks, they will be created when necessary.

Fixes #2170

## How to test

### Automated tests

### Manual tests

Reproduced the issue from the issue and on the OwnerController class.