### PR TITLE
Fix `DummySpringBootIntegrationTestClass` annotations

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SpringModelUtils.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SpringModelUtils.kt
@@ -15,7 +15,6 @@ object SpringModelUtils {
     val applicationContextClassId = ClassId("org.springframework.context.ApplicationContext")
     val crudRepositoryClassId = ClassId("org.springframework.data.repository.CrudRepository")
 
-    @Suppress("unused", "may be used instead of ExtendWith + BootstrapWith in future")
     val springBootTestClassId = ClassId("org.springframework.boot.test.context.SpringBootTest")
 
     val dirtiesContextClassId = ClassId("org.springframework.test.annotation.DirtiesContext")

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SpringModelUtils.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SpringModelUtils.kt
@@ -23,6 +23,8 @@ object SpringModelUtils {
     val autoConfigureTestDbClassId = ClassId("org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase")
 
     val runWithClassId = ClassId("org.junit.runner.RunWith")
+    val springRunnerClassId = ClassId("org.springframework.test.context.junit4.SpringRunner")
+
     val extendWithClassId = ClassId("org.junit.jupiter.api.extension.ExtendWith")
     val springExtensionClassId = ClassId("org.springframework.test.context.junit.jupiter.SpringExtension")
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringIntegrationTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringIntegrationTestClassConstructor.kt
@@ -17,7 +17,6 @@ import org.utbot.framework.plugin.api.SpringCodeGenerationContext
 import org.utbot.framework.plugin.api.SpringSettings.*
 import org.utbot.framework.plugin.api.SpringConfiguration.*
 import org.utbot.framework.plugin.api.util.IndentUtil.TAB
-import org.utbot.framework.plugin.api.util.SpringModelUtils
 import org.utbot.framework.plugin.api.util.SpringModelUtils.activeProfilesClassId
 import org.utbot.framework.plugin.api.util.SpringModelUtils.autoConfigureTestDbClassId
 import org.utbot.framework.plugin.api.util.SpringModelUtils.autowiredClassId
@@ -26,9 +25,12 @@ import org.utbot.framework.plugin.api.util.SpringModelUtils.contextConfiguration
 import org.utbot.framework.plugin.api.util.SpringModelUtils.crudRepositoryClassId
 import org.utbot.framework.plugin.api.util.SpringModelUtils.dirtiesContextClassId
 import org.utbot.framework.plugin.api.util.SpringModelUtils.dirtiesContextClassModeClassId
+import org.utbot.framework.plugin.api.util.SpringModelUtils.extendWithClassId
+import org.utbot.framework.plugin.api.util.SpringModelUtils.runWithClassId
 import org.utbot.framework.plugin.api.util.SpringModelUtils.springBootTestClassId
 import org.utbot.framework.plugin.api.util.SpringModelUtils.springBootTestContextBootstrapperClassId
 import org.utbot.framework.plugin.api.util.SpringModelUtils.springExtensionClassId
+import org.utbot.framework.plugin.api.util.SpringModelUtils.springRunnerClassId
 import org.utbot.framework.plugin.api.util.SpringModelUtils.transactionalClassId
 import org.utbot.framework.plugin.api.util.utContext
 import org.utbot.spring.api.UTSpringContextLoadingException
@@ -100,16 +102,16 @@ class CgSpringIntegrationTestClassConstructor(
     )
 
     private fun addNecessarySpringSpecificAnnotations() {
-        val springRunnerType = when (testFramework) {
-            Junit4 -> SpringModelUtils.runWithClassId
-            Junit5 -> SpringModelUtils.extendWithClassId
+        val (testFrameworkExtension, springExtension) = when (testFramework) {
+            Junit4 -> runWithClassId to springRunnerClassId
+            Junit5 -> extendWithClassId to springExtensionClassId
             TestNg -> error("Spring extension is not implemented in TestNg")
             else -> error("Trying to generate tests for Spring project with non-JVM framework")
         }
 
         addAnnotation(
-            classId = springRunnerType,
-            argument = createGetClassExpression(springExtensionClassId, codegenLanguage),
+            classId = testFrameworkExtension,
+            argument = createGetClassExpression(springExtension, codegenLanguage),
             target = Class,
         )
 

--- a/utbot-spring-commons/src/main/kotlin/org/utbot/spring/dummy/DummySpringBootIntegrationTestClass.kt
+++ b/utbot-spring-commons/src/main/kotlin/org/utbot/spring/dummy/DummySpringBootIntegrationTestClass.kt
@@ -1,11 +1,13 @@
 package org.utbot.spring.dummy
 
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTestContextBootstrapper
 import org.springframework.test.context.BootstrapWith
 
+@SpringBootTest
 @BootstrapWith(SpringBootTestContextBootstrapper::class)
-class DummySpringBootIntegrationTestClass : DummySpringIntegrationTestClass()
+open class DummySpringBootIntegrationTestClass : DummySpringIntegrationTestClass()
 
 @AutoConfigureTestDatabase
-class DummySpringBootIntegrationTestClassAutoconfigTestDB : DummySpringIntegrationTestClass()
+class DummySpringBootIntegrationTestClassAutoconfigTestDB : DummySpringBootIntegrationTestClass()


### PR DESCRIPTION
## Description

* `DummySpringBootIntegrationTestClassAutoconfigTestDB` was missing `@BootstrapWith(SpringBootTestContextBootstrapper::class)` annotation, because its parent class was `DummySpringIntegrationTestClass` instead of `DummySpringBootIntegrationTestClass`.
* `DummySpringBootIntegrationTestClass` didn't have `@SpringBootTest` annotation, even though according to `@SpringBootTest` javadoc it configures test context in more ways than just `@BootstrapWith(SpringBootTestContextBootstrapper::class)`.

Also, this PR performs same changes in generated code annotations.

## How to test

### Manual tests

Generate integration tests for [`Medical-Web-App`](https://github.com/MathAndMedLab/Medical-Web-App/tree/develop-new) project (while having all necessary docker containers running as described in the project README), there should be no exception stack trace rendered in `contextLoads()` test.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.