### PR TITLE
Correct one more scenario of staticsMocking selection

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -1107,7 +1107,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
 
         mockStrategies.addActionListener { _ ->
             updateControlsEnabledStatus()
-            if (staticsMocking.isSelected && mockStrategies.item == MockStrategyApi.NO_MOCKS) {
+            if (mockStrategies.item == MockStrategyApi.NO_MOCKS) {
                 staticsMocking.isSelected = false
             }
         }
@@ -1156,7 +1156,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
                 profileNames.text = ""
             }
 
-            if (!staticsMocking.isSelected && isSpringConfigSelected()) {
+            if (isSpringConfigSelected() && springTestType.item == UNIT_TEST) {
                 staticsMocking.isSelected = true
             }
 


### PR DESCRIPTION
## Description

Fixes a scenario when Spring tests type changed implicitly by changing another control

## How to test

### Manual tests

Statics mocking UI control standard scenarios.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.