### PR TITLE
Turn off Fuzzer in Spring unit tests

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -378,7 +378,7 @@ object UtTestsDialogProcessor {
                                         }
                                         val useFuzzing = when (model.projectType) {
                                             Spring -> when (model.springTestType) {
-                                                UNIT_TEST -> model.springSettings is AbsentSpringSettings
+                                                UNIT_TEST -> false
                                                 INTEGRATION_TEST -> true
                                             }
 


### PR DESCRIPTION
## Description

For now it was decided to turn off Fuzzer in unit tests.

Later, it's better to consider #2321 comments, i.e. generate two test classes, one with *@InjectMock* by Symbolic Engine, another without the annotation by Fuzzer.