### PR TITLE
Correct two regressions in Spring codegen

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/MockFrameworkManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/MockFrameworkManager.kt
@@ -220,7 +220,10 @@ private class MockitoMocker(context: CgContext) : ObjectMocker(context) {
                         }
 
                         val results = values
-                            .map { if (it === model) mockObject else variableConstructor.getOrCreateVariable(it) }
+                            .map { value ->
+                                // Sometimes we need mocks returning itself, e.g. for StringBuilder.append method
+                                if (value != model) variableConstructor.getOrCreateVariable(value) else mockObject
+                            }
                             .toTypedArray()
                         `when`(mockObject[executable](*matchers)).thenReturn(executable.returnType, *results)
                     }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/MockFrameworkManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/MockFrameworkManager.kt
@@ -183,8 +183,6 @@ private abstract class StaticMocker(
 
 private class MockitoMocker(context: CgContext) : ObjectMocker(context) {
 
-    private val alreadyMockedModels: MutableSet<UtCompositeModel> = Collections.newSetFromMap(IdentityHashMap())
-
     override fun createMock(model: UtCompositeModel, baseName: String): CgVariable {
         val modelClass = getClassOf(model.classId)
         val mockObject = newVar(model.classId, baseName = baseName, isMock = true) { mock(modelClass) }
@@ -195,10 +193,6 @@ private class MockitoMocker(context: CgContext) : ObjectMocker(context) {
     }
 
     fun mockForVariable(model: UtCompositeModel, mockObject: CgVariable) {
-        if (!alreadyMockedModels.add(model)) {
-            return
-        }
-
         for ((executable, values) in model.mocks) {
             val matchers = mockitoArgumentMatchersFor(executable)
 
@@ -225,7 +219,9 @@ private class MockitoMocker(context: CgContext) : ObjectMocker(context) {
                             error("Cannot mock method $executable as it is not accessible from package $testClassPackageName")
                         }
 
-                        val results = values.map { variableConstructor.getOrCreateVariable(it) }.toTypedArray()
+                        val results = values
+                            .map { if (it === model) mockObject else variableConstructor.getOrCreateVariable(it) }
+                            .toTypedArray()
                         `when`(mockObject[executable](*matchers)).thenReturn(executable.returnType, *results)
                     }
                     else -> error("Only MethodId was expected to appear in simple mocker but got $executable")

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringUnitTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringUnitTestClassConstructor.kt
@@ -35,9 +35,9 @@ class CgSpringUnitTestClassConstructor(context: CgContext) : CgAbstractSpringTes
             fields += injectingMocksFields
             fields += mockedFields
             fields += constructMockitoCloseables()
-        }
 
-        additionalMethodsRequired = fields.isNotEmpty()
+            additionalMethodsRequired = true
+        }
 
         return fields
     }


### PR DESCRIPTION
## Description

Fixes two significant regressions in Spring codegen:

1) After https://github.com/UnitTestBot/UTBotJava/pull/2230 I introduced a bug that lateinit variable `mockitoCloseableVariable` is not initialized. Fixed in `CgSpringUnitTestClassConstructor`.

2) After https://github.com/UnitTestBot/UTBotJava/pull/2157 I introduced a bug with missing mocks, now reverting changes. Stack overflow related problems still need to be fixed in https://github.com/UnitTestBot/UTBotJava/issues/2158

## How to test

### Automated tests

Codegen regression on `spring-petclinic` and similar projects.

### Manual tests

Manual verification of generated tests.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.