### PR TITLE
Another way to process failures in instrumented process not connected to concrete execution

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/UtExecutionResult.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/UtExecutionResult.kt
@@ -79,6 +79,14 @@ class InstrumentedProcessDeathException(cause: Throwable) :
 
 data class UtConcreteExecutionFailure(override val exception: InstrumentedProcessDeathException) : UtExecutionFailure()
 
+/**
+ * Represents a failure in instrumented process
+ * that is not actually caused by concrete execution.
+ *
+ * For example, failure may occured during data preparation for a concrete call.
+ */
+data class UtConcreteExecutionProcessedFailure(override val exception: Throwable): UtExecutionFailure()
+
 val UtExecutionResult.isSuccess: Boolean
     get() = this is UtExecutionSuccess
 

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/phases/ValueConstructionPhase.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/phases/ValueConstructionPhase.kt
@@ -11,6 +11,12 @@ typealias ConstructedParameters = List<UtConcreteValue<*>>
 typealias ConstructedStatics = Map<FieldId, UtConcreteValue<*>>
 typealias ConstructedCache = IdentityHashMap<Any, UtModel>
 
+data class ConstructedData(
+    val params: ConstructedParameters,
+    val statics: ConstructedStatics,
+    val cache: ConstructedCache,
+)
+
 /**
  * This phase of values instantiation from given models.
  */

--- a/utbot-summary/src/main/kotlin/org/utbot/summary/TagGenerator.kt
+++ b/utbot-summary/src/main/kotlin/org/utbot/summary/TagGenerator.kt
@@ -2,6 +2,7 @@ package org.utbot.summary
 
 import org.utbot.framework.plugin.api.Step
 import org.utbot.framework.plugin.api.UtConcreteExecutionFailure
+import org.utbot.framework.plugin.api.UtConcreteExecutionProcessedFailure
 import org.utbot.framework.plugin.api.UtExecution
 import org.utbot.framework.plugin.api.UtExecutionResult
 import org.utbot.framework.plugin.api.UtExecutionSuccess
@@ -220,6 +221,7 @@ private fun UtExecutionResult.clusterKind() = when (this) {
     is UtStreamConsumingFailure -> ExecutionGroup.ERROR_SUITE
     is UtOverflowFailure -> ExecutionGroup.OVERFLOWS
     is UtTimeoutException -> ExecutionGroup.TIMEOUTS
+    is UtConcreteExecutionProcessedFailure -> ExecutionGroup.CRASH_SUITE
     is UtConcreteExecutionFailure -> ExecutionGroup.CRASH_SUITE
     is UtSandboxFailure -> ExecutionGroup.SECURITY
     is UtTaintAnalysisFailure -> ExecutionGroup.TAINT_ANALYSIS


### PR DESCRIPTION
## Description

Sometimes `UtExecutionInstrumentation.invoke` may fail before concrete execution call.
In such case it is useless to waste time on killing instrumented process and catching death exception in fuzzer.
In Spring integration tests difficulties with autowired values constructing may happen more often.

## How to test

### Automated tests

`utbot-samples` pipeline as a set of regression checks

### Manual tests

Will be relevant when basic Spring integration tests support is completed.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.