### PR TITLE
Remove upper limit for night monitoring due to OutOfMemoryError

### DIFF
--- a/.github/workflows/collect-statistics.yml
+++ b/.github/workflows/collect-statistics.yml
@@ -197,7 +197,6 @@ jobs:
               --add-opens java.base/jdk.internal.vm=ALL-UNNAMED \
               --add-opens java.base/jdk.internal.vm.annotation=ALL-UNNAMED \
               -Dutbot.monitoring.settings.path=$monitoring_projects/${{ matrix.project }}/monitoring.properties \
-              -Xmx512M \
               utbot-junit-contest/build/libs/monitoring.jar \
               stats-$i.json
             mv logs/utbot.log logs/utbot-$i.log

--- a/.github/workflows/collect-statistics.yml
+++ b/.github/workflows/collect-statistics.yml
@@ -96,7 +96,8 @@ jobs:
     needs: setup_matrix
     continue-on-error: true
     strategy:
-      max-parallel: 3
+      # temporary commented, remove completely after 10.23 if all pipelines worked well
+      #max-parallel: 3
       matrix:
         project: ${{ fromJson(needs.setup_matrix.outputs.projects) }}
         value: ${{ fromJson(needs.setup_matrix.outputs.matrix) }}

--- a/.github/workflows/collect-statistics.yml
+++ b/.github/workflows/collect-statistics.yml
@@ -125,7 +125,7 @@ jobs:
         run: |
           docker run -d --rm --name busybox --privileged --net=host --pid=host --ipc=host --volume /:/host busybox sleep infinity
           docker exec busybox /bin/sh -c 'chroot /host /bin/bash -c "swapoff /mnt/swapfile"'
-          docker exec busybox /bin/sh -c 'chroot /host /bin/bash -c "dd if=/dev/zero of=/mnt/swapfile bs=1M count=4096 oflag=append conv=notrunc"'
+          docker exec busybox /bin/sh -c 'chroot /host /bin/bash -c "dd if=/dev/zero of=/mnt/swapfile bs=1M count=8192 oflag=append conv=notrunc"'
           docker exec busybox /bin/sh -c 'chroot /host /bin/bash -c "mkswap /mnt/swapfile"'
           docker exec busybox /bin/sh -c 'chroot /host /bin/bash -c "swapon /mnt/swapfile"'
 


### PR DESCRIPTION
## Description

There's a lot of `OutOfMemoryError` in [logs](https://github.com/UnitTestBot/UTBotJava/actions/runs/5815538056/job/15767259488). We added this limit only with the [latest fix](https://github.com/UnitTestBot/UTBotJava/pull/2308), so, it can be removed, I think.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.