### PR TITLE
Support using identifiers generated by database as method arguments

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgVariableConstructor.kt
@@ -241,7 +241,7 @@ open class CgVariableConstructor(val context: CgContext) :
         val params = statementCall.params
 
         // Don't use redundant constructors for primitives and String
-        val initExpr = if (executable is ConstructorId && isPrimitiveWrapperOrString(executable.classId)) {
+        val initExpr = if (executable is ConstructorId && isPrimitiveWrapperOrString(model.classId)) {
             cgLiteralForWrapper(params)
         } else {
             createCgExecutableCallFromUtExecutableCall(statementCall)

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgVariableConstructor.kt
@@ -240,18 +240,13 @@ open class CgVariableConstructor(val context: CgContext) :
         val executable = statementCall.statement
         val params = statementCall.params
 
-        val type = when (executable) {
-            is MethodId -> executable.returnType
-            is DirectFieldAccessId -> executable.fieldId.type
-            is ConstructorId -> executable.classId
-        }
         // Don't use redundant constructors for primitives and String
-        val initExpr = if (isPrimitiveWrapperOrString(type)) {
+        val initExpr = if (executable is ConstructorId && isPrimitiveWrapperOrString(executable.classId)) {
             cgLiteralForWrapper(params)
         } else {
             createCgExecutableCallFromUtExecutableCall(statementCall)
         }
-        newVar(type, model, baseName) {
+        newVar(model.classId, model, baseName) {
             initExpr
         }.also {
             valueByUtModelWrapper[model.wrap()] = it

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/MockValueConstructor.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/MockValueConstructor.kt
@@ -318,15 +318,17 @@ class MockValueConstructor(
     /**
      * Constructs object with [UtAssembleModel].
      */
-    private fun constructFromAssembleModel(assembleModel: UtAssembleModel): Any {
+    private fun constructFromAssembleModel(assembleModel: UtAssembleModel): Any? {
         constructedObjects[assembleModel]?.let { return it }
 
         val instantiationExecutableCall = assembleModel.instantiationCall
         val result = updateWithStatementCallModel(instantiationExecutableCall)
-        checkNotNull(result) {
-            "Tracked instance can't be null for call ${instantiationExecutableCall.statement} in model $assembleModel"
-        }
-        constructedObjects[assembleModel] = result
+        // TODO figure out the why tracked instance can't be null,
+        //  right now behaviour is incorrect as null producing models can get constructed multiple times
+//        checkNotNull(result) {
+//            "Tracked instance can't be null for call ${instantiationExecutableCall.statement} in model $assembleModel"
+//        }
+        result?.let { constructedObjects[assembleModel] = it }
 
         assembleModel.modificationsChain.forEach { statementModel ->
             when (statementModel) {
@@ -335,7 +337,7 @@ class MockValueConstructor(
             }
         }
 
-        return constructedObjects[assembleModel] ?: error("Can't assemble model: $assembleModel")
+        return constructedObjects[assembleModel] // ?: error("Can't assemble model: $assembleModel")
     }
 
     private fun constructFromLambdaModel(lambdaModel: UtLambdaModel): Any {
@@ -437,7 +439,7 @@ class MockValueConstructor(
             newInstance(*args.toTypedArray())
         }
 
-    private fun DirectFieldAccessId.get(instance: Any?): Any {
+    private fun DirectFieldAccessId.get(instance: Any?): Any? {
         val field = fieldId.jField
         return field.runSandbox {
             field.get(instance)

--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Collections.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Collections.kt
@@ -70,7 +70,7 @@ class EmptyCollectionValueProvider(
                         summary = "%var% = ${executableId.classId.simpleName}#${executableId.name}"
                     }
                 } else {
-                    UtNullModel(classId).fuzzed { summary = "%var% = null" }
+                    nullFuzzedValue(classId)
                 }
             },
         ))

--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Field.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Field.kt
@@ -1,0 +1,65 @@
+package org.utbot.fuzzing.providers
+
+import mu.KotlinLogging
+import org.utbot.framework.plugin.api.DirectFieldAccessId
+import org.utbot.framework.plugin.api.FieldId
+import org.utbot.framework.plugin.api.UtAssembleModel
+import org.utbot.framework.plugin.api.UtDirectGetFieldModel
+import org.utbot.framework.plugin.api.UtNullModel
+import org.utbot.framework.plugin.api.UtReferenceModel
+import org.utbot.framework.plugin.api.util.jClass
+import org.utbot.fuzzer.FuzzedType
+import org.utbot.fuzzer.FuzzedValue
+import org.utbot.fuzzer.IdGenerator
+import org.utbot.fuzzer.fuzzed
+import org.utbot.fuzzing.FuzzedDescription
+import org.utbot.fuzzing.JavaValueProvider
+import org.utbot.fuzzing.Routine
+import org.utbot.fuzzing.Seed
+import org.utbot.fuzzing.toFuzzerType
+
+class FieldValueProvider(
+    private val idGenerator: IdGenerator<Int>,
+    private val fieldId: FieldId,
+) : JavaValueProvider {
+    companion object {
+        private val logger = KotlinLogging.logger {}
+    }
+
+    override fun accept(type: FuzzedType): Boolean = type.classId == fieldId.type
+
+    override fun generate(description: FuzzedDescription, type: FuzzedType): Sequence<Seed<FuzzedType, FuzzedValue>> = sequenceOf(
+        Seed.Recursive(
+            construct = Routine.Create(listOf(
+                toFuzzerType(fieldId.declaringClass.jClass, description.typeCache)
+            )) { values ->
+                val thisInstanceValue = values.single()
+                val thisInstanceModel = when (val model = thisInstanceValue.model) {
+                    is UtReferenceModel -> model
+                    is UtNullModel -> return@Create nullFuzzedValue(type.classId)
+                    else -> {
+                        logger.warn { "This instance model can be only UtReferenceModel or UtNullModel, but $model is met" }
+                        return@Create nullFuzzedValue(type.classId)
+                    }
+                }
+                UtAssembleModel(
+                    id = idGenerator.createId(),
+                    classId = type.classId,
+                    modelName = "${thisInstanceModel.modelName}.${fieldId.name}",
+                    instantiationCall = UtDirectGetFieldModel(
+                        instance = thisInstanceModel,
+                        fieldAccess = DirectFieldAccessId(
+                            classId = fieldId.declaringClass,
+                            name = "<direct_get_${fieldId.name}>",
+                            fieldId = fieldId
+                        )
+                    )
+                ).fuzzed {
+                    summary = "${thisInstanceValue.summary}.${fieldId.name}"
+                }
+            },
+            modify = emptySequence(),
+            empty = nullRoutine(type.classId)
+        )
+    )
+}

--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Objects.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Objects.kt
@@ -86,11 +86,7 @@ class ObjectValueProvider(
                     }
                 }
             },
-            empty = Routine.Empty {
-                UtNullModel(classId).fuzzed {
-                    summary = "%var% = null"
-                }
-            }
+            empty = nullRoutine(classId)
         )
     }
 
@@ -133,9 +129,7 @@ object NullValueProvider : ValueProvider<FuzzedType, FuzzedValue, FuzzedDescript
         type: FuzzedType
     ) = sequence<Seed<FuzzedType, FuzzedValue>> {
         if (description.scope?.getProperty(NULLABLE_PROP) == true) {
-            yield(Seed.Simple(UtNullModel(type.classId).fuzzed {
-                summary = "%var% = null"
-            }))
+            yield(Seed.Simple(nullFuzzedValue(classClassId)))
         }
     }
 }

--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Utils.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Utils.kt
@@ -1,0 +1,14 @@
+package org.utbot.fuzzing.providers
+
+import org.utbot.framework.plugin.api.ClassId
+import org.utbot.framework.plugin.api.UtNullModel
+import org.utbot.fuzzer.FuzzedType
+import org.utbot.fuzzer.FuzzedValue
+import org.utbot.fuzzer.fuzzed
+import org.utbot.fuzzing.Routine
+
+fun nullRoutine(classId: ClassId): Routine.Empty<FuzzedType, FuzzedValue> =
+    Routine.Empty { nullFuzzedValue(classId) }
+
+fun nullFuzzedValue(classId: ClassId): FuzzedValue =
+    UtNullModel(classId).fuzzed { summary = "%var% = null" }

--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/spring/SavedEntity.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/spring/SavedEntity.kt
@@ -1,0 +1,46 @@
+package org.utbot.fuzzing.spring
+
+import org.utbot.framework.plugin.api.SpringRepositoryId
+import org.utbot.framework.plugin.api.UtAssembleModel
+import org.utbot.framework.plugin.api.UtReferenceModel
+import org.utbot.framework.plugin.api.util.SpringModelUtils
+import org.utbot.fuzzer.FuzzedType
+import org.utbot.fuzzer.FuzzedValue
+import org.utbot.fuzzer.IdGenerator
+import org.utbot.fuzzer.fuzzed
+import org.utbot.fuzzing.FuzzedDescription
+import org.utbot.fuzzing.JavaValueProvider
+import org.utbot.fuzzing.Routine
+import org.utbot.fuzzing.Seed
+import org.utbot.fuzzing.providers.nullRoutine
+
+class SavedEntityProvider(
+    private val idGenerator: IdGenerator<Int>,
+    private val repositoryId: SpringRepositoryId
+) : JavaValueProvider {
+    override fun accept(type: FuzzedType): Boolean = type.classId == repositoryId.entityClassId
+
+    override fun generate(description: FuzzedDescription, type: FuzzedType): Sequence<Seed<FuzzedType, FuzzedValue>> =
+        sequenceOf(
+            Seed.Recursive(
+                construct = Routine.Create(listOf(type)) { values ->
+                    val entityValue = values.single()
+                    val entityModel = entityValue.model
+                    UtAssembleModel(
+                        id = idGenerator.createId(),
+                        classId = type.classId,
+                        modelName = "${repositoryId.repositoryBeanName}.save(${(entityModel as? UtReferenceModel)?.modelName ?: "..."})",
+                        instantiationCall = SpringModelUtils.createSaveCallModel(
+                            repositoryId = repositoryId,
+                            id = idGenerator.createId(),
+                            entityModel = entityModel
+                        )
+                    ).fuzzed {
+                        summary = "%var% = ${repositoryId.repositoryBeanName}.save(${entityValue.summary})"
+                    }
+                },
+                modify = emptySequence(),
+                empty = nullRoutine(type.classId)
+            )
+        )
+}

--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/spring/SpringBeanValueProvider.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/spring/SpringBeanValueProvider.kt
@@ -9,6 +9,7 @@ import org.utbot.fuzzer.IdGenerator
 import org.utbot.fuzzer.fuzzed
 import org.utbot.fuzzing.*
 import org.utbot.fuzzing.providers.SPRING_BEAN_PROP
+import org.utbot.fuzzing.providers.nullRoutine
 
 class SpringBeanValueProvider(
     private val idGenerator: IdGenerator<Int>,
@@ -59,11 +60,7 @@ class SpringBeanValueProvider(
                             })
                         }
                     },
-                    empty = Routine.Empty {
-                        UtNullModel(type.classId).fuzzed {
-                            summary = "%var% = null"
-                        }
-                    }
+                    empty = nullRoutine(type.classId)
                 )
             )
         }


### PR DESCRIPTION
## Description

For reproduceable tests for methods that can read database and accept identifiers, we want to first fill up the database, take some identifier generated by the database and then pass that identifier to the method under test. That also solves the problem of fuzzer not always being able to guess identifiers that are used by the database, for example, when database uses random UUIDs.

## How to test

### Manual tests

Generate tests for `OrderService#deleteOrderById(Long)` from `spring-boot-testing-main` project, there should be test that looks like this:
```java
@Test
@DisplayName("deleteOrderById: id = orderRepository.save(id = Order()).id -> return true")
public void testDeleteOrderByIdReturnsTrue() throws ClassNotFoundException, IllegalAccessException, NoSuchFieldException, InvocationTargetException, NoSuchMethodException {
    OrderService orderService = ((OrderService) applicationContext.getBean("orderService"));
    OrderRepository orderRepository = ((OrderRepository) applicationContext.getBean("orderRepository"));
    Order order = new Order();
    orderRepository.save(order);
    OrderRepository orderRepository1 = ((OrderRepository) applicationContext.getBean("orderRepository"));
    Order order1 = new Order();
    order1.setQty(1);
    order1.setBuyer("");
    order1.setPrice(Double.NEGATIVE_INFINITY);
    order1.setId(0L);
    Order order2 = ((Order) orderRepository1.save(order1));
    Long id = ((Long) getFieldValue(order2, "com.rest.order.models.Order", "id"));

    boolean actual = orderService.deleteOrderById(id);

    assertTrue(actual);
}
```

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.