### PR TITLE
Avoid useless setField calls when value is default

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgMethodConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgMethodConstructor.kt
@@ -323,6 +323,7 @@ open class CgMethodConstructor(val context: CgContext) : CgContextOwner by conte
                         } else {
                             this.resultModel = resultModel
                             val expected = variableConstructor.getOrCreateVariable(resultModel, "expected")
+                            emptyLineIfNeeded()
                             assertEquality(expected, actual)
                         }
                     }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgVariableConstructor.kt
@@ -175,16 +175,13 @@ open class CgVariableConstructor(val context: CgContext) :
 
         for ((fieldId, fieldModel) in model.fields) {
             val variableForField = getOrCreateVariable(fieldModel)
-            setFieldValue(obj, fieldId, variableForField)
+            if (!variableForField.hasDefaultValue())
+                setFieldValue(obj, fieldId, variableForField)
         }
         return obj
     }
 
     fun setFieldValue(obj: CgValue, fieldId: FieldId, valueForField: CgValue) {
-        if (valueForField.hasDefaultValue()) {
-            return
-        }
-
         val field = fieldId.jField
         val fieldFromVariableSpecifiedType = obj.type.findFieldByIdOrNull(fieldId)
 


### PR DESCRIPTION
## Description

Our code generation created some useless statements to set field values to null, 0, false, that are default values of type. This PR removes such statements

## How to test

### Manual tests

Generate tests for `spring-boot-testing` project, `OrderController` class. Test size is about ten lines smaller.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.