### PR TITLE
Block parent classloader for instrumentation process

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineProcessMain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/process/EngineProcessMain.kt
@@ -74,9 +74,10 @@ private var idCounter: Long = 0
 private fun EngineProcessModel.setup(kryoHelper: KryoHelper, watchdog: IdleWatchdog, realProtocol: IProtocol) {
     val model = this
     watchdog.measureTimeForActiveCall(setupUtContext, "UtContext setup") { params ->
+        // we use parent classloader with null to disable autoload classes from system classloader
         UtContext.setUtContext(UtContext(URLClassLoader(params.classpathForUrlsClassloader.map {
             File(it).toURI().toURL()
-        }.toTypedArray())))
+        }.toTypedArray(), null)))
     }
     watchdog.measureTimeForActiveCall(getSpringBeanDefinitions, "Getting Spring bean definitions") { params ->
         try {


### PR DESCRIPTION
## Description

Fixes #2477

If parent classloader is set to system classloader (that is used by default), that it loads classes it can find itself before. In case of guava, it finds guava 30.0 as it is a part of plugin for IDE. Therefore, any method that is added in latter versions cannot be found by an engine process.

## How to test

### Manual tests

Try to generate tests for the method from the issue.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.