### PR TITLE
Fix JaCoCo for Contest Estimator

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -237,6 +237,11 @@ object UtSettings : AbstractSettings(logger, defaultKeyForSettingsPath, defaultS
     var fuzzingTimeoutInMillis: Long by getLongProperty(3_000L, 0, Long.MAX_VALUE)
 
     /**
+     * Fuzzer will create objects when they cannot be created by other providers (e.g. private classes)
+     */
+    var fuzzObjectWhenTheyCannotBeCreatedClean: Boolean by getBooleanProperty(false)
+
+    /**
      * Generate tests that treat possible overflows in arithmetic operations as errors
      * that throw Arithmetic Exception.
      */

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -237,9 +237,9 @@ object UtSettings : AbstractSettings(logger, defaultKeyForSettingsPath, defaultS
     var fuzzingTimeoutInMillis: Long by getLongProperty(3_000L, 0, Long.MAX_VALUE)
 
     /**
-     * Fuzzer will create objects when they cannot be created by other providers (e.g. private classes)
+     * Find implementations of interfaces and abstract classes to fuzz.
      */
-    var fuzzObjectWhenTheyCannotBeCreatedClean: Boolean by getBooleanProperty(false)
+    var fuzzingImplementationOfAbstractClasses: Boolean by getBooleanProperty(true)
 
     /**
      * Generate tests that treat possible overflows in arithmetic operations as errors

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -881,6 +881,8 @@ val Type.classId: ClassId
         else -> error("Unknown type $this")
     }
 
+private val logger = KotlinLogging.logger {}
+
 /**
  * Class id. Contains name, not a full qualified name.
  *
@@ -905,7 +907,9 @@ open class ClassId @JvmOverloads constructor(
         get() = jClass.modifiers
 
     open val canonicalName: String
-        get() = jClass.canonicalName ?: error("ClassId $name does not have canonical name")
+        get() = jClass.canonicalName ?: name.also {
+            logger.error("ClassId $name does not have canonical name")
+        }
 
     open val simpleName: String get() = jClass.simpleName
 

--- a/utbot-framework/src/main/kotlin/org/utbot/fuzzer/FuzzerFunctions.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/fuzzer/FuzzerFunctions.kt
@@ -1,11 +1,9 @@
 package org.utbot.fuzzer
 
 import mu.KotlinLogging
-import org.utbot.framework.UtSettings
 import org.utbot.framework.plugin.api.classId
 import org.utbot.framework.plugin.api.util.*
 import org.utbot.framework.util.executableId
-import org.utbot.fuzzing.providers.CreateObjectAnywayValueProvider
 import soot.BooleanType
 import soot.ByteType
 import soot.CharType
@@ -48,7 +46,6 @@ fun collectConstantsForFuzzer(graph: ExceptionalUnitGraph): Set<FuzzedConcreteVa
                 StringConstant,
                 RegexByVarStringConstant,
                 DateFormatByVarStringConstant,
-                AbstractMethodIsCalled,
             ).flatMap { finder ->
                 try {
                     finder.find(graph, unit, value)
@@ -244,16 +241,6 @@ private object DateFormatByVarStringConstant: ConstantsFinder {
             if (stringConstantWasPassedAsArg != null && stringConstantWasPassedAsArg is String) {
                 return listOf(FuzzedConcreteValue(stringClassId, stringConstantWasPassedAsArg, FuzzedContext.Call(value.method.executableId)))
             }
-        }
-        return emptyList()
-    }
-}
-
-private object AbstractMethodIsCalled: ConstantsFinder {
-    override fun find(graph: ExceptionalUnitGraph, unit: Unit, value: Value): List<FuzzedConcreteValue> {
-        if (UtSettings.fuzzObjectWhenTheyCannotBeCreatedClean && value is JInterfaceInvokeExpr) {
-            // todo do a better way to add information about virtual method calls to providers
-            return listOf(FuzzedConcreteValue(value.method.javaClass.id, CreateObjectAnywayValueProvider::class, FuzzedContext.Call(value.method.executableId)))
         }
         return emptyList()
     }

--- a/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/Api.kt
+++ b/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/Api.kt
@@ -289,7 +289,14 @@ private object EmptyFeedback : Feedback<Nothing, Nothing> {
 class NoSeedValueException internal constructor(
     // this type cannot be generalized because Java forbids types for [Throwable].
     val type: Any?
-) : Exception("No seed candidates generated for type: $type")
+) : Exception() {
+    override fun fillInStackTrace(): Throwable {
+        return this
+    }
+
+    override val message: String
+        get() = "No seed candidates generated for type: $type"
+}
 
 suspend fun <T, R, D : Description<T>, F : Feedback<T, R>> Fuzzing<T, R, D, F>.fuzz(
     description: D,

--- a/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/Api.kt
+++ b/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/Api.kt
@@ -7,6 +7,7 @@ import org.utbot.fuzzing.seeds.KnownValue
 import org.utbot.fuzzing.utils.MissedSeed
 import org.utbot.fuzzing.utils.chooseOne
 import org.utbot.fuzzing.utils.flipCoin
+import org.utbot.fuzzing.utils.transformIfNotEmpty
 import kotlin.random.Random
 
 private val logger by lazy { KotlinLogging.logger {} }
@@ -515,11 +516,11 @@ private fun <TYPE, RESULT, DESCRIPTION : Description<TYPE>, FEEDBACK : Feedback<
                 }
             ),
             modify = task.modify
-//                .toMutableList()
-//                .transformIfNotEmpty {
-//                    shuffle(random)
-//                    take(random.nextInt(size + 1))
-//                }
+                .toMutableList()
+                .transformIfNotEmpty {
+                    shuffle(random)
+                    take(configuration.maxNumberOfRecursiveSeedModifications)
+                }
                 .mapTo(arrayListOf()) { routine ->
                     fuzz(
                         routine.types,

--- a/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/Configuration.kt
+++ b/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/Configuration.kt
@@ -90,4 +90,9 @@ data class Configuration(
      * to generate a recursive object, but will use [Seed.Recursive.empty] instead.
      */
     var generateEmptyRecursiveForMissedTypes: Boolean = true,
+
+    /**
+     * Limits maximum number of recursive seed modifications
+     */
+    var maxNumberOfRecursiveSeedModifications: Int = 10,
 )

--- a/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/Providers.kt
+++ b/utbot-fuzzing/src/main/kotlin/org/utbot/fuzzing/Providers.kt
@@ -96,9 +96,9 @@ fun interface ValueProvider<T, R, D : Description<T>> {
      */
     fun except(filter: (ValueProvider<T, R, D>) -> Boolean): ValueProvider<T, R, D> {
         return if (this is Combined) {
-            Combined(providers.filterNot(filter))
+            Combined(providers.map { it.unwrapIfFallback() }.filterNot(filter))
         } else {
-            Combined(if (filter(this)) emptyList() else listOf(this))
+            Combined(if (filter(unwrapIfFallback())) emptyList() else listOf(this))
         }
     }
 
@@ -117,26 +117,7 @@ fun interface ValueProvider<T, R, D : Description<T>> {
      * Uses fallback value provider in case when 'this' one failed to generate any value.
      */
     fun withFallback(fallback: ValueProvider<T, R, D>) : ValueProvider<T, R, D> {
-        val thisProvider = this
-        return object : ValueProvider<T, R, D> {
-            override fun enrich(description: D, type: T, scope: Scope) {
-                thisProvider.enrich(description, type, scope)
-                // Enriching scope by fallback value provider in this point is not quite right,
-                // but it doesn't look as a problem right now.
-                fallback.enrich(description, type, scope)
-            }
-
-            override fun generate(description: D, type: T): Sequence<Seed<T, R>> {
-                val default = if (thisProvider.accept(type)) thisProvider.generate(description, type) else emptySequence()
-                return if (default.iterator().hasNext()) {
-                    default
-                } else if (fallback.accept(type)) {
-                    fallback.generate(description, type)
-                } else {
-                    emptySequence()
-                }
-            }
-        }
+        return Fallback(this, fallback)
     }
 
     /**
@@ -150,6 +131,42 @@ fun interface ValueProvider<T, R, D : Description<T>> {
 
     fun letIf(flag: Boolean, block: (ValueProvider<T, R, D>) -> ValueProvider<T, R, D>) : ValueProvider<T, R, D> {
         return if (flag) block(this) else this
+    }
+
+    /**
+     * Checks if current provider has fallback and return the initial provider.
+     *
+     * If the initial provider is also fallback, then it is unwrapped too.
+     *
+     * @return unwrapped provider or this if it is not fallback
+     */
+    fun unwrapIfFallback(): ValueProvider<T, R, D> {
+        return if (this is Fallback<T, R, D>) { provider.unwrapIfFallback() } else { this }
+    }
+
+    private class Fallback<T, R, D : Description<T>>(
+        val provider: ValueProvider<T, R, D>,
+        val fallback: ValueProvider<T, R, D>,
+    ): ValueProvider<T, R, D> {
+
+        override fun enrich(description: D, type: T, scope: Scope) {
+            provider.enrich(description, type, scope)
+            // Enriching scope by fallback value provider in this point is not quite right,
+            // but it doesn't look as a problem right now.
+            fallback.enrich(description, type, scope)
+        }
+
+        override fun generate(description: D, type: T): Sequence<Seed<T, R>> {
+            val default = if (provider.accept(type)) provider.generate(description, type) else emptySequence()
+            return if (default.iterator().hasNext()) {
+                default
+            } else if (fallback.accept(type)) {
+                fallback.generate(description, type)
+            } else {
+                emptySequence()
+            }
+        }
+
     }
 
     /**

--- a/utbot-fuzzing/src/test/kotlin/org/utbot/fuzzing/ProvidersTest.kt
+++ b/utbot-fuzzing/src/test/kotlin/org/utbot/fuzzing/ProvidersTest.kt
@@ -112,6 +112,27 @@ class ProvidersTest {
     }
 
     @Test
+    fun `test fallback unwrapping from providers`() {
+        val provider1 = p { 2 }
+        val provider2 = p { 3 }
+        val fallback = p { 4 }
+        val providers1 = ValueProvider.of(listOf(
+            provider1.withFallback(fallback),
+            provider2
+        ))
+        val seq1 = providers1.generate(description, Unit).toSet()
+        Assertions.assertEquals(2, seq1.count())
+        Assertions.assertEquals(2, (seq1.first() as Seed.Simple).value)
+        Assertions.assertEquals(3, (seq1.drop(1).first() as Seed.Simple).value)
+
+        val providers2 = providers1.except(provider1)
+
+        val seq2 = providers2.generate(description, Unit).toSet()
+        Assertions.assertEquals(1, seq2.count())
+        Assertions.assertEquals(3, (seq2.first() as Seed.Simple).value)
+    }
+
+    @Test
     fun `provider is not called when accept-method returns false`() {
         val seq = ValueProvider.of(listOf(
             p({ true }, { 1 }), p({ false }, { 2 }), p({ true }, { 3 }),

--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/JavaLanguage.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/JavaLanguage.kt
@@ -44,7 +44,7 @@ fun defaultValueProviders(idGenerator: IdentityPreservingIdGenerator<Int>) = lis
     StringValueProvider,
     NumberValueProvider,
     ObjectValueProvider(idGenerator).letIf(UtSettings.fuzzObjectWhenTheyCannotBeCreatedClean) { ovp ->
-        ovp.withFallback(CreateObjectAnywayValueProvider(idGenerator, useMock = true))
+        ovp.withFallback(CreateObjectAnywayValueProvider(idGenerator, useMock = false))
     },
     ArrayValueProvider(idGenerator),
     EnumValueProvider(idGenerator),

--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/JavaLanguage.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/JavaLanguage.kt
@@ -43,8 +43,8 @@ fun defaultValueProviders(idGenerator: IdentityPreservingIdGenerator<Int>) = lis
     FloatValueProvider,
     StringValueProvider,
     NumberValueProvider,
-    ObjectValueProvider(idGenerator).letIf(UtSettings.fuzzObjectWhenTheyCannotBeCreatedClean) { ovp ->
-        ovp.withFallback(CreateObjectAnywayValueProvider(idGenerator, useMock = false))
+    ObjectValueProvider(idGenerator).letIf(UtSettings.fuzzingImplementationOfAbstractClasses) { ovp ->
+        ovp.withFallback(AbstractsObjectValueProvider(idGenerator))
     },
     ArrayValueProvider(idGenerator),
     EnumValueProvider(idGenerator),

--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/JavaLanguage.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/JavaLanguage.kt
@@ -1,6 +1,7 @@
 package org.utbot.fuzzing
 
 import mu.KotlinLogging
+import org.utbot.framework.UtSettings
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.ExecutableId
 import org.utbot.framework.plugin.api.Instruction
@@ -42,7 +43,9 @@ fun defaultValueProviders(idGenerator: IdentityPreservingIdGenerator<Int>) = lis
     FloatValueProvider,
     StringValueProvider,
     NumberValueProvider,
-    ObjectValueProvider(idGenerator),
+    ObjectValueProvider(idGenerator).letIf(UtSettings.fuzzObjectWhenTheyCannotBeCreatedClean) { ovp ->
+        ovp.withFallback(CreateObjectAnywayValueProvider(idGenerator, useMock = true))
+    },
     ArrayValueProvider(idGenerator),
     EnumValueProvider(idGenerator),
     ListSetValueProvider(idGenerator),

--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Objects.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Objects.kt
@@ -151,7 +151,7 @@ class CreateObjectAnywayValueProvider(
         yield(Seed.Recursive(
             construct = Routine.Create(emptyList()) {
                 UtCompositeModel(idGenerator.createId(), type.classId, useMock).fuzzed {
-                    summary = "some object"
+                    summary = "Unsafe object"
                 }
             },
             modify = sequence {
@@ -188,7 +188,7 @@ class CreateObjectAnywayValueProvider(
             },
             empty = Routine.Empty {
                 UtCompositeModel(idGenerator.createId(), type.classId, useMock).fuzzed {
-                    summary = "some object"
+                    summary = "Unsafe object"
                 }
             }
         ))

--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Objects.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Objects.kt
@@ -134,7 +134,7 @@ object NullValueProvider : ValueProvider<FuzzedType, FuzzedValue, FuzzedDescript
 
 class CreateObjectAnywayValueProvider(
     val idGenerator: IdGenerator<Int>,
-    val useMock: Boolean = true,
+    val useMock: Boolean = false,
 ) : ValueProvider<FuzzedType, FuzzedValue, FuzzedDescription> {
 
     override fun accept(type: FuzzedType) = type.classId.isRefType

--- a/utbot-junit-contest/build.gradle
+++ b/utbot-junit-contest/build.gradle
@@ -13,22 +13,30 @@ compileJava {
 
 compileTestJava {
     options.fork = true
-    options.forkOptions.executable = 'javac'
     options.compilerArgs << "-XDignore.symbol.file"
 }
+
+def testProjects = [
+        'build/output/test/antlr',
+        'build/output/test/codeforces',
+        'build/output/test/fastjson-1.2.50',
+        'build/output/test/fescar',
+        'build/output/test/guava',
+        'build/output/test/guava-26.0',
+        'build/output/test/guava-30.0',
+        'build/output/test/pdfbox',
+        'build/output/test/seata',
+        'build/output/test/seata-core-0.5.0',
+        'build/output/test/spoon',
+        'build/output/test/spoon-core-7.0.0',
+]
 
 sourceSets {
     test {
         java {
-            srcDir('build/output/test/antlr')
-            srcDir('build/output/test/custom')
-            srcDir('build/output/test/guava')
-            srcDir('build/output/test/fescar')
-            srcDir('build/output/test/pdfbox')
-            srcDir('build/output/test/seata')
-            srcDir('build/output/test/spoon')
-            srcDir('build/output/test/samples')
-            srcDir('build/output/test/utbottest')
+            testProjects.forEach {
+                srcDir(it)
+            }
         }
     }
 }
@@ -39,7 +47,26 @@ test {
 }
 
 jacocoTestReport {
+    afterEvaluate {
+        def r = testProjects.collect {
+            fileTree(dir: it)
+        }.findAll {
+            it.dir.exists()
+        }
+        sourceDirectories.setFrom(r.collect {files(it) })
+        classDirectories.setFrom(
+                r.collect {
+                    fileTree(dir: it.dir.toPath().parent.resolveSibling("unzipped").resolve(it.dir.name))
+                }.findAll {
+                    it.dir.exists()
+                }.collect {
+                    files(it)
+                }
+        )
+    }
+
     reports {
+        csv.enabled = true
         html.enabled = true
     }
 }

--- a/utbot-junit-contest/src/main/kotlin/org/utbot/contest/Contest.kt
+++ b/utbot-junit-contest/src/main/kotlin/org/utbot/contest/Contest.kt
@@ -10,9 +10,6 @@ import org.utbot.common.isAbstract
 import org.utbot.engine.EngineController
 import org.utbot.framework.TestSelectionStrategyType
 import org.utbot.framework.UtSettings
-import org.utbot.framework.codegen.domain.ForceStaticMocking
-import org.utbot.framework.codegen.domain.StaticsMocking
-import org.utbot.framework.codegen.domain.junitByVersion
 import org.utbot.framework.plugin.api.util.UtContext
 import org.utbot.framework.plugin.api.util.executableId
 import org.utbot.framework.plugin.api.util.id
@@ -51,7 +48,7 @@ import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
 import org.utbot.framework.SummariesGenerationType
-import org.utbot.framework.codegen.domain.ProjectType
+import org.utbot.framework.codegen.domain.*
 import org.utbot.framework.codegen.generator.CodeGenerator
 import org.utbot.framework.codegen.services.language.CgLanguageAssistant
 import org.utbot.framework.minimization.minimizeExecutions
@@ -228,6 +225,7 @@ fun runGeneration(
             forceStaticMocking = forceStaticMocking,
             generateWarningsForStaticMocking = false,
             cgLanguageAssistant = CgLanguageAssistant.getByCodegenLanguage(CodegenLanguage.defaultItem),
+            runtimeExceptionTestsBehaviour = RuntimeExceptionTestsBehaviour.PASS,
         )
 
     logger.info().measureTime({ "class ${cut.fqn}" }, { statsForClass }) {


### PR DESCRIPTION
## Description

Contest Estimator's module was not able to generate JaCoCo reports due to obsolete `gradle.build` settings. Also, fuzzer now can generate objects using reflection or mocks to cover cases where only interfaces or abstract classes are expected.

## How to test

### Manual tests

1. Configure and run Contest Estimator class.
2. After it finishes run task `gradle :utbot-junit-contest:test`
3. You can find reports in a folder `build/reports`

NB! If there's several projects with different versions like `guava`, then report works only for the first one, because all these libraries are loaded by tests. You can manually remove unnecessary folders.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.