### PR TITLE
Replace all Spring specific models with models expressed in terms of `UtSpringContextModel`

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -1117,6 +1117,13 @@ sealed class ExecutableId : StatementId() {
     abstract override val name: String
     abstract val returnType: ClassId
     abstract val parameters: List<ClassId>
+
+    /**
+     * Normally during concrete execution every executable is executed in a
+     * [sandbox](https://github.com/UnitTestBot/UTBotJava/blob/main/docs/Sandboxing.md).
+     *
+     * However, if this flag is set to `true`, then `this` particular executable is executed without a sandbox.
+     */
     abstract val bypassesSandbox: Boolean
 
     abstract val modifiers: Int

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -59,6 +59,7 @@ import org.utbot.common.isAbstract
 import org.utbot.common.isStatic
 import org.utbot.framework.isFromTrustedLibrary
 import org.utbot.framework.plugin.api.TypeReplacementMode.*
+import org.utbot.framework.plugin.api.util.SpringModelUtils
 import org.utbot.framework.plugin.api.util.allDeclaredFieldIds
 import org.utbot.framework.plugin.api.util.fieldId
 import org.utbot.framework.plugin.api.util.isSubtypeOf
@@ -659,7 +660,7 @@ class UtLambdaModel(
 
 class UtSpringContextModel : UtReferenceModel(
     id = null,
-    classId = ClassId("org.springframework.context.ApplicationContext"),
+    classId = SpringModelUtils.applicationContextClassId,
     modelName = "applicationContext"
 )
 

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SignatureUtil.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SignatureUtil.kt
@@ -76,7 +76,7 @@ fun Class<*>.singleConstructor(signature: String): Constructor<*> =
 
 fun Class<*>.singleMethodOrNull(signature: String): Method? =
         generateSequence(this) { it.superclass }.mapNotNull { clazz ->
-            clazz.declaredMethods.firstOrNull { it.signature == signature }
+            (clazz.methods + clazz.declaredMethods).firstOrNull { it.signature == signature }
         }.firstOrNull()
 
 /**

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SpringModelUtils.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SpringModelUtils.kt
@@ -1,0 +1,53 @@
+package org.utbot.framework.plugin.api.util
+
+import org.utbot.framework.plugin.api.ClassId
+import org.utbot.framework.plugin.api.MethodId
+import org.utbot.framework.plugin.api.SpringRepositoryId
+import org.utbot.framework.plugin.api.UtAssembleModel
+import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtModel
+import org.utbot.framework.plugin.api.UtPrimitiveModel
+import org.utbot.framework.plugin.api.UtSpringContextModel
+
+object SpringModelUtils {
+    val applicationContextClassId = ClassId("org.springframework.context.ApplicationContext")
+    val crudRepositoryClassId = ClassId("org.springframework.data.repository.CrudRepository")
+
+    val getBeanMethodId = MethodId(
+        classId = applicationContextClassId,
+        name = "getBean",
+        returnType = Any::class.id,
+        parameters = listOf(String::class.id),
+        bypassesSandbox = true // TODO may be we can use some alternative sandbox that has more permissions
+    )
+
+    val saveMethodId = MethodId(
+        classId = crudRepositoryClassId,
+        name = "save",
+        returnType = Any::class.id,
+        parameters = listOf(Any::class.id)
+    )
+
+
+    fun createBeanModel(beanName: String, id: Int, classId: ClassId) = UtAssembleModel(
+        id = id,
+        classId = classId,
+        modelName = "@Autowired $beanName",
+        instantiationCall = UtExecutableCallModel(
+            instance = UtSpringContextModel(),
+            executable = getBeanMethodId,
+            params = listOf(UtPrimitiveModel(beanName))
+        ),
+        modificationsChainProvider = { mutableListOf() }
+    )
+
+    fun createSaveCallModel(repositoryId: SpringRepositoryId, id: Int, entityModel: UtModel) = UtExecutableCallModel(
+        instance = createBeanModel(
+            beanName = repositoryId.repositoryBeanName,
+            id = id,
+            classId = repositoryId.repositoryClassId,
+        ),
+        executable = saveMethodId,
+        params = listOf(entityModel)
+    )
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssembleModelGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssembleModelGenerator.kt
@@ -204,7 +204,7 @@ class AssembleModelGenerator(private val basePackageName: String) {
                     is UtArrayModel -> assembleArrayModel(utModel)
                     is UtCompositeModel -> assembleCompositeModel(utModel)
                     is UtAssembleModel -> assembleAssembleModel(utModel)
-                    // Python, JavaScript are supposed to be here as well
+                    // Python, JavaScript, UtSpringContextModel are supposed to be here as well
                     else -> utModel
                 }
             } catch (e: AssembleException) {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/builders/SpringTestClassModelBuilder.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/builders/SpringTestClassModelBuilder.kt
@@ -16,6 +16,7 @@ import org.utbot.framework.plugin.api.UtLambdaModel
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtNullModel
 import org.utbot.framework.plugin.api.UtPrimitiveModel
+import org.utbot.framework.plugin.api.UtSpringContextModel
 import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.framework.plugin.api.UtVoidModel
 import org.utbot.framework.plugin.api.isMockModel
@@ -95,7 +96,8 @@ class SpringTestClassModelBuilder(val context: CgContext): TestClassModelBuilder
             is UtPrimitiveModel,
             is UtClassRefModel,
             is UtVoidModel,
-            is UtEnumConstantModel -> {}
+            is UtEnumConstantModel,
+            is UtSpringContextModel -> {}
             is UtLambdaModel -> {
                 currentModel.capturedValues.forEach { collectRecursively(it, allModels) }
             }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgMethodConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgMethodConstructor.kt
@@ -1,5 +1,6 @@
 package org.utbot.framework.codegen.tree
 
+import mu.KotlinLogging
 import org.utbot.common.WorkaroundReason
 import org.utbot.common.isStatic
 import org.utbot.common.workaround
@@ -161,6 +162,10 @@ private const val DEEP_EQUALS_MAX_DEPTH = 5 // TODO move it to plugin settings?
 open class CgMethodConstructor(val context: CgContext) : CgContextOwner by context,
     CgCallableAccessManager by getCallableAccessManagerBy(context),
     CgStatementConstructor by getStatementConstructorBy(context) {
+
+    companion object {
+        private val logger = KotlinLogging.logger {}
+    }
 
     protected val nameGenerator = getNameGeneratorBy(context)
     protected val testFrameworkManager = getTestFrameworkManagerBy(context)
@@ -470,6 +475,8 @@ open class CgMethodConstructor(val context: CgContext) : CgContextOwner by conte
                 neededStackTraceLines += TAB + line
             }
         }
+        if (!executableCallFound)
+            logger.warn(exception) { "Failed to find executable call in stack trace" }
 
         +CgMultilineComment(warningLine + neededStackTraceLines.reversed())
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringVariableConstructor.kt
@@ -5,36 +5,19 @@ import org.utbot.framework.codegen.domain.context.CgContext
 import org.utbot.framework.codegen.domain.models.CgValue
 import org.utbot.framework.codegen.domain.models.CgVariable
 import org.utbot.framework.plugin.api.UtAssembleModel
-import org.utbot.framework.plugin.api.UtAutowiredBaseModel
-import org.utbot.framework.plugin.api.UtAutowiredStateBeforeModel
 import org.utbot.framework.plugin.api.UtCompositeModel
 import org.utbot.framework.plugin.api.UtModel
+import org.utbot.framework.plugin.api.UtSpringContextModel
 import org.utbot.framework.plugin.api.isMockModel
-import org.utbot.framework.plugin.api.util.jClass
 
 class CgSpringVariableConstructor(context: CgContext) : CgVariableConstructor(context) {
     val injectedMocksModelsVariables: MutableSet<UtModelWrapper> = mutableSetOf()
     val mockedModelsVariables: MutableSet<UtModelWrapper> = mutableSetOf()
 
     override fun getOrCreateVariable(model: UtModel, name: String?): CgValue {
-        if (model is UtAutowiredBaseModel) {
+        if (model is UtSpringContextModel) {
             // TODO also, properly render corresponding @Autowired field(s), and make sure name isn't taken
-            if (model is UtAutowiredStateBeforeModel) {
-                comment("begin repository fill up")
-                model.repositoriesContent.forEach { repositoryContent ->
-                    repositoryContent.entityModels.forEach { entity ->
-                        // TODO actually fill up repositories
-                        getOrCreateVariable(entity)
-                        emptyLine()
-                    }
-                }
-                comment("end repository fill up")
-            }
-            emptyLine()
-            return CgVariable(
-                name ?: model.classId.jClass.simpleName.let { it[0].lowercase() + it.drop(1) },
-                model.classId
-            )
+            return CgVariable(model.modelName, model.classId)
         }
 
         val alreadyCreatedInjectMocks = findCgValueByModel(model, injectedMocksModelsVariables)

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/fields/ExecutionStateAnalyzer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/fields/ExecutionStateAnalyzer.kt
@@ -8,7 +8,6 @@ import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.MissingState
 import org.utbot.framework.plugin.api.UtArrayModel
 import org.utbot.framework.plugin.api.UtAssembleModel
-import org.utbot.framework.plugin.api.UtAutowiredBaseModel
 import org.utbot.framework.plugin.api.UtClassRefModel
 import org.utbot.framework.plugin.api.UtCompositeModel
 import org.utbot.framework.plugin.api.UtEnumConstantModel
@@ -18,6 +17,7 @@ import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtNullModel
 import org.utbot.framework.plugin.api.UtPrimitiveModel
 import org.utbot.framework.plugin.api.UtReferenceModel
+import org.utbot.framework.plugin.api.UtSpringContextModel
 import org.utbot.framework.plugin.api.UtSymbolicExecution
 import org.utbot.framework.plugin.api.UtVoidModel
 import org.utbot.framework.util.UtModelVisitor
@@ -238,8 +238,8 @@ private class FieldStateVisitor : UtModelVisitor<FieldData>() {
         recordFieldState(data, element)
     }
 
-    override fun visit(element: UtAutowiredBaseModel, data: FieldData) {
-        element.origin.accept(this, data)
+    override fun visit(element: UtSpringContextModel, data: FieldData) {
+        recordFieldState(data, element)
     }
 
     private fun recordFieldState(data: FieldData, model: UtModel) {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/minimization/Minimization.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/minimization/Minimization.kt
@@ -235,7 +235,7 @@ private fun UtModel.calculateSize(used: MutableSet<UtModel> = mutableSetOf()): I
         }
         is UtCompositeModel -> 1 + fields.values.sumOf { it.calculateSize(used) }
         is UtLambdaModel -> 1 + capturedValues.sumOf { it.calculateSize(used) }
-        // PythonModel, JsUtModel may be here
+        // PythonModel, JsUtModel, UtSpringContextModel may be here
         else -> 0
     }
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/util/UtModelVisitor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/util/UtModelVisitor.kt
@@ -2,7 +2,6 @@ package org.utbot.framework.util
 
 import org.utbot.framework.plugin.api.UtArrayModel
 import org.utbot.framework.plugin.api.UtAssembleModel
-import org.utbot.framework.plugin.api.UtAutowiredBaseModel
 import org.utbot.framework.plugin.api.UtClassRefModel
 import org.utbot.framework.plugin.api.UtCompositeModel
 import org.utbot.framework.plugin.api.UtEnumConstantModel
@@ -11,6 +10,7 @@ import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtNullModel
 import org.utbot.framework.plugin.api.UtPrimitiveModel
 import org.utbot.framework.plugin.api.UtReferenceModel
+import org.utbot.framework.plugin.api.UtSpringContextModel
 import org.utbot.framework.plugin.api.UtVoidModel
 import java.util.Collections
 import java.util.IdentityHashMap
@@ -36,7 +36,7 @@ abstract class UtModelVisitor<D> {
             is UtAssembleModel -> visit(element, data)
             is UtCompositeModel -> visit(element, data)
             is UtLambdaModel -> visit(element, data)
-            is UtAutowiredBaseModel -> visit(element, data)
+            is UtSpringContextModel -> visit(element, data)
         }
     }
 
@@ -46,7 +46,7 @@ abstract class UtModelVisitor<D> {
     protected abstract fun visit(element: UtAssembleModel, data: D)
     protected abstract fun visit(element: UtCompositeModel, data: D)
     protected abstract fun visit(element: UtLambdaModel, data: D)
-    protected abstract fun visit(element: UtAutowiredBaseModel, data: D)
+    protected abstract fun visit(element: UtSpringContextModel, data: D)
 
     /**
      * Returns true when we can traverse the given model.

--- a/utbot-instrumentation/build.gradle.kts
+++ b/utbot-instrumentation/build.gradle.kts
@@ -62,7 +62,6 @@ dependencies {
     implementation("org.mockito:mockito-core:$mockitoVersion")
     implementation("org.mockito:mockito-inline:$mockitoInlineVersion")
 
-    compileOnly("org.springframework.boot:spring-boot:$springBootVersion")
     fetchSpringCommonsJar(project(":utbot-spring-commons", configuration = "springCommonsJar"))
 }
 

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/mock/SpringInstrumentationContext.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/mock/SpringInstrumentationContext.kt
@@ -1,6 +1,29 @@
 package org.utbot.instrumentation.instrumentation.execution.mock
 
-abstract class SpringInstrumentationContext : InstrumentationContext() {
-    abstract fun getBean(beanName: String): Any
-    abstract fun saveToRepository(repository: Any, entity: Any)
+import org.utbot.framework.plugin.api.util.utContext
+import org.utbot.spring.api.context.ContextWrapper
+import org.utbot.spring.api.instantiator.ApplicationInstantiatorFacade
+import org.utbot.spring.api.instantiator.InstantiationSettings
+
+class SpringInstrumentationContext(private val springConfig: String) : InstrumentationContext() {
+    // TODO: recreate context/app every time whenever we change method under test
+    val springContext: ContextWrapper by lazy {
+        val classLoader = utContext.classLoader
+        Thread.currentThread().contextClassLoader = classLoader
+
+        val instantiationSettings = InstantiationSettings(
+            configurationClasses = arrayOf(
+                classLoader.loadClass(springConfig),
+                classLoader.loadClass("org.utbot.spring.repositoryWrapper.RepositoryWrapperConfiguration")
+            ),
+            profileExpression = null, // TODO pass profile expression here
+        )
+
+        val springFacadeInstance =  classLoader
+            .loadClass("org.utbot.spring.instantiator.SpringApplicationInstantiatorFacade")
+            .getConstructor()
+            .newInstance() as ApplicationInstantiatorFacade
+
+        springFacadeInstance.instantiate(instantiationSettings)
+    }
 }

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/process/Security.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/process/Security.kt
@@ -32,11 +32,12 @@ internal fun permissions(block: SimplePolicy.() -> Unit) {
 
 /**
  * Make this [AccessibleObject] accessible and run a block inside sandbox.
+ *
+ * If [bypassSandbox] is `true` then block is run without sandbox.
  */
-fun <O: AccessibleObject, R> O.runSandbox(block: O.() -> R): R {
-    return withAccessibility {
-        sandbox { block() }
-    }
+fun <O: AccessibleObject, R> O.runSandbox(bypassSandbox: Boolean = false, block: O.() -> R): R = withAccessibility {
+    if (bypassSandbox) block()
+    else sandbox { block() }
 }
 
 /**

--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/spring/SpringBeanValueProvider.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/spring/SpringBeanValueProvider.kt
@@ -1,6 +1,8 @@
 package org.utbot.fuzzing.spring
 
 import org.utbot.framework.plugin.api.*
+import org.utbot.framework.plugin.api.util.id
+import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.fuzzer.FuzzedType
 import org.utbot.fuzzer.FuzzedValue
 import org.utbot.fuzzer.IdGenerator
@@ -10,15 +12,15 @@ import org.utbot.fuzzing.providers.SPRING_BEAN_PROP
 
 class SpringBeanValueProvider(
     private val idGenerator: IdGenerator<Int>,
-    private val beanProvider: (ClassId) -> List<String>,
-    private val autowiredModelOriginCreator: (beanName: String) -> UtModel
+    private val beanNameProvider: (ClassId) -> List<String>,
+    private val relevantRepositories: List<SpringRepositoryId>
 ) : ValueProvider<FuzzedType, FuzzedValue, FuzzedDescription> {
 
     override fun enrich(description: FuzzedDescription, type: FuzzedType, scope: Scope) {
         if (description.description.isStatic == false
             && scope.parameterIndex == 0
             && scope.recursionDepth == 1) {
-            scope.putProperty(SPRING_BEAN_PROP, beanProvider)
+            scope.putProperty(SPRING_BEAN_PROP, beanNameProvider)
         }
     }
 
@@ -31,33 +33,35 @@ class SpringBeanValueProvider(
             yield(
                 Seed.Recursive<FuzzedType, FuzzedValue>(
                     construct = Routine.Create(types = emptyList()) {
-                        UtAutowiredStateBeforeModel(
+                        createBeanModel(
+                            beanName = beanName,
                             id = idGenerator.createId(),
                             classId = type.classId,
-                            beanName = beanName,
-                            origin = autowiredModelOriginCreator(beanName), // TODO think about setting origin id and its fields ids
-                            // TODO properly detect which repositories need to be filled up (right now orderRepository is hardcoded)
-                            repositoriesContent = listOf(
-                                RepositoryContentModel(
-                                    repositoryBeanName = "orderRepository",
-                                    entityModels = mutableListOf()
-                                )
-                            ),
-                        ).fuzzed { "@Autowired ${type.classId.simpleName} $beanName" }
+                        ).fuzzed { summary = "@Autowired ${type.classId.simpleName} $beanName" }
                     },
                     modify = sequence {
                         // TODO mutate model itself (not just repositories)
-                        // TODO properly detect which repositories need to be filled up (right now orderRepository is hardcoded)
-                        yield(Routine.Call(
-                            listOf(FuzzedType(ClassId("com.rest.order.models.Order"))),
-                        ) { self, values ->
-                            val entityValue = values[0]
-                            val model = self.model as UtAutowiredStateBeforeModel
-                            // TODO maybe use `entityValue.summary` to update `model.summary`
-                            model.repositoriesContent
-                                .first { it.repositoryBeanName == "orderRepository" }
-                                .entityModels as MutableList += entityValue.model
-                        })
+                        relevantRepositories.forEach { repositoryId ->
+                            yield(Routine.Call(
+                                listOf(toFuzzerType(repositoryId.entityClassId.jClass, description.typeCache))
+                            ) { self, values ->
+                                val entityValue = values[0]
+                                val model = self.model as UtAssembleModel
+                                val modificationChain: MutableList<UtStatementModel> =
+                                    model.modificationsChain as MutableList<UtStatementModel>
+                                modificationChain.add(
+                                    UtExecutableCallModel(
+                                        instance = createBeanModel(
+                                            beanName = repositoryId.repositoryBeanName,
+                                            id = idGenerator.createId(),
+                                            classId = repositoryId.repositoryClassId,
+                                        ),
+                                        executable = createSaveMethodId,
+                                        params = listOf(entityValue.model)
+                                    )
+                                )
+                            })
+                        }
                     },
                     empty = Routine.Empty {
                         UtNullModel(type.classId).fuzzed {
@@ -67,5 +71,34 @@ class SpringBeanValueProvider(
                 )
             )
         }
+    }
+
+    companion object {
+        private val getBeanMethodId = MethodId(
+            classId = UtSpringContextModel().classId,
+            name = "getBean",
+            returnType = Any::class.id,
+            parameters = listOf(String::class.id),
+            bypassesSandbox = true // TODO may be we can use some alternative sandbox that has more permissions
+        )
+
+        val createSaveMethodId = MethodId(
+            classId = ClassId("org.springframework.data.repository.CrudRepository"),
+            name = "save",
+            returnType = Any::class.id,
+            parameters = listOf(Any::class.id)
+        )
+
+        fun createBeanModel(beanName: String, id: Int, classId: ClassId) = UtAssembleModel(
+            id = id,
+            classId = classId,
+            modelName = "@Autowired $beanName",
+            instantiationCall = UtExecutableCallModel(
+                instance = UtSpringContextModel(),
+                executable = getBeanMethodId,
+                params = listOf(UtPrimitiveModel(beanName))
+            ),
+            modificationsChainProvider = { mutableListOf() }
+        )
     }
 }

--- a/utbot-spring-commons-api/src/main/kotlin/org/utbot/spring/api/context/ContextWrapper.kt
+++ b/utbot-spring-commons-api/src/main/kotlin/org/utbot/spring/api/context/ContextWrapper.kt
@@ -1,7 +1,7 @@
 package org.utbot.spring.api.context
 
 interface ContextWrapper {
-    val context: Any?
+    val context: Any
 
     fun getBeanDefinition(beanName: String): Any
 


### PR DESCRIPTION
## Description

It's too time consuming to support multiple Spring specific models, to avoid that all Spring specific models have been expressed in terms of singular `UtSpringContextModel` using `UtAssembleModel`.

## How to test

### Manual tests

Generate integration tests for `spring-boot-testing-main` after putting the following in the `application.yml`.

```yml
spring:
  datasource:
    url: jdbc:h2:mem:testdb
    username: sa
    password: password
  jpa:
    hibernate:
      ddl-auto: create-drop
    show-sql: true
    generate-ddl: true
```

Code generation is still WIP, so `@SpringBootTest`, `@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)`, and `@Autowired private ApplicationContext applicationContext;` need to be manually added.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.