### PR TITLE
Use Mockito version compatible with Java 8

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,8 @@ goPluginVersion=231.8109.175
 junit5Version=5.8.2
 junit4Version=4.13.2
 junit4PlatformVersion=1.9.0
-mockitoVersion=5.2.0
+# NOTE: Mockito versions 5+ are not compatible with Java 8: https://www.davidvlijmincx.com/posts/upgrade-to-mockito-5
+mockitoVersion=4.11.0
 mockitoInlineVersion=5.2.0
 ksmtVersion=0.4.3
 sootVersion=4.4.0-FORK-2

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/ExternalLibraryDescriptors.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/models/ExternalLibraryDescriptors.kt
@@ -36,7 +36,7 @@ fun jUnit5ParametrizedTestsLibraryDescriptor(versionInProject: Version?): Extern
 }
 
 fun mockitoCoreLibraryDescriptor(versionInProject: Version?): ExternalLibraryDescriptor {
-    val preferredVersion = if (versionInProject?.hasNumericOrEmptyPatch() == true) versionInProject?.plainText else "5.2.0"
+    val preferredVersion = if (versionInProject?.hasNumericOrEmptyPatch() == true) versionInProject?.plainText else "4.11.0"
     return ExternalLibraryDescriptor(
         "org.mockito", "mockito-core",
         "3.5.0", null, preferredVersion


### PR DESCRIPTION
## Description

Newest versions of Mockito are not compatible with Java 8, see https://www.davidvlijmincx.com/posts/upgrade-to-mockito-5
As UtBot still supports it, we use 4.11.0 version everywhere.

## How to test

### Manual tests

Basic mocking regression.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.