### PR TITLE
Move KryoHelper to use it for different processes communication

### DIFF
--- a/utbot-framework-api/build.gradle.kts
+++ b/utbot-framework-api/build.gradle.kts
@@ -5,6 +5,8 @@ val sootVersion: String by rootProject
 val commonsLangVersion: String by rootProject
 val kotlinLoggingVersion: String? by rootProject
 val rdVersion: String? by rootProject
+val kryoVersion: String? by rootProject
+val kryoSerializersVersion: String? by rootProject
 
 plugins {
     id("com.github.johnrengelman.shadow") version "7.1.2"
@@ -22,6 +24,9 @@ dependencies {
     implementation(group = "io.github.microutils", name = "kotlin-logging", version = kotlinLoggingVersion)
     // TODO do we really need apache commons?
     implementation(group = "org.apache.commons", name = "commons-lang3", version = commonsLangVersion)
+    implementation(group = "com.esotericsoftware.kryo", name = "kryo5", version = kryoVersion)
+    // this is necessary for serialization of some collections
+    implementation(group = "de.javakaffee", name = "kryo-serializers", version = kryoSerializersVersion)
     testImplementation(group = "junit", name = "junit", version = junit4Version)
 }
 

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/process/kryo/KryoHelper.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/process/kryo/KryoHelper.kt
@@ -1,4 +1,4 @@
-package org.utbot.instrumentation.util
+package org.utbot.framework.process.kryo
 
 import com.esotericsoftware.kryo.kryo5.Kryo
 import com.esotericsoftware.kryo.kryo5.SerializerFactory

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/process/kryo/ProcessCommunicationException.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/process/kryo/ProcessCommunicationException.kt
@@ -1,0 +1,9 @@
+package org.utbot.framework.process.kryo
+
+open class ProcessCommunicationException(msg: String?, cause: Throwable? = null) : Exception(msg, cause)
+
+class ReadingFromKryoException(e: Throwable) :
+    ProcessCommunicationException("Reading from Kryo exception |> ${e.stackTraceToString()}", e)
+
+class WritingToKryoException(e: Throwable) :
+    ProcessCommunicationException("Writing to Kryo exception |> ${e.stackTraceToString()}", e)

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/process/kryo/ThrowableSerializer.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/process/kryo/ThrowableSerializer.kt
@@ -1,4 +1,4 @@
-package org.utbot.instrumentation.util
+package org.utbot.framework.process.kryo
 
 import com.esotericsoftware.kryo.kryo5.Kryo
 import com.esotericsoftware.kryo.kryo5.KryoException

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineProcessMain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineProcessMain.kt
@@ -29,8 +29,8 @@ import org.utbot.framework.plugin.services.JdkInfo
 import org.utbot.framework.process.generated.*
 import org.utbot.framework.process.generated.BeanAdditionalData
 import org.utbot.framework.process.generated.BeanDefinitionData
+import org.utbot.framework.process.kryo.KryoHelper
 import org.utbot.instrumentation.instrumentation.instrumenter.Instrumenter
-import org.utbot.instrumentation.util.KryoHelper
 import org.utbot.rd.IdleWatchdog
 import org.utbot.rd.ClientProtocolBuilder
 import org.utbot.rd.RdSettingsContainerFactory

--- a/utbot-instrumentation/build.gradle.kts
+++ b/utbot-instrumentation/build.gradle.kts
@@ -49,9 +49,6 @@ dependencies {
 
     implementation("org.ow2.asm:asm:$asmVersion")
     implementation("org.ow2.asm:asm-commons:$asmVersion")
-    implementation("com.esotericsoftware.kryo:kryo5:$kryoVersion")
-    // this is necessary for serialization of some collections
-    implementation("de.javakaffee:kryo-serializers:$kryoSerializersVersion")
     implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
 
     implementation("com.jetbrains.rd:rd-framework:$rdVersion")

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/process/InstrumentedProcessMain.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/process/InstrumentedProcessMain.kt
@@ -8,6 +8,7 @@ import org.mockito.Mockito
 import org.utbot.common.*
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.util.UtContext
+import org.utbot.framework.process.kryo.KryoHelper
 import org.utbot.instrumentation.agent.Agent
 import org.utbot.instrumentation.instrumentation.Instrumentation
 import org.utbot.instrumentation.instrumentation.coverage.CoverageInstrumentation
@@ -19,7 +20,6 @@ import org.utbot.instrumentation.process.generated.GetSpringRepositoriesResult
 import org.utbot.instrumentation.process.generated.InstrumentedProcessModel
 import org.utbot.instrumentation.process.generated.InvokeMethodCommandResult
 import org.utbot.instrumentation.process.generated.instrumentedProcessModel
-import org.utbot.instrumentation.util.KryoHelper
 import org.utbot.rd.IdleWatchdog
 import org.utbot.rd.ClientProtocolBuilder
 import org.utbot.rd.RdSettingsContainerFactory

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/rd/InstrumentedProcess.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/rd/InstrumentedProcess.kt
@@ -10,6 +10,8 @@ import org.utbot.framework.UtSettings
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.services.WorkingDirService
 import org.utbot.framework.process.AbstractRDProcessCompanion
+import org.utbot.framework.process.kryo.KryoHelper
+import org.utbot.instrumentation.agent.DynamicClassTransformer
 import org.utbot.instrumentation.instrumentation.Instrumentation
 import org.utbot.instrumentation.process.DISABLE_SANDBOX_OPTION
 import org.utbot.instrumentation.process.generated.AddPathsParams
@@ -17,7 +19,6 @@ import org.utbot.instrumentation.process.generated.GetSpringBeanParams
 import org.utbot.instrumentation.process.generated.InstrumentedProcessModel
 import org.utbot.instrumentation.process.generated.SetInstrumentationParams
 import org.utbot.instrumentation.process.generated.instrumentedProcessModel
-import org.utbot.instrumentation.util.KryoHelper
 import org.utbot.rd.ProcessWithRdServer
 import org.utbot.rd.exceptions.InstantProcessDeathException
 import org.utbot.rd.generated.LoggerModel

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/util/InstrumentationException.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/util/InstrumentationException.kt
@@ -20,12 +20,6 @@ class NoProbesArrayException(clazz: Class<*>, arrayName: String) :
 class CastProbesArrayException :
     InstrumentationException("Can't cast probes array to Boolean array")
 
-class ReadingFromKryoException(e: Throwable) :
-    InstrumentationException("Reading from Kryo exception |> ${e.stackTraceToString()}", e)
-
-class WritingToKryoException(e: Throwable) :
-    InstrumentationException("Writing to Kryo exception |> ${e.stackTraceToString()}", e)
-
 /**
  * this exception is thrown only in main process.
  * currently it means that {e: Throwable} happened in instrumented process,

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/process/EngineProcess.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/process/EngineProcess.kt
@@ -25,9 +25,9 @@ import org.utbot.framework.plugin.services.WorkingDirService
 import org.utbot.framework.process.AbstractRDProcessCompanion
 import org.utbot.framework.process.generated.*
 import org.utbot.framework.process.generated.MethodDescription
+import org.utbot.framework.process.kryo.KryoHelper
 import org.utbot.framework.util.Conflict
 import org.utbot.framework.util.ConflictTriggers
-import org.utbot.instrumentation.util.KryoHelper
 import org.utbot.intellij.plugin.UtbotBundle
 import org.utbot.intellij.plugin.models.GenerateTestsModel
 import org.utbot.intellij.plugin.ui.TestReportUrlOpeningListener


### PR DESCRIPTION
## Description

`KryoHelper` was located inside the instrumentation process.
I would like to use this serialization tool for communication with Spring analysis process too, so I moved it to the common project.

## How to test

### Manual tests

Verify that there is no regressions is serialization in instrumented process.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.