### PR TITLE
Support direct field accesses in call models

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -495,14 +495,14 @@ data class UtArrayModel(
  *
  * The default constructor is made private to enforce using a safe constructor.
  *
- * @param instantiationCall is an [UtExecutableCallModel] to instantiate represented object. It **must** not return `null`.
+ * @param instantiationCall is an [UtStatementCallModel] to instantiate represented object. It **must** not return `null`.
  * @param modificationsChain is a chain of [UtStatementModel] to construct object state.
  */
 data class UtAssembleModel private constructor(
     override val id: Int?,
     override val classId: ClassId,
     override val modelName: String,
-    val instantiationCall: UtExecutableCallModel,
+    val instantiationCall: UtStatementCallModel,
     val modificationsChain: List<UtStatementModel>,
     val origin: UtCompositeModel?
 ) : UtReferenceModel(id, classId, modelName) {
@@ -520,14 +520,14 @@ data class UtAssembleModel private constructor(
      * constructor or a method of another class, which returns the object of the [classId] type.
      *
      * @param modificationsChainProvider used for creating modifying statements. Its receiver corresponds to newly
-     * created [UtAssembleModel], so you can use it for caching and for creating [UtExecutableCallModel]s with it
-     * as [UtExecutableCallModel.instance].
+     * created [UtAssembleModel], so you can use it for caching and for creating [UtStatementCallModel]s with it
+     * as [UtStatementCallModel.instance].
      */
     constructor(
         id: Int?,
         classId: ClassId,
         modelName: String,
-        instantiationCall: UtExecutableCallModel,
+        instantiationCall: UtStatementCallModel,
         origin: UtCompositeModel? = null,
         modificationsChainProvider: UtAssembleModel.() -> List<UtStatementModel> = { emptyList() }
     ) : this(id, classId, modelName, instantiationCall, mutableListOf(), origin) {
@@ -691,23 +691,23 @@ sealed class UtStatementModel(
 )
 
 /**
- * Step of assemble instruction that calls executable.
+ * Step of assemble instruction that calls executable or accesses a field.
  *
- * Contains executable to call, call parameters and an instance model before call.
- *
+ * Contains statement to call, call parameters and an instance model before call.
  * @param [instance] **must be** `null` for static methods and constructors
  */
-data class UtExecutableCallModel(
+data class UtStatementCallModel(
     override val instance: UtReferenceModel?,
-    val executable: ExecutableId,
+    val statement: StatementId,
     val params: List<UtModel>,
 ) : UtStatementModel(instance) {
     override fun toString() = withToStringThreadLocalReentrancyGuard {
         buildString {
 
-            val executableName = when (executable) {
-                is ConstructorId -> executable.classId.name
-                is MethodId -> executable.name
+            val executableName = when (statement) {
+                is MethodId -> statement.name
+                is DirectFieldAccessId -> statement.name
+                is ConstructorId -> statement.classId.name
             }
 
             if (instance != null) {

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/CollectionIteratorWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/CollectionIteratorWrappers.kt
@@ -8,7 +8,7 @@ import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.FieldId
 import org.utbot.framework.plugin.api.MethodId
 import org.utbot.framework.plugin.api.UtAssembleModel
-import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtReferenceModel
 import org.utbot.framework.plugin.api.util.fieldId
@@ -41,9 +41,9 @@ abstract class CollectionIteratorWrapper(overriddenClass: KClass<*>) : BaseOverr
         val containerFieldId = overriddenClass.enclosingClassField
         val containerFieldModel = fieldModels[containerFieldId] as UtReferenceModel
 
-        val instantiationCall = UtExecutableCallModel(
+        val instantiationCall = UtStatementCallModel(
             instance = containerFieldModel,
-            executable = iteratorMethodId,
+            statement = iteratorMethodId,
             params = emptyList()
         )
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/CollectionWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/CollectionWrappers.kt
@@ -22,7 +22,7 @@ import org.utbot.framework.plugin.api.MethodId
 import org.utbot.framework.plugin.api.UtArrayModel
 import org.utbot.framework.plugin.api.UtAssembleModel
 import org.utbot.framework.plugin.api.UtCompositeModel
-import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtNullModel
 import org.utbot.framework.plugin.api.classId
@@ -126,14 +126,14 @@ abstract class BaseContainerWrapper(containerClassName: String) : BaseOverridden
 
         val classId = chooseClassIdWithConstructor(wrapper.type.sootClass.id)
 
-        val instantiationCall = UtExecutableCallModel(
+        val instantiationCall = UtStatementCallModel(
             instance = null,
-            executable = constructorId(classId),
+            statement = constructorId(classId),
             params = emptyList()
         )
 
         UtAssembleModel(addr, classId, modelName, instantiationCall) {
-            parameterModels.map { UtExecutableCallModel(this, modificationMethodId, it) }
+            parameterModels.map { UtStatementCallModel(this, modificationMethodId, it) }
         }
     }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ObjectWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ObjectWrappers.kt
@@ -58,7 +58,7 @@ import org.utbot.engine.types.THREAD_GROUP_TYPE
 import org.utbot.engine.types.THREAD_TYPE
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.UtAssembleModel
-import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtPrimitiveModel
 import org.utbot.framework.plugin.api.id
@@ -398,8 +398,8 @@ data class ThrowableWrapper(val throwable: Throwable) : WrapperInterface {
         val modelName = nextModelName(throwable.javaClass.simpleName.decapitalize())
 
         val instantiationCall = when (val message = throwable.message) {
-            null -> UtExecutableCallModel(instance = null, constructorId(classId), emptyList())
-            else -> UtExecutableCallModel(
+            null -> UtStatementCallModel(instance = null, constructorId(classId), emptyList())
+            else -> UtStatementCallModel(
                 instance = null,
                 constructorId(classId, stringClassId),
                 listOf(UtPrimitiveModel(message))

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/OptionalWrapper.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/OptionalWrapper.kt
@@ -13,10 +13,9 @@ import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.FieldId
 import org.utbot.framework.plugin.api.MethodId
 import org.utbot.framework.plugin.api.UtAssembleModel
-import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.framework.plugin.api.UtNullModel
 import org.utbot.framework.plugin.api.UtPrimitiveModel
-import org.utbot.framework.plugin.api.UtStatementModel
 import org.utbot.framework.plugin.api.classId
 import org.utbot.framework.plugin.api.id
 import org.utbot.framework.plugin.api.util.defaultValueModel
@@ -98,7 +97,7 @@ class OptionalWrapper(private val utOptionalClass: UtOptionalClass) : BaseOverri
         return UtAssembleModel(addr, classId, modelName, instantiationCall)
     }
 
-    private fun Resolver.instantiationFactoryCallModel(classId: ClassId, wrapper: ObjectValue) : UtExecutableCallModel {
+    private fun Resolver.instantiationFactoryCallModel(classId: ClassId, wrapper: ObjectValue) : UtStatementCallModel {
         val valueField = FieldId(overriddenClass.id, "value")
         val isPresentFieldId = FieldId(overriddenClass.id, "isPresent")
         val values = collectFieldModels(wrapper.addr, overriddenClass.type)
@@ -109,7 +108,7 @@ class OptionalWrapper(private val utOptionalClass: UtOptionalClass) : BaseOverri
             values[isPresentFieldId]?.let { (it as UtPrimitiveModel).value as Boolean } ?: false
         }
         return if (!isPresent) {
-            UtExecutableCallModel(
+            UtStatementCallModel(
                 instance = null,
                 MethodId(
                     classId,
@@ -119,7 +118,7 @@ class OptionalWrapper(private val utOptionalClass: UtOptionalClass) : BaseOverri
                 ), emptyList()
             )
         } else {
-            UtExecutableCallModel(
+            UtStatementCallModel(
                 instance = null,
                 MethodId(
                     classId,

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Resolver.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Resolver.kt
@@ -40,7 +40,7 @@ import org.utbot.framework.plugin.api.UtAssembleModel
 import org.utbot.framework.plugin.api.UtClassRefModel
 import org.utbot.framework.plugin.api.UtCompositeModel
 import org.utbot.framework.plugin.api.UtEnumConstantModel
-import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.framework.plugin.api.UtExecutionFailure
 import org.utbot.framework.plugin.api.UtExecutionResult
 import org.utbot.framework.plugin.api.UtExecutionSuccess
@@ -613,7 +613,7 @@ class Resolver(
             val baseModelName = primitiveClassId.name
             val constructorId = constructorId(classId, primitiveClassId)
             val valueModel = fields[FieldId(classId, "value")] ?: primitiveClassId.defaultValueModel()
-            val instantiationCall = UtExecutableCallModel(instance = null, constructorId, listOf(valueModel))
+            val instantiationCall = UtStatementCallModel(instance = null, constructorId, listOf(valueModel))
             UtAssembleModel(addr, classId, nextModelName(baseModelName), instantiationCall)
         }
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/SecurityManagerWrapper.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/SecurityManagerWrapper.kt
@@ -2,7 +2,7 @@ package org.utbot.engine
 
 import org.utbot.engine.overrides.security.UtSecurityManager
 import org.utbot.framework.plugin.api.UtAssembleModel
-import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.classId
 import org.utbot.framework.plugin.api.util.executableId
@@ -28,7 +28,7 @@ class SecurityManagerWrapper : BaseOverriddenWrapper(utSecurityManagerClass.name
         val addr = holder.concreteAddr(wrapper.addr)
         val modelName = nextModelName(baseModelName)
 
-        val instantiationCall = UtExecutableCallModel(
+        val instantiationCall = UtStatementCallModel(
             instance = null,
             System::getSecurityManager.executableId,
             emptyList()

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/StreamWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/StreamWrappers.kt
@@ -9,17 +9,15 @@ import org.utbot.framework.plugin.api.FieldId
 import org.utbot.framework.plugin.api.MethodId
 import org.utbot.framework.plugin.api.UtArrayModel
 import org.utbot.framework.plugin.api.UtAssembleModel
-import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtNullModel
 import org.utbot.framework.plugin.api.UtPrimitiveModel
-import org.utbot.framework.plugin.api.UtStatementModel
 import org.utbot.framework.plugin.api.classId
 import org.utbot.framework.plugin.api.util.defaultValueModel
 import org.utbot.framework.plugin.api.util.doubleArrayClassId
 import org.utbot.framework.plugin.api.util.doubleClassId
 import org.utbot.framework.plugin.api.util.doubleStreamClassId
-import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.intArrayClassId
 import org.utbot.framework.plugin.api.util.intClassId
 import org.utbot.framework.plugin.api.util.intStreamClassId
@@ -85,9 +83,9 @@ abstract class StreamWrapper(
             streamOfMethodId to listOf(parametersArrayModel)
         }
 
-        val instantiationCall = UtExecutableCallModel(
+        val instantiationCall = UtStatementCallModel(
             instance = null,
-            executable = builder,
+            statement = builder,
             params = params
         )
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Strings.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Strings.kt
@@ -20,7 +20,7 @@ import org.utbot.engine.symbolic.asHardConstraint
 import org.utbot.engine.types.STRING_TYPE
 import org.utbot.framework.plugin.api.UtArrayModel
 import org.utbot.framework.plugin.api.UtAssembleModel
-import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtPrimitiveModel
 import org.utbot.framework.plugin.api.classId
@@ -108,7 +108,7 @@ class StringWrapper : BaseOverriddenWrapper(utStringClass.name) {
         val charValues = CharArray(length) { (values.stores[it] as UtPrimitiveModel).value as Char }
         val stringModel = UtPrimitiveModel(String(charValues))
 
-        val instantiationCall = UtExecutableCallModel(
+        val instantiationCall = UtStatementCallModel(
             instance = null,
             constructorId(classId, STRING_TYPE.classId),
             listOf(stringModel)
@@ -240,7 +240,7 @@ sealed class UtAbstractStringBuilderWrapper(className: String) : BaseOverriddenW
         val charValues = CharArray(length) { (values.stores[it] as UtPrimitiveModel).value as Char }
         val stringModel = UtPrimitiveModel(String(charValues))
         val constructorId = constructorId(wrapper.type.classId, STRING_TYPE.classId)
-        val instantiationCall = UtExecutableCallModel(
+        val instantiationCall = UtStatementCallModel(
             instance = null,
             constructorId,
             listOf(stringModel)

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/ThreadWrappers.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/ThreadWrappers.kt
@@ -16,7 +16,7 @@ import org.utbot.engine.types.THREAD_TYPE
 import org.utbot.framework.plugin.api.ExecutableId
 import org.utbot.framework.plugin.api.FieldId
 import org.utbot.framework.plugin.api.UtAssembleModel
-import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.framework.plugin.api.UtLambdaModel
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtNullModel
@@ -68,7 +68,7 @@ class ThreadWrapper : BaseOverriddenWrapper(utThreadClass.name) {
                 constructorId(classId, runnableType.id) to listOf(targetModel)
             }
 
-            val instantiationCall = UtExecutableCallModel(
+            val instantiationCall = UtStatementCallModel(
                 instance = null,
                 constructor,
                 params
@@ -101,7 +101,7 @@ class ThreadGroupWrapper : BaseOverriddenWrapper(utThreadGroupClass.name) {
             val values = collectFieldModels(wrapper.addr, overriddenClass.type)
             val nameModel = values[nameFieldId] ?: UtNullModel(stringClassId)
 
-            val instantiationCall = UtExecutableCallModel(
+            val instantiationCall = UtStatementCallModel(
                 instance = null,
                 constructorId(classId, stringClassId),
                 listOf(nameModel)
@@ -161,7 +161,7 @@ class CompletableFutureWrapper : BaseOverriddenWrapper(utCompletableFutureClass.
             val values = collectFieldModels(wrapper.addr, overriddenClass.type)
             val resultModel = values[resultFieldId] ?: UtNullModel(objectClassId)
 
-            val instantiationCall = UtExecutableCallModel(
+            val instantiationCall = UtStatementCallModel(
                 instance = null,
                 constructorId(classId, objectClassId),
                 listOf(resultModel)
@@ -189,7 +189,7 @@ class ExecutorServiceWrapper : BaseOverriddenWrapper(utExecutorServiceClass.name
             val addr = holder.concreteAddr(wrapper.addr)
             val modelName = nextModelName("executorService")
 
-            val instantiationCall = UtExecutableCallModel(
+            val instantiationCall = UtStatementCallModel(
                 instance = null,
                 newSingleThreadExecutorMethod,
                 emptyList()
@@ -220,7 +220,7 @@ class CountDownLatchWrapper : BaseOverriddenWrapper(utCountDownLatchClass.name) 
             val values = collectFieldModels(wrapper.addr, overriddenClass.type)
             val countModel = values[countFieldId] ?: intClassId.defaultValueModel()
 
-            val instantiationCall = UtExecutableCallModel(
+            val instantiationCall = UtStatementCallModel(
                 instance = null,
                 constructorId(classId, intClassId),
                 listOf(countModel)

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssembleModelGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssembleModelGenerator.kt
@@ -23,7 +23,7 @@ import org.utbot.framework.plugin.api.UtClassRefModel
 import org.utbot.framework.plugin.api.UtCompositeModel
 import org.utbot.framework.plugin.api.UtDirectSetFieldModel
 import org.utbot.framework.plugin.api.UtEnumConstantModel
-import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.framework.plugin.api.UtLambdaModel
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtNewInstanceInstrumentation
@@ -346,7 +346,7 @@ class AssembleModelGenerator(private val basePackageName: String) {
      * Assembles internal structure of [UtStatementModel].
      */
     private fun assembleStatementModel(statementModel: UtStatementModel): UtStatementModel = when (statementModel) {
-        is UtExecutableCallModel -> assembleExecutableCallModel(statementModel)
+        is UtStatementCallModel -> assembleExecutableCallModel(statementModel)
         is UtDirectSetFieldModel -> assembleDirectSetFieldModel(statementModel)
     }
 
@@ -356,7 +356,7 @@ class AssembleModelGenerator(private val basePackageName: String) {
             fieldModel = assembleModel(statementModel.fieldModel)
         )
 
-    private fun assembleExecutableCallModel(statementModel: UtExecutableCallModel) =
+    private fun assembleExecutableCallModel(statementModel: UtStatementCallModel) =
         statementModel.copy(
             instance = statementModel.instance?.let { assembleModel(it) as UtReferenceModel },
             params = statementModel.params.map { assembleModel(it) }
@@ -395,7 +395,7 @@ class AssembleModelGenerator(private val basePackageName: String) {
     private fun constructorCall(
         compositeModel: UtCompositeModel,
         constructorInfo: ConstructorAssembleInfo,
-    ): UtExecutableCallModel {
+    ): UtStatementCallModel {
         val constructorParams = constructorInfo.constructorId.parameters.withIndex()
             .map { (index, param) ->
                 val modelOrNull = compositeModel.fields
@@ -406,7 +406,7 @@ class AssembleModelGenerator(private val basePackageName: String) {
                 assembleModel(fieldModel)
             }
 
-        return UtExecutableCallModel(instance = null, constructorInfo.constructorId, constructorParams)
+        return UtStatementCallModel(instance = null, constructorInfo.constructorId, constructorParams)
     }
 
     /**
@@ -464,7 +464,7 @@ class AssembleModelGenerator(private val basePackageName: String) {
             ?: throw AssembleException("No setter for field ${fieldId.name} of class ${declaringClassId.name}")
 
         return when (modifier) {
-            is ExecutableId -> UtExecutableCallModel(instance, modifier, listOf(value))
+            is ExecutableId -> UtStatementCallModel(instance, modifier, listOf(value))
             is DirectFieldAccessId -> UtDirectSetFieldModel(instance, fieldId, value)
         }
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssemblePrimitiveWrapper.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssemblePrimitiveWrapper.kt
@@ -1,7 +1,7 @@
 package org.utbot.framework.assemble
 
 import org.utbot.framework.plugin.api.UtAssembleModel
-import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.framework.plugin.api.UtPrimitiveModel
 import org.utbot.framework.plugin.api.util.booleanClassId
 import org.utbot.framework.plugin.api.util.byteClassId
@@ -33,9 +33,9 @@ fun assemble(model: UtPrimitiveModel): UtAssembleModel {
         else -> error("Model type $modelType is void or non-primitive")
     }
 
-    val constructorCallModel = UtExecutableCallModel(
+    val constructorCallModel = UtStatementCallModel(
         instance = null,
-        executable = constructorCall.executableId,
+        statement = constructorCall.executableId,
         params = listOf(model),
     )
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/builders/SpringTestClassModelBuilder.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/builders/SpringTestClassModelBuilder.kt
@@ -11,7 +11,7 @@ import org.utbot.framework.plugin.api.UtClassRefModel
 import org.utbot.framework.plugin.api.UtCompositeModel
 import org.utbot.framework.plugin.api.UtDirectSetFieldModel
 import org.utbot.framework.plugin.api.UtEnumConstantModel
-import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.framework.plugin.api.UtLambdaModel
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtNullModel
@@ -119,7 +119,7 @@ class SpringTestClassModelBuilder(val context: CgContext): TestClassModelBuilder
                 currentModel.modificationsChain.forEach { stmt ->
                     stmt.instance?.let { collectRecursively(it, allModels) }
                     when (stmt) {
-                        is UtExecutableCallModel -> stmt.params.forEach { collectRecursively(it, allModels) }
+                        is UtStatementCallModel -> stmt.params.forEach { collectRecursively(it, allModels) }
                         is UtDirectSetFieldModel -> collectRecursively(stmt.fieldModel, allModels)
                     }
                 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/minimization/Minimization.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/minimization/Minimization.kt
@@ -9,7 +9,7 @@ import org.utbot.framework.plugin.api.UtCompositeModel
 import org.utbot.framework.plugin.api.UtConcreteExecutionFailure
 import org.utbot.framework.plugin.api.UtDirectSetFieldModel
 import org.utbot.framework.plugin.api.UtEnumConstantModel
-import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.framework.plugin.api.UtExecution
 import org.utbot.framework.plugin.api.UtExecutionFailure
 import org.utbot.framework.plugin.api.UtExecutionResult
@@ -242,7 +242,7 @@ private fun UtModel.calculateSize(used: MutableSet<UtModel> = mutableSetOf()): I
 private fun UtStatementModel.calculateSize(used: MutableSet<UtModel> = mutableSetOf()): Int =
     when (this) {
         is UtDirectSetFieldModel -> 1 + fieldModel.calculateSize(used)
-        is UtExecutableCallModel -> 1 + params.sumOf { it.calculateSize(used) }
+        is UtStatementCallModel -> 1 + params.sumOf { it.calculateSize(used) }
     }
 
 /**

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/IterableConstructors.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/IterableConstructors.kt
@@ -4,7 +4,7 @@ import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.ConstructorId
 import org.utbot.framework.plugin.api.MethodId
 import org.utbot.framework.plugin.api.UtAssembleModel
-import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.framework.plugin.api.UtStatementModel
 import org.utbot.framework.plugin.api.util.booleanClassId
 import org.utbot.framework.plugin.api.util.id
@@ -26,15 +26,15 @@ internal class CollectionConstructor : UtAssembleModelConstructorBase() {
 
         val addMethodId = MethodId(classId, "add", booleanClassId, listOf(objectClassId))
 
-        return models.map { UtExecutableCallModel(this, addMethodId, listOf(it)) }
+        return models.map { UtStatementCallModel(this, addMethodId, listOf(it)) }
     }
 
     override fun provideInstantiationCall(
         internalConstructor: UtModelConstructorInterface,
         value: Any,
         classId: ClassId
-    ): UtExecutableCallModel =
-        UtExecutableCallModel(
+    ): UtStatementCallModel =
+        UtStatementCallModel(
             instance = null,
             ConstructorId(classId, emptyList()),
             emptyList()
@@ -46,8 +46,8 @@ internal class MapConstructor : UtAssembleModelConstructorBase() {
         internalConstructor: UtModelConstructorInterface,
         value: Any,
         classId: ClassId
-    ): UtExecutableCallModel =
-        UtExecutableCallModel(
+    ): UtStatementCallModel =
+        UtStatementCallModel(
             instance = null,
             ConstructorId(classId, emptyList()),
             emptyList()
@@ -66,7 +66,7 @@ internal class MapConstructor : UtAssembleModelConstructorBase() {
         val putMethodId = MethodId(classId, "put", objectClassId, listOf(objectClassId, objectClassId))
 
         return keyToValueModels.map { (key, value) ->
-            UtExecutableCallModel(this, putMethodId, listOf(key, value))
+            UtStatementCallModel(this, putMethodId, listOf(key, value))
         }
     }
 }

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/OptionalConstructors.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/OptionalConstructors.kt
@@ -8,7 +8,7 @@ import kotlin.reflect.KFunction1
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.MethodId
 import org.utbot.framework.plugin.api.UtAssembleModel
-import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.framework.plugin.api.util.doubleClassId
 import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.intClassId
@@ -27,19 +27,19 @@ internal sealed class OptionalConstructorBase : UtAssembleModelConstructorBase()
         internalConstructor: UtModelConstructorInterface,
         value: Any,
         classId: ClassId
-    ): UtExecutableCallModel {
+    ): UtStatementCallModel {
         require(classId.jClass.isInstance(value)) {
             "Can't cast $value to ${classId.jClass} in $this assemble constructor."
         }
 
         return if (!isPresent.call(value)) {
-            UtExecutableCallModel(
+            UtStatementCallModel(
                 instance = null,
                 emptyMethodId,
                 emptyList()
             )
         } else {
-            UtExecutableCallModel(
+            UtStatementCallModel(
                 instance = null,
                 ofMethodId,
                 listOf(internalConstructor.construct(getter.call(value), elementClassId))
@@ -53,7 +53,7 @@ internal sealed class OptionalConstructorBase : UtAssembleModelConstructorBase()
     final override fun UtAssembleModel.provideModificationChain(
         internalConstructor: UtModelConstructorInterface,
         value: Any
-    ): List<UtExecutableCallModel> = emptyList()
+    ): List<UtStatementCallModel> = emptyList()
 }
 
 internal class OptionalConstructor : OptionalConstructorBase() {

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/PrimitiveWrapperConstructor.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/PrimitiveWrapperConstructor.kt
@@ -2,7 +2,7 @@ package org.utbot.instrumentation.instrumentation.execution.constructors
 
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.UtAssembleModel
-import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.framework.plugin.api.UtPrimitiveModel
 import org.utbot.framework.plugin.api.UtStatementModel
 import org.utbot.framework.plugin.api.util.constructorId
@@ -15,10 +15,10 @@ internal class PrimitiveWrapperConstructor : UtAssembleModelConstructorBase() {
         internalConstructor: UtModelConstructorInterface,
         value: Any,
         classId: ClassId
-    ): UtExecutableCallModel {
+    ): UtStatementCallModel {
         checkClassCast(classId.jClass, value::class.java)
 
-        return UtExecutableCallModel(
+        return UtStatementCallModel(
             instance = null,
             constructorId(classId, classId.unbox()),
             listOf(UtPrimitiveModel(value))

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/StreamConstructors.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/StreamConstructors.kt
@@ -4,7 +4,7 @@ import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.MethodId
 import org.utbot.framework.plugin.api.UtArrayModel
 import org.utbot.framework.plugin.api.UtAssembleModel
-import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtNullModel
 import org.utbot.framework.plugin.api.UtPrimitiveModel
@@ -39,7 +39,7 @@ internal abstract class AbstractStreamConstructor(
         internalConstructor: UtModelConstructorInterface,
         value: Any,
         classId: ClassId,
-    ): UtExecutableCallModel {
+    ): UtStatementCallModel {
         value as java.util.stream.BaseStream<*, *>
 
         val valueAsArray = value
@@ -50,9 +50,9 @@ internal abstract class AbstractStreamConstructor(
             .toTypedArray()
 
         if (valueAsArray.isEmpty()) {
-            return UtExecutableCallModel(
+            return UtStatementCallModel(
                 instance = null,
-                executable = emptyMethodId,
+                statement = emptyMethodId,
                 params = emptyList()
             )
         }
@@ -63,9 +63,9 @@ internal abstract class AbstractStreamConstructor(
             .copy(classId = elementsClassId, constModel = elementDefaultValueModel)
             .apply { stores.replaceAll { _, m -> m.wrapperModelToPrimitiveModel() } }
 
-        return UtExecutableCallModel(
+        return UtStatementCallModel(
             instance = null,
-            executable = ofMethodId,
+            statement = ofMethodId,
             params = listOf(arrayModel)
         )
     }

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/UtAssembleModelConstructors.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/UtAssembleModelConstructors.kt
@@ -6,7 +6,7 @@ import java.util.stream.IntStream
 import java.util.stream.LongStream
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.UtAssembleModel
-import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.framework.plugin.api.UtStatementModel
 import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.framework.plugin.api.util.primitiveWrappers
@@ -116,7 +116,7 @@ internal abstract class UtAssembleModelConstructorBase {
         internalConstructor: UtModelConstructorInterface,
         value: Any,
         classId: ClassId
-    ): UtExecutableCallModel
+    ): UtStatementCallModel
 
     protected abstract fun UtAssembleModel.provideModificationChain(
         internalConstructor: UtModelConstructorInterface,

--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzer/objects/AssembleModelUtils.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzer/objects/AssembleModelUtils.kt
@@ -7,7 +7,7 @@ import org.utbot.framework.plugin.api.FieldId
 import org.utbot.framework.plugin.api.MethodId
 import org.utbot.framework.plugin.api.UtAssembleModel
 import org.utbot.framework.plugin.api.UtDirectSetFieldModel
-import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtStatementModel
 import org.utbot.framework.plugin.api.util.voidClassId
@@ -30,7 +30,7 @@ class AssembleModelDsl internal constructor(
     var id: () -> Int? = { null }
     var name: (Int?) -> String = { "<dsl generated model>" }
 
-    private lateinit var initialization: () -> UtExecutableCallModel
+    private lateinit var initialization: () -> UtStatementCallModel
     private val modChain = mutableListOf<(UtAssembleModel) -> UtStatementModel>()
 
     fun params(vararg params: ClassId) = params.toList()
@@ -51,19 +51,19 @@ class AssembleModelDsl internal constructor(
 
     @Suppress("UNUSED_PARAMETER")
     infix fun KeyWord.Using.empty(ignored: KeyWord.Constructor) {
-        initialization = { UtExecutableCallModel(null, ConstructorId(classId, emptyList()), emptyList()) }
+        initialization = { UtStatementCallModel(null, ConstructorId(classId, emptyList()), emptyList()) }
     }
 
     infix fun ConstructorId.with(models: List<UtModel>) {
-        initialization = { UtExecutableCallModel(null, this, models) }
+        initialization = { UtStatementCallModel(null, this, models) }
     }
 
     infix fun UsingDsl.with(models: List<UtModel>) {
-        initialization = { UtExecutableCallModel(null, executableId, models) }
+        initialization = { UtStatementCallModel(null, executableId, models) }
     }
 
     infix fun CallDsl.with(models: List<UtModel>) {
-        modChain += { UtExecutableCallModel(it, executableId, models.toList()) }
+        modChain += { UtStatementCallModel(it, executableId, models.toList()) }
     }
 
     infix fun FieldDsl.with(model: UtModel) {

--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Collections.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Collections.kt
@@ -53,7 +53,7 @@ class EmptyCollectionValueProvider(
                     id = idGenerator.createId(),
                     classId = classId,
                     modelName = "",
-                    instantiationCall = UtExecutableCallModel(null, executableId, value.map { it.model })
+                    instantiationCall = UtStatementCallModel(null, executableId, value.map { it.model })
                 ).fuzzed {
                     summary = "%var% = ${executableId.classId.simpleName}#${executableId.name}"
                 }
@@ -64,7 +64,7 @@ class EmptyCollectionValueProvider(
                         id = idGenerator.createId(),
                         classId = classId,
                         modelName = "",
-                        instantiationCall = UtExecutableCallModel(null, executableId, emptyList())
+                        instantiationCall = UtStatementCallModel(null, executableId, emptyList())
 
                     ).fuzzed{
                         summary = "%var% = ${executableId.classId.simpleName}#${executableId.name}"
@@ -187,7 +187,7 @@ abstract class CollectionValueProvider(
                         id = idGenerator.createId(),
                         classId = resolvedType.classId,
                         modelName = "",
-                        instantiationCall = UtExecutableCallModel(
+                        instantiationCall = UtStatementCallModel(
                             null,
                             ConstructorId(resolvedType.classId, emptyList()),
                             emptyList()
@@ -199,7 +199,7 @@ abstract class CollectionValueProvider(
                 },
                 modify = Routine.ForEach(typeParameter) { self, _, values ->
                     val model = self.model as UtAssembleModel
-                    (model.modificationsChain as MutableList) += UtExecutableCallModel(
+                    (model.modificationsChain as MutableList) += UtStatementCallModel(
                         model,
                         findMethod(resolvedType, values),
                         values.map { it.model }
@@ -235,9 +235,9 @@ class IteratorValueProvider(val idGenerator: IdGenerator<Int>) : ValueProvider<F
                     id = id,
                     classId = type.classId,
                     modelName = "iterator#${id.hex()}",
-                    instantiationCall = UtExecutableCallModel(
+                    instantiationCall = UtStatementCallModel(
                         instance = iterable,
-                        executable = MethodId(iterableClassId, "iterator", type.classId, emptyList()),
+                        statement = MethodId(iterableClassId, "iterator", type.classId, emptyList()),
                         params = emptyList()
                     )
                 ).fuzzed {
@@ -250,9 +250,9 @@ class IteratorValueProvider(val idGenerator: IdGenerator<Int>) : ValueProvider<F
                     id = id,
                     classId = type.classId,
                     modelName = "emptyIterator#${id.hex()}",
-                    instantiationCall = UtExecutableCallModel(
+                    instantiationCall = UtStatementCallModel(
                         instance = null,
-                        executable = MethodId(java.util.Collections::class.id, "emptyIterator", type.classId, emptyList()),
+                        statement = MethodId(java.util.Collections::class.id, "emptyIterator", type.classId, emptyList()),
                         params = emptyList()
                     )
                 ).fuzzed {

--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Objects.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Objects.kt
@@ -12,7 +12,6 @@ import java.lang.reflect.Field
 import java.lang.reflect.Member
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
-import java.util.*
 
 class ObjectValueProvider(
     val idGenerator: IdGenerator<Int>,
@@ -52,7 +51,7 @@ class ObjectValueProvider(
                     id = id,
                     classId = classId,
                     modelName = "${constructorId.classId.name}${constructorId.parameters}#" + id.hex(),
-                    instantiationCall = UtExecutableCallModel(
+                    instantiationCall = UtStatementCallModel(
                         null,
                         constructorId,
                         values.map { it.model }),
@@ -78,7 +77,7 @@ class ObjectValueProvider(
                         fd.setter != null && fd.getter != null -> {
                             yield(Routine.Call(listOf(fd.type)) { self, values ->
                                 val model = self.model as UtAssembleModel
-                                model.modificationsChain as MutableList += UtExecutableCallModel(
+                                model.modificationsChain as MutableList += UtStatementCallModel(
                                     model,
                                     fd.setter.executableId,
                                     values.map { it.model })

--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Others.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Others.kt
@@ -39,9 +39,9 @@ class DateValueProvider(
             id = idGenerator.createId(),
             classId = type.classId,
             modelName = "Date::now",
-            instantiationCall = UtExecutableCallModel(
+            instantiationCall = UtStatementCallModel(
                 instance = null,
-                executable = type.classId.allConstructors.firstOrNull { it.parameters.isEmpty() }
+                statement = type.classId.allConstructors.firstOrNull { it.parameters.isEmpty() }
                     ?: error("Cannot find default constructor of ${type.classId}"),
                 params = emptyList())
         ).fuzzed { }
@@ -78,7 +78,7 @@ class DateValueProvider(
                             id = idGenerator.createId(),
                             classId = type.classId,
                             modelName = "Date(${values.map { it.model.classId }})",
-                            instantiationCall = UtExecutableCallModel(null, constructor, values.map { it.model })
+                            instantiationCall = UtStatementCallModel(null, constructor, values.map { it.model })
                         ).fuzzed {  }
                     },
                     empty = Routine.Empty { nowDateModel }
@@ -106,7 +106,7 @@ class DateValueProvider(
         val simpleDateFormatModel = assembleSimpleDateFormat(idGenerator.createId(), formatString)
         val dateFormatParse = simpleDateFormatModel.classId.jClass
             .getMethod("parse", String::class.java).executableId
-        val instantiationCall = UtExecutableCallModel(
+        val instantiationCall = UtStatementCallModel(
             simpleDateFormatModel, dateFormatParse, listOf(UtPrimitiveModel(dateString))
         )
         return UtAssembleModel(
@@ -127,14 +127,14 @@ class DateValueProvider(
         val formatSetLenient = SimpleDateFormat::setLenient.executableId
         val formatModel = UtPrimitiveModel(formatString)
 
-        val instantiationCall = UtExecutableCallModel(instance = null, formatStringConstructor, listOf(formatModel))
+        val instantiationCall = UtStatementCallModel(instance = null, formatStringConstructor, listOf(formatModel))
         return UtAssembleModel(
             id,
             simpleDateFormatId,
             "$simpleDateFormatId[$stringClassId]#" + id.hex(),
             instantiationCall
         ) {
-            listOf(UtExecutableCallModel(instance = this, formatSetLenient, listOf(UtPrimitiveModel(false))))
+            listOf(UtStatementCallModel(instance = this, formatSetLenient, listOf(UtPrimitiveModel(false))))
         }
     }
 }

--- a/utbot-js/src/main/kotlin/api/JsUtModelConstructor.kt
+++ b/utbot-js/src/main/kotlin/api/JsUtModelConstructor.kt
@@ -17,8 +17,8 @@ import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.ConstructorId
 import org.utbot.framework.plugin.api.UtArrayModel
 import org.utbot.framework.plugin.api.UtAssembleModel
-import org.utbot.framework.plugin.api.UtExecutableCallModel
 import org.utbot.framework.plugin.api.UtModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.instrumentation.instrumentation.execution.constructors.UtModelConstructorInterface
 
 class JsUtModelConstructor : UtModelConstructorInterface {
@@ -57,7 +57,7 @@ class JsUtModelConstructor : UtModelConstructorInterface {
                     id = JsIdProvider.createId(),
                     classId = classId,
                     modelName = "",
-                    instantiationCall = UtExecutableCallModel(
+                    instantiationCall = UtStatementCallModel(
                         null,
                         ConstructorId(classId, emptyList()),
                         emptyList()
@@ -65,7 +65,7 @@ class JsUtModelConstructor : UtModelConstructorInterface {
                     modificationsChainProvider = { mutableListOf() }
                 ).apply {
                     this.modificationsChain as MutableList += values.map { value ->
-                        UtExecutableCallModel(
+                        UtStatementCallModel(
                             this,
                             JsMethodId(
                                 classId = classId,
@@ -96,7 +96,7 @@ class JsUtModelConstructor : UtModelConstructorInterface {
                     id = JsIdProvider.createId(),
                     classId = classId,
                     modelName = "",
-                    instantiationCall = UtExecutableCallModel(
+                    instantiationCall = UtStatementCallModel(
                         null,
                         ConstructorId(classId, emptyList()),
                         emptyList()
@@ -104,7 +104,7 @@ class JsUtModelConstructor : UtModelConstructorInterface {
                     modificationsChainProvider = { mutableListOf() }
                 ).apply {
                     this.modificationsChain as MutableList += values.map { value ->
-                        UtExecutableCallModel(
+                        UtStatementCallModel(
                             this,
                             JsMethodId(
                                 classId = classId,
@@ -130,7 +130,7 @@ class JsUtModelConstructor : UtModelConstructorInterface {
             construct(it, JsEmptyClassId())
         }
         val id = JsIdProvider.createId()
-        val instantiationCall = UtExecutableCallModel(null, constructor, values)
+        val instantiationCall = UtStatementCallModel(null, constructor, values)
         return UtAssembleModel(
             id = id,
             classId = constructor.classId,

--- a/utbot-js/src/main/kotlin/fuzzer/providers/MapValueProvider.kt
+++ b/utbot-js/src/main/kotlin/fuzzer/providers/MapValueProvider.kt
@@ -9,8 +9,8 @@ import fuzzer.JsIdProvider
 import fuzzer.JsMethodDescription
 import org.utbot.framework.plugin.api.ConstructorId
 import org.utbot.framework.plugin.api.UtAssembleModel
-import org.utbot.framework.plugin.api.UtExecutableCallModel
 import org.utbot.framework.plugin.api.UtModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.fuzzing.Routine
 import org.utbot.fuzzing.Seed
 import org.utbot.fuzzing.ValueProvider
@@ -30,7 +30,7 @@ object MapValueProvider : ValueProvider<JsClassId, UtModel, JsMethodDescription>
                         id = JsIdProvider.createId(),
                         classId = type,
                         modelName = "",
-                        instantiationCall = UtExecutableCallModel(
+                        instantiationCall = UtStatementCallModel(
                             null,
                             ConstructorId(type, emptyList()),
                             emptyList()
@@ -41,7 +41,7 @@ object MapValueProvider : ValueProvider<JsClassId, UtModel, JsMethodDescription>
                 modify = Routine.ForEach(listOf(jsUndefinedClassId, jsUndefinedClassId)) { self, _, values ->
                     val model = self as UtAssembleModel
                     model.modificationsChain as MutableList +=
-                        UtExecutableCallModel(
+                        UtStatementCallModel(
                             model,
                             JsMethodId(
                                 classId = type,

--- a/utbot-js/src/main/kotlin/fuzzer/providers/ObjectValueProvider.kt
+++ b/utbot-js/src/main/kotlin/fuzzer/providers/ObjectValueProvider.kt
@@ -6,9 +6,9 @@ import framework.api.js.util.isClass
 import fuzzer.JsIdProvider
 import fuzzer.JsMethodDescription
 import org.utbot.framework.plugin.api.UtAssembleModel
-import org.utbot.framework.plugin.api.UtExecutableCallModel
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtNullModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
 
 
 import org.utbot.fuzzing.Routine
@@ -41,7 +41,7 @@ class ObjectValueProvider : ValueProvider<JsClassId, UtModel, JsMethodDescriptio
                     id = id,
                     classId = classId,
                     modelName = "${constructorId.classId.name}${constructorId.parameters}#" + id.hex(),
-                    instantiationCall = UtExecutableCallModel(
+                    instantiationCall = UtStatementCallModel(
                         null,
                         constructorId,
                         values

--- a/utbot-js/src/main/kotlin/fuzzer/providers/SetValueProvider.kt
+++ b/utbot-js/src/main/kotlin/fuzzer/providers/SetValueProvider.kt
@@ -8,8 +8,8 @@ import fuzzer.JsIdProvider
 import fuzzer.JsMethodDescription
 import org.utbot.framework.plugin.api.ConstructorId
 import org.utbot.framework.plugin.api.UtAssembleModel
-import org.utbot.framework.plugin.api.UtExecutableCallModel
 import org.utbot.framework.plugin.api.UtModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.fuzzing.Routine
 import org.utbot.fuzzing.Seed
 import org.utbot.fuzzing.ValueProvider
@@ -29,7 +29,7 @@ object SetValueProvider : ValueProvider<JsClassId, UtModel, JsMethodDescription>
                         id = JsIdProvider.createId(),
                         classId = type,
                         modelName = "",
-                        instantiationCall = UtExecutableCallModel(
+                        instantiationCall = UtStatementCallModel(
                             null,
                             ConstructorId(type, emptyList()),
                             emptyList()
@@ -40,7 +40,7 @@ object SetValueProvider : ValueProvider<JsClassId, UtModel, JsMethodDescription>
                 modify = Routine.ForEach(listOf(jsUndefinedClassId)) { self, _, values ->
                     val model = self as UtAssembleModel
                     model.modificationsChain as MutableList +=
-                        UtExecutableCallModel(
+                        UtStatementCallModel(
                             model,
                             JsMethodId(
                                 classId = type,

--- a/utbot-js/src/main/kotlin/service/coverage/CoverageServiceProvider.kt
+++ b/utbot-js/src/main/kotlin/service/coverage/CoverageServiceProvider.kt
@@ -9,9 +9,9 @@ import fuzzer.JsMethodDescription
 import java.util.regex.Pattern
 import org.utbot.framework.plugin.api.UtArrayModel
 import org.utbot.framework.plugin.api.UtAssembleModel
-import org.utbot.framework.plugin.api.UtExecutableCallModel
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtNullModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.framework.plugin.api.util.isStatic
 import providers.imports.IImportsProvider
 import service.ContextOwner
@@ -286,8 +286,8 @@ fs.writeFileSync("$resFilePath$index.json", JSON.stringify(json$index))
     private fun UtAssembleModel.initModificationsAsString(stringBuilder: StringBuilder, varName: String) {
         with(stringBuilder) {
             this@initModificationsAsString.modificationsChain.forEach {
-                if (it is UtExecutableCallModel) {
-                    val exec = it.executable as JsMethodId
+                if (it is UtStatementCallModel) {
+                    val exec = it.statement as JsMethodId
                     appendLine(
                         it.params.joinToString(
                             prefix = "$varName.${exec.name}(",


### PR DESCRIPTION
## Description

Enlarges a way to construct assemble models.

Previously only executables could be used to modify intilial state. Actually, direct field acessors may be useful too (e.g. for Spring projects).

## How to test

Difficult to test.
Needs to take in mind all cycle of assemble models processing.
May be we should rely on pipeline...

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.