### PR TITLE
Try to improve staticMocking UI control behavior

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -1107,6 +1107,9 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
 
         mockStrategies.addActionListener { _ ->
             updateControlsEnabledStatus()
+            if (staticsMocking.isSelected && mockStrategies.item == MockStrategyApi.NO_MOCKS) {
+                staticsMocking.isSelected = false
+            }
         }
 
         testFrameworks.addActionListener { event ->
@@ -1240,9 +1243,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
 
     private fun updateStaticMockEnabled() {
         val mockStrategyIsSupported = mockStrategies.item != MockStrategyApi.NO_MOCKS
-
         staticsMocking.isEnabled = mockStrategyIsSupported && !isSpringConfigSelected()
-        staticsMocking.isSelected = mockStrategyIsSupported
     }
 
     private fun updateMockStrategyList() {

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -1155,6 +1155,11 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
 
                 profileNames.text = ""
             }
+
+            if (!staticsMocking.isSelected && isSpringConfigSelected()) {
+                staticsMocking.isSelected = true
+            }
+
             updateMockStrategyList()
             updateControlsEnabledStatus()
         }


### PR DESCRIPTION
## Description

- StaticsMocking control state is taken from Settings
- If mock strategy changes to DO_NOT_MOCK and StaticksMocking was selected, we deselect it.

## How to test

### Manual tests

All manual scenarios for static mocking in Spring and non-Spring projects

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.