### PR TITLE
Fix double-quoted spring-analyzer process classpath argument

### DIFF
--- a/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/process/SpringAnalyzerProcess.kt
+++ b/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/process/SpringAnalyzerProcess.kt
@@ -89,7 +89,7 @@ class SpringAnalyzerProcess private constructor(
                 val rdProcess = startUtProcessWithRdServer(lifetime) { port ->
                     classpathArgs = listOf(
                         "-cp",
-                        "\"${extendedClasspath.joinToString(File.pathSeparator)}\"",
+                        extendedClasspath.joinToString(File.pathSeparator),
                         "org.utbot.spring.process.SpringAnalyzerProcessMainKt"
                     )
                     val cmd = obtainProcessCommandLine(port)


### PR DESCRIPTION
## Description

One pair of quotes is already added by Java standard library, removed manually added second pair of quotes to fix spring-analyzer starting on macOS 13.3.1

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.