### PR TITLE
Prohibit generating integration tests with XML configuration

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -1168,7 +1168,10 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
                 staticsMocking.isEnabled = false
                 staticsMocking.isSelected = true
 
-                springTestsType.isEnabled = !isXmlSpringConfigUsed()
+                springTestsType.let {
+                    it.isEnabled = !isXmlSpringConfigUsed()
+                    if (!it.isEnabled) springTestsType.item = SpringTestsType.defaultItem
+                }
                 profileNames.isEnabled = true
             } else {
                 mockStrategies.item = when (model.projectType) {


### PR DESCRIPTION
## Description

Integration test *cannot* go with XML configuration for now, so this option should be unavailable to be selected.

Fixes #2336

## How to test

### Manual tests

1. Run `runIde`
2. Open Generate window
3. Choose any **class** configuration
4. Select **Integration tests**
5. Change class configuration to xml configuration and verify that test type was set to default which is Unit test.
