### PR TITLE
Remove classId comparison for UtCompositeModel

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -439,10 +439,7 @@ data class UtCompositeModel(
 
         other as UtCompositeModel
 
-        if (id != other.id) return false
-        if (classId != other.classId) return false
-
-        return true
+        return id == other.id
     }
 
     override fun hashCode(): Int {


### PR DESCRIPTION
## Description

We expect that `UtCompositeModel.id` is unique in execution.
So additional comparison on `classId` is not necessary.

## How to test

### Automated tests

utbot-samples pipeline as a set of regression checks

### Manual tests

Some regression in Spring codegen is possible.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.