### PR TITLE
Fix double-quoted engine process classpath argument

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/process/EngineProcess.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/process/EngineProcess.kt
@@ -85,9 +85,7 @@ private val log4j2ConfigSwitch = "-Dlog4j2.configurationFile=${log4j2ConfigFile.
 
 private val pluginClasspath: String
     get() = (EngineProcess::class.java.classLoader as PluginClassLoader).classPath.baseUrls.joinToString(
-        separator = File.pathSeparator,
-        prefix = "\"",
-        postfix = "\""
+        separator = File.pathSeparator
     )
 
 private const val startFileName = "org.utbot.framework.process.EngineProcessMainKt"


### PR DESCRIPTION
## Description

One pair of quotes is already added by Java standard library, removed manually added second pair of quotes to fix engine process starting on macOS 13.3.1

## Self-check list


- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.