### PR TITLE
Exclude third-party libs from coverage statistics

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -632,7 +632,14 @@ enum class TestSelectionStrategyType {
     /**
      * Adds new test only if it increases coverage
      */
-    COVERAGE_STRATEGY
+    COVERAGE_STRATEGY,
+
+    /**
+     * Works like the [COVERAGE_STRATEGY] strategy,
+     * but only user code instruction coverage is considered
+     * Used for Spring as default
+     */
+    USER_INSTRUCTION_COVERAGE_ONLY_STRATEGY
 }
 
 /**

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -633,13 +633,6 @@ enum class TestSelectionStrategyType {
      * Adds new test only if it increases coverage
      */
     COVERAGE_STRATEGY,
-
-    /**
-     * Works like the [COVERAGE_STRATEGY] strategy,
-     * but only user code instruction coverage is considered
-     * Used for Spring as default
-     */
-    USER_INSTRUCTION_COVERAGE_ONLY_STRATEGY
 }
 
 /**

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -140,7 +140,17 @@ abstract class UtExecution(
     var summary: List<DocStatement>? = null,
     var testMethodName: String? = null,
     var displayName: String? = null
-) : UtResult()
+) : UtResult() {
+    abstract fun copy(
+        stateBefore: EnvironmentModels = this.stateBefore,
+        stateAfter: EnvironmentModels = this.stateAfter,
+        result: UtExecutionResult = this.result,
+        coverage: Coverage? = this.coverage,
+        summary: List<DocStatement>? = this.summary,
+        testMethodName: String? = this.testMethodName,
+        displayName: String? = this.displayName,
+    ): UtExecution
+}
 
 /**
  * Symbolic execution.
@@ -176,6 +186,27 @@ class UtSymbolicExecution(
 
     var containsMocking: Boolean = false
 
+    override fun copy(
+        stateBefore: EnvironmentModels,
+        stateAfter: EnvironmentModels,
+        result: UtExecutionResult,
+        coverage: Coverage?,
+        summary: List<DocStatement>?,
+        testMethodName: String?,
+        displayName: String?
+    ): UtExecution = UtSymbolicExecution(
+        stateBefore = stateBefore,
+        stateAfter = stateAfter,
+        result = result,
+        instrumentation = instrumentation,
+        path = path,
+        fullPath = fullPath,
+        coverage = coverage,
+        summary = summary,
+        testMethodName = testMethodName,
+        displayName = displayName
+    )
+
     override fun toString(): String = buildString {
         append("UtSymbolicExecution(")
         appendLine()
@@ -200,25 +231,28 @@ class UtSymbolicExecution(
     }
 
     fun copy(
-        stateAfter: EnvironmentModels,
-        result: UtExecutionResult,
-        coverage: Coverage,
+        stateBefore: EnvironmentModels = this.stateBefore,
+        stateAfter: EnvironmentModels = this.stateAfter,
+        result: UtExecutionResult = this.result,
+        coverage: Coverage? = this.coverage,
+        summary: List<DocStatement>? = this.summary,
+        testMethodName: String? = this.testMethodName,
+        displayName: String? = this.displayName,
         instrumentation: List<UtInstrumentation> = this.instrumentation,
-    ): UtResult {
-        return UtSymbolicExecution(
-            stateBefore,
-            stateAfter,
-            result,
-            instrumentation,
-            path,
-            fullPath,
-            coverage,
-            summary,
-            testMethodName,
-            displayName,
-            symbolicSteps,
-        )
-    }
+        path: MutableList<Step> = this.path,
+        fullPath: List<Step> = this.fullPath
+    ): UtExecution = UtSymbolicExecution(
+        stateBefore = stateBefore,
+        stateAfter = stateAfter,
+        result = result,
+        instrumentation = instrumentation,
+        path = path,
+        fullPath = fullPath,
+        coverage = coverage,
+        summary = summary,
+        testMethodName = testMethodName,
+        displayName = displayName
+    )
 }
 
 /**
@@ -235,12 +269,31 @@ class UtSymbolicExecution(
  */
 class UtFailedExecution(
     stateBefore: EnvironmentModels,
-    result: UtExecutionFailure,
+    result: UtExecutionResult,
     coverage: Coverage? = null,
     summary: List<DocStatement>? = null,
     testMethodName: String? = null,
     displayName: String? = null
-) : UtExecution(stateBefore, MissingState, result, coverage, summary, testMethodName, displayName)
+) : UtExecution(stateBefore, MissingState, result, coverage, summary, testMethodName, displayName) {
+    override fun copy(
+        stateBefore: EnvironmentModels,
+        stateAfter: EnvironmentModels,
+        result: UtExecutionResult,
+        coverage: Coverage?,
+        summary: List<DocStatement>?,
+        testMethodName: String?,
+        displayName: String?
+    ): UtExecution {
+        return UtFailedExecution(
+            stateBefore,
+            result,
+            coverage,
+            summary,
+            testMethodName,
+            displayName
+        )
+    }
+}
 
 open class EnvironmentModels(
     val thisInstance: UtModel?,

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/CoverageApi.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/CoverageApi.kt
@@ -3,7 +3,7 @@ package org.utbot.framework.plugin.api
 /**
  * Represents a covered bytecode instruction.
  *
- * @param className a fqn of the class.
+ * @param className the fqn in internal form, i.e. com/rest/order/services/OrderService$InnerClass.
  * @param methodSignature the signature of the method.
  * @param lineNumber a number of the line in the source file.
  * @param id a unique identifier among all instructions in all classes.

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SpringModelUtils.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SpringModelUtils.kt
@@ -12,6 +12,7 @@ import org.utbot.framework.plugin.api.UtSpringContextModel
 object SpringModelUtils {
     val applicationContextClassId = ClassId("org.springframework.context.ApplicationContext")
     val crudRepositoryClassId = ClassId("org.springframework.data.repository.CrudRepository")
+    val entityClassId = ClassId("javax.persistence.Entity")
 
     val getBeanMethodId = MethodId(
         classId = applicationContextClassId,

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/minimization/Minimization.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/minimization/Minimization.kt
@@ -238,8 +238,8 @@ private fun UtModel.calculateSize(used: MutableSet<UtModel> = mutableSetOf()): I
 
 private fun UtStatementModel.calculateSize(used: MutableSet<UtModel> = mutableSetOf()): Int =
     when (this) {
-        is UtDirectSetFieldModel -> 1 + fieldModel.calculateSize(used)
-        is UtStatementCallModel -> 1 + params.sumOf { it.calculateSize(used) }
+        is UtDirectSetFieldModel -> 1 + fieldModel.calculateSize(used) + instance.calculateSize(used)
+        is UtStatementCallModel -> 1 + params.sumOf { it.calculateSize(used) } + (instance?.calculateSize(used) ?: 0)
     }
 
 /**

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineProcessMain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineProcessMain.kt
@@ -106,7 +106,8 @@ private fun EngineProcessModel.setup(kryoHelper: KryoHelper, watchdog: IdleWatch
         Instrumenter.adapter = RdInstrumenter(realProtocol.rdInstrumenterAdapter)
         val applicationContext: ApplicationContext = kryoHelper.readObject(params.applicationContext)
 
-        testGenerator = TestCaseGenerator(buildDirs = params.buildDir.map { Paths.get(it) },
+        testGenerator = TestCaseGenerator(
+            buildDirs = params.buildDir.map { Paths.get(it) },
             classpath = params.classpath,
             dependencyPaths = params.dependencyPaths,
             jdkInfo = JdkInfo(Paths.get(params.jdkInfo.path), params.jdkInfo.version),
@@ -115,7 +116,8 @@ private fun EngineProcessModel.setup(kryoHelper: KryoHelper, watchdog: IdleWatch
                 runBlocking {
                     model.isCancelled.startSuspending(Unit)
                 }
-            })
+            }
+        )
     }
     watchdog.measureTimeForActiveCall(generate, "Generating tests") { params ->
         val methods: List<ExecutableId> = kryoHelper.readObject(params.methods)

--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzer/UtFuzzedExecution.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzer/UtFuzzedExecution.kt
@@ -32,6 +32,29 @@ class UtFuzzedExecution(
     val staticFields: Set<FieldId>
         get() = stateBefore.statics.keys // TODO: should we keep it for the Fuzzed Execution?
 
+    override fun copy(
+        stateBefore: EnvironmentModels,
+        stateAfter: EnvironmentModels,
+        result: UtExecutionResult,
+        coverage: Coverage?,
+        summary: List<DocStatement>?,
+        testMethodName: String?,
+        displayName: String?
+    ): UtExecution {
+        return UtFuzzedExecution(
+            stateBefore,
+            stateAfter,
+            result,
+            coverage,
+            summary,
+            testMethodName,
+            displayName,
+            fuzzingValues = fuzzingValues,
+            fuzzedMethodDescription = fuzzedMethodDescription,
+            instrumentation = instrumentation,
+        )
+    }
+
     override fun toString(): String = buildString {
         append("UtFuzzedExecution(")
         appendLine()
@@ -51,4 +74,28 @@ class UtFuzzedExecution(
         append(result)
         append(")")
     }
+
+    fun copy(
+        stateBefore: EnvironmentModels = this.stateBefore,
+        stateAfter: EnvironmentModels = this.stateAfter,
+        result: UtExecutionResult = this.result,
+        coverage: Coverage? = this.coverage,
+        summary: List<DocStatement>? = this.summary,
+        testMethodName: String? = this.testMethodName,
+        displayName: String? = this.displayName,
+        fuzzingValues: List<FuzzedValue>? = this.fuzzingValues,
+        fuzzedMethodDescription: FuzzedMethodDescription? = this.fuzzedMethodDescription,
+        instrumentation: List<UtInstrumentation> = this.instrumentation,
+    ): UtExecution = UtFuzzedExecution(
+        stateBefore = stateBefore,
+        stateAfter = stateAfter,
+        result = result,
+        coverage = coverage,
+        summary = summary,
+        testMethodName = testMethodName,
+        displayName = displayName,
+        fuzzingValues = fuzzingValues,
+        fuzzedMethodDescription = fuzzedMethodDescription,
+        instrumentation = instrumentation,
+    )
 }

--- a/utbot-js/src/main/kotlin/framework/api/js/JsUtFuzzedExecution.kt
+++ b/utbot-js/src/main/kotlin/framework/api/js/JsUtFuzzedExecution.kt
@@ -1,11 +1,25 @@
 package framework.api.js
 
-import org.utbot.framework.plugin.api.EnvironmentModels
-import org.utbot.framework.plugin.api.UtExecution
-import org.utbot.framework.plugin.api.UtExecutionResult
+import org.utbot.framework.plugin.api.*
 
 class JsUtFuzzedExecution(
     stateBefore: EnvironmentModels,
     stateAfter: EnvironmentModels,
     result: UtExecutionResult
-) : UtExecution(stateBefore, stateAfter, result, null, null, null, null)
+) : UtExecution(stateBefore, stateAfter, result, null, null, null, null) {
+    override fun copy(
+        stateBefore: EnvironmentModels,
+        stateAfter: EnvironmentModels,
+        result: UtExecutionResult,
+        coverage: Coverage?,
+        summary: List<DocStatement>?,
+        testMethodName: String?,
+        displayName: String?
+    ): UtExecution {
+        return JsUtFuzzedExecution(
+            stateBefore = stateBefore,
+            stateAfter = stateAfter,
+            result = result
+        )
+    }
+}

--- a/utbot-python/src/main/kotlin/org/utbot/python/framework/api/python/PythonApi.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/framework/api/python/PythonApi.kt
@@ -1,13 +1,6 @@
 package org.utbot.python.framework.api.python
 
-import org.utbot.framework.plugin.api.ClassId
-import org.utbot.framework.plugin.api.Coverage
-import org.utbot.framework.plugin.api.DocStatement
-import org.utbot.framework.plugin.api.EnvironmentModels
-import org.utbot.framework.plugin.api.MethodId
-import org.utbot.framework.plugin.api.UtExecution
-import org.utbot.framework.plugin.api.UtExecutionResult
-import org.utbot.framework.plugin.api.UtModel
+import org.utbot.framework.plugin.api.*
 import org.utbot.python.framework.api.python.util.comparePythonTree
 import org.utbot.python.framework.api.python.util.moduleOfType
 
@@ -104,4 +97,26 @@ class PythonUtExecution(
     summary: List<DocStatement>? = null,
     testMethodName: String? = null,
     displayName: String? = null
-) : UtExecution(stateBefore, stateAfter, result, coverage, summary, testMethodName, displayName)
+) : UtExecution(stateBefore, stateAfter, result, coverage, summary, testMethodName, displayName) {
+    override fun copy(
+        stateBefore: EnvironmentModels,
+        stateAfter: EnvironmentModels,
+        result: UtExecutionResult,
+        coverage: Coverage?,
+        summary: List<DocStatement>?,
+        testMethodName: String?,
+        displayName: String?
+    ): UtExecution {
+        return PythonUtExecution(
+            stateInit = stateInit,
+            stateBefore = stateBefore,
+            stateAfter = stateAfter,
+            diffIds = diffIds,
+            result = result,
+            coverage = coverage,
+            summary = summary,
+            testMethodName = testMethodName,
+            displayName = displayName
+        )
+    }
+}

--- a/utbot-testing/src/main/kotlin/org/utbot/testing/TestSpecificTestCaseGenerator.kt
+++ b/utbot-testing/src/main/kotlin/org/utbot/testing/TestSpecificTestCaseGenerator.kt
@@ -100,7 +100,7 @@ class TestSpecificTestCaseGenerator(
         forceMockListener.detach(this, forceMockListener)
         forceStaticMockListener.detach(this, forceStaticMockListener)
 
-        val minimizedExecutions = super.minimizeExecutions(executions)
+        val minimizedExecutions = super.minimizeExecutions(method.classId, executions)
         return UtMethodTestSet(method, minimizedExecutions, jimpleBody(method), errors)
     }
 }


### PR DESCRIPTION
## Description

This PR improves minimization process in Spring-specific integration test generation process by excluding third-party and standard java lib instructions from coverage analysis. This fixes duplicate tests.

Fixes #2218

## How to test

1. Use `spring-boot-testing` project 
2. Enable 100% fuzzer
2. Generate integration tests with configuration for `OrderService.createOrder ` method

### Manual tests

Tested on `ilya_m/ilya_m/spring_integration_test_prototype` branch. There are two instead of >8 tests.