### PR TITLE
Field modifiers correction in Spring generated test classes

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/CgElement.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/CgElement.kt
@@ -173,7 +173,7 @@ class CgFieldDeclaration(
     val ownerClassId: ClassId,
     val declaration: CgDeclaration,
     val annotation: CgAnnotation? = null,
-    val visibility: VisibilityModifier = VisibilityModifier.PUBLIC,
+    val visibility: VisibilityModifier = VisibilityModifier.PRIVATE,
 ) : CgElement
 
 /**

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgAbstractSpringTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgAbstractSpringTestClassConstructor.kt
@@ -37,8 +37,6 @@ abstract class CgAbstractSpringTestClassConstructor(context: CgContext):
             fields += constructClassFields(testClassModel)
             clearUnwantedVariableModels()
 
-            methodRegions += constructAdditionalMethods()
-
             for ((testSetIndex, testSet) in testClassModel.methodTestSets.withIndex()) {
                 updateCurrentExecutable(testSet.executableId)
                 withTestSetIdScope(testSetIndex) {
@@ -50,6 +48,8 @@ abstract class CgAbstractSpringTestClassConstructor(context: CgContext):
                     methodRegions += executableUnderTestCluster
                 }
             }
+
+            methodRegions += constructAdditionalMethods()
 
             if (currentTestClass == outerMostTestClass) {
                 val utilEntities = collectUtilEntities()


### PR DESCRIPTION
## Description

Now, all class fields, annotated with `@InjectMocks`, `@Mock`, `@Autowired` or `mockitoCloseable` field are private

<img width="418" alt="image" src="https://github.com/UnitTestBot/UTBotJava/assets/73890886/7a6f29ce-ea8e-42c3-b0d9-6b2aac35fd9f">

\
Also, `setUp` and `tearDown` methods are under test methods.

#2325 closed

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.