### PR TITLE
Make `SpringTypeReplacer` actually call its delegate

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringTypeReplacer.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringTypeReplacer.kt
@@ -13,14 +13,13 @@ class SpringTypeReplacer(
     private val springApplicationContext: SpringApplicationContext
 ) : TypeReplacer {
     override val typeReplacementMode: TypeReplacementMode =
-        // TODO add ` || delegateTypeReplacer.typeReplacementMode == TypeReplacementMode.KnownImplementor`
-        //  (TODO is added as a part of only equivalent transformations refactoring PR and should be completed in the follow up PR)
-        if (springApplicationContext.beanDefinitions.isNotEmpty()) TypeReplacementMode.KnownImplementor
-        else TypeReplacementMode.NoImplementors
+        if (springApplicationContext.beanDefinitions.isNotEmpty() ||
+            delegateTypeReplacer.typeReplacementMode == TypeReplacementMode.KnownImplementor)
+            TypeReplacementMode.KnownImplementor
+        else
+            TypeReplacementMode.NoImplementors
 
     override fun replaceTypeIfNeeded(type: RefType): ClassId? =
-        // TODO add `delegateTypeReplacer.replaceTypeIfNeeded(type) ?: `
-        //  (TODO is added as a part of only equivalent transformations refactoring PR and should be completed in the follow up PR)
         if (type.isAbstractType) springApplicationContext.injectedTypes.singleOrNull { it.isSubtypeOf(type.id) }
-        else null
+        else delegateTypeReplacer.replaceTypeIfNeeded(type)
 }


### PR DESCRIPTION
## Description

Make `SpringTypeReplacer` call its delegates, so default non-Spring-specific type replacements are still used in Spring projects.

## How to test

### Manual tests

Generate unit tests (with and without configuration) on different Spring projects.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.