### PR TITLE
Fix problem with infinite running python-cli

### DIFF
--- a/utbot-python/src/main/kotlin/org/utbot/python/evaluation/PythonCoverageReceiver.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/evaluation/PythonCoverageReceiver.kt
@@ -17,6 +17,11 @@ class PythonCoverageReceiver(
         return "localhost" to socket.localPort.toString()
     }
 
+    fun kill() {
+        socket.close()
+        this.interrupt()
+    }
+
     override fun run() {
         try {
             while (System.currentTimeMillis() < until) {

--- a/utbot-python/src/main/kotlin/org/utbot/python/evaluation/PythonWorkerManager.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/evaluation/PythonWorkerManager.kt
@@ -65,7 +65,7 @@ class PythonWorkerManager(
     fun disconnect() {
         workerSocket.close()
         process.destroy()
-        coverageReceiver.interrupt()
+        coverageReceiver.kill()
     }
 
     fun reconnect() {


### PR DESCRIPTION
## Description

Now python-cli process will be closed after test generation.

There was a problem with opened sockets for coverage collection.

## How to test

### Manual tests

1. Run python-cli
2. __Expected__: process closed after test generation (after the last message `Finished test generation for the following functions: ...`)

## Self-check list

Check off the item if the statement is true. Hint: [x] is a marked item.

Please do not delete the list or its items.

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.