### PR TITLE
Support Spring autowire two and more different beans of one type

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringVariableConstructor.kt
@@ -15,7 +15,7 @@ class CgSpringVariableConstructor(context: CgContext) : CgVariableConstructor(co
     private val classFieldManager = ClassFieldManagerFacade(context)
 
     override fun getOrCreateVariable(model: UtModel, name: String?): CgValue {
-        val variable = classFieldManager.constructVariableForField(model, annotatedModelGroups)
+        val variable = classFieldManager.constructVariableForField(model)
 
         variable?.let { return it }
 


### PR DESCRIPTION
## Description

Fixes #2389 

Now Spring unit tests can autowire two different beans of one type.

If all test executions use only one autowired bean of some class, then we can mock this variable by @Mock annotation,
else we need to use simple mock.

## How to test

### Manual tests

Manually tested on a `spring-boot-testing` project and a project that does not use Spring framework.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.