### PR TITLE
Avoid `MissingState` being use as `stateBefore`

### DIFF
--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/SimpleUtExecutionInstrumentation.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/SimpleUtExecutionInstrumentation.kt
@@ -46,7 +46,7 @@ class SimpleUtExecutionInstrumentation(
         methodSignature: String,
         arguments: ArgumentList,
         parameters: Any?,
-        phasesWrapper: PhasesController.(invokeBasePhases: () -> UtConcreteExecutionResult) -> UtConcreteExecutionResult
+        phasesWrapper: PhasesController.(invokeBasePhases: () -> PreliminaryUtConcreteExecutionResult) -> PreliminaryUtConcreteExecutionResult
     ): UtConcreteExecutionResult {
         if (parameters !is UtConcreteExecutionData) {
             throw IllegalArgumentException("Argument parameters must be of type UtConcreteExecutionData, but was: ${parameters?.javaClass}")
@@ -115,8 +115,7 @@ class SimpleUtExecutionInstrumentation(
                         Triple(executionResult, stateAfter, newInstrumentation)
                     }
 
-                    UtConcreteExecutionResult(
-                        parameters.stateBefore,
+                    PreliminaryUtConcreteExecutionResult(
                         stateAfter,
                         executionResult,
                         coverage,
@@ -127,7 +126,7 @@ class SimpleUtExecutionInstrumentation(
                     applyPostprocessing()
                 }
             }
-        }
+        }.toCompleteUtConcreteExecutionResult(stateBefore = stateBefore)
     }
 
     override fun getStaticField(fieldId: FieldId): Result<UtModel> =

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/UtExecutionInstrumentation.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/UtExecutionInstrumentation.kt
@@ -22,6 +22,26 @@ data class UtConcreteExecutionData(
     val timeout: Long
 )
 
+/**
+ * [UtConcreteExecutionResult] that has not yet been populated with extra data, e.g.:
+ *  - updated `stateBefore: EnvironmentModels`
+ *  - `detectedMockingCandidates: Set<ExecutableId>` (not yet implemented, see #2321)
+ */
+data class PreliminaryUtConcreteExecutionResult(
+    val stateAfter: EnvironmentModels,
+    val result: UtExecutionResult,
+    val coverage: Coverage,
+    val newInstrumentation: List<UtInstrumentation>? = null,
+) {
+    fun toCompleteUtConcreteExecutionResult(stateBefore: EnvironmentModels) = UtConcreteExecutionResult(
+        stateBefore,
+        stateAfter,
+        result,
+        coverage,
+        newInstrumentation,
+    )
+}
+
 data class UtConcreteExecutionResult(
     val stateBefore: EnvironmentModels,
     val stateAfter: EnvironmentModels,
@@ -31,6 +51,7 @@ data class UtConcreteExecutionResult(
 ) {
     override fun toString(): String = buildString {
         appendLine("UtConcreteExecutionResult(")
+        appendLine("stateBefore=$stateBefore")
         appendLine("stateAfter=$stateAfter")
         appendLine("result=$result")
         appendLine("coverage=$coverage)")
@@ -52,7 +73,7 @@ interface UtExecutionInstrumentation : Instrumentation<UtConcreteExecutionResult
         methodSignature: String,
         arguments: ArgumentList,
         parameters: Any?,
-        phasesWrapper: PhasesController.(invokeBasePhases: () -> UtConcreteExecutionResult) -> UtConcreteExecutionResult
+        phasesWrapper: PhasesController.(invokeBasePhases: () -> PreliminaryUtConcreteExecutionResult) -> PreliminaryUtConcreteExecutionResult
     ): UtConcreteExecutionResult
 
     interface Factory<out TInstrumentation : UtExecutionInstrumentation> : Instrumentation.Factory<UtConcreteExecutionResult, TInstrumentation> {

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/phases/ExecutionPhase.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/phases/ExecutionPhase.kt
@@ -2,7 +2,7 @@ package org.utbot.instrumentation.instrumentation.execution.phases
 
 import com.jetbrains.rd.util.getLogger
 import org.utbot.common.measureTime
-import org.utbot.instrumentation.instrumentation.execution.UtConcreteExecutionResult
+import org.utbot.instrumentation.instrumentation.execution.PreliminaryUtConcreteExecutionResult
 import org.utbot.rd.loggers.debug
 
 private val logger = getLogger<ExecutionPhase>()
@@ -13,7 +13,7 @@ abstract class ExecutionPhaseException(override val message: String) : Exception
 class ExecutionPhaseError(phase: String, override val cause: Throwable) : ExecutionPhaseException(phase)
 
 // Execution will be stopped, but considered successful, result will be returned
-class ExecutionPhaseStop(phase: String, val result: UtConcreteExecutionResult) : ExecutionPhaseException(phase)
+class ExecutionPhaseStop(phase: String, val result: PreliminaryUtConcreteExecutionResult) : ExecutionPhaseException(phase)
 
 interface ExecutionPhase {
     fun wrapError(e: Throwable): ExecutionPhaseException

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/phases/InvocationPhase.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/phases/InvocationPhase.kt
@@ -5,7 +5,7 @@ import org.utbot.framework.plugin.api.MissingState
 import org.utbot.framework.plugin.api.TimeoutException
 import org.utbot.framework.plugin.api.UtTimeoutException
 import org.utbot.instrumentation.instrumentation.Instrumentation
-import org.utbot.instrumentation.instrumentation.execution.UtConcreteExecutionResult
+import org.utbot.instrumentation.instrumentation.execution.PreliminaryUtConcreteExecutionResult
 
 
 /**
@@ -20,8 +20,7 @@ class InvocationPhase(
         return when (e) {
             is TimeoutException -> ExecutionPhaseStop(
                 message,
-                UtConcreteExecutionResult(
-                    stateBefore = MissingState,
+                PreliminaryUtConcreteExecutionResult(
                     stateAfter = MissingState,
                     result = UtTimeoutException(e),
                     coverage = Coverage()

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/phases/ModelConstructionPhase.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/phases/ModelConstructionPhase.kt
@@ -7,7 +7,7 @@ import org.utbot.framework.plugin.api.util.jField
 import org.utbot.framework.plugin.api.visible.UtStreamConsumingException
 import org.utbot.instrumentation.instrumentation.et.ExplicitThrowInstruction
 import org.utbot.instrumentation.instrumentation.et.TraceHandler
-import org.utbot.instrumentation.instrumentation.execution.UtConcreteExecutionResult
+import org.utbot.instrumentation.instrumentation.execution.PreliminaryUtConcreteExecutionResult
 import org.utbot.instrumentation.instrumentation.execution.constructors.UtCompositeModelStrategy
 import org.utbot.instrumentation.instrumentation.execution.constructors.UtModelWithCompositeOriginConstructor
 import org.utbot.instrumentation.instrumentation.execution.constructors.UtModelConstructor
@@ -27,8 +27,7 @@ class ModelConstructionPhase(
         return when (e) {
             is TimeoutException -> ExecutionPhaseStop(
                 message,
-                UtConcreteExecutionResult(
-                    stateBefore = MissingState,
+                PreliminaryUtConcreteExecutionResult(
                     stateAfter = MissingState,
                     result = UtTimeoutException(e),
                     coverage = Coverage()

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/phases/PhasesController.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/phases/PhasesController.kt
@@ -12,8 +12,8 @@ import org.utbot.framework.plugin.api.util.utContext
 import org.utbot.framework.plugin.api.util.withUtContext
 import org.utbot.instrumentation.instrumentation.Instrumentation
 import org.utbot.instrumentation.instrumentation.et.TraceHandler
+import org.utbot.instrumentation.instrumentation.execution.PreliminaryUtConcreteExecutionResult
 import org.utbot.instrumentation.instrumentation.execution.UtConcreteExecutionData
-import org.utbot.instrumentation.instrumentation.execution.UtConcreteExecutionResult
 import org.utbot.instrumentation.instrumentation.execution.context.InstrumentationContext
 import java.security.AccessControlException
 
@@ -39,15 +39,14 @@ class PhasesController(
 
     val postprocessingPhase = PostprocessingPhase()
 
-    inline fun computeConcreteExecutionResult(block: PhasesController.() -> UtConcreteExecutionResult): UtConcreteExecutionResult {
+    inline fun computeConcreteExecutionResult(block: PhasesController.() -> PreliminaryUtConcreteExecutionResult): PreliminaryUtConcreteExecutionResult {
         try {
             return this.block()
         } catch (e: ExecutionPhaseStop) {
             return e.result
         } catch (e: ExecutionPhaseError) {
             if (e.cause.cause is AccessControlException) {
-                return UtConcreteExecutionResult(
-                    stateBefore = MissingState,
+                return PreliminaryUtConcreteExecutionResult(
                     stateAfter = MissingState,
                     result = UtSandboxFailure(e.cause.cause!!),
                     coverage = Coverage()

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/phases/StatisticsCollectionPhase.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/phases/StatisticsCollectionPhase.kt
@@ -6,7 +6,7 @@ import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.utContext
 import org.utbot.instrumentation.instrumentation.et.EtInstruction
 import org.utbot.instrumentation.instrumentation.et.TraceHandler
-import org.utbot.instrumentation.instrumentation.execution.UtConcreteExecutionResult
+import org.utbot.instrumentation.instrumentation.execution.PreliminaryUtConcreteExecutionResult
 import org.utbot.instrumentation.instrumentation.execution.ndd.NonDeterministicResultStorage
 import java.util.*
 
@@ -22,8 +22,7 @@ class StatisticsCollectionPhase(
         return when (e) {
             is TimeoutException -> ExecutionPhaseStop(
                 message,
-                UtConcreteExecutionResult(
-                    stateBefore = MissingState,
+                PreliminaryUtConcreteExecutionResult(
                     stateAfter = MissingState,
                     result = UtTimeoutException(e),
                     coverage = Coverage()

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/phases/ValueConstructionPhase.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/phases/ValueConstructionPhase.kt
@@ -5,7 +5,7 @@ import java.util.IdentityHashMap
 import org.utbot.instrumentation.instrumentation.execution.constructors.InstrumentationContextAwareValueConstructor
 import org.utbot.instrumentation.instrumentation.execution.context.InstrumentationContext
 import org.utbot.framework.plugin.api.util.isInaccessibleViaReflection
-import org.utbot.instrumentation.instrumentation.execution.UtConcreteExecutionResult
+import org.utbot.instrumentation.instrumentation.execution.PreliminaryUtConcreteExecutionResult
 
 typealias ConstructedParameters = List<UtConcreteValue<*>>
 typealias ConstructedStatics = Map<FieldId, UtConcreteValue<*>>
@@ -26,8 +26,7 @@ class ValueConstructionPhase(
 
     override fun wrapError(e: Throwable): ExecutionPhaseException = ExecutionPhaseStop(
         phase = this.javaClass.simpleName,
-        result = UtConcreteExecutionResult(
-            stateBefore = MissingState,
+        result = PreliminaryUtConcreteExecutionResult(
             stateAfter = MissingState,
             result = when(e) {
                 is TimeoutException -> UtTimeoutException(e)

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/spring/SpringUtExecutionInstrumentation.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/spring/SpringUtExecutionInstrumentation.kt
@@ -14,6 +14,7 @@ import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.instrumentation.instrumentation.ArgumentList
+import org.utbot.instrumentation.instrumentation.execution.PreliminaryUtConcreteExecutionResult
 import org.utbot.instrumentation.instrumentation.execution.UtConcreteExecutionResult
 import org.utbot.instrumentation.instrumentation.execution.UtExecutionInstrumentation
 import org.utbot.instrumentation.instrumentation.execution.constructors.UtModelConstructor
@@ -64,7 +65,7 @@ class SpringUtExecutionInstrumentation(
         methodSignature: String,
         arguments: ArgumentList,
         parameters: Any?,
-        phasesWrapper: PhasesController.(invokeBasePhases: () -> UtConcreteExecutionResult) -> UtConcreteExecutionResult
+        phasesWrapper: PhasesController.(invokeBasePhases: () -> PreliminaryUtConcreteExecutionResult) -> PreliminaryUtConcreteExecutionResult
     ): UtConcreteExecutionResult = synchronized(this) {
         getRelevantBeans(clazz).forEach { beanName -> springApi.resetBean(beanName) }
         return delegateInstrumentation.invoke(clazz, methodSignature, arguments, parameters) { invokeBasePhases ->


### PR DESCRIPTION
## Description

Makes it so `stateBefore` can't be a `MissingState` even on `ExecutionPhaseStop`.

## How to test

### Manual tests

Tests for timeout should generate correctly.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.