### PR TITLE
Close Spring transaction in the same thread that opened it even on timeout

### DIFF
--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/context/InstrumentationContext.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/context/InstrumentationContext.kt
@@ -36,13 +36,11 @@ interface InstrumentationContext {
     fun findUtModelWithCompositeOriginConstructor(classId: ClassId): UtModelWithCompositeOriginConstructor?
 
     /**
-     * Called when [failedPhase] fails while being executed under timeout.
-     * This method is executed in the same thread that [failedPhase] was run in.
-     * Implementor are expected to only perform some clean up operations (e.g. rollback transactions in Spring).
-     *
-     * In case of timeout [throwable] can be [ThreadDeath], [InterruptedException], or any other [Throwable].
+     * Called when [timedOutedPhase] times out.
+     * This method is executed in the same thread that [timedOutedPhase] was run in.
+     * Implementor is expected to only perform some clean up operations (e.g. rollback transactions in Spring).
      */
-    fun onPhaseUnderTimeoutFailure(failedPhase: ExecutionPhase, throwable: Throwable)
+    fun onPhaseTimeout(timedOutedPhase: ExecutionPhase)
 
     object MockGetter {
         data class MockContainer(private val values: List<*>) {

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/context/InstrumentationContext.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/context/InstrumentationContext.kt
@@ -4,6 +4,7 @@ import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.UtConcreteValue
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.instrumentation.instrumentation.execution.constructors.UtModelWithCompositeOriginConstructor
+import org.utbot.instrumentation.instrumentation.execution.phases.ExecutionPhase
 import java.lang.reflect.Method
 import java.util.IdentityHashMap
 import org.utbot.instrumentation.instrumentation.mock.computeKeyForMethod
@@ -33,6 +34,15 @@ interface InstrumentationContext {
      * construct models for instances of specified [class][classId].
      */
     fun findUtModelWithCompositeOriginConstructor(classId: ClassId): UtModelWithCompositeOriginConstructor?
+
+    /**
+     * Called when [failedPhase] fails while being executed under timeout.
+     * This method is executed in the same thread that [failedPhase] was run in.
+     * Implementor are expected to only perform some clean up operations (e.g. rollback transactions in Spring).
+     *
+     * In case of timeout [throwable] can be [ThreadDeath], [InterruptedException], or any other [Throwable].
+     */
+    fun onPhaseUnderTimeoutFailure(failedPhase: ExecutionPhase, throwable: Throwable)
 
     object MockGetter {
         data class MockContainer(private val values: List<*>) {

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/context/SimpleInstrumentationContext.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/context/SimpleInstrumentationContext.kt
@@ -6,6 +6,7 @@ import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.instrumentation.instrumentation.execution.constructors.UtModelWithCompositeOriginConstructor
 import org.utbot.instrumentation.instrumentation.execution.constructors.javaStdLibModelWithCompositeOriginConstructors
+import org.utbot.instrumentation.instrumentation.execution.phases.ExecutionPhase
 
 /**
  * Simple instrumentation context, that is used for pure JVM projects without
@@ -21,4 +22,6 @@ class SimpleInstrumentationContext : InstrumentationContext {
 
     override fun findUtModelWithCompositeOriginConstructor(classId: ClassId): UtModelWithCompositeOriginConstructor? =
         javaStdLibModelWithCompositeOriginConstructors[classId.jClass]?.invoke()
+
+    override fun onPhaseUnderTimeoutFailure(failedPhase: ExecutionPhase, throwable: Throwable) = Unit
 }

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/context/SimpleInstrumentationContext.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/context/SimpleInstrumentationContext.kt
@@ -23,5 +23,5 @@ class SimpleInstrumentationContext : InstrumentationContext {
     override fun findUtModelWithCompositeOriginConstructor(classId: ClassId): UtModelWithCompositeOriginConstructor? =
         javaStdLibModelWithCompositeOriginConstructors[classId.jClass]?.invoke()
 
-    override fun onPhaseUnderTimeoutFailure(failedPhase: ExecutionPhase, throwable: Throwable) = Unit
+    override fun onPhaseTimeout(timedOutedPhase: ExecutionPhase) = Unit
 }

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/phases/PhasesController.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/phases/PhasesController.kt
@@ -1,5 +1,7 @@
 package org.utbot.instrumentation.instrumentation.execution.phases
 
+import com.jetbrains.rd.util.error
+import com.jetbrains.rd.util.getLogger
 import org.utbot.common.StopWatch
 import org.utbot.common.ThreadBasedExecutor
 import org.utbot.framework.plugin.api.Coverage
@@ -17,7 +19,7 @@ import org.utbot.instrumentation.instrumentation.execution.context.Instrumentati
 import java.security.AccessControlException
 
 class PhasesController(
-    instrumentationContext: InstrumentationContext,
+    private val instrumentationContext: InstrumentationContext,
     traceHandler: TraceHandler,
     delegateInstrumentation: Instrumentation<Result<*>>,
     private val timeout: Long
@@ -56,13 +58,27 @@ class PhasesController(
         }
     }
 
+    companion object {
+        private val logger = getLogger<PhasesController>()
+    }
+
     fun <T, R : ExecutionPhase> executePhaseInTimeout(phase: R, block: R.() -> T): T = phase.start {
         val stopWatch = StopWatch()
         val context = UtContext(utContext.classLoader, stopWatch)
         val timeoutForCurrentPhase = timeout - currentlyElapsed
         val result = ThreadBasedExecutor.threadLocal.invokeWithTimeout(timeout - currentlyElapsed, stopWatch) {
             withUtContext(context) {
-                phase.block()
+                try {
+                    phase.block()
+                } catch (outerThrowable: Throwable) {
+                    try {
+                        instrumentationContext.onPhaseUnderTimeoutFailure(phase, outerThrowable)
+                    } catch (innerThrowable: Throwable) {
+                        logger.error("onPhaseUnderTimeoutFailure failed", innerThrowable)
+                    } finally {
+                        throw outerThrowable
+                    }
+                }
             }
         } ?: throw TimeoutException("Timeout $timeoutForCurrentPhase ms for phase ${phase.javaClass.simpleName} elapsed, controller timeout - $timeout")
 

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/spring/SpringInstrumentationContext.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/spring/SpringInstrumentationContext.kt
@@ -54,6 +54,6 @@ class SpringInstrumentationContext(
         if (classId.isSubtypeOf(resultActionsClassId)) UtMockMvcResultActionsModelConstructor()
         else delegateInstrumentationContext.findUtModelWithCompositeOriginConstructor(classId)
 
-    override fun onPhaseUnderTimeoutFailure(failedPhase: ExecutionPhase, throwable: Throwable) =
+    override fun onPhaseTimeout(timedOutedPhase: ExecutionPhase) =
         springApi.afterTestMethod()
 }

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/spring/SpringInstrumentationContext.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/spring/SpringInstrumentationContext.kt
@@ -11,6 +11,7 @@ import org.utbot.framework.plugin.api.util.isSubtypeOf
 import org.utbot.framework.plugin.api.util.utContext
 import org.utbot.instrumentation.instrumentation.execution.constructors.UtModelWithCompositeOriginConstructor
 import org.utbot.instrumentation.instrumentation.execution.context.InstrumentationContext
+import org.utbot.instrumentation.instrumentation.execution.phases.ExecutionPhase
 import org.utbot.spring.api.SpringApi
 import org.utbot.spring.api.provider.SpringApiProviderFacade
 import org.utbot.spring.api.provider.InstantiationSettings
@@ -52,4 +53,7 @@ class SpringInstrumentationContext(
     override fun findUtModelWithCompositeOriginConstructor(classId: ClassId): UtModelWithCompositeOriginConstructor? =
         if (classId.isSubtypeOf(resultActionsClassId)) UtMockMvcResultActionsModelConstructor()
         else delegateInstrumentationContext.findUtModelWithCompositeOriginConstructor(classId)
+
+    override fun onPhaseUnderTimeoutFailure(failedPhase: ExecutionPhase, throwable: Throwable) =
+        springApi.afterTestMethod()
 }

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/spring/SpringUtExecutionInstrumentation.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/spring/SpringUtExecutionInstrumentation.kt
@@ -65,7 +65,7 @@ class SpringUtExecutionInstrumentation(
         arguments: ArgumentList,
         parameters: Any?,
         phasesWrapper: PhasesController.(invokeBasePhases: () -> UtConcreteExecutionResult) -> UtConcreteExecutionResult
-    ): UtConcreteExecutionResult {
+    ): UtConcreteExecutionResult = synchronized(this) {
         getRelevantBeans(clazz).forEach { beanName -> springApi.resetBean(beanName) }
         return delegateInstrumentation.invoke(clazz, methodSignature, arguments, parameters) { invokeBasePhases ->
             phasesWrapper {

--- a/utbot-spring-commons/src/main/kotlin/org/utbot/spring/SpringApiImpl.kt
+++ b/utbot-spring-commons/src/main/kotlin/org/utbot/spring/SpringApiImpl.kt
@@ -152,6 +152,10 @@ class SpringApiImpl(
     }
 
     override fun afterTestMethod() {
+        if (!isInsideTestMethod) {
+            logger.warn { "afterTestMethod() was probably called twice, ignoring second call" }
+            return
+        }
         testContextManager.afterTestExecution(dummyTestClassInstance, dummyTestMethod, null)
         testContextManager.afterTestMethod(dummyTestClassInstance, dummyTestMethod, null)
         isInsideTestMethod = false


### PR DESCRIPTION
## Description

Fixes #2480 

## How to test

### Manual tests

#2480 should no longer reproduce.

**Note**: #2480 was fluky, so it should be manually tested multiple times with low values of (`Hanging test timeout` set in IDE settings) as well on methods that for some inputs take multiple seconds to run (including methods that explicitly call blocking methods like `Thread.sleep()` and methods that do some non-blocking work, e.g. enter infinite loop).

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.