### PR TITLE
Improved get-or-create-variable logic

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
@@ -12,7 +12,6 @@ import org.utbot.framework.plugin.api.CodeGenerationSettingItem
 import org.utbot.framework.plugin.api.MethodId
 import org.utbot.framework.plugin.api.TypeParameters
 import org.utbot.framework.plugin.api.UtModel
-import org.utbot.framework.plugin.api.idOrNull
 import org.utbot.framework.plugin.api.isolateCommandLineArgumentsToArgumentFile
 import org.utbot.framework.plugin.api.util.booleanArrayClassId
 import org.utbot.framework.plugin.api.util.booleanClassId
@@ -730,18 +729,13 @@ object SpringBoot : DependencyInjectionFramework(
 )
 
 /**
- * Extended id of [UtModel], unique for whole test set.
+ * Extended [UtModel] model with testSet id and execution id.
  *
- * Allows distinguishing models from different executions and test sets,
- * even if they have the same value of `UtModel.id` that is allowed.
+ * Used as a key in [valueByUtModelWrapper].
+ * Was introduced primarily for shared among all test methods global variables.
  */
-data class ModelId private constructor(
-    private val id: Int?,
-    private val executionId: Int,
-    private val testSetId: Int,
-) {
-    companion object {
-        fun create(model: UtModel, executionId: Int = -1, testSetId: Int = -1) = ModelId(model.idOrNull(), executionId, testSetId)
-    }
-}
-
+data class UtModelWrapper(
+    val testSetId: Int,
+    val executionId: Int,
+    val model: UtModel
+)

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/TestClassModel.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/TestClassModel.kt
@@ -1,9 +1,7 @@
 package org.utbot.framework.codegen.domain.models
 
+import org.utbot.framework.codegen.domain.UtModelWrapper
 import org.utbot.framework.plugin.api.ClassId
-import org.utbot.framework.plugin.api.UtModel
-
-typealias ClassModels = Map<ClassId, Set<UtModel>>
 
 /**
  * Stores method test sets in a structure that replicates structure of their methods in [classUnderTest].
@@ -32,7 +30,7 @@ class SpringTestClassModel(
     classUnderTest: ClassId,
     methodTestSets: List<CgMethodTestSet>,
     nestedClasses: List<SimpleTestClassModel>,
-    val injectedMockModels: ClassModels = mapOf(),
-    val mockedModels: ClassModels = mapOf(),
+    val injectedMockModels: Map<ClassId, Set<UtModelWrapper>> = mapOf(),
+    val mockedModels: Map<ClassId, Set<UtModelWrapper>> = mapOf(),
 ): TestClassModel(classUnderTest, methodTestSets, nestedClasses)
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/builders/SpringTestClassModelBuilder.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/builders/SpringTestClassModelBuilder.kt
@@ -1,9 +1,8 @@
 package org.utbot.framework.codegen.domain.models.builders
 
-import org.utbot.framework.codegen.domain.ModelId
+import org.utbot.framework.codegen.domain.UtModelWrapper
 import org.utbot.framework.codegen.domain.context.CgContext
 import org.utbot.framework.codegen.domain.models.CgMethodTestSet
-import org.utbot.framework.codegen.domain.models.ClassModels
 import org.utbot.framework.codegen.domain.models.SpringTestClassModel
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.UtArrayModel
@@ -27,61 +26,64 @@ class SpringTestClassModelBuilder(val context: CgContext): TestClassModelBuilder
         val (injectedModels, mockedModels) = collectInjectedAndMockedModels(testSets)
 
         return SpringTestClassModel(
-            baseModel.classUnderTest,
-            baseModel.methodTestSets,
-            baseModel.nestedClasses,
-            injectedModels,
-            mockedModels,
+            classUnderTest = baseModel.classUnderTest,
+            methodTestSets = baseModel.methodTestSets,
+            nestedClasses = baseModel.nestedClasses,
+            injectedMockModels = injectedModels,
+            mockedModels = mockedModels
         )
     }
 
-    private fun collectInjectedAndMockedModels(testSets: List<CgMethodTestSet>): Pair<ClassModels, ClassModels> {
-        val thisInstances = mutableSetOf<UtModel>()
-        val thisInstancesDependentModels = mutableSetOf<UtModel>()
+    private fun collectInjectedAndMockedModels(testSets: List<CgMethodTestSet>): Pair<Map<ClassId, Set<UtModelWrapper>>, Map<ClassId, Set<UtModelWrapper>>> {
+        val thisInstances = mutableSetOf<UtModelWrapper>()
+        val thisInstancesDependentModels = mutableSetOf<UtModelWrapper>()
 
-        for ((testSetIndex, testSet) in testSets.withIndex()) {
-            for ((executionIndex, execution) in testSet.executions.withIndex()) {
-
-                setOf(execution.stateBefore.thisInstance, execution.stateAfter.thisInstance)
-                    .filterNotNull()
-                    .forEach { model ->
-                        thisInstances += model
-                        thisInstancesDependentModels += collectByThisInstanceModel(model, executionIndex, testSetIndex)
+        with(context) {
+            for ((testSetIndex, testSet) in testSets.withIndex()) {
+                withTestSetIdScope(testSetIndex) {
+                    for ((executionIndex, execution) in testSet.executions.withIndex()) {
+                        withExecutionIdScope(executionIndex) {
+                            setOf(execution.stateBefore.thisInstance, execution.stateAfter.thisInstance)
+                                .filterNotNull()
+                                .forEach { model ->
+                                    thisInstances += model.wrap()
+                                    thisInstancesDependentModels += collectByThisInstanceModel(model)
+                                }
+                        }
                     }
+                }
             }
         }
 
         val dependentMockModels =
-            thisInstancesDependentModels.filterTo(mutableSetOf()) { it.isMockModel() && it !in thisInstances }
+            thisInstancesDependentModels
+                .filterTo(mutableSetOf()) { cgModel ->
+                    cgModel.model.isMockModel() && cgModel !in thisInstances
+                }
 
         return thisInstances.groupByClassId() to dependentMockModels.groupByClassId()
     }
 
-    private fun collectByThisInstanceModel(model: UtModel, executionIndex: Int, testSetIndex: Int): Set<UtModel> {
-        context.modelIds[model] = ModelId.create(model, executionIndex, testSetIndex)
-
-        val dependentModels = mutableSetOf<UtModel>()
+    private fun collectByThisInstanceModel(model: UtModel): Set<UtModelWrapper> {
+        val dependentModels = mutableSetOf<UtModelWrapper>()
         collectRecursively(model, dependentModels)
-
-        dependentModels.forEach { model ->
-            context.modelIds[model] = ModelId.create(model, executionIndex, testSetIndex)
-        }
 
         return dependentModels
     }
 
-    private fun Set<UtModel>.groupByClassId(): ClassModels {
-        val classModels = mutableMapOf<ClassId, Set<UtModel>>()
+    private fun Set<UtModelWrapper>.groupByClassId(): Map<ClassId, Set<UtModelWrapper>> {
+        val classModels = mutableMapOf<ClassId, Set<UtModelWrapper>>()
 
-        for (modelGroup in this.groupBy { it.classId }) {
+        for (modelGroup in this.groupBy { it.model.classId }) {
             classModels[modelGroup.key] = modelGroup.value.toSet()
         }
 
         return classModels
     }
 
-    private fun collectRecursively(currentModel: UtModel, allModels: MutableSet<UtModel>) {
-        if (!allModels.add(currentModel)) {
+    private fun collectRecursively(currentModel: UtModel, allModels: MutableSet<UtModelWrapper>) {
+        val cgModel = with(context) { currentModel.wrap() }
+        if (!allModels.add(cgModel)) {
             return
         }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgAbstractTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgAbstractTestClassConstructor.kt
@@ -98,7 +98,9 @@ abstract class CgAbstractTestClassConstructor<T : TestClassModel>(val context: C
             }
 
             for (i in checkedRange) {
-                currentTestCaseTestMethods += methodConstructor.createTestMethod(methodUnderTest, testSet.executions[i])
+                withExecutionIdScope(i) {
+                    currentTestCaseTestMethods += methodConstructor.createTestMethod(methodUnderTest, testSet.executions[i])
+                }
             }
 
             val comments = listOf("Actual number of generated tests (${executionIndices.last - executionIndices.first}) exceeds per-method limit (${UtSettings.maxTestsPerMethodInRegion})",

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringVariableConstructor.kt
@@ -1,5 +1,6 @@
 package org.utbot.framework.codegen.tree
 
+import org.utbot.framework.codegen.domain.UtModelWrapper
 import org.utbot.framework.codegen.domain.context.CgContext
 import org.utbot.framework.codegen.domain.models.CgValue
 import org.utbot.framework.codegen.domain.models.CgVariable
@@ -9,8 +10,8 @@ import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.isMockModel
 
 class CgSpringVariableConstructor(context: CgContext) : CgVariableConstructor(context) {
-    val injectedMocksModelsVariables: MutableMap<Set<UtModel>, CgValue> = mutableMapOf()
-    val mockedModelsVariables: MutableMap<Set<UtModel>, CgValue> = mutableMapOf()
+    val injectedMocksModelsVariables: MutableSet<UtModelWrapper> = mutableSetOf()
+    val mockedModelsVariables: MutableSet<UtModelWrapper> = mutableSetOf()
 
     override fun getOrCreateVariable(model: UtModel, name: String?): CgValue {
         val alreadyCreatedInjectMocks = findCgValueByModel(model, injectedMocksModelsVariables)
@@ -41,13 +42,8 @@ class CgSpringVariableConstructor(context: CgContext) : CgVariableConstructor(co
         return super.getOrCreateVariable(model, name)
     }
 
-    private fun findCgValueByModel(modelToFind: UtModel, modelToValueMap: Map<Set<UtModel>, CgValue>): CgValue? =
-        // Here we really need to compare models by reference.
-        // Standard equals is not appropriate because two models from different execution may have same `id`.
-        // Equals on `ModelId` is not appropriate because injected items from different execution have same `executionId`.
-        modelToValueMap
-            .filter { models -> models.key.any { it === modelToFind } }
-            .entries
-            .singleOrNull()
-            ?.value
+    private fun findCgValueByModel(model: UtModel, setOfModels: Set<UtModelWrapper>): CgValue? {
+        val key = setOfModels.find { it == model.wrap() }
+        return valueByUtModelWrapper[key]
+    }
 }

--- a/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/constructor/tree/PythonCgVariableConstructor.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/constructor/tree/PythonCgVariableConstructor.kt
@@ -22,7 +22,8 @@ class PythonCgVariableConstructor(cgContext: CgContext) : CgVariableConstructor(
     private val nameGenerator = CgComponents.getNameGeneratorBy(context)
     override fun getOrCreateVariable(model: UtModel, name: String?): CgValue {
         val baseName = name ?: nameGenerator.nameFrom(model.classId)
-        return valueByModel.getOrPut(model) {
+
+        return valueByUtModelWrapper.getOrPut(model.wrap()) {
             when (model) {
                 is PythonTreeModel -> {
                     val (value, arguments) = pythonBuildObject(model.tree, baseName)


### PR DESCRIPTION
## Description

This PR introduces extended version of UtModel, <ins>UtModelWrapper</ins>. For code-generation purposes we pack UtModels with test set ids and execution ids. It was made primarily for shared among all test methods global variables (i.e. class fields).

Fixes #2104, #2107, #2196

## How to test

### Automated tests

Run utbot-samples.

### Manual tests

Open [pet-clinic](https://github.com/spring-projects/spring-petclinic) project and generate tests for OwnerController and VetController. There must be no unused global variables, recreated global variables.

Open non-spring project and generate some tests. There everything must be as usual.