### PR TITLE
Improve the safety of typeCast method

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/ConstructorUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/ConstructorUtils.kt
@@ -16,6 +16,7 @@ import org.utbot.framework.codegen.domain.models.CgVariable
 import org.utbot.framework.codegen.services.access.CgCallableAccessManager
 import org.utbot.framework.codegen.util.at
 import org.utbot.framework.codegen.util.isAccessibleFrom
+import org.utbot.framework.codegen.util.nullLiteral
 import org.utbot.framework.fields.ArrayElementAccess
 import org.utbot.framework.fields.FieldAccess
 import org.utbot.framework.fields.FieldPath
@@ -44,6 +45,7 @@ import org.utbot.framework.plugin.api.util.executableId
 import org.utbot.framework.plugin.api.util.floatClassId
 import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.intClassId
+import org.utbot.framework.plugin.api.util.isAbstract
 import org.utbot.framework.plugin.api.util.isRefType
 import org.utbot.framework.plugin.api.util.isStatic
 import org.utbot.framework.plugin.api.util.isSubtypeOf
@@ -287,6 +289,13 @@ internal fun CgContextOwner.typeCast(
     isSafetyCast: Boolean = false
 ): CgExpression {
     val denotableTargetType = targetType.denotableType
+
+    // Casting null expressions to the abstract types leads to a compilation error.
+    // It may happen sometimes because of generic processing troubles: see issue 2420.
+    if (denotableTargetType.isAbstract && expression == nullLiteral()) {
+        return expression
+    }
+
     importIfNeeded(denotableTargetType)
     return CgTypeCast(denotableTargetType, expression, isSafetyCast)
 }


### PR DESCRIPTION
## Description

We avoid casting null values to abstract types because it leads to the compilation errors.
Partially fixes https://github.com/UnitTestBot/UTBotJava/issues/2420

## How to test

Automated tests - standard UTBot pipeline
Manual tests - scenario from the issue

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.