### PR TITLE
Show `utbot-engine-current.log` in a separate tab in IDE when debugging any process

### DIFF
--- a/.run/Listen for Engine Process.run.xml
+++ b/.run/Listen for Engine Process.run.xml
@@ -1,5 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Listen for Engine Process" type="Remote" folderName="Utility Configurations">
+    <log_file alias="utbot-engine-current.log (win)" path="$USER_HOME$/AppData/Local/Temp/UTBot/rdEngineProcessLogs/utbot-engine-current.log" />
+    <log_file alias="utbot-engine-current.log (linux)" path="/tmp/UTBot/rdEngineProcessLogs/utbot-engine-current.log" />
     <option name="USE_SOCKET_TRANSPORT" value="true" />
     <option name="SERVER_MODE" value="true" />
     <option name="SHMEM_ADDRESS" />

--- a/.run/Listen for Instrumented Process.run.xml
+++ b/.run/Listen for Instrumented Process.run.xml
@@ -1,5 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Listen for Instrumented Process" type="Remote" folderName="Utility Configurations">
+    <log_file alias="utbot-engine-current.log (win)" path="$USER_HOME$/AppData/Local/Temp/UTBot/rdEngineProcessLogs/utbot-engine-current.log" />
+    <log_file alias="utbot-engine-current.log (linux)" path="/tmp/UTBot/rdEngineProcessLogs/utbot-engine-current.log" />
     <option name="USE_SOCKET_TRANSPORT" value="true" />
     <option name="SERVER_MODE" value="true" />
     <option name="SHMEM_ADDRESS" />

--- a/.run/Listen for Spring Analyzer Process.run.xml
+++ b/.run/Listen for Spring Analyzer Process.run.xml
@@ -1,5 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Listen for Spring Analyzer Process" type="Remote" folderName="Utility Configurations">
+    <log_file alias="utbot-engine-current.log (win)" path="$USER_HOME$/AppData/Local/Temp/UTBot/rdEngineProcessLogs/utbot-engine-current.log" />
+    <log_file alias="utbot-engine-current.log (linux)" path="/tmp/UTBot/rdEngineProcessLogs/utbot-engine-current.log" />
     <option name="USE_SOCKET_TRANSPORT" value="true" />
     <option name="SERVER_MODE" value="true" />
     <option name="SHMEM_ADDRESS" />


### PR DESCRIPTION
## Description

Made it so `utbot-engine-current.log` can be viewed from within Intellij IDEA when debugging any process.

Configured it so Intellij IDEA looks for `utbot-engine-current.log` in default folders that are used by Windows 10 and Ubuntu 23.04. If IDE fails to find the log file, then it just ignores it and everything works as it did before this PR.

![logs-in-ide](https://github.com/UnitTestBot/UTBotJava/assets/71839386/15d5b6f5-f504-44f0-b0e3-44c6881d2aa5)