### PR TITLE
Make Spring Java fuzzer fallback to `null` value when nothing else works

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
@@ -43,6 +43,7 @@ import org.utbot.framework.util.graph
 import org.utbot.framework.util.sootMethod
 import org.utbot.fuzzer.*
 import org.utbot.fuzzing.*
+import org.utbot.fuzzing.providers.AnyDepthNullValueProvider
 import org.utbot.fuzzing.utils.Trie
 import org.utbot.instrumentation.ConcreteExecutor
 import org.utbot.instrumentation.instrumentation.Instrumentation
@@ -392,6 +393,7 @@ class UtBotSymbolicEngine(
             emit(UtError(e.message ?: "Failed to create ValueProvider", e))
             return@flow
         }.let(transform)
+            .withFallback(AnyDepthNullValueProvider)
 
         val coverageToMinStateBeforeSize = mutableMapOf<Trie.Node<Instruction>, Int>()
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
@@ -43,7 +43,6 @@ import org.utbot.framework.util.graph
 import org.utbot.framework.util.sootMethod
 import org.utbot.fuzzer.*
 import org.utbot.fuzzing.*
-import org.utbot.fuzzing.providers.AnyDepthNullValueProvider
 import org.utbot.fuzzing.utils.Trie
 import org.utbot.instrumentation.ConcreteExecutor
 import org.utbot.instrumentation.instrumentation.Instrumentation
@@ -393,7 +392,6 @@ class UtBotSymbolicEngine(
             emit(UtError(e.message ?: "Failed to create ValueProvider", e))
             return@flow
         }.let(transform)
-            .withFallback(AnyDepthNullValueProvider)
 
         val coverageToMinStateBeforeSize = mutableMapOf<Trie.Node<Instruction>, Int>()
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringIntegrationTestConcreteExecutionContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringIntegrationTestConcreteExecutionContext.kt
@@ -15,6 +15,7 @@ import org.utbot.framework.plugin.api.util.utContext
 import org.utbot.fuzzer.IdentityPreservingIdGenerator
 import org.utbot.fuzzing.JavaValueProvider
 import org.utbot.fuzzing.ValueProvider
+import org.utbot.fuzzing.providers.AnyDepthNullValueProvider
 import org.utbot.fuzzing.providers.FieldValueProvider
 import org.utbot.fuzzing.providers.ObjectValueProvider
 import org.utbot.fuzzing.providers.anyObjectValueProvider
@@ -93,6 +94,7 @@ class SpringIntegrationTestConcreteExecutionContext(
             .with(springBeanValueProvider)
             .with(createSavedEntityValueProviders(relevantRepositories, idGenerator))
             .with(createFieldValueProviders(relevantRepositories, idGenerator))
+            .withFallback(AnyDepthNullValueProvider)
     }
 
     private fun createSavedEntityValueProviders(

--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Objects.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Objects.kt
@@ -133,6 +133,21 @@ object NullValueProvider : ValueProvider<FuzzedType, FuzzedValue, FuzzedDescript
 }
 
 /**
+ * Unlike [NullValueProvider] can generate `null` values at any depth.
+ *
+ * Intended to be used as a last fallback.
+ */
+object AnyDepthNullValueProvider : ValueProvider<FuzzedType, FuzzedValue, FuzzedDescription> {
+
+    override fun accept(type: FuzzedType) = type.classId.isRefType
+
+    override fun generate(
+        description: FuzzedDescription,
+        type: FuzzedType
+    ) = sequenceOf<Seed<FuzzedType, FuzzedValue>>(Seed.Simple(nullFuzzedValue(classClassId)))
+}
+
+/**
  * Finds and create object from implementations of abstract classes or interfaces.
  */
 class AbstractsObjectValueProvider(


### PR DESCRIPTION
## Description

Allow Spring Java fuzzer use `null` value at any depth for types it can't instantiate otherwise.

Makes #2428 no longer relevant for Spring Java fuzzer.

## How to test

### Manual tests

Generate tests for `methodUnderTest` with `Fuzzing 100%`

```java
public class VoidHolder {
    public VoidHolder(Void voidInstance) {}

    public void methodUnderTest() {}
}
```

One test should generate that uses `null` value for `java.lang.Void` (type that can't be directly instantiated otherwise).

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.