### PR TITLE
Support fuzzing for regular expressions in Python

### DIFF
--- a/utbot-python/samples/easy_samples/regex.py
+++ b/utbot-python/samples/easy_samples/regex.py
@@ -1,0 +1,18 @@
+import re
+import time
+
+
+def check_regex(string: str) -> bool:
+    pattern = r"'(''|\\\\|\\'|[^'])*'"
+    if re.match(pattern, string):
+        return True
+    return False
+
+
+def timetest():
+    t = time.time()
+    print(check_regex("\'\J/\\\\\\'\\N''''P'''\'x'L''\'';'\'N\$'\\\'\'\`''D\\''�='''m\\\\\'\'\\H\\No'F'(''U]\'V"))
+    print((time.time() - t))
+
+if __name__ == '__main__':
+    timetest()

--- a/utbot-python/src/main/kotlin/org/utbot/python/PythonEngine.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/PythonEngine.kt
@@ -25,6 +25,7 @@ import org.utbot.python.newtyping.pythonTypeRepresentation
 import org.utbot.python.utils.camelToSnakeCase
 import org.utbot.summary.fuzzer.names.TestSuggestedInfo
 import java.net.ServerSocket
+import kotlin.random.Random
 
 private val logger = KotlinLogging.logger {}
 
@@ -290,7 +291,8 @@ class PythonEngine(
                 parameters,
                 fuzzedConcreteValues,
                 pythonTypeStorage,
-                Trie(Instruction::id)
+                Trie(Instruction::id),
+                Random(0),
             )
 
             if (parameters.isEmpty()) {

--- a/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/PythonApi.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/PythonApi.kt
@@ -12,6 +12,7 @@ import org.utbot.python.fuzzing.provider.*
 import org.utbot.python.fuzzing.provider.utils.isAny
 import org.utbot.python.newtyping.*
 import org.utbot.python.newtyping.general.Type
+import kotlin.random.Random
 
 private val logger = KotlinLogging.logger {}
 
@@ -27,6 +28,7 @@ class PythonMethodDescription(
     val concreteValues: Collection<PythonFuzzedConcreteValue> = emptyList(),
     val pythonTypeStorage: PythonTypeStorage,
     val tracer: Trie<Instruction, *>,
+    val random: Random,
 ) : Description<Type>(parameters)
 
 sealed interface FuzzingExecutionFeedback

--- a/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/StrValueProvider.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/StrValueProvider.kt
@@ -3,6 +3,7 @@ package org.utbot.python.fuzzing.provider
 import org.utbot.fuzzing.Seed
 import org.utbot.fuzzing.ValueProvider
 import org.utbot.fuzzing.seeds.KnownValue
+import org.utbot.fuzzing.seeds.RegexValue
 import org.utbot.fuzzing.seeds.StringValue
 import org.utbot.python.framework.api.python.PythonTree
 import org.utbot.python.framework.api.python.util.pythonStrClassId
@@ -10,31 +11,45 @@ import org.utbot.python.fuzzing.PythonFuzzedConcreteValue
 import org.utbot.python.fuzzing.PythonFuzzedValue
 import org.utbot.python.fuzzing.PythonMethodDescription
 import org.utbot.python.fuzzing.provider.utils.generateSummary
+import org.utbot.python.fuzzing.provider.utils.isPattern
 import org.utbot.python.fuzzing.provider.utils.transformQuotationMarks
+import org.utbot.python.fuzzing.provider.utils.transformRawString
 import org.utbot.python.newtyping.general.Type
 import org.utbot.python.newtyping.pythonTypeName
+import kotlin.random.Random
 
 object StrValueProvider : ValueProvider<Type, PythonFuzzedValue, PythonMethodDescription> {
     override fun accept(type: Type): Boolean {
         return type.pythonTypeName() == pythonStrClassId.canonicalName
     }
 
-    private fun getStrConstants(concreteValues: Collection<PythonFuzzedConcreteValue>): List<StringValue> {
+    private fun getStrConstants(concreteValues: Collection<PythonFuzzedConcreteValue>): List<String> {
         return concreteValues
             .filter { accept(it.type) }
             .map {
-                StringValue((it.value as String).transformQuotationMarks())
+                val value = it.value as String
+                value.transformRawString()
+            }
+            .map {
+                it.transformQuotationMarks()
             }
     }
 
     override fun generate(description: PythonMethodDescription, type: Type) = sequence {
         val strConstants = getStrConstants(description.concreteValues) + listOf(
-            StringValue("pythön"),
-            StringValue("abcdefghijklmnopqrst"),
-            StringValue("foo"),
-            StringValue("€"),
+            "pythön",
+            "foo",
+            "\t\n\r",
         )
-        strConstants.forEach { yieldStrings(it) { value } }
+        strConstants.forEach { yieldStrings(StringValue(it)) { value } }
+
+        strConstants
+            .filter {
+                it.isPattern()
+            }
+            .forEach {
+                yieldStrings(RegexValue(it, Random(0)), StringValue::value)
+            }
     }
 
     private suspend fun <T : KnownValue<T>> SequenceScope<Seed<Type, PythonFuzzedValue>>.yieldStrings(value: T, block: T.() -> Any) {

--- a/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/StrValueProvider.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/StrValueProvider.kt
@@ -38,7 +38,7 @@ object StrValueProvider : ValueProvider<Type, PythonFuzzedValue, PythonMethodDes
         val strConstants = getStrConstants(description.concreteValues) + listOf(
             "pythön",
             "foo",
-            "\t\n\r",
+            "",
         )
         strConstants.forEach { yieldStrings(StringValue(it)) { value } }
 

--- a/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/StrValueProvider.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/StrValueProvider.kt
@@ -16,7 +16,6 @@ import org.utbot.python.fuzzing.provider.utils.transformQuotationMarks
 import org.utbot.python.fuzzing.provider.utils.transformRawString
 import org.utbot.python.newtyping.general.Type
 import org.utbot.python.newtyping.pythonTypeName
-import kotlin.random.Random
 
 object StrValueProvider : ValueProvider<Type, PythonFuzzedValue, PythonMethodDescription> {
     override fun accept(type: Type): Boolean {
@@ -48,7 +47,7 @@ object StrValueProvider : ValueProvider<Type, PythonFuzzedValue, PythonMethodDes
                 it.isPattern()
             }
             .forEach {
-                yieldStrings(RegexValue(it, Random(0)), StringValue::value)
+                yieldStrings(RegexValue(it, description.random), StringValue::value)
             }
     }
 

--- a/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/utils/StringUtils.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/utils/StringUtils.kt
@@ -1,9 +1,12 @@
 package org.utbot.python.fuzzing.provider.utils
 
+import java.util.regex.Pattern
+import java.util.regex.PatternSyntaxException
+
 fun String.transformQuotationMarks(): String {
 
     val doubleQuotationMarks = this.startsWith("\"") && this.endsWith("\"")
-    val oneQuotationMarks = this.startsWith("'") && this.endsWith("'")
+//    val oneQuotationMarks = this.startsWith("'") && this.endsWith("'")
 
     val tripleDoubleQuotationMarks = this.startsWith("\"\"\"") && this.endsWith("\"\"\"")
     val tripleOneQuotationMarks = this.startsWith("'''") && this.endsWith("'''")
@@ -12,9 +15,25 @@ fun String.transformQuotationMarks(): String {
         return this.drop(3).dropLast(3)
     }
 
-    if (oneQuotationMarks || doubleQuotationMarks) {
+    if (doubleQuotationMarks) {
         return this.drop(1).dropLast(1)
     }
 
     return this
+}
+
+fun String.transformRawString(): String {
+    return if (Pattern.matches("r\".*\"", this) || Pattern.matches("r'.*'", this)) {
+        this.drop(2).dropLast(1)
+    } else {
+        this
+    }
+}
+
+fun String.isPattern(): Boolean {
+    return try {
+        Pattern.compile(this); true
+    } catch (_: PatternSyntaxException) {
+        false
+    }
 }

--- a/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/utils/StringUtils.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/utils/StringUtils.kt
@@ -23,8 +23,10 @@ fun String.transformQuotationMarks(): String {
 }
 
 fun String.transformRawString(): String {
-    return if (Pattern.matches("r\".*\"", this) || Pattern.matches("r'.*'", this)) {
-        this.drop(2).dropLast(1)
+    val rawStringWithDoubleQuotationMarks = this.startsWith("r\"") && this.endsWith("\"")
+    val rawStringWithOneQuotationMarks = this.startsWith("r'") && this.endsWith("'")
+    return if (rawStringWithOneQuotationMarks || rawStringWithDoubleQuotationMarks) {
+        this.substring(2, this.length-1)
     } else {
         this
     }


### PR DESCRIPTION
## Description

Supported fuzzing generation strings by regular expressions from python testing function.

## How to test

### Manual tests

See sample `utbot-python/samples/easy_samples/regex.py`:
```python
def check_regex(string: str) -> bool:
    pattern = r"'(''|\\\\|\\'|[^'])*'"
    if re.match(pattern, string):
        return True
    return False
```

1. Try to generate tests
2. __Expected__: test with string for regex

## Self-check list

Check off the item if the statement is true. Hint: [x] is a marked item.

Please do not delete the list or its items.

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.