### PR TITLE
Make fuzzer use generic field types

### DIFF
--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Objects.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Objects.kt
@@ -200,7 +200,7 @@ internal fun findAccessibleModifiableFields(description: FuzzedDescription?, cla
             FieldDescription(
                 name = field.name,
                 type = if (description != null) toFuzzerType(
-                    field.type,
+                    field.genericType,
                     description.typeCache
                 ) else FuzzedType(field.type.id),
                 canBeSetDirectly = isAccessible(

--- a/utbot-java-fuzzing/src/test/java/org/utbot/fuzzing/samples/StringListHolder.java
+++ b/utbot-java-fuzzing/src/test/java/org/utbot/fuzzing/samples/StringListHolder.java
@@ -1,0 +1,20 @@
+package org.utbot.fuzzing.samples;
+
+import java.util.List;
+
+public class StringListHolder {
+    private List<String> strings;
+
+
+    public List<String> getStrings() {
+        return strings;
+    }
+
+
+    public void setStrings(List<String> strings) {
+        this.strings = strings;
+    }
+
+
+    public void methodUnderTest() {}
+}


### PR DESCRIPTION
## Description

Fixes #2430 

## How to test

### Automated tests

> The proposed changes are verified with tests:
> `utbot-java-fuzzing/src/test/kotlin/org/utbot/fuzzing/JavaFuzzingTest.kt`

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.