### PR TITLE
Add socket channel for coverage collection

### DIFF
--- a/utbot-python/samples/easy_samples/long_function_coverage.py
+++ b/utbot-python/samples/easy_samples/long_function_coverage.py
@@ -1,0 +1,11 @@
+import time
+
+
+def long_function(x: int):
+    x += 4
+    x /= 2
+    x += 100
+    x *= 3
+    x -= 15
+    time.sleep(2000)
+    return x

--- a/utbot-python/src/main/kotlin/org/utbot/python/PythonEngine.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/PythonEngine.kt
@@ -12,6 +12,7 @@ import org.utbot.python.evaluation.*
 import org.utbot.python.evaluation.serialiation.MemoryDump
 import org.utbot.python.evaluation.serialiation.toPythonTree
 import org.utbot.python.evaluation.utils.CoverageIdGenerator
+import org.utbot.python.evaluation.utils.coveredLinesToInstructions
 import org.utbot.python.framework.api.python.PythonTree
 import org.utbot.python.framework.api.python.PythonTreeModel
 import org.utbot.python.framework.api.python.PythonTreeWrapper
@@ -85,6 +86,7 @@ class PythonEngine(
     private fun handleTimeoutResult(
         arguments: List<PythonFuzzedValue>,
         methodUnderTestDescription: PythonMethodDescription,
+        coveredLines: Collection<Int>,
     ): FuzzingExecutionFeedback {
         val summary = arguments
             .zip(methodUnderTest.arguments)
@@ -101,12 +103,16 @@ class PythonEngine(
         val beforeThisObject = beforeThisObjectTree?.let { PythonTreeModel(it.tree) }
         val beforeModelList = beforeModelListTree.map { PythonTreeModel(it.tree) }
 
+        val coveredInstructions = coveredLinesToInstructions(coveredLines, methodUnderTest)
+        val coverage = Coverage(coveredInstructions)
+
         val utFuzzedExecution = PythonUtExecution(
             stateInit = EnvironmentModels(beforeThisObject, beforeModelList, emptyMap()),
             stateBefore = EnvironmentModels(beforeThisObject, beforeModelList, emptyMap()),
             stateAfter = EnvironmentModels(beforeThisObject, beforeModelList, emptyMap()),
             diffIds = emptyList(),
             result = executionResult,
+            coverage = coverage,
             testMethodName = testMethodName.testName?.camelToSnakeCase(),
             displayName = testMethodName.displayName,
             summary = summary.map { DocRegularStmt(it) }
@@ -219,7 +225,9 @@ class PythonEngine(
                     methodUnderTest.argumentsNames
                 )
                 try {
-                    return when (val evaluationResult = manager.run(functionArguments, localAdditionalModules)) {
+                    val coverageId = CoverageIdGenerator.createId()
+                    return when (val evaluationResult =
+                        manager.runWithCoverage(functionArguments, localAdditionalModules, coverageId)) {
                         is PythonEvaluationError -> {
                             val utError = UtError(
                                 "Error evaluation: ${evaluationResult.status}, ${evaluationResult.message}",
@@ -230,8 +238,20 @@ class PythonEngine(
                         }
 
                         is PythonEvaluationTimeout -> {
-                            val utTimeoutException = handleTimeoutResult(arguments, description)
-                            PythonExecutionResult(utTimeoutException, PythonFeedback(control = Control.PASS))
+                            val coveredLines =
+                                manager.coverageReceiver.coverageStorage.getOrDefault(coverageId, mutableSetOf())
+                            val utTimeoutException = handleTimeoutResult(arguments, description, coveredLines)
+                            val coveredInstructions = coveredLinesToInstructions(coveredLines, methodUnderTest)
+                            val trieNode: Trie.Node<Instruction> =
+                                if (coveredInstructions.isEmpty())
+                                    Trie.emptyNode()
+                                else description.tracer.add(
+                                    coveredInstructions
+                                )
+                            PythonExecutionResult(
+                                utTimeoutException,
+                                PythonFeedback(control = Control.PASS, result = trieNode)
+                            )
                         }
 
                         is PythonEvaluationSuccess -> {

--- a/utbot-python/src/main/kotlin/org/utbot/python/PythonEngine.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/PythonEngine.kt
@@ -11,6 +11,7 @@ import org.utbot.fuzzing.utils.Trie
 import org.utbot.python.evaluation.*
 import org.utbot.python.evaluation.serialiation.MemoryDump
 import org.utbot.python.evaluation.serialiation.toPythonTree
+import org.utbot.python.evaluation.utils.CoverageIdGenerator
 import org.utbot.python.framework.api.python.PythonTree
 import org.utbot.python.framework.api.python.PythonTreeModel
 import org.utbot.python.framework.api.python.PythonTreeWrapper

--- a/utbot-python/src/main/kotlin/org/utbot/python/evaluation/CodeEvaluationApi.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/evaluation/CodeEvaluationApi.kt
@@ -17,6 +17,12 @@ interface PythonCodeExecutor {
         additionalModulesToImport: Set<String>
     ): PythonEvaluationResult
 
+    fun runWithCoverage(
+        fuzzedValues: FunctionArguments,
+        additionalModulesToImport: Set<String>,
+        coverageId: String,
+    ): PythonEvaluationResult
+
     fun stop()
 }
 

--- a/utbot-python/src/main/kotlin/org/utbot/python/evaluation/PythonCodeSocketExecutor.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/evaluation/PythonCodeSocketExecutor.kt
@@ -50,6 +50,15 @@ class PythonCodeSocketExecutor(
         fuzzedValues: FunctionArguments,
         additionalModulesToImport: Set<String>
     ): PythonEvaluationResult {
+        val coverageId = CoverageIdGenerator.createId()
+        return runWithCoverage(fuzzedValues, additionalModulesToImport, coverageId)
+    }
+
+    override fun runWithCoverage(
+        fuzzedValues: FunctionArguments,
+        additionalModulesToImport: Set<String>,
+        coverageId: String
+    ): PythonEvaluationResult {
         val (arguments, memory) = serializeObjects(fuzzedValues.allArguments.map { it.tree })
 
         val containingClass = method.containingPythonClass
@@ -61,7 +70,6 @@ class PythonCodeSocketExecutor(
                 fullname.drop(moduleToImport.length).removePrefix(".")
             }
 
-        val coverageId = CoverageIdGenerator.createId()
         val request = ExecutionRequest(
             functionTextName,
             moduleToImport,

--- a/utbot-python/src/main/kotlin/org/utbot/python/evaluation/PythonCodeSocketExecutor.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/evaluation/PythonCodeSocketExecutor.kt
@@ -92,6 +92,7 @@ class PythonCodeSocketExecutor(
         val (status, response) = UtExecutorThread.run(pythonWorker, executionTimeout)
         return when (status) {
             UtExecutorThread.Status.TIMEOUT -> {
+
                 PythonEvaluationTimeout()
             }
 

--- a/utbot-python/src/main/kotlin/org/utbot/python/evaluation/PythonCodeSocketExecutor.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/evaluation/PythonCodeSocketExecutor.kt
@@ -12,6 +12,7 @@ import org.utbot.python.evaluation.serialiation.FailExecution
 import org.utbot.python.evaluation.serialiation.PythonExecutionResult
 import org.utbot.python.evaluation.serialiation.SuccessExecution
 import org.utbot.python.evaluation.serialiation.serializeObjects
+import org.utbot.python.evaluation.utils.CoverageIdGenerator
 import org.utbot.python.framework.api.python.util.pythonAnyClassId
 import org.utbot.python.newtyping.pythonTypeName
 import org.utbot.python.newtyping.pythonTypeRepresentation
@@ -60,6 +61,7 @@ class PythonCodeSocketExecutor(
                 fullname.drop(moduleToImport.length).removePrefix(".")
             }
 
+        val coverageId = CoverageIdGenerator.createId()
         val request = ExecutionRequest(
             functionTextName,
             moduleToImport,
@@ -69,6 +71,7 @@ class PythonCodeSocketExecutor(
             emptyMap(),  // here can be only-kwargs arguments
             memory,
             method.moduleFilename,
+            coverageId,
         )
         val message = ExecutionRequestSerializer.serializeRequest(request) ?: error("Cannot serialize request to python executor")
         try {

--- a/utbot-python/src/main/kotlin/org/utbot/python/evaluation/PythonCoverageReceiver.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/evaluation/PythonCoverageReceiver.kt
@@ -1,0 +1,29 @@
+package org.utbot.python.evaluation
+
+import mu.KotlinLogging
+import java.io.IOException
+import java.net.DatagramPacket
+import java.net.DatagramSocket
+import java.net.SocketException
+
+class PythonCoverageReceiver(
+    private val port: Int,
+) {
+    val coverageStorage = mutableMapOf<String, MutableSet<Int>>()
+    private val socket = DatagramSocket(port)
+    private val logger = KotlinLogging.logger {}
+
+    private fun run() {
+        try {
+            while (true) {
+                val request = DatagramPacket(byteArrayOf(1), 1)
+                socket.receive(request)
+                println(request.data)
+            }
+        } catch (ex: SocketException) {
+            logger.error("Socket error: " + ex.message);
+        } catch (ex: IOException) {
+            logger.error("IO error: " + ex.message);
+        }
+    }
+}

--- a/utbot-python/src/main/kotlin/org/utbot/python/evaluation/PythonCoverageReceiver.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/evaluation/PythonCoverageReceiver.kt
@@ -24,14 +24,14 @@ class PythonCoverageReceiver(
                 val request = DatagramPacket(buf, buf.size)
                 socket.receive(request)
                 val (id, line) = request.data.decodeToString().take(request.length).split(":")
-                logger.info { "Got coverage: $id, $line" }
+                logger.debug { "Got coverage: $id, $line" }
                 val lineNumber = line.toInt()
                 coverageStorage.getOrPut(id) { mutableSetOf() } .add(lineNumber)
             }
         } catch (ex: SocketException) {
-            logger.error("Socket error: " + ex.message);
+            logger.error("Socket error: " + ex.message)
         } catch (ex: IOException) {
-            logger.error("IO error: " + ex.message);
+            logger.error("IO error: " + ex.message)
         }
     }
 }

--- a/utbot-python/src/main/kotlin/org/utbot/python/evaluation/PythonWorkerManager.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/evaluation/PythonWorkerManager.kt
@@ -38,7 +38,7 @@ class PythonWorkerManager(
             "localhost",
             serverSocket.localPort.toString(),
             "--logfile", logfile.absolutePath,
-            "--loglevel", "INFO",  // "DEBUG", "INFO", "WARNING", "ERROR"
+            "--loglevel", "DEBUG",  // "DEBUG", "INFO", "WARNING", "ERROR"
         ))
         timeout = max(until - processStartTime, 0)
         workerSocket = try {

--- a/utbot-python/src/main/kotlin/org/utbot/python/evaluation/PythonWorkerManager.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/evaluation/PythonWorkerManager.kt
@@ -43,7 +43,7 @@ class PythonWorkerManager(
             coverageReceiver.address().first,
             coverageReceiver.address().second,
             "--logfile", logfile.absolutePath,
-            "--loglevel", "DEBUG",  // "DEBUG", "INFO", "WARNING", "ERROR"
+            "--loglevel", "INFO",  // "DEBUG", "INFO", "WARNING", "ERROR"
         ))
         timeout = max(until - processStartTime, 0)
         workerSocket = try {
@@ -85,7 +85,7 @@ class PythonWorkerManager(
             reconnect()
             PythonEvaluationTimeout()
         }
-        if (evaluationResult is PythonEvaluationError) {
+        if (evaluationResult is PythonEvaluationError || evaluationResult is PythonEvaluationTimeout) {
             reconnect()
         }
         return evaluationResult

--- a/utbot-python/src/main/kotlin/org/utbot/python/evaluation/serialiation/ExecutionRequestSerializer.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/evaluation/serialiation/ExecutionRequestSerializer.kt
@@ -24,4 +24,5 @@ data class ExecutionRequest(
     val kwargumentsIds: Map<String, String>,
     val serializedMemory: String,
     val filepath: String,
+    val coverageId: String,
 )

--- a/utbot-python/src/main/kotlin/org/utbot/python/evaluation/utils/CoverageIdGenerator.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/evaluation/utils/CoverageIdGenerator.kt
@@ -1,0 +1,14 @@
+package org.utbot.python.evaluation.utils
+
+import java.util.concurrent.atomic.AtomicLong
+
+object CoverageIdGenerator {
+    private const val lower_bound: Long = 1500_000_000
+
+    private val lastId: AtomicLong = AtomicLong(lower_bound)
+
+    fun createId(): String {
+        return lastId.incrementAndGet().toString(radix = 16)
+    }
+
+}

--- a/utbot-python/src/main/kotlin/org/utbot/python/evaluation/utils/CoverageIdGenerator.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/evaluation/utils/CoverageIdGenerator.kt
@@ -10,5 +10,4 @@ object CoverageIdGenerator {
     fun createId(): String {
         return lastId.incrementAndGet().toString(radix = 16)
     }
-
 }

--- a/utbot-python/src/main/kotlin/org/utbot/python/evaluation/utils/Utils.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/evaluation/utils/Utils.kt
@@ -1,0 +1,17 @@
+package org.utbot.python.evaluation.utils
+
+import org.utbot.framework.plugin.api.Instruction
+import org.utbot.python.PythonMethod
+import org.utbot.python.framework.api.python.util.pythonAnyClassId
+import org.utbot.python.newtyping.pythonTypeRepresentation
+
+fun coveredLinesToInstructions(coveredLines: Collection<Int>, method: PythonMethod): List<Instruction> {
+    return coveredLines.map {
+        Instruction(
+            method.containingPythonClass?.pythonTypeRepresentation() ?: pythonAnyClassId.name,
+            method.methodSignature(),
+            it,
+            it.toLong()
+        )
+    }
+}

--- a/utbot-python/src/main/kotlin/org/utbot/python/utils/RequirementsUtils.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/utils/RequirementsUtils.kt
@@ -3,7 +3,7 @@ package org.utbot.python.utils
 object RequirementsUtils {
     val requirements: List<String> = listOf(
         "mypy==1.0.0",
-        "utbot-executor==1.4.23",
+        "utbot-executor==1.4.26",
         "utbot-mypy-runner==0.2.8",
     )
 

--- a/utbot-python/src/main/kotlin/org/utbot/python/utils/RequirementsUtils.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/utils/RequirementsUtils.kt
@@ -3,7 +3,7 @@ package org.utbot.python.utils
 object RequirementsUtils {
     val requirements: List<String> = listOf(
         "mypy==1.0.0",
-        "utbot-executor==1.4.21",
+        "utbot-executor==1.4.23",
         "utbot-mypy-runner==0.2.8",
     )
 


### PR DESCRIPTION
## Description

New UDP socket channel has been added for sending numbers of the covered lines while python code are executing.

Now if function is too long, we can minimise test case by covered lines before execution timeout.

Fixes #2100

## How to test

### Manual tests

1. Open a long python function, e.g. from `utbot-python/samples/easy_samples/long_function_coverage.py`
```python
import time

def long_function(x: int):
    x += 4
    x /= 2
    x += 100
    x *= 3
    x -= 15
    time.sleep(2000)
    return x
```
2. Try to generate tests with a normal `Handing test timeout` (1000ms) and `Test generation timeout` (60s)
3. __Expected__; test have been minimised (for `long_function_coverage.py` only one test)

## Self-check list

Check off the item if the statement is true. Hint: [x] is a marked item.

Please do not delete the list or its items.

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.