### PR TITLE
Make Spring integration tests use `AbstractsValueProvider`

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringIntegrationTestConcreteExecutionContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringIntegrationTestConcreteExecutionContext.kt
@@ -17,6 +17,7 @@ import org.utbot.fuzzing.JavaValueProvider
 import org.utbot.fuzzing.ValueProvider
 import org.utbot.fuzzing.providers.FieldValueProvider
 import org.utbot.fuzzing.providers.ObjectValueProvider
+import org.utbot.fuzzing.providers.anyObjectValueProvider
 import org.utbot.fuzzing.spring.SavedEntityValueProvider
 import org.utbot.fuzzing.spring.SpringBeanValueProvider
 import org.utbot.instrumentation.ConcreteExecutor
@@ -85,7 +86,7 @@ class SpringIntegrationTestConcreteExecutionContext(
                 springApplicationContext.getBeansAssignableTo(classId).map { it.beanName }
             },
             relevantRepositories = relevantRepositories
-        ).withFallback(ObjectValueProvider(idGenerator))
+        ).withFallback(anyObjectValueProvider(idGenerator))
 
         return delegateContext.tryCreateValueProvider(concreteExecutor, classUnderTest, idGenerator)
             .except { p -> p is ObjectValueProvider }

--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/JavaLanguage.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/JavaLanguage.kt
@@ -1,7 +1,6 @@
 package org.utbot.fuzzing
 
 import mu.KotlinLogging
-import org.utbot.framework.UtSettings
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.ExecutableId
 import org.utbot.framework.plugin.api.Instruction
@@ -43,9 +42,7 @@ fun defaultValueProviders(idGenerator: IdentityPreservingIdGenerator<Int>) = lis
     FloatValueProvider,
     StringValueProvider,
     NumberValueProvider,
-    ObjectValueProvider(idGenerator).letIf(UtSettings.fuzzingImplementationOfAbstractClasses) { ovp ->
-        ovp.withFallback(AbstractsObjectValueProvider(idGenerator))
-    },
+    anyObjectValueProvider(idGenerator),
     ArrayValueProvider(idGenerator),
     EnumValueProvider(idGenerator),
     ListSetValueProvider(idGenerator),

--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Objects.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Objects.kt
@@ -1,6 +1,7 @@
 package org.utbot.fuzzing.providers
 
 import mu.KotlinLogging
+import org.utbot.framework.UtSettings
 import org.utbot.framework.plugin.api.*
 import org.utbot.framework.plugin.api.util.*
 import org.utbot.fuzzer.*
@@ -29,6 +30,11 @@ private fun isIgnored(type: ClassId): Boolean {
             || type.isAbstract
             || (type.isInner && !type.isStatic)
 }
+
+fun anyObjectValueProvider(idGenerator: IdentityPreservingIdGenerator<Int>) =
+    ObjectValueProvider(idGenerator).letIf(UtSettings.fuzzingImplementationOfAbstractClasses) { ovp ->
+        ovp.withFallback(AbstractsObjectValueProvider(idGenerator))
+    }
 
 class ObjectValueProvider(
     val idGenerator: IdGenerator<Int>,


### PR DESCRIPTION
## Description

Makes Spring integration tests use `AbstractsValueProvider` (i.e. use instances of sub type where abstract types are expected).

## How to test

### Manual tests

Generate integration tests for [`OwnerController.processCreationForm(@Valid Owner owner, BindingResult result)` in spring-petclinic project](https://github.com/spring-projects/spring-petclinic/blob/0a529015bc7933bcd724a5ae92605f0e9ee0e3f7/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java#L73) using `PetClinicApplication` configuration. There should be tests that use non-`null` values for `BindingResult`.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.