### PR TITLE
Do not miss non-injected fields in Spring unit test generation

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringVariableConstructor.kt
@@ -31,6 +31,9 @@ class CgSpringVariableConstructor(context: CgContext) : CgVariableConstructor(co
 
             modelFields?.forEach{ (fieldId, fieldModel) ->
                 val variableForField = getOrCreateVariable(fieldModel)
+
+                // If field model is a mock, it is set in the connected with instance under test automatically via @InjectMocks;
+                // Otherwise we need to set this field manually.
                 if(!fieldModel.isMockModel()) {
                     setFieldValue(alreadyCreatedInjectMocks, fieldId, variableForField)
                 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringVariableConstructor.kt
@@ -32,7 +32,7 @@ class CgSpringVariableConstructor(context: CgContext) : CgVariableConstructor(co
             modelFields?.forEach{ (fieldId, fieldModel) ->
                 val variableForField = getOrCreateVariable(fieldModel)
                 if(!fieldModel.isMockModel()) {
-                    +utilsClassId[setField](alreadyCreatedInjectMocks, fieldId.declaringClass.name, fieldId.name, variableForField)
+                    setFieldValue(alreadyCreatedInjectMocks, fieldId, variableForField)
                 }
             }
 


### PR DESCRIPTION
## Description

Fixes #2386
 
Now a separate `SetField()` is prescribed for non-Mock fields

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.