### PR TITLE
Divide test set "examples-part2" into two sets

### DIFF
--- a/.github/workflows/framework-tests-matrix.json
+++ b/.github/workflows/framework-tests-matrix.json
@@ -53,7 +53,7 @@
       "TESTS_TO_RUN": "--tests \"org.utbot.examples.codegen.*\""
     },
     {
-      "PART_NAME": "examples-part8",
+      "PART_NAME": "examples-part9",
       "TESTS_TO_RUN": "--tests \"org.utbot.examples.mock.*\" --tests \"org.utbot.examples.models.*\" --tests \"org.utbot.examples.natives.*\" --tests \"org.utbot.examples.objects.*\" --tests \"org.utbot.examples.reflection.*\" --tests \"org.utbot.examples.threads.*\""
     },
     {

--- a/.github/workflows/framework-tests-matrix.json
+++ b/.github/workflows/framework-tests-matrix.json
@@ -26,7 +26,7 @@
     },
     {
       "PART_NAME": "examples-part2",
-      "TESTS_TO_RUN": "--tests \"org.utbot.examples.exceptions.*\" --tests \"org.utbot.examples.invokes.*\" --tests \"org.utbot.examples.lambda.*\" --tests \"org.utbot.examples.make.symbolic.*\" --tests \"org.utbot.examples.math.*\" --tests \"org.utbot.examples.mixed.*\" --tests \"org.utbot.examples.mock.*\" --tests \"org.utbot.examples.models.*\" --tests \"org.utbot.examples.natives.*\" --tests \"org.utbot.examples.objects.*\" --tests \"org.utbot.examples.reflection.*\" --tests \"org.utbot.examples.threads.*\""
+      "TESTS_TO_RUN": "--tests \"org.utbot.examples.exceptions.*\" --tests \"org.utbot.examples.invokes.*\" --tests \"org.utbot.examples.lambda.*\" --tests \"org.utbot.examples.make.symbolic.*\" --tests \"org.utbot.examples.math.*\" --tests \"org.utbot.examples.mixed.*\""
     },
     {
       "PART_NAME": "examples-part3",
@@ -51,6 +51,10 @@
     {
       "PART_NAME": "examples-part8",
       "TESTS_TO_RUN": "--tests \"org.utbot.examples.codegen.*\""
+    },
+    {
+      "PART_NAME": "examples-part8",
+      "TESTS_TO_RUN": "--tests \"org.utbot.examples.mock.*\" --tests \"org.utbot.examples.models.*\" --tests \"org.utbot.examples.natives.*\" --tests \"org.utbot.examples.objects.*\" --tests \"org.utbot.examples.reflection.*\" --tests \"org.utbot.examples.threads.*\""
     },
     {
       "PART_NAME": "examples-lists",


### PR DESCRIPTION
## Description

Test run of `examples-part2` test set is taking 30+ minutes.
https://github.com/UnitTestBot/UTBotJava/actions/runs/5530269415/usage
Suggest to divide this set into two to reduce the build_and_run_tests job run time.

## How to test

### Manual tests

Open the build_and_run_tests details.
Open Usage and check the time of the different sets.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.