### PR TITLE
Remove unnecessary annotations from Spring integration tests

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -1320,7 +1320,12 @@ enum class TypeReplacementMode {
 }
 
 sealed class SpringConfiguration(val fullDisplayName: String) {
-    class JavaConfiguration(val classBinaryName: String) : SpringConfiguration(classBinaryName)
+    abstract class JavaBasedConfiguration(open val configBinaryName: String) : SpringConfiguration(configBinaryName)
+
+    class JavaConfiguration(override val configBinaryName: String) : JavaBasedConfiguration(configBinaryName)
+
+    class SpringBootConfiguration(override val configBinaryName: String, val isUnique: Boolean): JavaBasedConfiguration(configBinaryName)
+
     class XMLConfiguration(val absolutePath: String) : SpringConfiguration(absolutePath)
 }
 

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/spring/SpringInstrumentationContext.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/spring/SpringInstrumentationContext.kt
@@ -26,7 +26,7 @@ class SpringInstrumentationContext(
                 //  so we expect JavaConfigurations only.
                 //  After fix rewrite the following.
                 classLoader.loadClass(
-                    (springSettings.configuration as? JavaConfiguration)?.classBinaryName
+                    (springSettings.configuration as? JavaBasedConfiguration)?.configBinaryName
                         ?: error("JavaConfiguration was expected, but ${springSettings.configuration.javaClass.name} was provided.")
                 )
             ),

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -180,10 +180,10 @@ object UtTestsDialogProcessor {
                 is AbsentSpringSettings -> null
                 is PresentSpringSettings ->
                     when (val config = settings.configuration) {
-                        is JavaConfiguration -> {
+                        is JavaBasedConfiguration -> {
                             PsiClassHelper
-                                .findClass(config.classBinaryName, project)
-                                ?: error("Cannot find configuration class ${config.classBinaryName}.")
+                                .findClass(config.configBinaryName, project)
+                                ?: error("Cannot find configuration class ${config.configBinaryName}.")
                         }
                         // TODO: for XML config we also need to compile module containing,
                         //  since it may reference classes from that module

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -703,7 +703,16 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
                             SpringConfiguration.XMLConfiguration(absolutePath)
                         } else {
                             val classBinaryName = javaConfigurationHelper.restoreFullName(shortConfigName)
-                            SpringConfiguration.JavaConfiguration(classBinaryName)
+
+                            val springBootConfigs = model.getSortedSpringBootApplicationClasses()
+                            if (springBootConfigs.contains(classBinaryName)) {
+                                SpringConfiguration.SpringBootConfiguration(
+                                    configBinaryName = classBinaryName,
+                                    isUnique = springBootConfigs.size == 1,
+                                    )
+                            } else {
+                                SpringConfiguration.JavaConfiguration(classBinaryName)
+                            }
                         }
 
                     PresentSpringSettings(

--- a/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/utils/SourceFinder.kt
+++ b/utbot-spring-analyzer/src/main/kotlin/org/utbot/spring/utils/SourceFinder.kt
@@ -7,7 +7,6 @@ import org.utbot.common.patchAnnotation
 import org.utbot.framework.plugin.api.SpringConfiguration.*
 import org.utbot.spring.api.ApplicationData
 import org.utbot.spring.config.TestApplicationConfiguration
-import org.utbot.spring.configurators.ApplicationConfigurationType
 import java.nio.file.Path
 import kotlin.io.path.Path
 
@@ -20,11 +19,11 @@ class SourceFinder(
 
     fun findSources(): Array<Class<*>> =
         when (val config = applicationData.springSettings.configuration) {
-            is JavaConfiguration -> {
+            is JavaBasedConfiguration -> {
                 logger.info { "Using java Spring configuration" }
                 arrayOf(
                     TestApplicationConfiguration::class.java,
-                    classLoader.loadClass(config.classBinaryName)
+                    classLoader.loadClass(config.configBinaryName)
                 )
             }
 


### PR DESCRIPTION
## Description

- Avoid setting default profile as active with annotation
- Avoid setting unique application class as context with annotation
- Render `@SpringBootTest` annotation on the top of others
- Do not render `@ExtendWith(SpringExtension.class)` if `@SpringBootTest` is used.

## How to test

### Manual tests

Generate Spring integration tests for an arbitrary class in spring-boot-testing main.

Verify that annotations are the following for JUnit5

```java
@SpringBootTest
@BootstrapWith(SpringBootTestContextBootstrapper.class)
@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
@Transactional
@AutoConfigureTestDatabase
```

with additional `RunWith(SpringRunner.class)` annotation for JUnit4

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.