### PR TITLE
Support direct field accesses in call models

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -740,7 +740,7 @@ data class UtExecutableCallModel(
  *
  * Contains parameter value to set and an instance model before call.
  */
-data class UtDirectFieldAccessModel(
+data class UtDirectGetFieldModel(
     override val instance: UtReferenceModel,
     val fieldAccess: DirectFieldAccessId,
 ) : UtStatementCallModel(instance, fieldAccess, emptyList()) {

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -502,7 +502,7 @@ data class UtAssembleModel private constructor(
     override val id: Int?,
     override val classId: ClassId,
     override val modelName: String,
-    val instantiationCall: UtExecutableCallModel,
+    val instantiationCall: UtStatementCallModel,
     val modificationsChain: List<UtStatementModel>,
     val origin: UtCompositeModel?
 ) : UtReferenceModel(id, classId, modelName) {
@@ -527,7 +527,7 @@ data class UtAssembleModel private constructor(
         id: Int?,
         classId: ClassId,
         modelName: String,
-        instantiationCall: UtExecutableCallModel,
+        instantiationCall: UtStatementCallModel,
         origin: UtCompositeModel? = null,
         modificationsChainProvider: UtAssembleModel.() -> List<UtStatementModel> = { emptyList() }
     ) : this(id, classId, modelName, instantiationCall, mutableListOf(), origin) {
@@ -691,28 +691,23 @@ sealed class UtStatementModel(
 )
 
 /**
- * Step of assemble instruction that calls executable.
- *
- * Contains executable to call, call parameters and an instance model before call.
- *
- * @param [instance] **must be** `null` for static methods and constructors
+ * Step of assemble instruction that calls executable or accesses the field.
  */
-data class UtExecutableCallModel(
+sealed class UtStatementCallModel(
     override val instance: UtReferenceModel?,
-    val executable: ExecutableId,
-    val params: List<UtModel>,
-) : UtStatementModel(instance) {
+    open val statement: StatementId,
+    open val params: List<UtModel>,
+): UtStatementModel(instance) {
     override fun toString() = withToStringThreadLocalReentrancyGuard {
         buildString {
 
-            val executableName = when (executable) {
-                is ConstructorId -> executable.classId.name
-                is MethodId -> executable.name
+            val executableName = when (statement) {
+                is ConstructorId -> statement.classId.name
+                is DirectFieldAccessId -> statement.name
+                is MethodId -> statement.name
             }
 
-            if (instance != null) {
-                append("${instance.modelName}.")
-            }
+            instance?.let { append("${it.modelName}.") }
 
             append(executableName)
             val paramsRepresentation = params.map { param ->
@@ -725,6 +720,28 @@ data class UtExecutableCallModel(
         }
     }
 }
+
+/**
+ * Step of assemble instruction that calls executable.
+ *
+ * Contains executable to call, call parameters and an instance model before call.
+ * @param [instance] **must be** `null` for static methods and constructors
+ */
+data class UtExecutableCallModel(
+    override val instance: UtReferenceModel?,
+    val executable: ExecutableId,
+    override val params: List<UtModel>,
+) : UtStatementCallModel(instance, executable, params)
+
+/**
+ * Step of assemble instruction that directly accesses a field.
+ *
+ * Contains parameter value to set and an instance model before call.
+ */
+data class UtDirectFieldAccessModel(
+    override val instance: UtReferenceModel,
+    val fieldAccess: DirectFieldAccessId,
+) : UtStatementCallModel(instance, fieldAccess, emptyList())
 
 /**
  * Step of assemble instruction that sets public field with direct setter.

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -731,7 +731,9 @@ data class UtExecutableCallModel(
     override val instance: UtReferenceModel?,
     val executable: ExecutableId,
     override val params: List<UtModel>,
-) : UtStatementCallModel(instance, executable, params)
+) : UtStatementCallModel(instance, executable, params) {
+    override fun toString(): String = super.toString()
+}
 
 /**
  * Step of assemble instruction that directly accesses a field.
@@ -741,7 +743,9 @@ data class UtExecutableCallModel(
 data class UtDirectFieldAccessModel(
     override val instance: UtReferenceModel,
     val fieldAccess: DirectFieldAccessId,
-) : UtStatementCallModel(instance, fieldAccess, emptyList())
+) : UtStatementCallModel(instance, fieldAccess, emptyList()) {
+    override fun toString(): String = super.toString()
+}
 
 /**
  * Step of assemble instruction that sets public field with direct setter.

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/constructor/ValueConstructor.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/constructor/ValueConstructor.kt
@@ -21,7 +21,7 @@ import org.utbot.framework.plugin.api.UtClassRefModel
 import org.utbot.framework.plugin.api.UtCompositeModel
 import org.utbot.framework.plugin.api.UtConcreteValue
 import org.utbot.framework.plugin.api.UtDirectSetFieldModel
-import org.utbot.framework.plugin.api.UtDirectFieldAccessModel
+import org.utbot.framework.plugin.api.UtDirectGetFieldModel
 import org.utbot.framework.plugin.api.UtEnumConstantModel
 import org.utbot.framework.plugin.api.UtExecutableCallModel
 import org.utbot.framework.plugin.api.UtExecution
@@ -389,7 +389,7 @@ class ValueConstructor {
                     is ConstructorId -> executable.call(params)
                 }
             }
-            is UtDirectFieldAccessModel -> {
+            is UtDirectGetFieldModel -> {
                 val fieldAccess = callModel.fieldAccess
                 val instanceValue = value(callModel.instance)
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssembleModelGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssembleModelGenerator.kt
@@ -21,7 +21,7 @@ import org.utbot.framework.plugin.api.UtArrayModel
 import org.utbot.framework.plugin.api.UtAssembleModel
 import org.utbot.framework.plugin.api.UtClassRefModel
 import org.utbot.framework.plugin.api.UtCompositeModel
-import org.utbot.framework.plugin.api.UtDirectFieldAccessModel
+import org.utbot.framework.plugin.api.UtDirectGetFieldModel
 import org.utbot.framework.plugin.api.UtDirectSetFieldModel
 import org.utbot.framework.plugin.api.UtEnumConstantModel
 import org.utbot.framework.plugin.api.UtExecutableCallModel
@@ -363,7 +363,7 @@ class AssembleModelGenerator(private val basePackageName: String) {
                 instance = statementModel.instance?.let { assembleModel(it) as UtReferenceModel },
                 params = statementModel.params.map { assembleModel(it) }
             )
-            is UtDirectFieldAccessModel -> statementModel.copy(
+            is UtDirectGetFieldModel -> statementModel.copy(
                 instance = assembleModel(statementModel.instance) as UtReferenceModel
             )
         }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/builders/SpringTestClassModelBuilder.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/builders/SpringTestClassModelBuilder.kt
@@ -16,6 +16,7 @@ import org.utbot.framework.plugin.api.UtLambdaModel
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtNullModel
 import org.utbot.framework.plugin.api.UtPrimitiveModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.framework.plugin.api.UtVoidModel
 import org.utbot.framework.plugin.api.isMockModel
 
@@ -119,7 +120,7 @@ class SpringTestClassModelBuilder(val context: CgContext): TestClassModelBuilder
                 currentModel.modificationsChain.forEach { stmt ->
                     stmt.instance?.let { collectRecursively(it, allModels) }
                     when (stmt) {
-                        is UtExecutableCallModel -> stmt.params.forEach { collectRecursively(it, allModels) }
+                        is UtStatementCallModel -> stmt.params.forEach { collectRecursively(it, allModels) }
                         is UtDirectSetFieldModel -> collectRecursively(stmt.fieldModel, allModels)
                     }
                 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgVariableConstructor.kt
@@ -43,7 +43,7 @@ import org.utbot.framework.plugin.api.UtArrayModel
 import org.utbot.framework.plugin.api.UtAssembleModel
 import org.utbot.framework.plugin.api.UtClassRefModel
 import org.utbot.framework.plugin.api.UtCompositeModel
-import org.utbot.framework.plugin.api.UtDirectFieldAccessModel
+import org.utbot.framework.plugin.api.UtDirectGetFieldModel
 import org.utbot.framework.plugin.api.UtDirectSetFieldModel
 import org.utbot.framework.plugin.api.UtEnumConstantModel
 import org.utbot.framework.plugin.api.UtExecutableCallModel
@@ -278,7 +278,7 @@ open class CgVariableConstructor(val context: CgContext) :
                     }
                 }
             }
-            is UtDirectFieldAccessModel -> {
+            is UtDirectGetFieldModel -> {
                 val instance = declareOrGet(statementModel.instance)
                 val fieldAccess = statementModel.fieldAccess
                 utilsClassId[getFieldValue](instance, fieldAccess.fieldId.declaringClass.canonicalName, fieldAccess.fieldId.name)

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgVariableConstructor.kt
@@ -242,7 +242,7 @@ open class CgVariableConstructor(val context: CgContext) :
 
         val type = when (executable) {
             is MethodId -> executable.returnType
-            is DirectFieldAccessId -> executable.fieldId.declaringClass
+            is DirectFieldAccessId -> executable.fieldId.type
             is ConstructorId -> executable.classId
         }
         // Don't use redundant constructors for primitives and String

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/minimization/Minimization.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/minimization/Minimization.kt
@@ -17,6 +17,7 @@ import org.utbot.framework.plugin.api.UtLambdaModel
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtNullModel
 import org.utbot.framework.plugin.api.UtPrimitiveModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.framework.plugin.api.UtStatementModel
 import org.utbot.framework.plugin.api.UtSymbolicExecution
 import org.utbot.framework.plugin.api.UtVoidModel
@@ -242,7 +243,7 @@ private fun UtModel.calculateSize(used: MutableSet<UtModel> = mutableSetOf()): I
 private fun UtStatementModel.calculateSize(used: MutableSet<UtModel> = mutableSetOf()): Int =
     when (this) {
         is UtDirectSetFieldModel -> 1 + fieldModel.calculateSize(used)
-        is UtExecutableCallModel -> 1 + params.sumOf { it.calculateSize(used) }
+        is UtStatementCallModel -> 1 + params.sumOf { it.calculateSize(used) }
     }
 
 /**

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/MockValueConstructor.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/MockValueConstructor.kt
@@ -5,8 +5,10 @@ import org.mockito.stubbing.Answer
 import org.objectweb.asm.Type
 import org.utbot.common.Reflection
 import org.utbot.common.invokeCatching
+import org.utbot.common.withAccessibility
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.ConstructorId
+import org.utbot.framework.plugin.api.DirectFieldAccessId
 import org.utbot.framework.plugin.api.ExecutableId
 import org.utbot.framework.plugin.api.FieldId
 import org.utbot.framework.plugin.api.MethodId
@@ -16,6 +18,7 @@ import org.utbot.framework.plugin.api.UtAutowiredStateBeforeModel
 import org.utbot.framework.plugin.api.UtClassRefModel
 import org.utbot.framework.plugin.api.UtCompositeModel
 import org.utbot.framework.plugin.api.UtConcreteValue
+import org.utbot.framework.plugin.api.UtDirectFieldAccessModel
 import org.utbot.framework.plugin.api.UtDirectSetFieldModel
 import org.utbot.framework.plugin.api.UtEnumConstantModel
 import org.utbot.framework.plugin.api.UtExecutableCallModel
@@ -25,6 +28,7 @@ import org.utbot.framework.plugin.api.UtNewInstanceInstrumentation
 import org.utbot.framework.plugin.api.UtNullModel
 import org.utbot.framework.plugin.api.UtPrimitiveModel
 import org.utbot.framework.plugin.api.UtReferenceModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.framework.plugin.api.UtStaticMethodInstrumentation
 import org.utbot.framework.plugin.api.UtVoidModel
 import org.utbot.framework.plugin.api.util.anyInstance
@@ -318,15 +322,15 @@ class MockValueConstructor(
         constructedObjects[assembleModel]?.let { return it }
 
         val instantiationExecutableCall = assembleModel.instantiationCall
-        val result = updateWithExecutableCallModel(instantiationExecutableCall)
+        val result = updateWithStatementCallModel(instantiationExecutableCall)
         checkNotNull(result) {
-            "Tracked instance can't be null for call ${instantiationExecutableCall.executable} in model $assembleModel"
+            "Tracked instance can't be null for call ${instantiationExecutableCall.statement} in model $assembleModel"
         }
         constructedObjects[assembleModel] = result
 
         assembleModel.modificationsChain.forEach { statementModel ->
             when (statementModel) {
-                is UtExecutableCallModel -> updateWithExecutableCallModel(statementModel)
+                is UtStatementCallModel -> updateWithStatementCallModel(statementModel)
                 is UtDirectSetFieldModel -> updateWithDirectSetFieldModel(statementModel)
             }
         }
@@ -381,19 +385,25 @@ class MockValueConstructor(
      *
      * @return the result of [callModel] invocation
      */
-    private fun updateWithExecutableCallModel(
-        callModel: UtExecutableCallModel,
-    ): Any? {
-        val executable = callModel.executable
-        val instanceValue = callModel.instance?.let { value(it) }
-        val params = callModel.params.map { value(it) }
+    private fun updateWithStatementCallModel(callModel: UtStatementCallModel): Any? {
+        when (callModel) {
+            is UtExecutableCallModel -> {
+                val executable = callModel.executable
+                val instanceValue = callModel.instance?.let { value(it) }
+                val params = callModel.params.map { value(it) }
 
-        val result = when (executable) {
-            is MethodId -> executable.call(params, instanceValue)
-            is ConstructorId -> executable.call(params)
+                return when (executable) {
+                    is MethodId -> executable.call(params, instanceValue)
+                    is ConstructorId -> executable.call(params)
+                }
+            }
+            is UtDirectFieldAccessModel -> {
+                val fieldAccess = callModel.fieldAccess
+                val instanceValue = value(callModel.instance)
+
+                return fieldAccess.get(instanceValue)
+            }
         }
-
-        return result
     }
 
     /**
@@ -439,6 +449,13 @@ class MockValueConstructor(
         constructor.runSandbox {
             newInstance(*args.toTypedArray())
         }
+
+    private fun DirectFieldAccessId.get(instance: Any?): Any {
+        val field = fieldId.jField
+        return field.runSandbox {
+            field.get(instance)
+        }
+    }
 
     /**
      * Fetches primitive value from NutsModel to create array of primitives.

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/MockValueConstructor.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/MockValueConstructor.kt
@@ -18,7 +18,7 @@ import org.utbot.framework.plugin.api.UtAutowiredStateBeforeModel
 import org.utbot.framework.plugin.api.UtClassRefModel
 import org.utbot.framework.plugin.api.UtCompositeModel
 import org.utbot.framework.plugin.api.UtConcreteValue
-import org.utbot.framework.plugin.api.UtDirectFieldAccessModel
+import org.utbot.framework.plugin.api.UtDirectGetFieldModel
 import org.utbot.framework.plugin.api.UtDirectSetFieldModel
 import org.utbot.framework.plugin.api.UtEnumConstantModel
 import org.utbot.framework.plugin.api.UtExecutableCallModel
@@ -397,7 +397,7 @@ class MockValueConstructor(
                     is ConstructorId -> executable.call(params)
                 }
             }
-            is UtDirectFieldAccessModel -> {
+            is UtDirectGetFieldModel -> {
                 val fieldAccess = callModel.fieldAccess
                 val instanceValue = value(callModel.instance)
 


### PR DESCRIPTION
## Description

Enlarges a way to construct assemble models.

Previously only executables could be used to modify intilial state. Actually, direct field acessors may be useful too (e.g. for Spring projects).

## How to test

Difficult to test.
Needs to take in mind all cycle of assemble models processing.
May be we should rely on pipeline...

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.