### PR TITLE
Improve mutation API in Fuzzing Platform

### DIFF
--- a/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/Configuration.kt
+++ b/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/Configuration.kt
@@ -37,17 +37,22 @@ data class Configuration(
     /**
      * Probability of creating shifted array values instead of generating new values for modification.
      */
-    var probCollectionMutationInsteadCreateNew: Int = 50,
+    var probCollectionMutationInsteadCreateNew: Int = 75,
+
+    /**
+     * Probability of creating empty collections
+     */
+    var probEmptyCollectionCreation: Int = 1,
 
     /**
      * Probability to prefer change constructor instead of modification.
      */
-    var probConstructorMutationInsteadModificationMutation: Int = 90,
+    var probConstructorMutationInsteadModificationMutation: Int = 30,
 
     /**
-     * Probability to shuffle modification list of the recursive object
+     * Probability to a shuffle modification list of the recursive object
      */
-    var probShuffleAndCutRecursiveObjectModificationMutation: Int = 10,
+    var probShuffleAndCutRecursiveObjectModificationMutation: Int = 30,
 
     /**
      * Probability to prefer create rectangle collections instead of creating saw-like one.

--- a/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/Configuration.kt
+++ b/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/Configuration.kt
@@ -62,17 +62,7 @@ data class Configuration(
     /**
      * When mutating StringValue a new string will not exceed this value.
      */
-    var maxStringLengthWhenMutated: Int = 64,
-
-    /**
-     * Probability of adding a new character when mutating StringValue
-     */
-    var probStringAddCharacter: Int = 50,
-
-    /**
-     * Probability of removing an old character from StringValue when mutating
-     */
-    var probStringRemoveCharacter: Int = 50,
+    var maxStringLengthWhenMutated: Int = 128,
 
     /**
      * Probability of reusing same generated value when 2 or more parameters have the same type.

--- a/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/Configuration.kt
+++ b/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/Configuration.kt
@@ -37,7 +37,7 @@ data class Configuration(
     /**
      * Probability of creating shifted array values instead of generating new values for modification.
      */
-    var probCollectionMutationInsteadCreateNew: Int = 75,
+    var probCollectionDuplicationInsteadCreateNew: Int = 10,
 
     /**
      * Probability of creating empty collections

--- a/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/Mutations.kt
+++ b/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/Mutations.kt
@@ -4,8 +4,104 @@ package org.utbot.fuzzing
 
 import org.utbot.fuzzing.seeds.BitVectorValue
 import org.utbot.fuzzing.seeds.IEEE754Value
+import org.utbot.fuzzing.seeds.KnownValue
 import org.utbot.fuzzing.seeds.StringValue
+import org.utbot.fuzzing.utils.chooseOne
+import org.utbot.fuzzing.utils.flipCoin
 import kotlin.random.Random
+
+class MutationFactory<TYPE, RESULT> {
+
+    fun mutate(node: Node<TYPE, RESULT>, random: Random, configuration: Configuration): Node<TYPE, RESULT> {
+        if (node.result.isEmpty()) return node
+        val indexOfMutatedResult = random.chooseOne(node.result.map(::rate).toDoubleArray())
+        val recursive: NodeMutation<TYPE, RESULT> = NodeMutation { n, r, c ->
+            mutate(n, r, c)
+        }
+        val mutated = when (val resultToMutate = node.result[indexOfMutatedResult]) {
+            is Result.Simple<TYPE, RESULT> -> Result.Simple(resultToMutate.mutation(resultToMutate.result, random), resultToMutate.mutation)
+            is Result.Known<TYPE, RESULT, *> -> {
+                val mutations = resultToMutate.value.mutations()
+                if (mutations.isNotEmpty()) {
+                    resultToMutate.mutate(mutations.random(random), random, configuration)
+                } else {
+                    resultToMutate
+                }
+            }
+            is Result.Recursive<TYPE, RESULT> -> {
+                when {
+                    resultToMutate.modify.isEmpty() || random.flipCoin(configuration.probConstructorMutationInsteadModificationMutation) ->
+                        RecursiveMutations.Constructor<TYPE, RESULT>()
+                    random.flipCoin(configuration.probShuffleAndCutRecursiveObjectModificationMutation) ->
+                        RecursiveMutations.ShuffleAndCutModifications()
+                    else ->
+                        RecursiveMutations.Mutate()
+                }.mutate(resultToMutate, recursive, random, configuration)
+            }
+            is Result.Collection<TYPE, RESULT> -> if (resultToMutate.modify.isNotEmpty()) {
+                when {
+                    random.flipCoin(100 - configuration.probCollectionShuffleInsteadResultMutation) ->
+                        CollectionMutations.Mutate()
+                    else ->
+                        CollectionMutations.Shuffle<TYPE, RESULT>()
+                }.mutate(resultToMutate, recursive, random, configuration)
+            } else {
+                resultToMutate
+            }
+            is Result.Empty -> resultToMutate
+        }
+        return Node(node.result.toMutableList().apply {
+            set(indexOfMutatedResult, mutated)
+        }, node.parameters, node.builder)
+    }
+
+    /**
+     * Rates somehow the result.
+     *
+     * For example, fuzzing should not try to mutate some empty structures, like empty collections or objects.
+     */
+    private fun <TYPE, RESULT> rate(result: Result<TYPE, RESULT>): Double {
+        if (!canMutate(result)) {
+            return ALMOST_ZERO
+        }
+        return when (result) {
+            is Result.Recursive<TYPE, RESULT> -> if (result.construct.parameters.isEmpty() and result.modify.isEmpty()) ALMOST_ZERO else 0.5
+            is Result.Collection<TYPE, RESULT> -> if (result.iterations == 0) return ALMOST_ZERO else 0.7
+            is StringValue -> 2.0
+            is Result.Known<TYPE, RESULT, *> -> 1.2
+            is Result.Simple<TYPE, RESULT> -> 2.0
+            is Result.Empty -> ALMOST_ZERO
+        }
+    }
+
+    private fun <TYPE, RESULT> canMutate(node: Result<TYPE, RESULT>): Boolean {
+        return when (node) {
+            is Result.Simple<TYPE, RESULT> -> node.mutation === emptyMutation<RESULT>()
+            is Result.Known<TYPE, RESULT, *> -> node.value.mutations().isNotEmpty()
+            is Result.Recursive<TYPE, RESULT> -> node.modify.isNotEmpty()
+            is Result.Collection<TYPE, RESULT> -> node.modify.isNotEmpty() && node.iterations > 0
+            is Result.Empty<TYPE, RESULT> -> false
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <TYPE, RESULT, T : KnownValue<T>> Result.Known<TYPE, RESULT, *>.mutate(mutation: Mutation<T>, random: Random, configuration: Configuration): Result.Known<TYPE, RESULT, T> {
+        val source: T = value as T
+        val mutate = mutation.mutate(source, random, configuration)
+        return Result.Known(
+            mutate,
+            build as (T) -> RESULT
+        )
+    }
+}
+
+private const val ALMOST_ZERO = 1E-7
+private val IDENTITY_MUTATION: (Any, random: Random) -> Any = { f, _ -> f }
+
+fun <RESULT> emptyMutation(): (RESULT, random: Random) -> RESULT {
+    @Suppress("UNCHECKED_CAST")
+    return IDENTITY_MUTATION as (RESULT, random: Random) -> RESULT
+}
 
 /**
  * Mutations is an object which applies some changes to the source object

--- a/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/Mutations.kt
+++ b/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/Mutations.kt
@@ -4,6 +4,7 @@ package org.utbot.fuzzing
 
 import org.utbot.fuzzing.seeds.BitVectorValue
 import org.utbot.fuzzing.seeds.IEEE754Value
+import org.utbot.fuzzing.seeds.StringValue
 import kotlin.random.Random
 
 /**
@@ -27,7 +28,7 @@ sealed class BitVectorMutations : Mutation<BitVectorValue> {
     override fun mutate(source: BitVectorValue, random: Random, configuration: Configuration): BitVectorValue {
         with (rangeOfMutation(source)) {
             val firstBits = random.nextInt(start, endInclusive.coerceAtLeast(1))
-            return BitVectorValue(source).apply { this[firstBits] = !this[firstBits] }
+            return BitVectorValue(source, this@BitVectorMutations).apply { this[firstBits] = !this[firstBits] }
         }
     }
 
@@ -48,7 +49,7 @@ sealed class IEEE754Mutations : Mutation<IEEE754Value> {
 
     object ChangeSign : IEEE754Mutations() {
         override fun mutate(source: IEEE754Value, random: Random, configuration: Configuration): IEEE754Value {
-            return IEEE754Value(source).apply {
+            return IEEE754Value(source, this).apply {
                 setRaw(0, !getRaw(0))
             }
         }
@@ -57,7 +58,7 @@ sealed class IEEE754Mutations : Mutation<IEEE754Value> {
     object Mantissa : IEEE754Mutations() {
         override fun mutate(source: IEEE754Value, random: Random, configuration: Configuration): IEEE754Value {
             val i = random.nextInt(0, source.mantissaSize)
-            return IEEE754Value(source).apply {
+            return IEEE754Value(source, this).apply {
                 setRaw(1 + exponentSize + i, !getRaw(1 + exponentSize + i))
             }
         }
@@ -66,9 +67,55 @@ sealed class IEEE754Mutations : Mutation<IEEE754Value> {
     object Exponent : IEEE754Mutations() {
         override fun mutate(source: IEEE754Value, random: Random, configuration: Configuration): IEEE754Value {
             val i = random.nextInt(0, source.exponentSize)
-            return IEEE754Value(source).apply {
+            return IEEE754Value(source, this).apply {
                 setRaw(1 + i, !getRaw(1 + i))
             }
         }
     }
+}
+
+sealed class StringMutations : Mutation<StringValue> {
+
+    object AddCharacter : StringMutations() {
+        override fun mutate(source: StringValue, random: Random, configuration: Configuration): StringValue {
+            val value = source.value
+            if (value.length >= configuration.maxStringLengthWhenMutated) {
+                return source
+            }
+            val position = random.nextInt(value.length + 1)
+            val charToMutate = if (value.isNotEmpty()) {
+                value.random(random)
+            } else {
+                // use any meaningful character from the ascii table
+                random.nextInt(33, 127).toChar()
+            }
+            val newString = buildString {
+                append(value.substring(0, position))
+                // try to change char to some that is close enough to origin char
+                val charTableSpread = 64
+                if (random.nextBoolean()) {
+                    append(charToMutate - random.nextInt(1, charTableSpread))
+                } else {
+                    append(charToMutate + random.nextInt(1, charTableSpread))
+                }
+                append(value.substring(position, value.length))
+            }
+            return StringValue(newString, lastMutation = this)
+        }
+    }
+
+    object RemoveCharacter : StringMutations() {
+        override fun mutate(source: StringValue, random: Random, configuration: Configuration): StringValue {
+            val value = source.value
+            val position = random.nextInt(value.length + 1)
+            if (position >= value.length) return source
+            val toRemove = random.nextInt(value.length)
+            val newString = buildString {
+                append(value.substring(0, toRemove))
+                append(value.substring(toRemove + 1, value.length))
+            }
+            return StringValue(newString, this)
+        }
+    }
+
 }

--- a/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/demo/HttpRequest.kt
+++ b/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/demo/HttpRequest.kt
@@ -1,0 +1,60 @@
+package org.utbot.fuzzing.demo
+
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.utbot.fuzzing.*
+import java.util.concurrent.TimeUnit
+
+fun main() = runBlocking {
+    withTimeout(TimeUnit.SECONDS.toMillis(10)) {
+        object : Fuzzing<String, String, Description<String>, Feedback<String, String>> {
+            override fun generate(description: Description<String>, type: String) = sequence<Seed<String, String>> {
+                when (type) {
+                    "url" -> yield(Seed.Recursive(
+                        construct = Routine.Create(
+                            listOf("protocol", "host", "port", "path")
+                        ) {
+                            val (protocol, host, port, path) = it
+                            "$protocol://$host${if (port.isNotBlank()) ":$port" else ""}/$path"
+                        },
+                        empty = Routine.Empty { error("error") }
+                    ))
+                    "protocol" -> {
+                        yield(Seed.Simple("http"))
+                        yield(Seed.Simple("https"))
+                        yield(Seed.Simple("ftp"))
+                    }
+                    "host" -> {
+                        yield(Seed.Simple("localhost"))
+                        yield(Seed.Simple("127.0.0.1"))
+                    }
+                    "port" -> {
+                        yield(Seed.Simple("8080"))
+                        yield(Seed.Simple(""))
+                    }
+                    "path" -> yield(Seed.Recursive(
+                        construct = Routine.Create(listOf("page", "id")) {
+                            it.joinToString("/")
+                        },
+                        empty = Routine.Empty { error("error") }
+                    ))
+                    "page" -> {
+                        yield(Seed.Simple("owners"))
+                        yield(Seed.Simple("users"))
+                        yield(Seed.Simple("admins"))
+                    }
+                    "id" -> (0..1000).forEach { yield(Seed.Simple(it.toString())) }
+                    else -> error("unknown type '$type'")
+                }
+            }
+
+            override suspend fun handle(
+                description: Description<String>,
+                values: List<String>
+            ): Feedback<String, String> {
+                println(values[0])
+                return BaseFeedback(values[0], Control.PASS)
+            }
+        }.fuzz(Description(listOf("url")))
+    }
+}

--- a/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/demo/JsonFuzzing.kt
+++ b/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/demo/JsonFuzzing.kt
@@ -30,7 +30,6 @@ private class JsonBuilder(
  *
  * Also, some utility class such as [BaseFuzzing] and [TypeProvider] are used to start fuzzing without class inheritance.
  */
-@Suppress("RemoveExplicitTypeArguments")
 suspend fun main() {
     var count = 0
     val set = mutableMapOf<String, AtomicLong>()
@@ -85,7 +84,7 @@ suspend fun main() {
         println(result)
         set.computeIfAbsent(result) { AtomicLong() }.incrementAndGet()
         if (++count < 10000) emptyFeedback() else {
-            println("Duplication ratio:" + set.size / count.toDouble())
+            println("Unique ratio:" + set.size / count.toDouble())
             error("Forced from the example")
         }
     }.fuzz(

--- a/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/seeds/BitVectorValue.kt
+++ b/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/seeds/BitVectorValue.kt
@@ -5,7 +5,7 @@ import org.utbot.fuzzing.utils.Endian
 import java.math.BigInteger
 import java.util.BitSet
 
-class BitVectorValue : KnownValue {
+class BitVectorValue : KnownValue<BitVectorValue> {
 
     /**
      * Vector of value bits.
@@ -15,8 +15,8 @@ class BitVectorValue : KnownValue {
      */
     private val vector: BitSet
     val size: Int
-    override val lastMutation: Mutation<KnownValue>?
-    override val mutatedFrom: KnownValue?
+    override val lastMutation: Mutation<BitVectorValue>?
+    override val mutatedFrom: BitVectorValue?
 
     constructor(bits: Int, bound: Bound) {
         vector = BitSet(bits).also {
@@ -29,7 +29,7 @@ class BitVectorValue : KnownValue {
         mutatedFrom = null
     }
 
-    constructor(other: BitVectorValue, mutation: Mutation<KnownValue>? = null) {
+    constructor(other: BitVectorValue, mutation: Mutation<BitVectorValue>? = null) {
         vector = other.vector.clone() as BitSet
         size = other.size
         lastMutation = mutation
@@ -80,10 +80,10 @@ class BitVectorValue : KnownValue {
         return !carry && shift == size
     }
 
-    override fun mutations() = listOf<Mutation<KnownValue>>(
-        BitVectorMutations.SlightDifferent.adapt(),
-        BitVectorMutations.DifferentWithSameSign.adapt(),
-        BitVectorMutations.ChangeSign.adapt()
+    override fun mutations() = listOf<Mutation<BitVectorValue>>(
+        BitVectorMutations.SlightDifferent,
+        BitVectorMutations.DifferentWithSameSign,
+        BitVectorMutations.ChangeSign
     )
 
     override fun equals(other: Any?): Boolean {
@@ -106,6 +106,7 @@ class BitVectorValue : KnownValue {
 
     override fun toString() = toString(10)
 
+    @Suppress("unused")
     internal fun toBinaryString(endian: Endian) = buildString {
         for (i in endian.range(0, size - 1)) {
             append(if (this@BitVectorValue[i]) '1' else '0')

--- a/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/seeds/IEEE754Value.kt
+++ b/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/seeds/IEEE754Value.kt
@@ -12,7 +12,7 @@ import kotlin.math.pow
 //val DOUBLE_POSITIVE_INFINITY = DefaultFloatBound.POSITIVE_INFINITY(52, 11)
 //val DOUBLE_NEGATIVE_INFINITY = DefaultFloatBound.NEGATIVE_INFINITY(52, 11)
 
-class IEEE754Value : KnownValue {
+class IEEE754Value : KnownValue<IEEE754Value> {
 
     val isPositive: Boolean
         get() = !vector[0]
@@ -34,8 +34,8 @@ class IEEE754Value : KnownValue {
 
     val mantissaSize: Int
     val exponentSize: Int
-    override val lastMutation: Mutation<KnownValue>?
-    override val mutatedFrom: KnownValue?
+    override val lastMutation: Mutation<IEEE754Value>?
+    override val mutatedFrom: IEEE754Value?
 
     private val vector: BitVectorValue
 
@@ -56,7 +56,7 @@ class IEEE754Value : KnownValue {
         mutatedFrom = null
     }
 
-    constructor(value: IEEE754Value, mutation: Mutation<KnownValue>? = null) {
+    constructor(value: IEEE754Value, mutation: Mutation<IEEE754Value>? = null) {
         this.vector = BitVectorValue(value.vector)
         this.mantissaSize = value.mantissaSize
         this.exponentSize = value.exponentSize
@@ -127,10 +127,10 @@ class IEEE754Value : KnownValue {
         }
     }
 
-    override fun mutations() = listOf<Mutation<KnownValue>>(
-        IEEE754Mutations.ChangeSign.adapt(),
-        IEEE754Mutations.Mantissa.adapt(),
-        IEEE754Mutations.Exponent.adapt()
+    override fun mutations() = listOf<Mutation<IEEE754Value>>(
+        IEEE754Mutations.ChangeSign,
+        IEEE754Mutations.Mantissa,
+        IEEE754Mutations.Exponent,
     )
 
     override fun equals(other: Any?): Boolean {

--- a/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/seeds/KnownValue.kt
+++ b/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/seeds/KnownValue.kt
@@ -2,12 +2,14 @@ package org.utbot.fuzzing.seeds
 
 import org.utbot.fuzzing.Mutation
 
-interface KnownValue {
-    val lastMutation: Mutation<KnownValue>?
+interface KnownValue<T : KnownValue<T>> {
+    val lastMutation: Mutation<out T>?
         get() = null
 
-    val mutatedFrom: KnownValue?
+    val mutatedFrom: T?
         get() = null
 
-    fun mutations(): List<Mutation<KnownValue>>
+    fun mutations(): List<Mutation<out T>> {
+        return emptyList()
+    }
 }

--- a/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/seeds/RegexValue.kt
+++ b/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/seeds/RegexValue.kt
@@ -7,18 +7,21 @@ import org.utbot.fuzzing.Mutation
 import kotlin.random.Random
 import kotlin.random.asJavaRandom
 
-class RegexValue(val pattern: String, val random: Random) : KnownValue {
+class RegexValue(val pattern: String, val random: Random) : StringValue(
+    valueProvider = {
+        RgxGen(pattern).apply {
+            setProperties(rgxGenProperties)
+        }.generate(random.asJavaRandom())
+    }
+) {
 
-    val value: String by lazy { RgxGen(pattern).apply {
-        setProperties(rgxGenProperties)
-    }.generate(random.asJavaRandom()) }
-
-    override fun mutations() = listOf(Mutation<KnownValue> { source, random, _ ->
-        require(this === source)
-        RegexValue(pattern, random)
-    })
+    override fun mutations(): List<Mutation<out StringValue>> {
+        return super.mutations() + Mutation<RegexValue> { source, random, _ ->
+            RegexValue(source.pattern, random)
+        }
+    }
 }
 
 private val rgxGenProperties = RgxGenProperties().apply {
-    setProperty(RgxGenOption.INFINITE_PATTERN_REPETITION.key, "5")
+    setProperty(RgxGenOption.INFINITE_PATTERN_REPETITION.key, "100")
 }

--- a/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/seeds/StringValue.kt
+++ b/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/seeds/StringValue.kt
@@ -1,53 +1,21 @@
 package org.utbot.fuzzing.seeds
 
 import org.utbot.fuzzing.Mutation
-import org.utbot.fuzzing.utils.flipCoin
-import kotlin.random.Random
+import org.utbot.fuzzing.StringMutations
 
-class StringValue(val value: String) : KnownValue {
+open class StringValue(
+    val valueProvider: () -> String,
+    override val lastMutation: Mutation<out StringValue>? = null
+) : KnownValue<StringValue> {
 
-    override fun mutations(): List<Mutation<KnownValue>> {
-        return listOf(Mutation { source, random, configuration ->
-            require(source == this)
-            // we can miss some mutation for a purpose
-            val position = random.nextInt(value.length + 1)
-            var result: String = value
-            if (random.flipCoin(configuration.probStringRemoveCharacter)) {
-                result = tryRemoveChar(random, result, position) ?: value
-            }
-            if (result.length < configuration.maxStringLengthWhenMutated && random.flipCoin(configuration.probStringAddCharacter)) {
-                result = tryAddChar(random, result, position)
-            }
-            StringValue(result)
-        })
-    }
+    constructor(value: String, lastMutation: Mutation<out StringValue>? = null) : this(valueProvider = { value }, lastMutation)
 
-    private fun tryAddChar(random: Random, value: String, position: Int): String {
-        val charToMutate = if (value.isNotEmpty()) {
-            value.random(random)
-        } else {
-            // use any meaningful character from the ascii table
-            random.nextInt(33, 127).toChar()
-        }
-        return buildString {
-            append(value.substring(0, position))
-            // try to change char to some that is close enough to origin char
-            val charTableSpread = 64
-            if (random.nextBoolean()) {
-                append(charToMutate - random.nextInt(1, charTableSpread))
-            } else {
-                append(charToMutate + random.nextInt(1, charTableSpread))
-            }
-            append(value.substring(position, value.length))
-        }
-    }
+    val value by lazy { valueProvider() }
 
-    private fun tryRemoveChar(random: Random, value: String, position: Int): String? {
-        if (position >= value.length) return null
-        val toRemove = random.nextInt(value.length)
-        return buildString {
-            append(value.substring(0, toRemove))
-            append(value.substring(toRemove + 1, value.length))
-        }
+    override fun mutations(): List<Mutation<out StringValue>> {
+        return listOf(
+            StringMutations.AddCharacter,
+            StringMutations.RemoveCharacter,
+        )
     }
 }

--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Primitives.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Primitives.kt
@@ -206,7 +206,7 @@ object FloatValueProvider : PrimitiveValueProvider(
     }
 }
 
-object StringValueProvider : PrimitiveValueProvider(stringClassId) {
+object StringValueProvider : PrimitiveValueProvider(stringClassId, java.lang.CharSequence::class.java.id) {
     override fun generate(
         description: FuzzedDescription,
         type: FuzzedType

--- a/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/BoolValueProvider.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/BoolValueProvider.kt
@@ -23,7 +23,7 @@ object BoolValueProvider : ValueProvider<Type, PythonFuzzedValue, PythonMethodDe
         yieldBool(Bool.FALSE()) { false }
     }
 
-    private suspend fun <T : KnownValue> SequenceScope<Seed<Type, PythonFuzzedValue>>.yieldBool(value: T, block: T.() -> Boolean) {
+    private suspend fun <T : KnownValue<T>> SequenceScope<Seed<Type, PythonFuzzedValue>>.yieldBool(value: T, block: T.() -> Boolean) {
         yield(Seed.Known(value) {
             PythonFuzzedValue(
                 PythonTree.fromBool(block(it)),

--- a/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/IntValueProvider.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/IntValueProvider.kt
@@ -28,7 +28,7 @@ object IntValueProvider : ValueProvider<Type, PythonFuzzedValue, PythonMethodDes
     }
 
     private fun BitVectorValue.change(func: BitVectorValue.() -> Unit): BitVectorValue {
-        return Mutation<KnownValue> { _, _, _ ->
+        return Mutation<KnownValue<*>> { _, _, _ ->
             BitVectorValue(this).apply { func() }
         }.mutate(this, randomStubWithNoUsage, configurationStubWithNoUsage) as BitVectorValue
     }

--- a/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/StrValueProvider.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/StrValueProvider.kt
@@ -37,7 +37,7 @@ object StrValueProvider : ValueProvider<Type, PythonFuzzedValue, PythonMethodDes
         strConstants.forEach { yieldStrings(it) { value } }
     }
 
-    private suspend fun <T : KnownValue> SequenceScope<Seed<Type, PythonFuzzedValue>>.yieldStrings(value: T, block: T.() -> Any) {
+    private suspend fun <T : KnownValue<T>> SequenceScope<Seed<Type, PythonFuzzedValue>>.yieldStrings(value: T, block: T.() -> Any) {
         yield(Seed.Known(value) {
             PythonFuzzedValue(
                 PythonTree.fromString(block(it).toString()),

--- a/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/utils/SummaryGeneration.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/utils/SummaryGeneration.kt
@@ -7,7 +7,7 @@ import org.utbot.fuzzing.seeds.KnownValue
 import org.utbot.fuzzing.seeds.Signed
 import org.utbot.fuzzing.seeds.StringValue
 
-fun <T : KnownValue> T.valueToString(): String {
+fun <T : KnownValue<T>> T.valueToString(): String {
     when (this) {
         is BitVectorValue -> {
             for (defaultBound in Signed.values()) {
@@ -43,7 +43,7 @@ fun <T : KnownValue> T.valueToString(): String {
     }
 }
 
-fun <T: KnownValue> T.generateSummary(): String {
+fun <T: KnownValue<T>> T.generateSummary(): String {
     return buildString {
         append("%var% = ${valueToString()}")
         if (mutatedFrom != null) {

--- a/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/value/UndefValue.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/value/UndefValue.kt
@@ -3,8 +3,4 @@ package org.utbot.python.fuzzing.value
 import org.utbot.fuzzing.Mutation
 import org.utbot.fuzzing.seeds.KnownValue
 
-class ObjectValue : KnownValue {
-    override fun mutations(): List<Mutation<KnownValue>> {
-        return emptyList()
-    }
-}
+class ObjectValue : KnownValue<ObjectValue>


### PR DESCRIPTION
## Description

Fixes #2294

This PR isolates mutation API. `RegexValue` now is a subclass of `StringValue` that gives to regex values all string mutations. Before, regexes were mutated by generating only a new correct input for regex. After this change it is possible to generate some bad inputs for regex, when input string is processed too long.

Also, all mutations with collections and recursions are moved under a `Mutation` interface. In the future, these mutations can be collected and chosen by fuzzing process to get better results.

## How to test

### Automated tests

All fuzzing tests should pass.

### Manual tests

Try generate tests with only fuzzing for this example:

```
    public static boolean test(String str) {
        if (Pattern.compile("'(''|\\\\\\\\|\\\\'|[^'])*'").matcher(str).matches()) {
            return true;
        }
        return false;
    }
```

It should find some bad results (when timeout is over) with different settings of a test timeout.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.