### PR TITLE
Fix unmatched variables in Spring test methods

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -62,7 +62,7 @@ import org.utbot.framework.plugin.api.TypeReplacementMode.*
 import org.utbot.framework.plugin.api.util.allDeclaredFieldIds
 import org.utbot.framework.plugin.api.util.fieldId
 import org.utbot.framework.plugin.api.util.isSubtypeOf
-import org.utbot.framework.plugin.api.util.objectClassId
+import org.utbot.framework.plugin.api.util.isNotSubtypeOf
 import org.utbot.framework.plugin.api.util.utContext
 import org.utbot.framework.process.OpenModulesContainer
 import soot.SootField
@@ -546,7 +546,9 @@ data class UtAssembleModel private constructor(
         other as UtAssembleModel
 
         if (id != other.id) return false
-        if (classId != other.classId) return false
+        if (classId != other.classId) {
+            if (classId isNotSubtypeOf other.classId && other.classId isNotSubtypeOf classId) return false
+        }
 
         return true
     }

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -544,7 +544,11 @@ data class UtAssembleModel private constructor(
         if (javaClass != other?.javaClass) return false
 
         other as UtAssembleModel
-        return id == other.id
+
+        if (id != other.id) return false
+        if (classId != other.classId) return false
+
+        return true
     }
 
     override fun hashCode(): Int = id ?: 0

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
@@ -732,16 +732,17 @@ object SpringBoot : DependencyInjectionFramework(
 /**
  * Extended id of [UtModel], unique for whole test set.
  *
- * Allows distinguishing models from different executions and test sets,
+ * Allows distinguishing models from different classId, executions and test sets,
  * even if they have the same value of `UtModel.id` that is allowed.
  */
 data class ModelId private constructor(
     private val id: Int?,
+    private val classId: ClassId,
     private val executionId: Int,
     private val testSetId: Int,
 ) {
     companion object {
-        fun create(model: UtModel, executionId: Int = -1, testSetId: Int = -1) = ModelId(model.idOrNull(), executionId, testSetId)
+        fun create(model: UtModel, executionId: Int = -1, testSetId: Int = -1) = ModelId(model.idOrNull(), model.classId, executionId, testSetId)
     }
 }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringVariableConstructor.kt
@@ -41,12 +41,9 @@ class CgSpringVariableConstructor(context: CgContext) : CgVariableConstructor(co
         return super.getOrCreateVariable(model, name)
     }
 
-    private fun findCgValueByModel(modelToFind: UtModel, modelToValueMap: Map<Set<UtModel>, CgValue>): CgValue? =
-        // Here we really need to compare models by reference.
-        // Standard equals is not appropriate because two models from different execution may have same `id`.
-        // Equals on `ModelId` is not appropriate because injected items from different execution have same `executionId`.
+    private fun findCgValueByModel(model: UtModel, modelToValueMap: Map<Set<UtModel>, CgValue>): CgValue? =
         modelToValueMap
-            .filter { models -> models.key.any { it === modelToFind } }
+            .filter { it.key.contains(model) }
             .entries
             .singleOrNull()
             ?.value


### PR DESCRIPTION
## Description

For some reason UtAssembleModel *equal method* did not have comparison by ClassId, while one in UtCompositeModel has it.
Some observations proved that the former should also have it due to problems with Maps where keys are UtModels...

![image](https://user-images.githubusercontent.com/54685068/235194526-55569015-0396-4bca-a757-07a6a3ef8415.png)

The necessity of ClassId comparisons in UtAssembleModels was under consideration some time ago, but it was ignored for an unknown reason. From a cursory glance, it does seem missing. If by any chance it's true, it may require some refactoring.

Fixes #2107, #2104

See the comment below⬇️.

## How to test

### Automated tests

### Manual tests

Tested several times on OwnerController and VetController classes.