### PR TITLE
Support `__setstate__` for custom state of python objects

### DIFF
--- a/utbot-python/samples/easy_samples/setstate_test.py
+++ b/utbot-python/samples/easy_samples/setstate_test.py
@@ -1,0 +1,20 @@
+import typing
+
+
+class MyClass:
+    __slots__ = ['a', 'b']
+
+    def __init__(self, a: int, b: typing.Dict[int, str]):
+        self.a = a
+        self.b = b
+
+    def __eq__(self, other):
+        return self.a == other.a and self.b == other.b
+
+    def __setstate__(self, state):
+        self.a = state[1]['a']
+        self.b = state[1]['b']
+
+
+def make_my_class(a: int, b: typing.Dict[int, str]) -> MyClass:
+    return MyClass(a, b)

--- a/utbot-python/src/main/kotlin/org/utbot/python/framework/api/python/PythonTree.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/framework/api/python/PythonTree.kt
@@ -212,6 +212,7 @@ object PythonTree {
         var state: MutableMap<String, PythonTreeNode>,
         var listitems: List<PythonTreeNode>,
         var dictitems: Map<PythonTreeNode, PythonTreeNode>,
+        var customState: Boolean = false,  // if this field is true, state must have structure {'state': <PythonTreeNode>}
     ) : PythonTreeNode(id, type) {
         constructor(
             type: PythonClassId,

--- a/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/constructor/tree/PythonCgVariableConstructor.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/constructor/tree/PythonCgVariableConstructor.kt
@@ -107,8 +107,23 @@ class PythonCgVariableConstructor(cgContext: CgContext) : CgVariableConstructor(
                     keyObj to valueObj
                 }
 
-                state.forEach { (key, value) ->
-                    obj[FieldId(objectNode.type, key)] `=` value
+                if (objectNode.customState) {
+                    val setstate = state["state"]!!
+                    val methodCall = CgMethodCall(
+                        obj,
+                        PythonMethodId(
+                            obj.type as PythonClassId,
+                            "__setstate__",
+                            NormalizedPythonAnnotation(pythonNoneClassId.name),
+                            listOf(RawPythonAnnotation(setstate.type.name))
+                        ),
+                        listOf(setstate)
+                    )
+                    +methodCall
+                } else {
+                    state.forEach { (key, value) ->
+                        obj[FieldId(objectNode.type, key)] `=` value
+                    }
                 }
                 listitems.forEach {
                     val methodCall = CgMethodCall(

--- a/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/ReduceValueProvider.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/ReduceValueProvider.kt
@@ -59,6 +59,10 @@ object ReduceValueProvider : ValueProvider<Type, PythonFuzzedValue, PythonMethod
             .forEach {
                 // TODO: here we need to use same as .getPythonAttributeByName but without name
                 // TODO: now we do not have fields from parents
+                // val slots = type.getPythonAttributeByName(description.pythonTypeStorage, "__slots__")
+                // if (slots != null) {
+                //     TODO: here we should use only attributes from __slots__
+                //}
                 val fields = type.getPythonAttributes()
                     .filter { attr ->
                         !(attr.meta.name.startsWith("__") && attr.meta.name.endsWith("__") && attr.meta.name.length >= 4) &&

--- a/utbot-python/src/main/kotlin/org/utbot/python/utils/RequirementsUtils.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/utils/RequirementsUtils.kt
@@ -3,7 +3,7 @@ package org.utbot.python.utils
 object RequirementsUtils {
     val requirements: List<String> = listOf(
         "mypy==1.0.0",
-        "utbot-executor==1.4.26",
+        "utbot-executor==1.4.31",
         "utbot-mypy-runner==0.2.8",
     )
 


### PR DESCRIPTION
## Description

Supported serialisation and deserialsation of python objects that have custom states (e.g. have `__slots__` with a list of valid attributes). For these objects we should use `__reduce_ex__` method instead of `__reduce__` to serialise if it is possible and then use custom method `__setstate__` to deserialise state.

Changes in `utbot-executor`: https://github.com/tamarinvs19/utbot_executor/pull/1

## How to test

### Automated tests

There are tests for serialization and deserialization processes in `utbot-executor` (`utbot_executor/deep_serialization/tests.py`)

### Manual tests

See example `utbot-python/samples/easy_samples/setstate_test.py`

Expected: success test generation for `make_my_class`

## Self-check list

Check off the item if the statement is true. Hint: [x] is a marked item.

Please do not delete the list or its items.

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.