### PR TITLE
Autowire not applicationContext but actual variables

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -658,7 +658,7 @@ class UtLambdaModel(
     }
 }
 
-class UtSpringContextModel : UtReferenceModel(
+object UtSpringContextModel : UtReferenceModel(
     id = null,
     classId = SpringModelUtils.applicationContextClassId,
     modelName = "applicationContext"

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -91,9 +91,7 @@ data class Step(
         other as Step
 
         if (stmt != other.stmt) return false
-        if (decision != other.decision) return false
-
-        return true
+        return decision == other.decision
     }
 
     override fun hashCode(): Int {
@@ -497,9 +495,7 @@ data class UtArrayModel(
 
         other as UtArrayModel
 
-        if (id != other.id) return false
-
-        return true
+        return id == other.id
     }
 
     override fun hashCode(): Int = id
@@ -638,9 +634,7 @@ class UtLambdaModel(
 
         other as UtLambdaModel
 
-        if (id != other.id) return false
-
-        return true
+        return id == other.id
     }
 
     override fun hashCode(): Int = id
@@ -662,7 +656,13 @@ object UtSpringContextModel : UtReferenceModel(
     id = null,
     classId = SpringModelUtils.applicationContextClassId,
     modelName = "applicationContext"
-)
+) {
+    // NOTE that overriding equals is required just because without it
+    // we will lose equality for objects after deserialization
+    override fun equals(other: Any?): Boolean = other is UtSpringContextModel
+
+    override fun hashCode(): Int = 0
+}
 
 data class SpringRepositoryId(
     val repositoryBeanName: String,
@@ -1058,9 +1058,7 @@ open class FieldId(val declaringClass: ClassId, val name: String) {
         other as FieldId
 
         if (declaringClass != other.declaringClass) return false
-        if (name != other.name) return false
-
-        return true
+        return name == other.name
     }
 
     override fun hashCode(): Int {
@@ -1229,9 +1227,7 @@ open class TypeParameters(val parameters: List<ClassId> = emptyList()) {
 
         other as TypeParameters
 
-        if (parameters != other.parameters) return false
-
-        return true
+        return parameters == other.parameters
     }
 
     override fun hashCode(): Int {

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -91,7 +91,9 @@ data class Step(
         other as Step
 
         if (stmt != other.stmt) return false
-        return decision == other.decision
+        if (decision != other.decision) return false
+
+        return true
     }
 
     override fun hashCode(): Int {
@@ -495,7 +497,9 @@ data class UtArrayModel(
 
         other as UtArrayModel
 
-        return id == other.id
+        if (id != other.id) return false
+
+        return true
     }
 
     override fun hashCode(): Int = id
@@ -634,7 +638,9 @@ class UtLambdaModel(
 
         other as UtLambdaModel
 
-        return id == other.id
+        if (id != other.id) return false
+
+        return true
     }
 
     override fun hashCode(): Int = id
@@ -656,13 +662,7 @@ object UtSpringContextModel : UtReferenceModel(
     id = null,
     classId = SpringModelUtils.applicationContextClassId,
     modelName = "applicationContext"
-) {
-    // NOTE that overriding equals is required just because without it
-    // we will lose equality for objects after deserialization
-    override fun equals(other: Any?): Boolean = other is UtSpringContextModel
-
-    override fun hashCode(): Int = 0
-}
+)
 
 data class SpringRepositoryId(
     val repositoryBeanName: String,
@@ -1058,7 +1058,9 @@ open class FieldId(val declaringClass: ClassId, val name: String) {
         other as FieldId
 
         if (declaringClass != other.declaringClass) return false
-        return name == other.name
+        if (name != other.name) return false
+
+        return true
     }
 
     override fun hashCode(): Int {
@@ -1227,7 +1229,9 @@ open class TypeParameters(val parameters: List<ClassId> = emptyList()) {
 
         other as TypeParameters
 
-        return parameters == other.parameters
+        if (parameters != other.parameters) return false
+
+        return true
     }
 
     override fun hashCode(): Int {

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -662,7 +662,13 @@ object UtSpringContextModel : UtReferenceModel(
     id = null,
     classId = SpringModelUtils.applicationContextClassId,
     modelName = "applicationContext"
-)
+) {
+    // NOTE that overriding equals is required just because without it
+    // we will lose equality for objects after deserialization
+    override fun equals(other: Any?): Boolean = other is UtSpringContextModel
+
+    override fun hashCode(): Int = 0
+}
 
 data class SpringRepositoryId(
     val repositoryBeanName: String,

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SpringModelUtils.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SpringModelUtils.kt
@@ -13,7 +13,7 @@ object SpringModelUtils {
     val applicationContextClassId = ClassId("org.springframework.context.ApplicationContext")
     val crudRepositoryClassId = ClassId("org.springframework.data.repository.CrudRepository")
 
-    val getBeanMethodId = MethodId(
+    private val getBeanMethodId = MethodId(
         classId = applicationContextClassId,
         name = "getBean",
         returnType = Any::class.id,
@@ -21,7 +21,7 @@ object SpringModelUtils {
         bypassesSandbox = true // TODO may be we can use some alternative sandbox that has more permissions
     )
 
-    val saveMethodId = MethodId(
+    private val saveMethodId = MethodId(
         classId = crudRepositoryClassId,
         name = "save",
         returnType = Any::class.id,
@@ -50,4 +50,8 @@ object SpringModelUtils {
         executable = saveMethodId,
         params = listOf(entityModel)
     )
+
+    fun UtModel.isApplicationContext(): Boolean = this is UtSpringContextModel
+    fun UtModel.isAutowiredFromContext(): Boolean =
+        this is UtAssembleModel && this.instantiationCall.instance is UtSpringContextModel
 }

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SpringModelUtils.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SpringModelUtils.kt
@@ -34,7 +34,7 @@ object SpringModelUtils {
         classId = classId,
         modelName = "@Autowired $beanName",
         instantiationCall = UtExecutableCallModel(
-            instance = UtSpringContextModel(),
+            instance = UtSpringContextModel,
             executable = getBeanMethodId,
             params = listOf(UtPrimitiveModel(beanName))
         ),
@@ -51,7 +51,6 @@ object SpringModelUtils {
         params = listOf(entityModel)
     )
 
-    fun UtModel.isApplicationContext(): Boolean = this is UtSpringContextModel
     fun UtModel.isAutowiredFromContext(): Boolean =
         this is UtAssembleModel && this.instantiationCall.instance is UtSpringContextModel
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/TestClassModel.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/TestClassModel.kt
@@ -34,6 +34,5 @@ class SpringTestClassModel(
 class SpringSpecificInformation(
     val thisInstanceModels: TypedModelWrappers = mapOf(),
     val thisInstanceDependentMocks: TypedModelWrappers = mapOf(),
-    val applicationContextModels: TypedModelWrappers = mapOf(),
     val autowiredFromContextModels: TypedModelWrappers = mapOf(),
 )

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/TestClassModel.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/TestClassModel.kt
@@ -35,4 +35,5 @@ class SpringSpecificInformation(
     val thisInstanceModels: TypedModelWrappers = mapOf(),
     val thisInstanceDependentMocks: TypedModelWrappers = mapOf(),
     val applicationContextModels: TypedModelWrappers = mapOf(),
+    val autowiredFromContextModels: TypedModelWrappers = mapOf(),
 )

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/builders/SpringTestClassModelBuilder.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/builders/SpringTestClassModelBuilder.kt
@@ -20,6 +20,8 @@ import org.utbot.framework.plugin.api.UtSpringContextModel
 import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.framework.plugin.api.UtVoidModel
 import org.utbot.framework.plugin.api.isMockModel
+import org.utbot.framework.plugin.api.util.SpringModelUtils.isAutowiredFromContext
+import org.utbot.framework.plugin.api.util.SpringModelUtils.isApplicationContext
 
 typealias TypedModelWrappers = Map<ClassId, Set<UtModelWrapper>>
 
@@ -70,14 +72,16 @@ class SpringTestClassModelBuilder(val context: CgContext): TestClassModelBuilder
                     cgModel.model.isMockModel() && cgModel !in thisInstanceModels
                 }
 
-        val applicationContextModels = stateBeforeDependentModels
-                .filter { it.model is UtSpringContextModel }
-                .toSet()
+        val applicationContextModels =
+            stateBeforeDependentModels.filterTo(HashSet()) { it.model.isApplicationContext() }
+        val autowiredFromContextModels =
+            stateBeforeDependentModels.filterTo(HashSet()) { it.model.isAutowiredFromContext() }
 
         return SpringSpecificInformation(
             thisInstanceModels.groupByClassId(),
             dependentMockModels.groupByClassId(),
             applicationContextModels.groupByClassId(),
+            autowiredFromContextModels.groupByClassId(),
         )
     }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/builders/SpringTestClassModelBuilder.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/builders/SpringTestClassModelBuilder.kt
@@ -21,7 +21,6 @@ import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.framework.plugin.api.UtVoidModel
 import org.utbot.framework.plugin.api.isMockModel
 import org.utbot.framework.plugin.api.util.SpringModelUtils.isAutowiredFromContext
-import org.utbot.framework.plugin.api.util.SpringModelUtils.isApplicationContext
 
 typealias TypedModelWrappers = Map<ClassId, Set<UtModelWrapper>>
 
@@ -72,15 +71,12 @@ class SpringTestClassModelBuilder(val context: CgContext): TestClassModelBuilder
                     cgModel.model.isMockModel() && cgModel !in thisInstanceModels
                 }
 
-        val applicationContextModels =
-            stateBeforeDependentModels.filterTo(HashSet()) { it.model.isApplicationContext() }
         val autowiredFromContextModels =
             stateBeforeDependentModels.filterTo(HashSet()) { it.model.isAutowiredFromContext() }
 
         return SpringSpecificInformation(
             thisInstanceModels.groupByClassId(),
             dependentMockModels.groupByClassId(),
-            applicationContextModels.groupByClassId(),
             autowiredFromContextModels.groupByClassId(),
         )
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgAbstractSpringTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgAbstractSpringTestClassConstructor.kt
@@ -1,9 +1,6 @@
 package org.utbot.framework.codegen.tree
 
 import org.utbot.framework.codegen.domain.builtin.TestClassUtilMethodProvider
-import org.utbot.framework.codegen.domain.builtin.autowiredClassId
-import org.utbot.framework.codegen.domain.builtin.injectMocksClassId
-import org.utbot.framework.codegen.domain.builtin.mockClassId
 import org.utbot.framework.codegen.domain.context.CgContext
 import org.utbot.framework.codegen.domain.models.CgClassBody
 import org.utbot.framework.codegen.domain.models.CgDeclaration
@@ -19,6 +16,7 @@ import org.utbot.framework.codegen.domain.models.CgVariable
 import org.utbot.framework.codegen.domain.models.SpringTestClassModel
 import org.utbot.framework.codegen.domain.models.builders.TypedModelWrappers
 import org.utbot.framework.plugin.api.ClassId
+import org.utbot.framework.plugin.api.UtSpringContextModel
 import org.utbot.framework.plugin.api.util.id
 import java.lang.Exception
 
@@ -111,7 +109,7 @@ abstract class CgAbstractSpringTestClassConstructor(context: CgContext):
     }
 
     /**
-     * Clears the results of variable instantiations that occured
+     * Clears the results of variable instantiations that occurred
      * when we create class variables with specific annotations.
      * Actually, only mentioned variables should be stored in `valueByModelId`.
      *
@@ -121,10 +119,11 @@ abstract class CgAbstractSpringTestClassConstructor(context: CgContext):
      * but it will take very long time to do it now.
      */
     private fun clearUnwantedVariableModels() {
-        val whiteListOfModels = variableConstructor.annotatedModelVariables.values.flatten()
+        val trustedListOfModels =
+            variableConstructor.annotatedModelVariables.values.flatten() + listOf(UtSpringContextModel.wrap())
 
         valueByUtModelWrapper
-            .filter { it.key !in whiteListOfModels }
+            .filterNot { it.key in trustedListOfModels }
             .forEach { valueByUtModelWrapper.remove(it.key) }
     }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringIntegrationTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringIntegrationTestClassConstructor.kt
@@ -10,11 +10,6 @@ import org.utbot.framework.plugin.api.UtSpringContextModel
 class CgSpringIntegrationTestClassConstructor(context: CgContext) : CgAbstractSpringTestClassConstructor(context) {
 
     override fun constructClassFields(testClassModel: SpringTestClassModel): List<CgFieldDeclaration> {
-        // NOTE that it is important to construct applicationContext variable
-        // even though it is not used in generated code
-        // because it is used in some assemble models as an instance of instantiation call.
-        variableConstructor.getOrCreateVariable(UtSpringContextModel)
-
         val autowiredFromContextModels = testClassModel.springSpecificInformation.autowiredFromContextModels
         return constructFieldsWithAnnotation(autowiredClassId, autowiredFromContextModels)
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringIntegrationTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringIntegrationTestClassConstructor.kt
@@ -5,20 +5,18 @@ import org.utbot.framework.codegen.domain.context.CgContext
 import org.utbot.framework.codegen.domain.models.CgFieldDeclaration
 import org.utbot.framework.codegen.domain.models.CgMethodsCluster
 import org.utbot.framework.codegen.domain.models.SpringTestClassModel
+import org.utbot.framework.plugin.api.UtSpringContextModel
 
 class CgSpringIntegrationTestClassConstructor(context: CgContext) : CgAbstractSpringTestClassConstructor(context) {
 
     override fun constructClassFields(testClassModel: SpringTestClassModel): List<CgFieldDeclaration> {
-        val applicationContextModels = testClassModel.springSpecificInformation.applicationContextModels
-        val autowiredFromContextModels = testClassModel.springSpecificInformation.autowiredFromContextModels
-
         // NOTE that it is important to construct applicationContext variable
-        // before other class variables that will get beans from it.
-        val fields = mutableListOf<CgFieldDeclaration>()
-        fields += constructFieldsWithAnnotation(autowiredClassId, applicationContextModels)
-        fields += constructFieldsWithAnnotation(autowiredClassId, autowiredFromContextModels)
+        // even though it is not used in generated code
+        // because it is used in some assemble models as an instance of instantiation call.
+        variableConstructor.getOrCreateVariable(UtSpringContextModel)
 
-        return fields
+        val autowiredFromContextModels = testClassModel.springSpecificInformation.autowiredFromContextModels
+        return constructFieldsWithAnnotation(autowiredClassId, autowiredFromContextModels)
     }
 
     override fun constructAdditionalMethods() = CgMethodsCluster(

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringIntegrationTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringIntegrationTestClassConstructor.kt
@@ -10,7 +10,15 @@ class CgSpringIntegrationTestClassConstructor(context: CgContext) : CgAbstractSp
 
     override fun constructClassFields(testClassModel: SpringTestClassModel): List<CgFieldDeclaration> {
         val applicationContextModels = testClassModel.springSpecificInformation.applicationContextModels
-        return constructFieldsWithAnnotation(autowiredClassId, applicationContextModels)
+        val autowiredFromContextModels = testClassModel.springSpecificInformation.autowiredFromContextModels
+
+        // NOTE that it is important to construct applicationContext variable
+        // before other class variables that will get beans from it.
+        val fields = mutableListOf<CgFieldDeclaration>()
+        fields += constructFieldsWithAnnotation(autowiredClassId, applicationContextModels)
+        fields += constructFieldsWithAnnotation(autowiredClassId, autowiredFromContextModels)
+
+        return fields
     }
 
     override fun constructAdditionalMethods() = CgMethodsCluster(

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringVariableConstructor.kt
@@ -14,7 +14,6 @@ import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtSpringContextModel
 import org.utbot.framework.plugin.api.isMockModel
 import org.utbot.framework.plugin.api.util.SpringModelUtils.isAutowiredFromContext
-import org.utbot.framework.plugin.api.util.SpringModelUtils.isApplicationContext
 
 class CgSpringVariableConstructor(context: CgContext) : CgVariableConstructor(context) {
     val annotatedModelVariables: MutableMap<ClassId, MutableSet<UtModelWrapper>> = mutableMapOf()
@@ -48,7 +47,6 @@ class CgSpringVariableConstructor(context: CgContext) : CgVariableConstructor(co
         val alreadyCreatedAutowired = findCgValueByModel(model, annotatedModelVariables[autowiredClassId])
         if (alreadyCreatedAutowired != null) {
             return when  {
-                model.isApplicationContext() -> alreadyCreatedAutowired
                 model.isAutowiredFromContext() -> {
                     super.constructAssembleForVariable(model as UtAssembleModel)
                 }
@@ -57,17 +55,17 @@ class CgSpringVariableConstructor(context: CgContext) : CgVariableConstructor(co
         }
 
         return when (model) {
-            is UtSpringContextModel -> createApplicationContextVariable(model, name)
+            is UtSpringContextModel -> createApplicationContextVariable()
             else -> super.getOrCreateVariable(model, name)
         }
     }
 
-    private fun createApplicationContextVariable(model: UtSpringContextModel, baseName: String?): CgValue =
-        newVar(model.classId, baseName) {
+    private fun createApplicationContextVariable(): CgValue =
+        newVar(UtSpringContextModel.classId) {
             //TODO: this init statement is useless, but the refactoring is required to avoid it.
-            utilsClassId[createInstance](model.classId.name)
+            utilsClassId[createInstance](UtSpringContextModel.classId.name)
         }.also {
-            valueByUtModelWrapper[model.wrap()] = it
+            valueByUtModelWrapper[UtSpringContextModel.wrap()] = it
         }
 
     private fun findCgValueByModel(model: UtModel, setOfModels: Set<UtModelWrapper>?): CgValue? {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringVariableConstructor.kt
@@ -50,7 +50,7 @@ class CgSpringVariableConstructor(context: CgContext) : CgVariableConstructor(co
             return when  {
                 model.isApplicationContext() -> alreadyCreatedAutowired
                 model.isAutowiredFromContext() -> {
-                    super.constructAssembleForVariable(model as UtAssembleModel, alreadyCreatedAutowired)
+                    super.constructAssembleForVariable(model as UtAssembleModel)
                 }
                 else -> error("Trying to autowire model $model but it is not appropriate")
             }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringVariableConstructor.kt
@@ -5,6 +5,7 @@ import org.utbot.framework.codegen.domain.builtin.autowiredClassId
 import org.utbot.framework.codegen.domain.builtin.injectMocksClassId
 import org.utbot.framework.codegen.domain.builtin.mockClassId
 import org.utbot.framework.codegen.domain.context.CgContext
+import org.utbot.framework.codegen.domain.models.CgLiteral
 import org.utbot.framework.codegen.domain.models.CgValue
 import org.utbot.framework.codegen.domain.models.CgVariable
 import org.utbot.framework.plugin.api.ClassId
@@ -13,7 +14,9 @@ import org.utbot.framework.plugin.api.UtCompositeModel
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtSpringContextModel
 import org.utbot.framework.plugin.api.isMockModel
+import org.utbot.framework.plugin.api.util.SpringModelUtils.applicationContextClassId
 import org.utbot.framework.plugin.api.util.SpringModelUtils.isAutowiredFromContext
+import org.utbot.framework.plugin.api.util.stringClassId
 
 class CgSpringVariableConstructor(context: CgContext) : CgVariableConstructor(context) {
     val annotatedModelVariables: MutableMap<ClassId, MutableSet<UtModelWrapper>> = mutableMapOf()
@@ -60,13 +63,16 @@ class CgSpringVariableConstructor(context: CgContext) : CgVariableConstructor(co
         }
     }
 
-    private fun createApplicationContextVariable(): CgValue =
-        newVar(UtSpringContextModel.classId) {
-            //TODO: this init statement is useless, but the refactoring is required to avoid it.
-            utilsClassId[createInstance](UtSpringContextModel.classId.name)
-        }.also {
+    private fun createApplicationContextVariable(): CgValue {
+        // This is a kind of HACK
+        // Actually, applicationContext variable is useless as it is not used in the generated code.
+        // However, this variable existence is required for autowired fields creation process.
+        val applicationContextVariable = CgLiteral(stringClassId, "applicationContext")
+
+        return applicationContextVariable.also {
             valueByUtModelWrapper[UtSpringContextModel.wrap()] = it
         }
+    }
 
     private fun findCgValueByModel(model: UtModel, setOfModels: Set<UtModelWrapper>?): CgValue? {
         val key = setOfModels?.find { it == model.wrap() } ?: return null

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgStatementConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgStatementConstructor.kt
@@ -72,6 +72,7 @@ import kotlin.reflect.KFunction
 import kotlin.reflect.jvm.kotlinFunction
 
 interface CgStatementConstructor {
+
     fun newVar(baseType: ClassId, baseName: String? = null, init: () -> CgExpression): CgVariable =
         newVar(baseType, model = null, baseName, isMutable = false, init)
 


### PR DESCRIPTION
## Description

Consider tests generation for `OrderService.getOrders` from `spring-boot-testing` project.

In the previous version we autowired the `applicationContext` and called `getBean` method for real objects.
Currently we autowire real objects without context variable.

One of generated tests looks as follows:

```java
public final class OrderServiceTest {
    @Autowired
    public OrderRepository orderRepository;

    @Autowired
    public OrderService orderService;

    @Test
    @DisplayName("getOrders: ")
    public void testGetOrders() {
        Order order1 = new Order();
        order1.setQty(Integer.MAX_VALUE);
        order1.setId(1L);
        orderRepository.save(order1);

        ArrayList actual = ((ArrayList) orderService.getOrders());

        ArrayList expected = new ArrayList();
        Long long1 = 1L;
        Order order2 = new Order(long1, null, null, Integer.MAX_VALUE);
        expected.add(order2);
        assertTrue(deepEquals(expected, actual));
    }
}
```

## How to test

Standalone testing is not required.
Will be tested as a part of Spring integration tests verification

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.