### PR TITLE
Emit `UtError` when there are no beans for this instance during integration test generation

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -1537,6 +1537,14 @@ class SpringApplicationContext(
                 exception
             )
         }.orEmpty() + super.getErrors()
+
+    fun getBeansAssignableTo(classId: ClassId): List<BeanDefinitionData> = beanDefinitions.filter { beanDef ->
+        // some bean classes may fail to load
+        runCatching {
+            val beanClass = ClassId(beanDef.beanTypeName).jClass
+            classId.jClass.isAssignableFrom(beanClass)
+        }.getOrElse { false }
+    }
 }
 
 enum class SpringTestType(


### PR DESCRIPTION
## Description

Integration tests can't be generated when there are no beans for tested class, so we display an error.

## How to test

### Manual tests

Generate integration tests for `AnimalService.getInjectedName()` in `TwoAnimals` project using `DolphinConfig`, the following error should be reported, because `DolphinConfig` doesn't have any bean for `AnimalService`:
```java
public void testGetInjectedName_errors() {
    // Couldn't generate some tests. List of errors:
    // 
    // 1 occurrences of:
    /* No beans of type org.example.service.AnimalService are found. Try choosing different
    Spring configuration or adding beans to org.example.DolphinConfig */

}
```

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.