### PR TITLE
Fuzzer should create object without any modifications

### DIFF
--- a/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/Mutations.kt
+++ b/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/Mutations.kt
@@ -303,7 +303,7 @@ sealed interface RecursiveMutations<TYPE, RESULT> : Mutation<Pair<Result.Recursi
         ): Result.Recursive<TYPE, RESULT> {
             return Result.Recursive(
                 construct = source.construct,
-                modify = source.modify.shuffled(random).take(random.nextInt(source.modify.size + 1).coerceAtLeast(1))
+                modify = source.modify.shuffled(random).take(random.nextInt(source.modify.size + 1))
             )
         }
     }


### PR DESCRIPTION
## Description

Fixes a problem described in [this comment](https://github.com/UnitTestBot/UTBotJava/issues/2311#issuecomment-1607952655). There was a check that always set minimum number of modifications to 1. Looks like it is not needed at the moment. 

## How to test

### Automated tests
New test was added: `FuzzerSmokeTestKt#fuzzer can generate value without mutations`

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.