### PR TITLE
Avoid collecting useless models in SpringTestClassModelBuilder

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/builders/SpringTestClassModelBuilder.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/builders/SpringTestClassModelBuilder.kt
@@ -110,10 +110,8 @@ class SpringTestClassModelBuilder(val context: CgContext):
             is UtPrimitiveModel,
             is UtClassRefModel,
             is UtVoidModel,
-            is UtEnumConstantModel -> {}
-            is UtCustomModel -> currentModel.origin?.let {
-                collectRecursively(it.wrap(currentModelWrapper.modelTagName), allModels)
-            }
+            is UtEnumConstantModel,
+            is UtCustomModel-> {}
             is UtLambdaModel -> {
                 currentModel.capturedValues.forEach { collectRecursively(it.wrap(), allModels) }
             }
@@ -134,8 +132,6 @@ class SpringTestClassModelBuilder(val context: CgContext):
                 }
             }
             is UtAssembleModel -> {
-                currentModel.origin?.let { collectRecursively(it.wrap(), allModels) }
-
                 currentModel.instantiationCall.instance?.let { collectRecursively(it.wrap(), allModels) }
                 currentModel.instantiationCall.params.forEach { collectRecursively(it.wrap(), allModels) }
 


### PR DESCRIPTION
## Description

When we implemented models traverser in February, we collected some of them just "to have". Now we realised that it is useless.

## How to test

### Automated tests

Standard Spring tests pipeline

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.