### PR TITLE
Hard set static mocking depending on Spring test type

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -849,7 +849,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
 
         mockStrategies.item = when (model.projectType) {
             ProjectType.Spring -> MockStrategyApi.springDefaultItem
-            else ->    settings.mockStrategy
+            else -> settings.mockStrategy
         }
         staticsMocking.isSelected = settings.staticsMocking == MockitoStaticMocking
         parametrizedTestSources.isSelected = (settings.parametrizedTestSource == ParametrizedTestSource.PARAMETRIZE
@@ -1173,9 +1173,11 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
             when (item) {
                 UNIT_TEST -> {
                     mockStrategies.item = MockStrategyApi.springDefaultItem
+                    staticsMocking.isSelected = true
                 }
                 INTEGRATION_TEST -> {
                     mockStrategies.item = MockStrategyApi.springIntegrationTestItem
+                    staticsMocking.isSelected = false
                 }
             }
             updateMockStrategyList()


### PR DESCRIPTION
## Description

Hard set static mocking depending on Spring test type.

## How to test

### Automated tests

Not relevant.

### Manual tests

1. Open generate window
2. Choose configuration
3. Select unit test (verify that static mocking is enabled)
4. Select integration test (verify that static mocking is disabled)
5. Repeat steps 4 and 5 to see that the (unit test -> enabled static mocking) and (integration test -> disabled static mocking) scheme is preserved.