### PR TITLE
Select only raw-strings for regex fuzzing and filter blank strings

### DIFF
--- a/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/utils/StringUtils.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/fuzzing/provider/utils/StringUtils.kt
@@ -23,19 +23,28 @@ fun String.transformQuotationMarks(): String {
 }
 
 fun String.transformRawString(): String {
-    val rawStringWithDoubleQuotationMarks = this.startsWith("r\"") && this.endsWith("\"")
-    val rawStringWithOneQuotationMarks = this.startsWith("r'") && this.endsWith("'")
-    return if (rawStringWithOneQuotationMarks || rawStringWithDoubleQuotationMarks) {
+    return if (this.isRawString()) {
         this.substring(2, this.length-1)
     } else {
         this
     }
 }
 
+fun String.isRawString(): Boolean {
+    val rawStringWithDoubleQuotationMarks = this.startsWith("r\"") && this.endsWith("\"")
+    val rawStringWithOneQuotationMarks = this.startsWith("r'") && this.endsWith("'")
+    return rawStringWithOneQuotationMarks || rawStringWithDoubleQuotationMarks
+}
+
 fun String.isPattern(): Boolean {
-    return try {
-        Pattern.compile(this); true
-    } catch (_: PatternSyntaxException) {
-        false
-    }
+    return if (this.isRawString()) {
+        val stringContent = this.transformRawString()
+        if (stringContent.isNotBlank()) {
+            try {
+                Pattern.compile(stringContent); true
+            } catch (_: PatternSyntaxException) {
+                false
+            }
+        } else false
+    } else false
 }


### PR DESCRIPTION
## Description

Split all string constants to raw-strings and other. Not blank raw-strings for regex fuzzing, other - for normal string fuzzing.

## How to test

### Manual tests

See `utbot-python/samples/easy_samples/regex.py`

## Self-check list

Check off the item if the statement is true. Hint: [x] is a marked item.

Please do not delete the list or its items.

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.