### PR TITLE
Improve profile selection options on UI

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -252,7 +252,7 @@ object UtTestsDialogProcessor {
                                                     classpathForClassLoader,
                                                     approach.config,
                                                     fileStorage,
-                                                    model.profileExpression,
+                                                    model.profileNames,
                                                 )
                                             }
                                         }

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/GenerateTestsModel.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/GenerateTestsModel.kt
@@ -55,7 +55,7 @@ class GenerateTestsModel(
     lateinit var commentStyle: JavaDocCommentStyle
 
     lateinit var typeReplacementApproach: TypeReplacementApproach
-    lateinit var profileExpression: String
+    lateinit var profileNames: String
 
     val conflictTriggers: ConflictTriggers = ConflictTriggers()
 

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -1146,9 +1146,6 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
     private fun updateSpringConfigurationEnabled() {
         // We check for > 1 because there is already extra-dummy NO_SPRING_CONFIGURATION_OPTION option
         springConfig.isEnabled = model.projectType == ProjectType.Spring && springConfig.itemCount > 1
-
-        profileNames.isEnabled =
-            model.projectType == ProjectType.Spring && springConfig.item != NO_SPRING_CONFIGURATION_OPTION
     }
 
     private fun staticsMockingConfigured(): Boolean {

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -658,7 +658,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
                     TypeReplacementApproach.ReplaceIfPossible(fullConfigName)
                 }
             }
-        model.profileExpression = profileNames.text.let { it.ifEmpty { DEFAULT_SPRING_PROFILE_NAME } }
+        model.profileNames = profileNames.text.let { it.ifEmpty { DEFAULT_SPRING_PROFILE_NAME } }
 
         val settings = model.project.service<Settings>()
         with(settings) {

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -57,6 +57,7 @@ import com.intellij.ui.SimpleTextAttributes
 import com.intellij.ui.components.CheckBox
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.components.JBTextField
 import com.intellij.ui.components.panels.HorizontalLayout
 import com.intellij.ui.components.panels.NonOpaquePanel
 import com.intellij.ui.components.panels.OpaquePanel
@@ -200,7 +201,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
     private val staticsMocking = JCheckBox("Mock static methods")
 
     private val springConfig = createComboBoxWithSeparatorsForSpringConfigs(shortenConfigurationNames())
-    private val profileExpression = JTextField(DEFAULT_SPRING_PROFILE_NAME, 23)
+    private val profileExpression = JBTextField(23).apply { emptyText.text = DEFAULT_SPRING_PROFILE_NAME }
 
     private val timeoutSpinner =
         JBIntSpinner(TimeUnit.MILLISECONDS.toSeconds(model.timeout).toInt(), 1, Int.MAX_VALUE, 1).also {
@@ -656,7 +657,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
                     TypeReplacementApproach.ReplaceIfPossible(fullConfigName)
                 }
             }
-        model.profileExpression = profileExpression.text
+        model.profileExpression = profileExpression.text.let { if (it == "") DEFAULT_SPRING_PROFILE_NAME else it }
 
         val settings = model.project.service<Settings>()
         with(settings) {
@@ -1074,22 +1075,6 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
             testPackageField.text = if (packageNameIsNeeded) testPackageName else ""
             testPackageField.isEnabled = !testPackageField.isEnabled
         }
-
-        profileExpression.addFocusListener(object : FocusListener {
-            override fun focusGained(e: FocusEvent) {
-                if (profileExpression.text == DEFAULT_SPRING_PROFILE_NAME) {
-                    profileExpression.text = ""
-                    profileExpression.foreground = Color.BLACK
-                }
-            }
-
-            override fun focusLost(e: FocusEvent) {
-                if (profileExpression.text.isEmpty()) {
-                    profileExpression.text = DEFAULT_SPRING_PROFILE_NAME
-                    profileExpression.foreground = Color.GRAY
-                }
-            }
-        })
     }
 
     private lateinit var currentFrameworkItem: TestFramework

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -1066,7 +1066,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
                 updateMockStrategyList()
 
                 profileNames.isEnabled = false
-                profileNames.text = DEFAULT_SPRING_PROFILE_NAME
+                profileNames.text = ""
             }
         }
 

--- a/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/utils/EnvironmentFactory.kt
+++ b/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/utils/EnvironmentFactory.kt
@@ -1,8 +1,12 @@
 package org.utbot.spring.utils
 
+import com.jetbrains.rd.util.getLogger
+import com.jetbrains.rd.util.info
 import org.springframework.core.env.ConfigurableEnvironment
 import org.springframework.core.env.StandardEnvironment
 import org.utbot.spring.api.ApplicationData
+
+private val logger = getLogger<EnvironmentFactory>()
 
 class EnvironmentFactory(
     private val applicationData: ApplicationData
@@ -12,15 +16,33 @@ class EnvironmentFactory(
     }
 
     fun createEnvironment(): ConfigurableEnvironment {
-        val profilesToActivate = parseProfileExpression(applicationData.profileExpression ?: DEFAULT_PROFILE_NAME)
+        val profilesToActivate = parseProfileExpression(applicationData.profileExpression)
 
         val environment = StandardEnvironment()
-        environment.setActiveProfiles(*profilesToActivate)
+
+        try {
+            environment.setActiveProfiles(*profilesToActivate)
+        } catch (e: Exception) {
+            logger.info { "Setting ${applicationData.profileExpression} as active profiles failed with exception $e" }
+        }
 
         return environment
     }
 
-    //TODO: implement this, e.g. 'prod|web' -> listOf(prod, web)
-    private fun parseProfileExpression(profileExpression: String) : Array<String> = arrayOf(profileExpression)
+    /*
+     * Transforms active profile information
+     * from the form of user input to a list of active profiles.
+     *
+     * Current user input form is comma-separated values, but it may be changed later.
+     */
+    private fun parseProfileExpression(profileExpression: String?): Array<String> {
+        if (profileExpression.isNullOrEmpty()) {
+            return arrayOf(DEFAULT_PROFILE_NAME)
+        }
 
+        return profileExpression
+            .filter { !it.isWhitespace() }
+            .split(',')
+            .toTypedArray()
+    }
 }


### PR DESCRIPTION
## Description

Profile selection reduced to one text field on UI

It is disabled in NoConfiguration mode and allows to enter text otherwise.
Default text is shown depending on focus

Also fixes https://github.com/UnitTestBot/UTBotJava/issues/2186

## How to test

### Automated tests

Not relevant

### Manual tests

Verify that the behavior coincides with our plan from whiteboard

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.