### PR TITLE
Automatically install Spring test dependencies into user project if required

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -1341,6 +1341,32 @@ class SpringApplicationContext(
     ): Boolean = field.fieldId in classUnderTest.allDeclaredFieldIds && field.declaringClass.id !in springInjectedClasses
 }
 
+enum class SpringTestType(
+    override val id: String,
+    override val displayName: String,
+    override val description: String,
+    // Integration tests generation requires spring test framework being installed
+    var frameworkInstalled: Boolean = false,
+) : CodeGenerationSettingItem {
+    UNIT_TESTS(
+        "Unit tests",
+        "Unit tests",
+        "Generate unit tests mocking other classes"
+    ),
+    INTEGRATION_TESTS(
+        "Integration tests",
+        "Integration tests",
+        "Generate integration tests autowiring real instance"
+    );
+
+    override fun toString() = id
+
+    companion object : CodeGenerationSettingBox {
+        override val defaultItem = UNIT_TESTS
+        override val allItems: List<SpringTestType> = values().toList()
+    }
+}
+
 /**
  * Describes information about beans obtained from Spring analysis process.
  *

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/utils/DependencyPatterns.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/utils/DependencyPatterns.kt
@@ -76,6 +76,21 @@ fun DependencyInjectionFramework.patterns(): Patterns {
     return Patterns(moduleLibraryPatterns, libraryPatterns)
 }
 
+fun DependencyInjectionFramework.testPatterns(): Patterns {
+    val moduleLibraryPatterns = when (this) {
+        SpringBoot -> springBootTestModulePatterns
+        SpringBeans -> springBeansTestModulePatterns
+        else -> throw UnsupportedOperationException("Unknown dependency injection framework $this")
+    }
+    val libraryPatterns = when (this) {
+        SpringBoot -> springBootTestPatterns
+        SpringBeans -> springBeansTestPatterns
+        else -> throw UnsupportedOperationException("Unknown dependency injection framework $this")
+    }
+
+    return Patterns(moduleLibraryPatterns, libraryPatterns)
+}
+
 val JUNIT_4_JAR_PATTERN = Regex("junit-4(\\.1[2-9])(\\.[0-9]+)?")
 val JUNIT_4_MVN_PATTERN = Regex("junit:junit:4(\\.1[2-9])(\\.[0-9]+)?")
 val junit4Patterns = listOf(JUNIT_4_JAR_PATTERN, JUNIT_4_MVN_PATTERN)
@@ -120,9 +135,24 @@ val springBeansPatterns = listOf(SPRING_BEANS_JAR_PATTERN, SPRING_BEANS_MVN_PATT
 val SPRING_BEANS_BASIC_MODULE_PATTERN = Regex("spring-beans")
 val springBeansModulePatterns = listOf(SPRING_BEANS_BASIC_MODULE_PATTERN)
 
+val SPRING_BEANS_TEST_JAR_PATTERN = Regex("spring-test-([0-9]+)(\\.[0-9]+){1,2}")
+val SPRING_BEANS_TEST_MVN_PATTERN = Regex("org\\.springframework:spring-test:([0-9]+)(\\.[0-9]+){1,2}")
+val springBeansTestPatterns = listOf(SPRING_BEANS_TEST_JAR_PATTERN, SPRING_BEANS_TEST_MVN_PATTERN)
+
+val SPRING_BEANS_TEST_BASIC_MODULE_PATTERN = Regex("spring-test")
+val springBeansTestModulePatterns = listOf(SPRING_BEANS_TEST_BASIC_MODULE_PATTERN)
+
 val SPRING_BOOT_JAR_PATTERN = Regex("spring-boot-([0-9]+)(\\.[0-9]+){1,2}")
 val SPRING_BOOT_MVN_PATTERN = Regex("org\\.springframework\\.boot:spring-boot:([0-9]+)(\\.[0-9]+){1,2}")
 val springBootPatterns = listOf(SPRING_BOOT_JAR_PATTERN, SPRING_BOOT_MVN_PATTERN)
 
 val SPRING_BOOT_BASIC_MODULE_PATTERN = Regex("spring-boot")
 val springBootModulePatterns = listOf(SPRING_BOOT_BASIC_MODULE_PATTERN)
+
+val SPRING_BOOT_TEST_JAR_PATTERN = Regex("spring-boot-test-([0-9]+)(\\.[0-9]+){1,2}")
+val SPRING_BOOT_TEST_MVN_PATTERN = Regex("org\\.springframework\\.boot:spring-boot-test:([0-9]+)(\\.[0-9]+){1,2}")
+
+val springBootTestPatterns = listOf(SPRING_BOOT_TEST_JAR_PATTERN, SPRING_BOOT_TEST_MVN_PATTERN)
+
+val SPRING_BOOT_TEST_BASIC_MODULE_PATTERN = Regex("spring-boot-test")
+val springBootTestModulePatterns = listOf(SPRING_BOOT_TEST_BASIC_MODULE_PATTERN)

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/ExternalLibraryDescriptors.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/ExternalLibraryDescriptors.kt
@@ -22,6 +22,13 @@ fun jUnit5ParametrizedTestsLibraryDescriptor(versionInProject: String?) =
 fun mockitoCoreLibraryDescriptor(versionInProject: String?) =
     ExternalLibraryDescriptor("org.mockito", "mockito-core", "3.5.0", null, versionInProject ?: "4.2.0")
 
+fun springBootTestLibraryDescriptor(versionInProject: String?) =
+    ExternalLibraryDescriptor("org.springframework.boot", "spring-boot-test", "2.4.0", null, versionInProject ?: "3.0.6")
+
+fun springTestLibraryDescriptor(versionInProject: String?) =
+    ExternalLibraryDescriptor("org.springframework", "spring-test", "2.5", null, versionInProject ?: "6.0.8")
+
+
 /**
  * TestNg requires JDK 11 since version 7.6.0
  * For projects with JDK 8 version 7.5 should be installed.

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/GenerateTestsModel.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/GenerateTestsModel.kt
@@ -15,11 +15,13 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiJavaFile
 import com.intellij.refactoring.util.classMembers.MemberInfo
+import org.jetbrains.concurrency.Promise
 import org.jetbrains.kotlin.psi.KtFile
 import org.utbot.framework.SummariesGenerationType
 import org.utbot.framework.UtSettings
 import org.utbot.framework.codegen.domain.TypeReplacementApproach
 import org.utbot.framework.plugin.api.JavaDocCommentStyle
+import org.utbot.framework.plugin.api.SpringTestType
 import org.utbot.framework.util.ConflictTriggers
 import org.utbot.intellij.plugin.settings.Settings
 
@@ -52,12 +54,14 @@ class GenerateTestsModel(
     var runInspectionAfterTestGeneration: Boolean = true
     lateinit var forceStaticMocking: ForceStaticMocking
     lateinit var chosenClassesToMockAlways: Set<ClassId>
+    lateinit var springTestType: SpringTestType
     lateinit var commentStyle: JavaDocCommentStyle
 
     lateinit var typeReplacementApproach: TypeReplacementApproach
     lateinit var profileNames: String
 
     val conflictTriggers: ConflictTriggers = ConflictTriggers()
+    val preCompilePromises: MutableList<Promise<*>> = mutableListOf()
 
     var runGeneratedTestsWithCoverage : Boolean = false
     var summariesGenerationType : SummariesGenerationType = UtSettings.summaryGenerationType

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/Settings.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/Settings.kt
@@ -23,6 +23,7 @@ private fun fromGenerateTestsModel(model: GenerateTestsModel): Settings.State {
         forceStaticMocking = model.forceStaticMocking,
         parametrizedTestSource = model.parametrizedTestSource,
         classesToMockAlways = model.chosenClassesToMockAlways.mapTo(mutableSetOf()) { it.name }.toTypedArray(),
+        springTestType = model.springTestType,
         fuzzingValue = model.fuzzingValue,
         runGeneratedTestsWithCoverage = model.runGeneratedTestsWithCoverage,
         commentStyle = model.commentStyle,

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/LibraryMatcher.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/LibraryMatcher.kt
@@ -3,53 +3,53 @@ package org.utbot.intellij.plugin.ui.utils
 import org.utbot.framework.codegen.domain.TestFramework
 import org.utbot.framework.plugin.api.MockFramework
 import com.intellij.openapi.module.Module
-import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.LibraryOrderEntry
 import org.utbot.framework.codegen.domain.DependencyInjectionFramework
 import org.utbot.framework.plugin.api.utils.Patterns
 import org.utbot.framework.plugin.api.utils.parametrizedTestsPatterns
 import org.utbot.framework.plugin.api.utils.patterns
+import org.utbot.framework.plugin.api.utils.testPatterns
 
 fun findFrameworkLibrary(
-    project: Project,
-    testModule: Module,
+    module: Module,
     testFramework: TestFramework,
     scope: LibrarySearchScope = LibrarySearchScope.Module,
-): LibraryOrderEntry? {
-    return findMatchingLibrary(project, testModule, testFramework.patterns(), scope)
-}
+): LibraryOrderEntry? = findMatchingLibraryOrNull(module, testFramework.patterns(), scope)
 
 fun findFrameworkLibrary(
-    project: Project,
-    testModule: Module,
+    module: Module,
     mockFramework: MockFramework,
     scope: LibrarySearchScope = LibrarySearchScope.Module,
-): LibraryOrderEntry? = findMatchingLibrary(project, testModule, mockFramework.patterns(), scope)
+): LibraryOrderEntry? = findMatchingLibraryOrNull(module, mockFramework.patterns(), scope)
 
 fun findParametrizedTestsLibrary(
-    project: Project,
-    testModule: Module,
+    module: Module,
     testFramework: TestFramework,
     scope: LibrarySearchScope = LibrarySearchScope.Module,
-): LibraryOrderEntry? = findMatchingLibrary(project, testModule, testFramework.parametrizedTestsPatterns(), scope)
+): LibraryOrderEntry? = findMatchingLibraryOrNull(module, testFramework.parametrizedTestsPatterns(), scope)
 
 fun findDependencyInjectionLibrary(
-    project: Project,
-    testModule: Module,
-    springModule: DependencyInjectionFramework,
+    module: Module,
+    springFrameworkType: DependencyInjectionFramework,
     scope: LibrarySearchScope = LibrarySearchScope.Module
-): LibraryOrderEntry? = findMatchingLibrary(project, testModule, springModule.patterns(), scope)
+): LibraryOrderEntry? = findMatchingLibraryOrNull(module, springFrameworkType.patterns(), scope)
 
-private fun findMatchingLibrary(
-    project: Project,
-    testModule: Module,
+fun findDependencyInjectionTestLibrary(
+    module: Module,
+    springFrameworkType: DependencyInjectionFramework,
+    scope: LibrarySearchScope = LibrarySearchScope.Module
+): LibraryOrderEntry? = findMatchingLibraryOrNull(module, springFrameworkType.testPatterns(), scope)
+
+private fun findMatchingLibraryOrNull(
+    module: Module,
     patterns: Patterns,
     scope: LibrarySearchScope,
 ): LibraryOrderEntry? {
     val installedLibraries = when (scope) {
-        LibrarySearchScope.Module -> testModule.allLibraries()
-        LibrarySearchScope.Project -> project.allLibraries()
+        LibrarySearchScope.Module -> module.allLibraries()
+        LibrarySearchScope.Project -> module.project.allLibraries()
     }
+
     return installedLibraries
         .matchesFrameworkPatterns(patterns.moduleLibraryPatterns, patterns.libraryPatterns)
 }

--- a/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/settings/CommonSettings.kt
+++ b/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/settings/CommonSettings.kt
@@ -36,6 +36,7 @@ import java.util.concurrent.CompletableFuture
 import kotlin.reflect.KClass
 import org.utbot.common.isWindows
 import org.utbot.framework.SummariesGenerationType
+import org.utbot.framework.plugin.api.SpringTestType
 import org.utbot.framework.plugin.api.isSummarizationCompatible
 
 @State(
@@ -60,6 +61,7 @@ class Settings(val project: Project) : PersistentStateComponent<Settings.State> 
         var treatOverflowAsError: TreatOverflowAsError = TreatOverflowAsError.defaultItem,
         var parametrizedTestSource: ParametrizedTestSource = ParametrizedTestSource.defaultItem,
         var classesToMockAlways: Array<String> = Mocker.defaultSuperClassesToMockAlwaysNames.toTypedArray(),
+        var springTestType: SpringTestType = SpringTestType.defaultItem,
         var fuzzingValue: Double = 0.05,
         var runGeneratedTestsWithCoverage: Boolean = false,
         var commentStyle: JavaDocCommentStyle = JavaDocCommentStyle.defaultItem,
@@ -87,6 +89,7 @@ class Settings(val project: Project) : PersistentStateComponent<Settings.State> 
             if (treatOverflowAsError != other.treatOverflowAsError) return false
             if (parametrizedTestSource != other.parametrizedTestSource) return false
             if (!classesToMockAlways.contentEquals(other.classesToMockAlways)) return false
+            if (springTestType != other.springTestType) return false
             if (fuzzingValue != other.fuzzingValue) return false
             if (runGeneratedTestsWithCoverage != other.runGeneratedTestsWithCoverage) return false
             if (commentStyle != other.commentStyle) return false
@@ -109,6 +112,7 @@ class Settings(val project: Project) : PersistentStateComponent<Settings.State> 
             result = 31 * result + treatOverflowAsError.hashCode()
             result = 31 * result + parametrizedTestSource.hashCode()
             result = 31 * result + classesToMockAlways.contentHashCode()
+            result = 31 * result + springTestType.hashCode()
             result = 31 * result + fuzzingValue.hashCode()
             result = 31 * result + if (runGeneratedTestsWithCoverage) 1 else 0
             result = 31 * result + summariesGenerationType.hashCode()
@@ -154,6 +158,8 @@ class Settings(val project: Project) : PersistentStateComponent<Settings.State> 
     val parametrizedTestSource: ParametrizedTestSource get() = state.parametrizedTestSource
 
     val classesToMockAlways: Set<String> get() = state.classesToMockAlways.toSet()
+
+    val springTestType: SpringTestType get() = state.springTestType
 
     val javaDocCommentStyle: JavaDocCommentStyle get() = state.commentStyle
 

--- a/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/DialogWindowUtils.kt
+++ b/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/ui/utils/DialogWindowUtils.kt
@@ -5,7 +5,7 @@ import com.intellij.ui.SimpleTextAttributes
 import org.utbot.framework.codegen.domain.TestFramework
 import javax.swing.JList
 
-fun createTestFrameworksRenderer(willBeInstalledLabel: String): ColoredListCellRenderer<TestFramework> {
+fun createTestFrameworksRenderer(additionalText: String): ColoredListCellRenderer<TestFramework> {
     return object : ColoredListCellRenderer<TestFramework>() {
         override fun customizeCellRenderer(
             list: JList<out TestFramework>, value: TestFramework,
@@ -13,7 +13,7 @@ fun createTestFrameworksRenderer(willBeInstalledLabel: String): ColoredListCellR
         ) {
             this.append(value.displayName, SimpleTextAttributes.REGULAR_ATTRIBUTES)
             if (!value.isInstalled) {
-                this.append(willBeInstalledLabel, SimpleTextAttributes.ERROR_ATTRIBUTES)
+                this.append(additionalText, SimpleTextAttributes.ERROR_ATTRIBUTES)
             }
         }
     }


### PR DESCRIPTION
## Description

Supported an auto-installation of Spring or Spring Boot testing dependencies into user projects

Also:
- Added a setting to choose unit or integration testing
- "Framework will be installed" message is shown
- This setting is stored in State
- `LibraryMatcher` class refactored

## How to test

### Manual tests

- Pure Spring project, no test dependency => it is installed with the same version as in project
- Pure Spring project, test dependency is present => no more dependencies installed
- Same two scenarios for Spring Boot projects

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.