### PR TITLE
Add exception serializing fallback that only considers `message`, `stackTrace`, and `cause`

### DIFF
--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/util/KryoHelper.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/util/KryoHelper.kt
@@ -1,12 +1,10 @@
 package org.utbot.instrumentation.util
 
 import com.esotericsoftware.kryo.kryo5.Kryo
-import com.esotericsoftware.kryo.kryo5.Serializer
 import com.esotericsoftware.kryo.kryo5.SerializerFactory
 import com.esotericsoftware.kryo.kryo5.io.Input
 import com.esotericsoftware.kryo.kryo5.io.Output
 import com.esotericsoftware.kryo.kryo5.objenesis.instantiator.ObjectInstantiator
-import com.esotericsoftware.kryo.kryo5.objenesis.strategy.InstantiatorStrategy
 import com.esotericsoftware.kryo.kryo5.objenesis.strategy.StdInstantiatorStrategy
 import com.esotericsoftware.kryo.kryo5.util.DefaultInstantiatorStrategy
 import com.jetbrains.rd.util.lifetime.Lifetime
@@ -109,7 +107,7 @@ internal class TunedKryo : Kryo() {
 
         // Kryo cannot (at least, the current used version) deserialize stacktraces that are required for SARIF reports.
         // TODO: JIRA:1492
-        addDefaultSerializer(java.lang.Throwable::class.java, JavaSerializerWrapper())
+        addDefaultSerializer(java.lang.Throwable::class.java, ThrowableSerializer())
 
         val factory = object : SerializerFactory.FieldSerializerFactory() {}
         factory.config.ignoreSyntheticFields = true


### PR DESCRIPTION
## Description

Oftentimes Spring puts dynamic proxies inside of exceptions, for example, `jakarta.validation.ConstraintViolationException` contains an array of annotations which are implemented with dynamic proxies.

To cope with that, a fallback for serializing exceptions was added that always constructs an instance of `Exception`, `RuntimeException`, or `Error` (instead of specific exception class) and injects `message`, `stackTrace`, and `cause` into it.

## How to test

### Manual tests

Add `throwAnnotation` method into `OrderService` in `spring-boot-testing` project:

```java
@Service
public class OrderService {

    public static class AnnotationException extends RuntimeException {
        private final Annotation[] annotations;

        public AnnotationException(Annotation[] annotations) {
            this.annotations = annotations;
        }
    }

    @Autowired
    private OrderRepository orderRepository;

    public void throwAnnotation(int x) {
        throw new AnnotationException(this.getClass().getAnnotations());
    }
}
```

There should be test that looks like this (and no tests saying that JVM crushes):
```java
@Test
@DisplayName("throwAnnotation: x = -2147483644 (mutated from min) -> throw RuntimeException")
public void testThrowAnnotationThrowsRE() {
    Order order1 = new Order();
    order1.setId(1L);
    order1.setBuyer("#$\\\"'");
    order1.setPrice(0.0);
    order1.setQty(Integer.MAX_VALUE);
    orderRepository.save(order1);
    assertThrows(RuntimeException.class, () -> orderService.throwAnnotation(-2147483644));
}
```

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.