### PR TITLE
Python small fixes

### DIFF
--- a/utbot-intellij-python/src/main/kotlin/org/utbot/intellij/plugin/language/python/PythonLanguageAssistant.kt
+++ b/utbot-intellij-python/src/main/kotlin/org/utbot/intellij/plugin/language/python/PythonLanguageAssistant.kt
@@ -44,7 +44,7 @@ object PythonLanguageAssistant : LanguageAssistant() {
         PythonDialogProcessor.createDialogAndGenerateTests(
             project,
             targets.pyClasses + targets.pyFunctions,
-            targets.focusedClass ?: targets.focusedFunction,
+            targets.focusedFunction ?: targets.focusedClass,
             targets.editor,
         )
     }
@@ -66,8 +66,8 @@ object PythonLanguageAssistant : LanguageAssistant() {
             val file = e.getData(CommonDataKeys.PSI_FILE) as? PyFile ?: return null
             val element = findPsiElement(file, editor) ?: return null
 
-            val allFunctions = file.topLevelFunctions.filter { fineFunction(it) }
-            val allClasses = file.topLevelClasses.filter { fineClass(it) }
+            val rootFunctions = file.topLevelFunctions.filter { fineFunction(it) }
+            val rootClasses = file.topLevelClasses.filter { fineClass(it) }
 
             val containingClass = getContainingElement<PyClass>(element) { fineClass(it) }
             val containingFunction: PyFunction? =
@@ -80,18 +80,18 @@ object PythonLanguageAssistant : LanguageAssistant() {
                                 ancestors.count { it is PyClass } == 1 && fineFunction(func)
                     }
 
-            if (allClasses.isEmpty()) {
-                return if (allFunctions.isEmpty()) {
+            if (rootClasses.isEmpty()) {
+                return if (rootFunctions.isEmpty()) {
                     null
                 } else {
-                    resultFunctions.addAll(allFunctions)
+                    resultFunctions.addAll(rootFunctions)
                     focusedFunction = containingFunction
                     Targets(resultClasses, resultFunctions, null, focusedFunction, editor)
                 }
             } else {
                 if (containingClass == null) {
-                    resultClasses.addAll(allClasses)
-                    resultFunctions.addAll(allFunctions)
+                    resultClasses.addAll(rootClasses)
+                    resultFunctions.addAll(rootFunctions)
                     focusedFunction = containingFunction
                 } else {
                     resultFunctions.addAll(containingClass.methods.filter { fineFunction(it) })

--- a/utbot-python/samples/easy_samples/general.py
+++ b/utbot-python/samples/easy_samples/general.py
@@ -206,3 +206,9 @@ def n(x, y):
 
 def list_of_list(x: List[List[InventoryItem]]):
     return x
+
+
+def make_tuple(x: list[int]):
+    if len(x) == 0:
+        return tuple()
+    return tuple(x)

--- a/utbot-python/src/main/kotlin/org/utbot/python/PythonEngine.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/PythonEngine.kt
@@ -339,7 +339,7 @@ class PythonEngine(
                     logger.info { "Cannot fuzz values for types: ${parameters.map { it.pythonTypeRepresentation() }}" }
                 }
             }
-            manager.disconnect()
+            manager.shutdown()
         }
     }
 }

--- a/utbot-python/src/main/kotlin/org/utbot/python/evaluation/PythonWorkerManager.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/evaluation/PythonWorkerManager.kt
@@ -33,7 +33,7 @@ class PythonWorkerManager(
         connect()
     }
 
-    fun connect() {
+    private fun connect() {
         val processStartTime = System.currentTimeMillis()
         process = startProcess(listOf(
             pythonPath,
@@ -65,12 +65,16 @@ class PythonWorkerManager(
     fun disconnect() {
         workerSocket.close()
         process.destroy()
-        coverageReceiver.kill()
     }
 
-    fun reconnect() {
+    private fun reconnect() {
         disconnect()
         connect()
+    }
+
+    fun shutdown() {
+        disconnect()
+        coverageReceiver.kill()
     }
 
     fun runWithCoverage(

--- a/utbot-python/src/main/kotlin/org/utbot/python/evaluation/serialiation/PythonObjectParser.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/evaluation/serialiation/PythonObjectParser.kt
@@ -5,7 +5,6 @@ import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import org.utbot.python.framework.api.python.PythonClassId
 import org.utbot.python.framework.api.python.PythonTree
-import org.utbot.python.framework.api.python.util.pythonStrClassId
 
 object PythonObjectParser {
     private val moshi = Moshi.Builder()
@@ -149,10 +148,7 @@ fun PythonTree.PythonTreeNode.toMemoryObject(memoryDump: MemoryDump): String {
 
         is PythonTree.ReduceNode -> {
             val stateObjId = PythonTree.DictNode(this.state.entries.associate {
-                PythonTree.PrimitiveNode(
-                    pythonStrClassId,
-                    it.key
-                ) to it.value
+                PythonTree.fromString(it.key) to it.value
             }.toMutableMap())
             val argsIds = PythonTree.ListNode(this.args.withIndex().associate { it.index to it.value }.toMutableMap())
             val listItemsIds =

--- a/utbot-python/src/main/kotlin/org/utbot/python/framework/api/python/PythonTree.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/framework/api/python/PythonTree.kt
@@ -305,9 +305,15 @@ object PythonTree {
     }
 
     fun fromFloat(value: Double): PrimitiveNode {
+        val stringValue =
+            when (value) {
+                Double.POSITIVE_INFINITY -> "float('inf')"
+                Double.NEGATIVE_INFINITY -> "-float('inf')"
+                else -> value.toString()
+            }
         return PrimitiveNode(
             pythonFloatClassId,
-            value.toString()
+            stringValue
         )
     }
 

--- a/utbot-python/src/main/kotlin/org/utbot/python/framework/api/python/util/PythonUtils.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/framework/api/python/util/PythonUtils.kt
@@ -18,6 +18,7 @@ fun String.toSnakeCase(): String {
 
 fun String.toPythonRepr(): String {
     val repr = this
+        .replace(Regex("((?<!\\\\)(\\\\\\\\)*)(\\\\)(?!\\\\)$"), "$1$3$3")
         .replace("\"", "\\\"")
         .replace("\\\\\"", "\\\"")
     return "\"$repr\""

--- a/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/constructor/visitor/CgPythonRenderer.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/constructor/visitor/CgPythonRenderer.kt
@@ -536,12 +536,16 @@ internal class CgPythonRenderer(
     }
 
     override fun visit(element: CgPythonTuple) {
-        print("(")
-        element.elements.renderSeparated()
-        if (element.elements.size == 1) {
-            print(",")
+        if (element.elements.isEmpty()) {
+            print("tuple()")
+        } else {
+            print("(")
+            element.elements.renderSeparated()
+            if (element.elements.size == 1) {
+                print(",")
+            }
+            print(")")
         }
-        print(")")
     }
 
     override fun visit(element: CgPythonSet) {


### PR DESCRIPTION
## Description

A few small fixes in UTBot Python:
1. fixed empty and one-element tuple code generation
2. fixed missing imports for constructors
3. fixed disconnecting socket for coverage
4. fixed wrong strings with \ at the end
5. fixed serialisation of `Infinity` from fuzzer
6. fixed serialisation of `state` field in reduce object
7. fixed focused item in dialog window 

## How to test

### Manual tests

1. generate tests for function which returns empty or one-element tuple, expected: no syntax error
```python
def f(x): return tuple()
def g(x): return (x,)
```
2. generate tests for [`utbot-python/samples/samples/using_collections.py`](https://github.com/UnitTestBot/UTBotJava/blob/main/utbot-python/samples/samples/using_collections.py), expected: no syntax error
3. no stop generation after some exception in execution
4. no message about in in logs
5. `Infinity` from fuzzer serialised to `float('inf')`
6. no problem with serialisation of composite objects
7. try to generate tests for one function from the file with other functions or for one method from the class with other methods, expected: only tested function / method is selected in dialog window.

## Self-check list

Check off the item if the statement is true. Hint: [x] is a marked item.

Please do not delete the list or its items.

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.