### PR TITLE
Make thread stopping in `ThreadBasedExecutor` more safe

### DIFF
--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/phases/PhasesController.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/phases/PhasesController.kt
@@ -72,8 +72,9 @@ class PhasesController(
                 try {
                     phase.block()
                 } finally {
-                    if (executor.isCurrentThreadTimedOut())
+                    executor.runCleanUpIfTimedOut {
                         instrumentationContext.onPhaseTimeout(phase)
+                    }
                 }
             }
         } ?: throw TimeoutException("Timeout $timeoutForCurrentPhase ms for phase ${phase.javaClass.simpleName} elapsed, controller timeout - $timeout")


### PR DESCRIPTION
## Description

Previously `ThreadBasedExecutor`:
- wasn't actually killing timed out threads (`ThreadDeath` was caught by `kotlin.runCatching`)
- wasn't waiting for old `thread` to die before starting a new one, causing race condition
- was able to forcefully `stop()` a thread even during clean up operations, causing `java.lang.IllegalStateException: Cannot start new transaction without ending existing transaction`

## How to test

### Manual tests

Generate integration tests for `OrderService` from `spring-boot-testing` project with low hanging test time out.

![image](https://github.com/UnitTestBot/UTBotJava/assets/71839386/01e22d13-c435-4ec7-a14c-2e0ecbeeeb48)

There should be no `Caused by: java.lang.IllegalStateException: Cannot start new transaction without ending existing transaction`.

Some time out tests should generate.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.