### PR TITLE
Support autowiring collections in Spring Unit tests

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -399,6 +399,18 @@ fun UtModel.hasDefaultValue() =
 fun UtModel.isMockModel() = this is UtCompositeModel && isMock
 
 /**
+ * Checks that this [UtModel] must be constructed with @Spy annotation in generated tests.
+ * Used only for construct variables with @Spy annotation.
+ */
+fun UtModel.canBeSpied(): Boolean {
+    val javaClass = this.classId.jClass
+
+    return this is UtAssembleModel &&
+            (Collection::class.java.isAssignableFrom(javaClass)
+                    || Map::class.java.isAssignableFrom(javaClass))
+}
+
+/**
  * Get model id (symbolic null value for UtNullModel)
  * or null if model has no id (e.g., a primitive model) or the id is null.
  */

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
@@ -757,12 +757,9 @@ object SpringBoot : DependencyInjectionFramework(
  *
  * Used as a key in [valueByUtModelWrapper].
  * Was introduced primarily for shared among all test methods global variables.
- *
- * `modelTagName` is used to distinguish between variables with annotation @Mock that have the same model
  */
 data class UtModelWrapper(
     val testSetId: Int,
     val executionId: Int,
     val model: UtModel,
-    val modelTagName: String?
 )

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/builtin/MockitoBuiltins.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/builtin/MockitoBuiltins.kt
@@ -25,6 +25,11 @@ internal val mockClassId = BuiltinClassId(
     simpleName = "Mock",
 )
 
+internal val spyClassId = BuiltinClassId(
+    canonicalName = "org.mockito.Spy",
+    simpleName = "Spy"
+)
+
 internal val injectMocksClassId = BuiltinClassId(
     canonicalName = "org.mockito.InjectMocks",
     simpleName = "InjectMocks",

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/builtin/UtilMethodBuiltins.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/builtin/UtilMethodBuiltins.kt
@@ -318,6 +318,26 @@ val closeMethodId = MethodId(
     parameters = emptyList(),
 )
 
+private val clearCollectionMethodId = MethodId(
+    classId = Collection::class.java.id,
+    name = "clear",
+    returnType = voidClassId,
+    parameters = emptyList()
+)
+
+private val clearMapMethodId = MethodId(
+    classId = Map::class.java.id,
+    name = "clear",
+    returnType = voidClassId,
+    parameters = emptyList()
+)
+
+fun clearMethodId(javaClass: Class<*>): MethodId = when {
+    Collection::class.java.isAssignableFrom(javaClass) -> clearCollectionMethodId
+    Map::class.java.isAssignableFrom(javaClass) -> clearMapMethodId
+    else -> error("Clear method is not implemented for $javaClass")
+}
+
 val mocksAutoCloseable: Set<ClassId> = setOf(
     MockitoStaticMocking.mockedStaticClassId,
     MockitoStaticMocking.mockedConstructionClassId

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/context/CgContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/context/CgContext.kt
@@ -457,12 +457,11 @@ interface CgContextOwner {
     val getLambdaMethod: MethodId
         get() = utilMethodProvider.getLambdaMethodMethodId
 
-    fun UtModel.wrap(modelTagName: String? = null): UtModelWrapper =
+    fun UtModel.wrap(): UtModelWrapper =
         UtModelWrapper(
             testSetId = currentTestSetId,
             executionId = currentExecutionId,
             model = this,
-            modelTagName = modelTagName
         )
 }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/TestClassModel.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/TestClassModel.kt
@@ -33,5 +33,6 @@ class SpringTestClassModel(
 class SpringSpecificInformation(
     val thisInstanceModels: TypedModelWrappers,
     val thisInstanceDependentMocks: TypedModelWrappers,
+    val thisInstanceDependentSpies: TypedModelWrappers,
     val autowiredFromContextModels: TypedModelWrappers,
 )

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/builders/SpringTestClassModelBuilder.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/builders/SpringTestClassModelBuilder.kt
@@ -74,7 +74,7 @@ class SpringTestClassModelBuilder(val context: CgContext) :
         val dependentSpyModels =
             thisInstancesDependentModels
                 .filterTo(mutableSetOf()) { cgModel ->
-                    cgModel.model.canBeSpied() && cgModel !in thisInstanceModels
+                    cgModel.model.canBeSpied() && cgModel !in thisInstanceModels && cgModel !in dependentMockModels
                 }
 
         val autowiredFromContextModels =

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/SpyFrameworkManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/SpyFrameworkManager.kt
@@ -1,14 +1,12 @@
 package org.utbot.framework.codegen.services.framework
 
 import org.utbot.framework.codegen.domain.context.CgContext
-import org.utbot.framework.codegen.domain.models.CgVariable
 import org.utbot.framework.plugin.api.UtAssembleModel
 
 class SpyFrameworkManager(context: CgContext) : CgVariableConstructorComponent(context) {
 
-    fun spyForVariable(model: UtAssembleModel, variable: CgVariable): CgVariable{
+    fun spyForVariable(model: UtAssembleModel){
         variableConstructor.constructAssembleForVariable(model)
-        return variable
     }
 
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/SpyFrameworkManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/SpyFrameworkManager.kt
@@ -1,0 +1,14 @@
+package org.utbot.framework.codegen.services.framework
+
+import org.utbot.framework.codegen.domain.context.CgContext
+import org.utbot.framework.codegen.domain.models.CgVariable
+import org.utbot.framework.plugin.api.UtAssembleModel
+
+class SpyFrameworkManager(context: CgContext) : CgVariableConstructorComponent(context) {
+
+    fun spyForVariable(model: UtAssembleModel, variable: CgVariable): CgVariable{
+        variableConstructor.constructAssembleForVariable(model)
+        return variable
+    }
+
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgAbstractSpringTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgAbstractSpringTestClassConstructor.kt
@@ -110,10 +110,10 @@ abstract class CgAbstractSpringTestClassConstructor(context: CgContext) :
             val modelWrapper = modelWrappers.firstOrNull() ?: continue
             val model = modelWrapper.model
 
-            val baseVarName = model.getBeanNameOrNull()
+            val baseVarName = fieldManager.getBaseVarName(model)
 
             val createdVariable = variableConstructor.getOrCreateVariable(model, baseVarName) as? CgVariable
-                ?: error("`UtCompositeModel` model was expected, but $model was found")
+                ?: error("`UtCompositeModel` or `UtAssembleModel` model was expected, but $model was found")
 
             val declaration = CgDeclaration(classId, variableName = createdVariable.name, initializer = null)
 
@@ -126,17 +126,10 @@ abstract class CgAbstractSpringTestClassConstructor(context: CgContext) :
             modelWrappers
                 .forEach { modelWrapper ->
 
-                    val modelWrapperWithNullTagName = UtModelWrapper(
-                        testSetId = modelWrapper.testSetId,
-                        executionId = modelWrapper.executionId,
-                        model = modelWrapper.model,
-                        modelTagName = null,
-                    )
-
-                    valueByUtModelWrapper[modelWrapperWithNullTagName] = createdVariable
+                    valueByUtModelWrapper[modelWrapper] = createdVariable
 
                     variableConstructor.annotatedModelGroups
-                        .getOrPut(annotationClassId) { mutableSetOf() } += modelWrapperWithNullTagName
+                        .getOrPut(annotationClassId) { mutableSetOf() } += modelWrapper
                 }
         }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgAbstractSpringTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgAbstractSpringTestClassConstructor.kt
@@ -108,10 +108,10 @@ abstract class CgAbstractSpringTestClassConstructor(context: CgContext) :
                 continue
             }
 
-            val baseVarName = fieldManager.getBaseVarName(model)
+            val baseVarName = fieldManager.constructBaseVarName(model)
 
             val createdVariable = variableConstructor.getOrCreateVariable(model, baseVarName) as? CgVariable
-                ?: error("`UtCompositeModel` or `UtAssembleModel` model was expected, but $model was found")
+                ?: error("`CgVariable` cannot be constructed from a $model model")
 
             val declaration = CgDeclaration(classId, variableName = createdVariable.name, initializer = null)
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgAbstractSpringTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgAbstractSpringTestClassConstructor.kt
@@ -1,6 +1,5 @@
 package org.utbot.framework.codegen.tree
 
-import org.utbot.framework.codegen.domain.UtModelWrapper
 import org.utbot.framework.codegen.domain.builtin.TestClassUtilMethodProvider
 import org.utbot.framework.codegen.domain.context.CgContext
 import org.utbot.framework.codegen.domain.models.AnnotationTarget.*
@@ -19,7 +18,6 @@ import org.utbot.framework.codegen.domain.models.SpringTestClassModel
 import org.utbot.framework.codegen.domain.models.builders.TypedModelWrappers
 import org.utbot.framework.plugin.api.UtExecution
 import org.utbot.framework.plugin.api.UtSpringContextModel
-import org.utbot.framework.plugin.api.util.SpringModelUtils.getBeanNameOrNull
 import org.utbot.framework.plugin.api.util.id
 import java.lang.Exception
 
@@ -102,13 +100,13 @@ abstract class CgAbstractSpringTestClassConstructor(context: CgContext) :
         val constructedDeclarations = mutableListOf<CgFieldDeclaration>()
         for ((classId, modelWrappers) in groupedModelsByClassId) {
 
-            val fieldWithAnnotationIsRequired = fieldManager.fieldWithAnnotationIsRequired(modelWrappers)
+            val modelWrapper = modelWrappers.firstOrNull() ?: continue
+            val model = modelWrapper.model
+
+            val fieldWithAnnotationIsRequired = fieldManager.fieldWithAnnotationIsRequired(model.classId)
             if (!fieldWithAnnotationIsRequired) {
                 continue
             }
-
-            val modelWrapper = modelWrappers.firstOrNull() ?: continue
-            val model = modelWrapper.model
 
             val baseVarName = fieldManager.getBaseVarName(model)
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgClassFieldManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgClassFieldManager.kt
@@ -43,9 +43,6 @@ abstract class CgClassFieldManagerImpl(context: CgContext) :
 
     private val nameGenerator = CgComponents.getNameGeneratorBy(context)
 
-    val mockFrameworkManager = CgComponents.getMockFrameworkManagerBy(context)
-    val spyFrameworkManager = SpyFrameworkManager(context)
-
     fun findCgValueByModel(model: UtModel, setOfModels: Set<UtModelWrapper>?): CgValue? {
         val key = setOfModels?.find { it == model.wrap() } ?: return null
         return valueByUtModelWrapper[key]
@@ -58,6 +55,10 @@ abstract class CgClassFieldManagerImpl(context: CgContext) :
 
 abstract class CgUnitTestsClassFieldManager(context: CgContext) : CgClassFieldManagerImpl(context){
 
+    /*
+     * If count of fields of the same type is 1, then we mock/spy variable by @Mock/@Spy annotation,
+     * otherwise we will create this variable by simple variable constructor.
+     */
     override fun fieldWithAnnotationIsRequired(classId: ClassId) =
         classUnderTest.allDeclaredFieldIds.filter { classId.isSubtypeOf(it.type) }.toList().size == 1
 }
@@ -98,6 +99,8 @@ class CgInjectingMocksFieldsManager(val context: CgContext) : CgClassFieldManage
 
 class CgMockedFieldsManager(context: CgContext) : CgUnitTestsClassFieldManager(context) {
 
+    private val mockFrameworkManager = CgComponents.getMockFrameworkManagerBy(context)
+
     override val annotationType = mockClassId
 
     override fun constructVariableForField(model: UtModel, modelVariable: CgValue) {
@@ -118,6 +121,9 @@ class CgMockedFieldsManager(context: CgContext) : CgUnitTestsClassFieldManager(c
 }
 
 class CgSpiedFieldsManager(context: CgContext) : CgUnitTestsClassFieldManager(context) {
+
+    private val spyFrameworkManager = SpyFrameworkManager(context)
+
     override val annotationType = spyClassId
 
     override fun constructVariableForField(model: UtModel, modelVariable: CgValue) {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringUnitTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringUnitTestClassConstructor.kt
@@ -4,6 +4,7 @@ import org.utbot.framework.codegen.domain.builtin.closeMethodId
 import org.utbot.framework.codegen.domain.builtin.injectMocksClassId
 import org.utbot.framework.codegen.domain.builtin.mockClassId
 import org.utbot.framework.codegen.domain.builtin.openMocksMethodId
+import org.utbot.framework.codegen.domain.builtin.clearMethodId
 import org.utbot.framework.codegen.domain.context.CgContext
 import org.utbot.framework.codegen.domain.models.CgAssignment
 import org.utbot.framework.codegen.domain.models.CgDeclaration
@@ -17,30 +18,38 @@ import org.utbot.framework.codegen.domain.models.CgVariable
 import org.utbot.framework.codegen.domain.models.SpringTestClassModel
 import org.utbot.framework.plugin.api.UtCompositeModel
 import org.utbot.framework.plugin.api.util.id
+import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.framework.plugin.api.util.objectClassId
 
 class CgSpringUnitTestClassConstructor(context: CgContext) : CgAbstractSpringTestClassConstructor(context) {
 
     private var additionalMethodsRequired: Boolean = false
     private lateinit var mockitoCloseableVariable: CgValue
+    private lateinit var spyClearVariables: List<CgValue>
 
     private val injectingMocksFieldsManager = CgInjectingMocksFieldsManager(context)
     private val mocksFieldsManager = CgMockedFieldsManager(context)
+    private val spiesFieldsManager = CgSpiedFieldsManager(context)
 
     override fun constructClassFields(testClassModel: SpringTestClassModel): List<CgFieldDeclaration> {
         val fields = mutableListOf<CgFieldDeclaration>()
         val thisInstances = testClassModel.springSpecificInformation.thisInstanceModels
         val mocks = testClassModel.springSpecificInformation.thisInstanceDependentMocks
+        val spies = testClassModel.springSpecificInformation.thisInstanceDependentSpies
 
-        if (mocks.isNotEmpty()) {
-            val mockedFields = constructFieldsWithAnnotation(mocksFieldsManager, mocks)
+        val spiesFields = constructFieldsWithAnnotation(spiesFieldsManager, spies)
+        val mockedFields = constructFieldsWithAnnotation(mocksFieldsManager, mocks)
+
+        if ((spiesFields + mockedFields).isNotEmpty()) {
             val injectingMocksFields = constructFieldsWithAnnotation(injectingMocksFieldsManager, thisInstances)
 
             fields += injectingMocksFields
             fields += mockedFields
+            fields += spiesFields
             fields += constructMockitoCloseables()
 
             additionalMethodsRequired = true
+            spyClearVariables = spiesFields.map { it.declaration.variable }
         }
 
         return fields
@@ -64,13 +73,22 @@ class CgSpringUnitTestClassConstructor(context: CgContext) : CgAbstractSpringTes
             arguments = emptyList(),
         )
 
+        val clearSpyModelCalls = spyClearVariables.map { spyVariable ->
+            CgMethodCall(
+                caller = spyVariable,
+                executableId = clearMethodId(spyVariable.type.jClass),
+                arguments = emptyList()
+            )
+        }
+
         val openMocksStatement = CgAssignment(mockitoCloseableVariable, openMocksCall)
         val closeStatement = CgStatementExecutableCall(closeCall)
+        val clearSpyModels = clearSpyModelCalls.map { CgStatementExecutableCall(it) }
 
         return CgMethodsCluster.withoutDocs(
             listOf(
                 constructBeforeMethod(listOf(openMocksStatement)),
-                constructAfterMethod(listOf(closeStatement)),
+                constructAfterMethod(clearSpyModels + listOf(closeStatement)),
             )
         )
     }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgVariableConstructor.kt
@@ -74,7 +74,7 @@ open class CgVariableConstructor(val context: CgContext) :
     }
 
     private val nameGenerator = getNameGeneratorBy(context)
-    val mockFrameworkManager = getMockFrameworkManagerBy(context)
+    private val mockFrameworkManager = getMockFrameworkManagerBy(context)
 
     /**
      * Take already created CgValue or construct either a new [CgVariable] or new [CgLiteral] for the given model.


### PR DESCRIPTION
## Description

Fixes #2436

Add supporting autowiring collections by `Spy` annotation in Spring Unit tests.

#### The class under test:

```java
@Service
public class OrderService {

    @Autowired
    private List<Person> lst;

    public Boolean checkLst() {
        return !lst.get(0).getName().equals("ABC");
    }

}
```


#### Generated test:

```java
public final class OrderServiceTest {
    @InjectMocks
    private OrderService orderService;

    @Spy
    private ArrayList lstSpy;

    public void testCheckLst_NotLstGet0GetNameEquals_1() {
        Person personMock1 = mock(Person.class);
        String string1 = "ABC";
        (when(personMock1.getName())).thenReturn(string1);
        lstSpy.add(personMock1);

        Boolean actual = orderService.checkLst();

        Boolean expected = false;

        assertEquals(expected, actual);
    }
...
}
```

## How to test

### Manual tests

Manual tested cases:
- List
- Map
- Set
- Two and more collections of one type
- Two and more collections of different type

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.