### PR TITLE
Improve `UtModel` construction

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/IdUtil.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/IdUtil.kt
@@ -308,6 +308,7 @@ val mapClassId = java.util.Map::class.id
 val collectionClassId = java.util.Collection::class.id
 
 val listClassId = List::class.id
+val setClassId = Set::class.id
 
 val baseStreamClassId = java.util.stream.BaseStream::class.id
 val streamClassId = java.util.stream.Stream::class.id

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SpringModelUtils.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SpringModelUtils.kt
@@ -257,7 +257,7 @@ object SpringModelUtils {
     )
 
     val resultMatchersViewMethodId = MethodId(
-        classId = contentResultMatchersClassId,
+        classId = mockMvcResultMatchersClassId,
         name = "view",
         parameters = listOf(),
         returnType = viewResultMatchersClassId

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/IterableConstructors.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/IterableConstructors.kt
@@ -7,7 +7,8 @@ import org.utbot.framework.plugin.api.UtAssembleModel
 import org.utbot.framework.plugin.api.UtExecutableCallModel
 import org.utbot.framework.plugin.api.UtStatementModel
 import org.utbot.framework.plugin.api.util.booleanClassId
-import org.utbot.framework.plugin.api.util.id
+import org.utbot.framework.plugin.api.util.collectionClassId
+import org.utbot.framework.plugin.api.util.mapClassId
 import org.utbot.framework.plugin.api.util.objectClassId
 
 internal class CollectionConstructor : UtAssembleModelConstructorBase() {
@@ -22,9 +23,7 @@ internal class CollectionConstructor : UtAssembleModelConstructorBase() {
         // This value will be constructed as UtCompositeModel.
         val models = value.map { internalConstructor.construct(it, valueToClassId(it)) }
 
-        val classId = value::class.java.id
-
-        val addMethodId = MethodId(classId, "add", booleanClassId, listOf(objectClassId))
+        val addMethodId = MethodId(collectionClassId, "add", booleanClassId, listOf(objectClassId))
 
         return models.map { UtExecutableCallModel(this, addMethodId, listOf(it)) }
     }
@@ -63,7 +62,7 @@ internal class MapConstructor : UtAssembleModelConstructorBase() {
             internalConstructor.run { construct(key, valueToClassId(key)) to construct(value, valueToClassId(value)) }
         }
 
-        val putMethodId = MethodId(classId, "put", objectClassId, listOf(objectClassId, objectClassId))
+        val putMethodId = MethodId(mapClassId, "put", objectClassId, listOf(objectClassId, objectClassId))
 
         return keyToValueModels.map { (key, value) ->
             UtExecutableCallModel(this, putMethodId, listOf(key, value))

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/UtModelConstructor.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/UtModelConstructor.kt
@@ -6,6 +6,7 @@ import org.utbot.framework.plugin.api.*
 import org.utbot.framework.plugin.api.util.*
 import org.utbot.framework.plugin.api.visible.UtStreamConsumingException
 import java.lang.reflect.Modifier
+import java.lang.reflect.Proxy
 import java.util.*
 import java.util.stream.BaseStream
 
@@ -85,6 +86,52 @@ class UtModelConstructor(
         return UtLambdaModel.createFake(handleId(value), classId, baseClass)
     }
 
+    private fun isProxy(value: Any?): Boolean =
+        value != null && Proxy.isProxyClass(value::class.java)
+
+    /**
+     * Using `UtAssembleModel` for dynamic proxies helps to avoid exceptions like
+     * `java.lang.ClassNotFoundException: jdk.proxy3.$Proxy184` during code generation.
+     */
+    private fun constructProxy(value: Any, classId: ClassId): UtAssembleModel {
+        val newProxyInstanceExecutableId = java.lang.reflect.Proxy::newProxyInstance.executableId
+
+        // we don't want to construct deep models for invocationHandlers, since they can be quite large
+        val argsRemainingDepth = 0L
+
+        val classLoader = UtAssembleModel(
+            id = computeUnusedIdAndUpdate(),
+            classId = newProxyInstanceExecutableId.parameters[0],
+            modelName = "systemClassLoader",
+            instantiationCall = UtExecutableCallModel(
+                instance = null,
+                executable = ClassLoader::getSystemClassLoader.executableId,
+                params = emptyList()
+            )
+        )
+        val interfaces = construct(
+            value::class.java.interfaces,
+            newProxyInstanceExecutableId.parameters[1],
+            remainingDepth = argsRemainingDepth
+        )
+        val invocationHandler = construct(
+            Proxy.getInvocationHandler(value),
+            newProxyInstanceExecutableId.parameters[2],
+            remainingDepth = argsRemainingDepth
+        )
+
+        return UtAssembleModel(
+            id = handleId(value),
+            classId = classId,
+            modelName = "dynamicProxy",
+            instantiationCall = UtExecutableCallModel(
+                instance = null,
+                executable = newProxyInstanceExecutableId,
+                params = listOf(classLoader, interfaces, invocationHandler)
+            )
+        )
+    }
+
     /**
      * Constructs a UtModel from a concrete [value] with a specific [classId]. The result can be a [UtAssembleModel]
      * as well.
@@ -102,6 +149,9 @@ class UtModelConstructor(
         }
         if (isProxyLambda(value)) {
             return constructFakeLambda(value!!, classId)
+        }
+        if (isProxy(value)) {
+            return constructProxy(value!!, classId)
         }
         return when (value) {
             null -> UtNullModel(classId)


### PR DESCRIPTION
## Description

* Fixes #2499
* Introduces construction of assemble models for dynamic proxies to avoid exceptions like `java.lang.ClassNotFoundException: jdk.proxy3.$Proxy184` during code generation

## How to test

### Manual tests

Generate integration tests for all methods in the following class.

```java
@Service
public class Examples {
    public interface SomeInterface {}
    public class SomeInvocationHandler implements InvocationHandler {
        @Override
        public Object invoke(Object proxy, Method method, Object[] args) throws InvocationTargetException, IllegalAccessException {
            return method.invoke(this, args);
        }
    }

    public SomeInterface proxy() {
         return (SomeInterface) Proxy.newProxyInstance(
            this.getClass().getClassLoader(),
            new Class[]{ SomeInterface.class },
            new SomeInvocationHandler()
        );
    }

    public Map<String, String> emptyMap() {
        return Collections.emptyMap();
    }

    public static class MyTreeMap extends TreeMap<String, String> {
        public MyTreeMap() {
            super();
            put("key1", "value1");
            put("key2", "value2");
        }
    }

    public Map<String, String> myTreeMap1() {
        return new MyTreeMap();
    }

    public MyTreeMap myTreeMap2() {
        return new MyTreeMap();
    }
}
```

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.