### PR TITLE
Automatically detect `@GeneratedValue` fields

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SpringModelUtils.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SpringModelUtils.kt
@@ -12,7 +12,13 @@ import org.utbot.framework.plugin.api.UtSpringContextModel
 object SpringModelUtils {
     val applicationContextClassId = ClassId("org.springframework.context.ApplicationContext")
     val crudRepositoryClassId = ClassId("org.springframework.data.repository.CrudRepository")
-    val entityClassId = ClassId("javax.persistence.Entity")
+
+    // most likely only one persistent library is on the classpath, but we need to be able to work with either of them
+    private val persistentLibraries = listOf("javax.persistence", "jakarta.persistence")
+    private fun persistentClassIds(simpleName: String) = persistentLibraries.map { ClassId("$it.$simpleName") }
+
+    val entityClassIds = persistentClassIds("Entity")
+    val generatedValueClassIds = persistentClassIds("GeneratedValue")
 
     private val getBeanMethodId = MethodId(
         classId = applicationContextClassId,
@@ -26,7 +32,8 @@ object SpringModelUtils {
         classId = crudRepositoryClassId,
         name = "save",
         returnType = Any::class.id,
-        parameters = listOf(Any::class.id)
+        parameters = listOf(Any::class.id),
+        bypassesSandbox = true // TODO may be we can use some alternative sandbox that has more permissions
     )
 
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestCaseGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/plugin/api/TestCaseGenerator.kt
@@ -29,7 +29,7 @@ import org.utbot.framework.UtSettings.utBotGenerationTimeoutInMillis
 import org.utbot.framework.UtSettings.warmupConcreteExecution
 import org.utbot.framework.plugin.api.utils.checkFrameworkDependencies
 import org.utbot.framework.minimization.minimizeTestCase
-import org.utbot.framework.plugin.api.util.SpringModelUtils.entityClassId
+import org.utbot.framework.plugin.api.util.SpringModelUtils.entityClassIds
 import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.utContext
 import org.utbot.framework.plugin.services.JdkInfo
@@ -369,8 +369,8 @@ open class TestCaseGenerator(
         // in order to exclude such instructions for some reason
         // E.g. we exclude instructions (which classes have @Entity) when it is not a class under test
         // because we are not interested in coverage which was possibly produced by Spring itself
-        val annotationsToIgnore =
-            listOfNotNull(utContext.classLoader.tryLoadClass(entityClassId.name))
+        val annotationsToIgnoreCoverage =
+            entityClassIds.mapNotNull { utContext.classLoader.tryLoadClass(it.name) }
 
         val buildDirsClassLoader = createBuildDirsClassLoader()
         val isClassOnUserClasspathCache = mutableMapOf<String, Boolean>()
@@ -401,7 +401,7 @@ open class TestCaseGenerator(
 
                         // We do not want to take instructions in classes
                         // marked with annotations from [annotationsToIgnore]
-                        return@filter !hasAnnotations(instrClassFqn, annotationsToIgnore)
+                        return@filter !hasAnnotations(instrClassFqn, annotationsToIgnoreCoverage)
                     }
                     .ifEmpty {
                         coverage.coveredInstructions

--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/spring/SavedEntity.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/spring/SavedEntity.kt
@@ -4,6 +4,7 @@ import org.utbot.framework.plugin.api.SpringRepositoryId
 import org.utbot.framework.plugin.api.UtAssembleModel
 import org.utbot.framework.plugin.api.UtReferenceModel
 import org.utbot.framework.plugin.api.util.SpringModelUtils
+import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.fuzzer.FuzzedType
 import org.utbot.fuzzer.FuzzedValue
 import org.utbot.fuzzer.IdGenerator
@@ -13,17 +14,18 @@ import org.utbot.fuzzing.JavaValueProvider
 import org.utbot.fuzzing.Routine
 import org.utbot.fuzzing.Seed
 import org.utbot.fuzzing.providers.nullRoutine
+import org.utbot.fuzzing.toFuzzerType
 
-class SavedEntityProvider(
+class SavedEntityValueProvider(
     private val idGenerator: IdGenerator<Int>,
     private val repositoryId: SpringRepositoryId
 ) : JavaValueProvider {
-    override fun accept(type: FuzzedType): Boolean = type.classId == repositoryId.entityClassId
+    override fun accept(type: FuzzedType): Boolean = type.classId.jClass.isAssignableFrom(repositoryId.entityClassId.jClass)
 
     override fun generate(description: FuzzedDescription, type: FuzzedType): Sequence<Seed<FuzzedType, FuzzedValue>> =
         sequenceOf(
             Seed.Recursive(
-                construct = Routine.Create(listOf(type)) { values ->
+                construct = Routine.Create(listOf(toFuzzerType(repositoryId.entityClassId.jClass, description.typeCache))) { values ->
                     val entityValue = values.single()
                     val entityModel = entityValue.model
                     UtAssembleModel(


### PR DESCRIPTION
## Description

* Automatically detect  `@GeneratedValue` field in classes of relevant entities and their super classes
* Support both `javax.persistence` and `jakarta.persistence`
* Make it so entity sub classes can get generated by fuzzer when super class is needed (e.g. `ownerRepository.save(new Owner()).id` should be able to generate despite `id` being a field declared in `BaseEntity` class that not in `Owner` class itself)
* Make `save` method of repository bypass sandbox

## How to test

Standalone testing is not required, just as a part of full Spring integration test generation testing.

## Self-check list

Check off the item if the statement is true. Hint: [x] is a marked item.

Please do not delete the list or its items.

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.