### PR TITLE
Introduce fuzzing in Spring unit tests

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -498,6 +498,8 @@ data class UtClassRefModel(
  * - isMock flag
  * - calculated field values (models)
  * - mocks for methods with return values
+ * - [canHaveRedundantOrMissingMocks] flag, which is set to `true` for mocks
+ *   created by fuzzer without knowing which methods will actually be called
  *
  * [fields] contains non-static fields
  */
@@ -507,6 +509,8 @@ data class UtCompositeModel(
     val isMock: Boolean,
     val fields: MutableMap<FieldId, UtModel> = mutableMapOf(),
     val mocks: MutableMap<ExecutableId, List<UtModel>> = mutableMapOf(),
+    // TODO handle it in instrumentation & codegen
+    val canHaveRedundantOrMissingMocks: Boolean = false,
 ) : UtReferenceModel(id, classId) {
     //TODO: SAT-891 - rewrite toString() method
     override fun toString() = withToStringThreadLocalReentrancyGuard {

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -509,7 +509,6 @@ data class UtCompositeModel(
     val isMock: Boolean,
     val fields: MutableMap<FieldId, UtModel> = mutableMapOf(),
     val mocks: MutableMap<ExecutableId, List<UtModel>> = mutableMapOf(),
-    // TODO handle it in instrumentation & codegen
     val canHaveRedundantOrMissingMocks: Boolean = false,
 ) : UtReferenceModel(id, classId) {
     //TODO: SAT-891 - rewrite toString() method
@@ -767,13 +766,17 @@ abstract class UtCustomModel(
     classId: ClassId,
     modelName: String = id.toString(),
     override val origin: UtCompositeModel? = null,
-) : UtModelWithCompositeOrigin(id, classId, modelName, origin)
+) : UtModelWithCompositeOrigin(id, classId, modelName, origin) {
+    abstract val dependencies: Collection<UtModel>
+}
 
 object UtSpringContextModel : UtCustomModel(
     id = null,
     classId = SpringModelUtils.applicationContextClassId,
     modelName = "applicationContext"
 ) {
+    override val dependencies: Collection<UtModel> get() = emptySet()
+
     // NOTE that overriding equals is required just because without it
     // we will lose equality for objects after deserialization
     override fun equals(other: Any?): Boolean = other is UtSpringContextModel
@@ -786,6 +789,8 @@ class UtSpringEntityManagerModel : UtCustomModel(
     classId = SpringModelUtils.entityManagerClassIds.first(),
     modelName = "entityManager"
 ) {
+    override val dependencies: Collection<UtModel> get() = emptySet()
+
     // NOTE that overriding equals is required just because without it
     // we will lose equality for objects after deserialization
     override fun equals(other: Any?): Boolean = other is UtSpringEntityManagerModel
@@ -814,7 +819,9 @@ data class UtSpringMockMvcResultActionsModel(
     classId = SpringModelUtils.resultActionsClassId,
     id = id,
     modelName = "mockMvcResultActions@$id"
-)
+) {
+    override val dependencies: Collection<UtModel> get() = emptySet()
+}
 
 /**
  * Model for a step to obtain [UtAssembleModel].

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/IdUtil.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/IdUtil.kt
@@ -11,6 +11,7 @@ import org.utbot.framework.plugin.api.MethodId
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtNullModel
 import org.utbot.framework.plugin.api.UtPrimitiveModel
+import org.utbot.framework.plugin.api.UtVoidModel
 import org.utbot.framework.plugin.api.id
 import soot.SootField
 import java.lang.reflect.Constructor
@@ -449,6 +450,7 @@ fun ClassId.defaultValueModel(): UtModel = when (this) {
     doubleClassId -> UtPrimitiveModel(0.0)
     booleanClassId -> UtPrimitiveModel(false)
     charClassId -> UtPrimitiveModel('\u0000')
+    voidClassId -> UtVoidModel
     else -> UtNullModel(this)
 }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
@@ -425,7 +425,7 @@ class UtBotSymbolicEngine(
      * @param until is used by fuzzer to cancel all tasks if the current time is over this value
      * @param transform provides model values for a method
      */
-    fun fuzzing(until: Long = Long.MAX_VALUE, transform: (JavaValueProvider) -> JavaValueProvider = { it }) = flow {
+    fun fuzzing(until: Long = Long.MAX_VALUE) = flow {
         val isFuzzable = methodUnderTest.parameters.all { classId ->
             classId != Method::class.java.id && // causes the instrumented process crash at invocation
                 classId != Class::class.java.id  // causes java.lang.IllegalAccessException: java.lang.Class at sun.misc.Unsafe.allocateInstance(Native Method)
@@ -453,7 +453,7 @@ class UtBotSymbolicEngine(
             methodUnderTest,
             constants = collectConstantsForFuzzer(graph),
             names = names,
-            providers = listOf(transform(fuzzingContext.valueProvider)),
+            providers = listOf(fuzzingContext.valueProvider),
         ) { thisInstance, descr, values ->
             val diff = until - System.currentTimeMillis()
             val thresholdMillisForFuzzingOperation = 0 // may be better use 10-20 millis as it might not be possible

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/context/ConcreteExecutionContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/context/ConcreteExecutionContext.kt
@@ -2,14 +2,8 @@ package org.utbot.framework.context
 
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.ConcreteContextLoadingResult
-import org.utbot.framework.plugin.api.EnvironmentModels
-import org.utbot.framework.plugin.api.ExecutableId
-import org.utbot.framework.plugin.api.FieldId
 import org.utbot.framework.plugin.api.UtExecution
-import org.utbot.framework.plugin.api.UtModel
-import org.utbot.fuzzer.IdGenerator
 import org.utbot.fuzzer.IdentityPreservingIdGenerator
-import org.utbot.fuzzing.JavaValueProvider
 import org.utbot.instrumentation.ConcreteExecutor
 import org.utbot.instrumentation.instrumentation.execution.UtConcreteExecutionResult
 import org.utbot.instrumentation.instrumentation.execution.UtExecutionInstrumentation
@@ -26,17 +20,9 @@ interface ConcreteExecutionContext {
         classUnderTestId: ClassId
     ): List<UtExecution>
 
-    fun tryCreateValueProvider(
+    fun tryCreateFuzzingContext(
         concreteExecutor: ConcreteExecutor<UtConcreteExecutionResult, UtExecutionInstrumentation>,
         classUnderTest: ClassId,
         idGenerator: IdentityPreservingIdGenerator<Int>,
-    ): JavaValueProvider
-
-    fun createStateBefore(
-        thisInstance: UtModel?,
-        parameters: List<UtModel>,
-        statics: Map<FieldId, UtModel>,
-        executableToCall: ExecutableId,
-        idGenerator: IdGenerator<Int>
-    ): EnvironmentModels
+    ): JavaFuzzingContext
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/context/JavaFuzzingContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/context/JavaFuzzingContext.kt
@@ -1,0 +1,25 @@
+package org.utbot.framework.context
+
+import org.utbot.framework.plugin.api.ClassId
+import org.utbot.framework.plugin.api.EnvironmentModels
+import org.utbot.framework.plugin.api.ExecutableId
+import org.utbot.framework.plugin.api.FieldId
+import org.utbot.framework.plugin.api.UtModel
+import org.utbot.fuzzer.IdentityPreservingIdGenerator
+import org.utbot.fuzzing.JavaValueProvider
+import org.utbot.instrumentation.instrumentation.execution.UtConcreteExecutionResult
+
+interface JavaFuzzingContext {
+    val classUnderTest: ClassId
+    val idGenerator: IdentityPreservingIdGenerator<Int>
+    val valueProvider: JavaValueProvider
+
+    fun createStateBefore(
+        thisInstance: UtModel?,
+        parameters: List<UtModel>,
+        statics: Map<FieldId, UtModel>,
+        executableToCall: ExecutableId,
+    ): EnvironmentModels
+
+    fun handleFuzzedConcreteExecutionResult(concreteExecutionResult: UtConcreteExecutionResult)
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/context/custom/MockingJavaFuzzingContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/context/custom/MockingJavaFuzzingContext.kt
@@ -1,0 +1,42 @@
+package org.utbot.framework.context.custom
+
+import org.utbot.framework.context.JavaFuzzingContext
+import org.utbot.fuzzing.JavaValueProvider
+import org.utbot.fuzzing.providers.MapValueProvider
+import org.utbot.fuzzing.spring.unit.MockValueProvider
+import org.utbot.fuzzing.providers.NullValueProvider
+import org.utbot.fuzzing.providers.ObjectValueProvider
+import org.utbot.fuzzing.providers.StringValueProvider
+import org.utbot.instrumentation.instrumentation.execution.UtConcreteExecutionResult
+
+/**
+ * Makes fuzzer mock all types that don't have *specific* [JavaValueProvider],
+ * like [MapValueProvider] or [StringValueProvider].
+ *
+ * NOTE: the caller is responsible for providing some *specific* [JavaValueProvider]
+ *       that can create values for class under test (otherwise it will be mocked),
+ *       [ObjectValueProvider] and [NullValueProvider] do not count as *specific*.
+ */
+fun JavaFuzzingContext.mockAllTypesWithoutSpecificValueProvider() =
+    MockingJavaFuzzingContext(delegateContext = this)
+
+class MockingJavaFuzzingContext(
+    val delegateContext: JavaFuzzingContext
+) : JavaFuzzingContext by delegateContext {
+    private val mockValueProvider = MockValueProvider(delegateContext.idGenerator)
+
+    override val valueProvider: JavaValueProvider =
+        // NOTE: we first remove `NullValueProvider` from `delegateContext.valueProvider` and then
+        //       add it back as a part of our `withFallback` so it has the same priority as
+        //       `mockValueProvider`, otherwise mocks will never be used where `null` can be used.
+        delegateContext.valueProvider
+            .except { it is NullValueProvider }
+            .except { it is ObjectValueProvider }
+            .withFallback(
+                mockValueProvider
+                    .with(NullValueProvider)
+            )
+
+    override fun handleFuzzedConcreteExecutionResult(concreteExecutionResult: UtConcreteExecutionResult) =
+        mockValueProvider.addMockingCandidates(concreteExecutionResult.detectedMockingCandidates)
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/context/simple/SimpleApplicationContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/context/simple/SimpleApplicationContext.kt
@@ -13,7 +13,10 @@ import org.utbot.framework.context.TypeReplacer
  * A context to use when no specific data is required.
  */
 class SimpleApplicationContext(
-    override val mockerContext: MockerContext,
+    override val mockerContext: MockerContext = SimpleMockerContext(
+        mockFrameworkInstalled = true,
+        staticsMockingIsConfigured = true
+    ),
     override val typeReplacer: TypeReplacer = SimpleTypeReplacer(),
     override val nonNullSpeculator: NonNullSpeculator = SimpleNonNullSpeculator()
 ) : ApplicationContext {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/context/simple/SimpleConcreteExecutionContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/context/simple/SimpleConcreteExecutionContext.kt
@@ -1,18 +1,11 @@
 package org.utbot.framework.context.simple
 
 import org.utbot.framework.context.ConcreteExecutionContext
+import org.utbot.framework.context.JavaFuzzingContext
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.ConcreteContextLoadingResult
-import org.utbot.framework.plugin.api.EnvironmentModels
-import org.utbot.framework.plugin.api.ExecutableId
-import org.utbot.framework.plugin.api.FieldId
 import org.utbot.framework.plugin.api.UtExecution
-import org.utbot.framework.plugin.api.UtModel
-import org.utbot.fuzzer.IdGenerator
 import org.utbot.fuzzer.IdentityPreservingIdGenerator
-import org.utbot.fuzzing.JavaValueProvider
-import org.utbot.fuzzing.ValueProvider
-import org.utbot.fuzzing.defaultValueProviders
 import org.utbot.instrumentation.ConcreteExecutor
 import org.utbot.instrumentation.instrumentation.execution.SimpleUtExecutionInstrumentation
 import org.utbot.instrumentation.instrumentation.execution.UtConcreteExecutionResult
@@ -32,22 +25,9 @@ class SimpleConcreteExecutionContext(fullClassPath: String) : ConcreteExecutionC
         classUnderTestId: ClassId
     ): List<UtExecution> = executions
 
-    override fun tryCreateValueProvider(
+    override fun tryCreateFuzzingContext(
         concreteExecutor: ConcreteExecutor<UtConcreteExecutionResult, UtExecutionInstrumentation>,
         classUnderTest: ClassId,
         idGenerator: IdentityPreservingIdGenerator<Int>
-    ): JavaValueProvider = ValueProvider.of(defaultValueProviders(idGenerator))
-
-    override fun createStateBefore(
-        thisInstance: UtModel?,
-        parameters: List<UtModel>,
-        statics: Map<FieldId, UtModel>,
-        executableToCall: ExecutableId,
-        idGenerator: IdGenerator<Int>
-    ): EnvironmentModels = EnvironmentModels(
-        thisInstance = thisInstance,
-        parameters = parameters,
-        statics = statics,
-        executableToCall = executableToCall
-    )
+    ): JavaFuzzingContext = SimpleJavaFuzzingContext(classUnderTest, idGenerator)
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/context/simple/SimpleJavaFuzzingContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/context/simple/SimpleJavaFuzzingContext.kt
@@ -1,0 +1,36 @@
+package org.utbot.framework.context.simple
+
+import org.utbot.framework.context.JavaFuzzingContext
+import org.utbot.framework.plugin.api.ClassId
+import org.utbot.framework.plugin.api.EnvironmentModels
+import org.utbot.framework.plugin.api.ExecutableId
+import org.utbot.framework.plugin.api.FieldId
+import org.utbot.framework.plugin.api.UtModel
+import org.utbot.fuzzer.IdentityPreservingIdGenerator
+import org.utbot.fuzzing.JavaValueProvider
+import org.utbot.fuzzing.ValueProvider
+import org.utbot.fuzzing.defaultValueProviders
+import org.utbot.instrumentation.instrumentation.execution.UtConcreteExecutionResult
+
+class SimpleJavaFuzzingContext(
+    override val classUnderTest: ClassId,
+    override val idGenerator: IdentityPreservingIdGenerator<Int>,
+) : JavaFuzzingContext {
+    override val valueProvider: JavaValueProvider =
+        ValueProvider.of(defaultValueProviders(idGenerator))
+
+    override fun createStateBefore(
+        thisInstance: UtModel?,
+        parameters: List<UtModel>,
+        statics: Map<FieldId, UtModel>,
+        executableToCall: ExecutableId,
+    ): EnvironmentModels = EnvironmentModels(
+        thisInstance = thisInstance,
+        parameters = parameters,
+        statics = statics,
+        executableToCall = executableToCall
+    )
+
+    override fun handleFuzzedConcreteExecutionResult(concreteExecutionResult: UtConcreteExecutionResult) =
+        Unit
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringIntegrationTestConcreteExecutionContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringIntegrationTestConcreteExecutionContext.kt
@@ -1,38 +1,13 @@
 package org.utbot.framework.context.spring
 
 import mu.KotlinLogging
-import org.utbot.common.tryLoadClass
 import org.utbot.framework.context.ConcreteExecutionContext
+import org.utbot.framework.context.JavaFuzzingContext
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.ConcreteContextLoadingResult
-import org.utbot.framework.plugin.api.ConstructorId
-import org.utbot.framework.plugin.api.EnvironmentModels
-import org.utbot.framework.plugin.api.ExecutableId
-import org.utbot.framework.plugin.api.FieldId
-import org.utbot.framework.plugin.api.MethodId
-import org.utbot.framework.plugin.api.SpringRepositoryId
 import org.utbot.framework.plugin.api.SpringSettings
 import org.utbot.framework.plugin.api.UtExecution
-import org.utbot.framework.plugin.api.UtModel
-import org.utbot.framework.plugin.api.util.SpringModelUtils
-import org.utbot.framework.plugin.api.util.SpringModelUtils.createMockMvcModel
-import org.utbot.framework.plugin.api.util.SpringModelUtils.createRequestBuilderModelOrNull
-import org.utbot.framework.plugin.api.util.SpringModelUtils.mockMvcPerformMethodId
-import org.utbot.framework.plugin.api.util.allDeclaredFieldIds
-import org.utbot.framework.plugin.api.util.jField
-import org.utbot.framework.plugin.api.util.utContext
-import org.utbot.fuzzer.IdGenerator
 import org.utbot.fuzzer.IdentityPreservingIdGenerator
-import org.utbot.fuzzing.JavaValueProvider
-import org.utbot.fuzzing.ValueProvider
-import org.utbot.fuzzing.providers.AnyDepthNullValueProvider
-import org.utbot.fuzzing.spring.GeneratedFieldValueProvider
-import org.utbot.fuzzing.spring.SpringBeanValueProvider
-import org.utbot.fuzzing.spring.preserveProperties
-import org.utbot.fuzzing.spring.valid.EmailValueProvider
-import org.utbot.fuzzing.spring.valid.NotBlankStringValueProvider
-import org.utbot.fuzzing.spring.valid.NotEmptyStringValueProvider
-import org.utbot.fuzzing.spring.valid.ValidEntityValueProvider
 import org.utbot.instrumentation.ConcreteExecutor
 import org.utbot.instrumentation.getRelevantSpringRepositories
 import org.utbot.instrumentation.instrumentation.execution.UtConcreteExecutionResult
@@ -40,8 +15,6 @@ import org.utbot.instrumentation.instrumentation.execution.UtExecutionInstrument
 import org.utbot.instrumentation.instrumentation.spring.SpringUtExecutionInstrumentation
 import org.utbot.instrumentation.tryLoadingSpringContext
 import java.io.File
-import org.utbot.fuzzing.providers.ObjectValueProvider
-import org.utbot.fuzzing.providers.anyObjectValueProvider
 
 class SpringIntegrationTestConcreteExecutionContext(
     private val delegateContext: ConcreteExecutionContext,
@@ -79,11 +52,11 @@ class SpringIntegrationTestConcreteExecutionContext(
         classUnderTestId: ClassId
     ): List<UtExecution> = delegateContext.transformExecutionsBeforeMinimization(executions, classUnderTestId)
 
-    override fun tryCreateValueProvider(
+    override fun tryCreateFuzzingContext(
         concreteExecutor: ConcreteExecutor<UtConcreteExecutionResult, UtExecutionInstrumentation>,
         classUnderTest: ClassId,
         idGenerator: IdentityPreservingIdGenerator<Int>
-    ): JavaValueProvider {
+    ): JavaFuzzingContext {
         if (springApplicationContext.getBeansAssignableTo(classUnderTest).isEmpty())
             error(
                 "No beans of type ${classUnderTest.name} are found. " +
@@ -94,77 +67,10 @@ class SpringIntegrationTestConcreteExecutionContext(
         val relevantRepositories = concreteExecutor.getRelevantSpringRepositories(classUnderTest)
         logger.info { "Detected relevant repositories for class $classUnderTest: $relevantRepositories" }
 
-        val springBeanValueProvider = SpringBeanValueProvider(
-            idGenerator,
-            beanNameProvider = { classId ->
-                springApplicationContext.getBeansAssignableTo(classId).map { it.beanName }
-            },
-            relevantRepositories = relevantRepositories
+        return SpringIntegrationTestJavaFuzzingContext(
+            delegateContext = delegateContext.tryCreateFuzzingContext(concreteExecutor, classUnderTest, idGenerator),
+            relevantRepositories = relevantRepositories,
+            springApplicationContext = springApplicationContext,
         )
-
-        return springBeanValueProvider
-            .withFallback(ValidEntityValueProvider(idGenerator, onlyAcceptWhenValidIsRequired = true))
-            .withFallback(EmailValueProvider())
-            .withFallback(NotBlankStringValueProvider())
-            .withFallback(NotEmptyStringValueProvider())
-            .withFallback(
-                delegateContext.tryCreateValueProvider(concreteExecutor, classUnderTest, idGenerator)
-                    .except { p -> p is ObjectValueProvider }
-                    .with(anyObjectValueProvider(idGenerator, shouldMutateWithMethods = true))
-                    .with(ValidEntityValueProvider(idGenerator, onlyAcceptWhenValidIsRequired = false))
-                    .with(createGeneratedFieldValueProviders(relevantRepositories, idGenerator))
-                    .withFallback(AnyDepthNullValueProvider)
-            )
-            .preserveProperties()
-    }
-
-    private fun createGeneratedFieldValueProviders(
-        relevantRepositories: Set<SpringRepositoryId>,
-        idGenerator: IdentityPreservingIdGenerator<Int>
-    ): JavaValueProvider {
-        val generatedValueAnnotationClasses = SpringModelUtils.generatedValueClassIds.mapNotNull {
-            @Suppress("UNCHECKED_CAST") // type system fails to understand that @GeneratedValue is indeed an annotation
-            utContext.classLoader.tryLoadClass(it.name) as Class<out Annotation>?
-        }
-
-        val generatedValueFields =
-            relevantRepositories
-                .flatMap { springRepositoryId ->
-                    val entityClassId = springRepositoryId.entityClassId
-                    entityClassId.allDeclaredFieldIds
-                        .filter { fieldId -> generatedValueAnnotationClasses.any { fieldId.jField.isAnnotationPresent(it) } }
-                        .map { entityClassId to it }
-                }
-
-        logger.info { "Detected @GeneratedValue fields: $generatedValueFields" }
-
-        return ValueProvider.of(generatedValueFields.map { (entityClassId, fieldId) ->
-            GeneratedFieldValueProvider(idGenerator, entityClassId, fieldId)
-        })
-    }
-
-    override fun createStateBefore(
-        thisInstance: UtModel?,
-        parameters: List<UtModel>,
-        statics: Map<FieldId, UtModel>,
-        executableToCall: ExecutableId,
-        idGenerator: IdGenerator<Int>
-    ): EnvironmentModels {
-        val delegateStateBefore = delegateContext.createStateBefore(thisInstance, parameters, statics, executableToCall, idGenerator)
-        return when (executableToCall) {
-            is ConstructorId -> delegateStateBefore
-            is MethodId -> {
-                val requestBuilderModel = createRequestBuilderModelOrNull(
-                    methodId = executableToCall,
-                    arguments = parameters,
-                    idGenerator = { idGenerator.createId() }
-                ) ?: return delegateStateBefore
-                delegateStateBefore.copy(
-                    thisInstance = createMockMvcModel { idGenerator.createId() },
-                    parameters = listOf(requestBuilderModel),
-                    executableToCall = mockMvcPerformMethodId,
-                )
-            }
-        }
     }
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringIntegrationTestJavaFuzzingContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringIntegrationTestJavaFuzzingContext.kt
@@ -1,0 +1,110 @@
+package org.utbot.framework.context.spring
+
+import mu.KotlinLogging
+import org.utbot.common.tryLoadClass
+import org.utbot.framework.context.JavaFuzzingContext
+import org.utbot.framework.plugin.api.ConstructorId
+import org.utbot.framework.plugin.api.EnvironmentModels
+import org.utbot.framework.plugin.api.ExecutableId
+import org.utbot.framework.plugin.api.FieldId
+import org.utbot.framework.plugin.api.MethodId
+import org.utbot.framework.plugin.api.SpringRepositoryId
+import org.utbot.framework.plugin.api.UtModel
+import org.utbot.framework.plugin.api.util.SpringModelUtils
+import org.utbot.framework.plugin.api.util.allDeclaredFieldIds
+import org.utbot.framework.plugin.api.util.jField
+import org.utbot.framework.plugin.api.util.utContext
+import org.utbot.fuzzer.IdentityPreservingIdGenerator
+import org.utbot.fuzzing.JavaValueProvider
+import org.utbot.fuzzing.ValueProvider
+import org.utbot.fuzzing.providers.AnyDepthNullValueProvider
+import org.utbot.fuzzing.providers.ObjectValueProvider
+import org.utbot.fuzzing.providers.anyObjectValueProvider
+import org.utbot.fuzzing.spring.GeneratedFieldValueProvider
+import org.utbot.fuzzing.spring.SpringBeanValueProvider
+import org.utbot.fuzzing.spring.preserveProperties
+import org.utbot.fuzzing.spring.valid.EmailValueProvider
+import org.utbot.fuzzing.spring.valid.NotBlankStringValueProvider
+import org.utbot.fuzzing.spring.valid.NotEmptyStringValueProvider
+import org.utbot.fuzzing.spring.valid.ValidEntityValueProvider
+
+class SpringIntegrationTestJavaFuzzingContext(
+    val delegateContext: JavaFuzzingContext,
+    relevantRepositories: Set<SpringRepositoryId>,
+    springApplicationContext: SpringApplicationContext,
+) : JavaFuzzingContext by delegateContext {
+    companion object {
+        private val logger = KotlinLogging.logger {}
+    }
+
+    override val valueProvider: JavaValueProvider =
+        SpringBeanValueProvider(
+            idGenerator,
+            beanNameProvider = { classId ->
+                springApplicationContext.getBeansAssignableTo(classId).map { it.beanName }
+            },
+            relevantRepositories = relevantRepositories
+        )
+            .withFallback(ValidEntityValueProvider(idGenerator, onlyAcceptWhenValidIsRequired = true))
+            .withFallback(EmailValueProvider())
+            .withFallback(NotBlankStringValueProvider())
+            .withFallback(NotEmptyStringValueProvider())
+            .withFallback(
+                delegateContext.valueProvider
+                    .except { p -> p is ObjectValueProvider }
+                    .with(anyObjectValueProvider(idGenerator, shouldMutateWithMethods = true))
+                    .with(ValidEntityValueProvider(idGenerator, onlyAcceptWhenValidIsRequired = false))
+                    .with(createGeneratedFieldValueProviders(relevantRepositories, idGenerator))
+                    .withFallback(AnyDepthNullValueProvider)
+            )
+            .preserveProperties()
+
+    private fun createGeneratedFieldValueProviders(
+        relevantRepositories: Set<SpringRepositoryId>,
+        idGenerator: IdentityPreservingIdGenerator<Int>
+    ): JavaValueProvider {
+        val generatedValueAnnotationClasses = SpringModelUtils.generatedValueClassIds.mapNotNull {
+            @Suppress("UNCHECKED_CAST") // type system fails to understand that @GeneratedValue is indeed an annotation
+            utContext.classLoader.tryLoadClass(it.name) as Class<out Annotation>?
+        }
+
+        val generatedValueFields =
+            relevantRepositories
+                .flatMap { springRepositoryId ->
+                    val entityClassId = springRepositoryId.entityClassId
+                    entityClassId.allDeclaredFieldIds
+                        .filter { fieldId -> generatedValueAnnotationClasses.any { fieldId.jField.isAnnotationPresent(it) } }
+                        .map { entityClassId to it }
+                }
+
+        logger.info { "Detected @GeneratedValue fields: $generatedValueFields" }
+
+        return ValueProvider.of(generatedValueFields.map { (entityClassId, fieldId) ->
+            GeneratedFieldValueProvider(idGenerator, entityClassId, fieldId)
+        })
+    }
+
+    override fun createStateBefore(
+        thisInstance: UtModel?,
+        parameters: List<UtModel>,
+        statics: Map<FieldId, UtModel>,
+        executableToCall: ExecutableId,
+    ): EnvironmentModels {
+        val delegateStateBefore = delegateContext.createStateBefore(thisInstance, parameters, statics, executableToCall)
+        return when (executableToCall) {
+            is ConstructorId -> delegateStateBefore
+            is MethodId -> {
+                val requestBuilderModel = SpringModelUtils.createRequestBuilderModelOrNull(
+                    methodId = executableToCall,
+                    arguments = parameters,
+                    idGenerator = { idGenerator.createId() }
+                ) ?: return delegateStateBefore
+                delegateStateBefore.copy(
+                    thisInstance = SpringModelUtils.createMockMvcModel { idGenerator.createId() },
+                    parameters = listOf(requestBuilderModel),
+                    executableToCall = SpringModelUtils.mockMvcPerformMethodId,
+                )
+            }
+        }
+    }
+}

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/context/utils/ApplicationContextUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/context/utils/ApplicationContextUtils.kt
@@ -1,0 +1,22 @@
+package org.utbot.framework.context.utils
+
+import org.utbot.framework.context.ApplicationContext
+import org.utbot.framework.context.ConcreteExecutionContext
+import org.utbot.fuzzing.JavaValueProvider
+
+fun ApplicationContext.transformConcreteExecutionContext(
+    transformer: (ConcreteExecutionContext) -> ConcreteExecutionContext
+) = object : ApplicationContext by this {
+    override fun createConcreteExecutionContext(
+        fullClasspath: String,
+        classpathWithoutDependencies: String
+    ): ConcreteExecutionContext = transformer(
+        this@transformConcreteExecutionContext.createConcreteExecutionContext(
+            fullClasspath, classpathWithoutDependencies
+        )
+    )
+}
+
+fun ApplicationContext.transformValueProvider(
+    transformer: (JavaValueProvider) -> JavaValueProvider
+) = transformConcreteExecutionContext { it.transformValueProvider(transformer) }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/context/utils/ConcreteExecutionContextUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/context/utils/ConcreteExecutionContextUtils.kt
@@ -1,0 +1,26 @@
+package org.utbot.framework.context.utils
+
+import org.utbot.framework.context.ConcreteExecutionContext
+import org.utbot.framework.context.JavaFuzzingContext
+import org.utbot.framework.plugin.api.ClassId
+import org.utbot.fuzzer.IdentityPreservingIdGenerator
+import org.utbot.fuzzing.JavaValueProvider
+import org.utbot.instrumentation.ConcreteExecutor
+import org.utbot.instrumentation.instrumentation.execution.UtConcreteExecutionResult
+import org.utbot.instrumentation.instrumentation.execution.UtExecutionInstrumentation
+
+fun ConcreteExecutionContext.transformJavaFuzzingContext(
+    transformer: (JavaFuzzingContext) -> JavaFuzzingContext
+) = object : ConcreteExecutionContext by this {
+    override fun tryCreateFuzzingContext(
+        concreteExecutor: ConcreteExecutor<UtConcreteExecutionResult, UtExecutionInstrumentation>,
+        classUnderTest: ClassId,
+        idGenerator: IdentityPreservingIdGenerator<Int>
+    ): JavaFuzzingContext = transformer(
+        this@transformJavaFuzzingContext.tryCreateFuzzingContext(concreteExecutor, classUnderTest, idGenerator)
+    )
+}
+
+fun ConcreteExecutionContext.transformValueProvider(
+    transformer: (JavaValueProvider) -> JavaValueProvider
+) = transformJavaFuzzingContext { it.transformValueProvider(transformer) }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/context/utils/JavaFuzzingContextUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/context/utils/JavaFuzzingContextUtils.kt
@@ -1,0 +1,15 @@
+package org.utbot.framework.context.utils
+
+import org.utbot.framework.context.JavaFuzzingContext
+import org.utbot.fuzzing.JavaValueProvider
+
+fun JavaFuzzingContext.transformValueProvider(
+    transformer: (JavaValueProvider) -> JavaValueProvider
+) = object : JavaFuzzingContext by this {
+    override val valueProvider: JavaValueProvider =
+        transformer(this@transformValueProvider.valueProvider)
+}
+
+fun JavaFuzzingContext.withValueProvider(
+    valueProvider: JavaValueProvider
+) = transformValueProvider { it.with(valueProvider) }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/util/UtConcreteExecutionResultUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/util/UtConcreteExecutionResultUtils.kt
@@ -21,12 +21,9 @@ private fun UtConcreteExecutionResult.updateWithAssembleModels(
     val resolvedResult =
         (result as? UtExecutionSuccess)?.model?.let { UtExecutionSuccess(toAssemble(it)) } ?: result
 
-    return UtConcreteExecutionResult(
-        stateBefore,
-        resolvedStateAfter,
-        resolvedResult,
-        coverage,
-        newInstrumentation
+    return copy(
+        stateAfter = resolvedStateAfter,
+        result = resolvedResult,
     )
 }
 

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/UtExecutionInstrumentation.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/UtExecutionInstrumentation.kt
@@ -24,8 +24,8 @@ data class UtConcreteExecutionData(
 
 /**
  * [UtConcreteExecutionResult] that has not yet been populated with extra data, e.g.:
- *  - updated `stateBefore: EnvironmentModels`
- *  - `detectedMockingCandidates: Set<ExecutableId>` (not yet implemented, see #2321)
+ *  - updated [UtConcreteExecutionResult.stateBefore]
+ *  - [UtConcreteExecutionResult.detectedMockingCandidates]
  */
 data class PreliminaryUtConcreteExecutionResult(
     val stateAfter: EnvironmentModels,
@@ -33,12 +33,16 @@ data class PreliminaryUtConcreteExecutionResult(
     val coverage: Coverage,
     val newInstrumentation: List<UtInstrumentation>? = null,
 ) {
-    fun toCompleteUtConcreteExecutionResult(stateBefore: EnvironmentModels) = UtConcreteExecutionResult(
-        stateBefore,
-        stateAfter,
-        result,
-        coverage,
-        newInstrumentation,
+    fun toCompleteUtConcreteExecutionResult(
+        stateBefore: EnvironmentModels,
+        detectedMockingCandidates: Set<MethodId>
+    ) = UtConcreteExecutionResult(
+        stateBefore = stateBefore,
+        stateAfter = stateAfter,
+        result = result,
+        coverage = coverage,
+        newInstrumentation = newInstrumentation,
+        detectedMockingCandidates = detectedMockingCandidates,
     )
 }
 
@@ -48,6 +52,7 @@ data class UtConcreteExecutionResult(
     val result: UtExecutionResult,
     val coverage: Coverage,
     val newInstrumentation: List<UtInstrumentation>? = null,
+    val detectedMockingCandidates: Set<MethodId>,
 ) {
     override fun toString(): String = buildString {
         appendLine("UtConcreteExecutionResult(")

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/InstrumentationContextAwareValueConstructor.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/InstrumentationContextAwareValueConstructor.kt
@@ -236,7 +236,13 @@ class InstrumentationContextAwareValueConstructor(
                 val answerValue = answerValues[pointer]
                 val answerModel = answerModels[pointer]
                 pointer = (pointer + 1) % answerValues.size
-                (mockModel.mocks.getOrPut(executableId) { mutableListOf() } as MutableList).add(answerModel)
+
+                // Record mock answers into `mockModel.mocks` as these answers are used.
+                // Avoid recording multiple answers if same answer is reused over and over again.
+                if (answerValues.size > 1 || executableId !in mockModel.mocks) {
+                    (mockModel.mocks.getOrPut(executableId) { mutableListOf() } as MutableList).add(answerModel)
+                }
+
                 return answerValue
             }
         }

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/StateBeforeAwareIdGenerator.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/StateBeforeAwareIdGenerator.kt
@@ -1,0 +1,103 @@
+package org.utbot.instrumentation.instrumentation.execution.constructors
+
+import org.utbot.framework.plugin.api.UtArrayModel
+import org.utbot.framework.plugin.api.UtAssembleModel
+import org.utbot.framework.plugin.api.UtClassRefModel
+import org.utbot.framework.plugin.api.UtCompositeModel
+import org.utbot.framework.plugin.api.UtCustomModel
+import org.utbot.framework.plugin.api.UtDirectSetFieldModel
+import org.utbot.framework.plugin.api.UtEnumConstantModel
+import org.utbot.framework.plugin.api.UtLambdaModel
+import org.utbot.framework.plugin.api.UtModel
+import org.utbot.framework.plugin.api.UtNewInstanceInstrumentation
+import org.utbot.framework.plugin.api.UtNullModel
+import org.utbot.framework.plugin.api.UtPrimitiveModel
+import org.utbot.framework.plugin.api.UtReferenceModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
+import org.utbot.framework.plugin.api.UtStatementModel
+import org.utbot.framework.plugin.api.UtStaticMethodInstrumentation
+import org.utbot.framework.plugin.api.UtVoidModel
+import org.utbot.instrumentation.instrumentation.execution.UtConcreteExecutionData
+import java.util.*
+
+class StateBeforeAwareIdGenerator(preExistingModels: Collection<UtModel>) {
+    private val seenIds = mutableSetOf<Int>()
+
+    // there's no `IdentityHashSet`, so we use `IdentityHashMap` with dummy values
+    private val seenModels = IdentityHashMap<UtModel, Unit>()
+
+    private var nextId = 0
+
+    init {
+        collectIds(preExistingModels)
+    }
+
+    private fun collectIds(models: Collection<UtModel>) =
+        models.forEach { collectIds(it) }
+
+    private fun collectIds(model: UtModel) {
+        if (model !in seenModels) {
+            seenModels[model] = Unit
+            (model as? UtReferenceModel)?.id?.let { seenIds.add(it) }
+            when (model) {
+                is UtNullModel,
+                is UtPrimitiveModel,
+                is UtEnumConstantModel,
+                is UtClassRefModel,
+                is UtVoidModel -> {}
+                is UtCompositeModel -> {
+                    collectIds(model.fields.values)
+                    model.mocks.values.forEach { collectIds(it) }
+                }
+                is UtArrayModel -> {
+                    collectIds(model.constModel)
+                    collectIds(model.stores.values)
+                }
+                is UtAssembleModel -> {
+                    model.origin?.let { collectIds(it) }
+                    collectIds(model.instantiationCall)
+                    model.modificationsChain.forEach { collectIds(it) }
+                }
+                is UtCustomModel -> {
+                    model.origin?.let { collectIds(it) }
+                    collectIds(model.dependencies)
+                }
+                is UtLambdaModel -> {
+                    collectIds(model.capturedValues)
+                }
+                else -> error("Can't collect ids from $model")
+            }
+        }
+    }
+
+    private fun collectIds(call: UtStatementModel): Unit = when (call) {
+        is UtStatementCallModel -> {
+            call.instance?.let { collectIds(it) }
+            collectIds(call.params)
+        }
+        is UtDirectSetFieldModel -> {
+            collectIds(call.instance)
+            collectIds(call.fieldModel)
+        }
+    }
+
+    fun createId(): Int {
+        while (nextId in seenIds) nextId++
+        return nextId++
+    }
+
+    companion object {
+        fun fromUtConcreteExecutionData(data: UtConcreteExecutionData): StateBeforeAwareIdGenerator =
+            StateBeforeAwareIdGenerator(
+                listOfNotNull(data.stateBefore.thisInstance) +
+                        data.stateBefore.parameters +
+                        data.stateBefore.statics.values +
+                        data.instrumentation.flatMap {
+                            when (it) {
+                                is UtNewInstanceInstrumentation -> it.instances
+                                is UtStaticMethodInstrumentation -> it.values
+                            }
+                        }
+            )
+    }
+}

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/phases/ModelConstructionPhase.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/phases/ModelConstructionPhase.kt
@@ -8,6 +8,7 @@ import org.utbot.framework.plugin.api.visible.UtStreamConsumingException
 import org.utbot.instrumentation.instrumentation.et.ExplicitThrowInstruction
 import org.utbot.instrumentation.instrumentation.et.TraceHandler
 import org.utbot.instrumentation.instrumentation.execution.PreliminaryUtConcreteExecutionResult
+import org.utbot.instrumentation.instrumentation.execution.constructors.StateBeforeAwareIdGenerator
 import org.utbot.instrumentation.instrumentation.execution.constructors.UtCompositeModelStrategy
 import org.utbot.instrumentation.instrumentation.execution.constructors.UtModelWithCompositeOriginConstructor
 import org.utbot.instrumentation.instrumentation.execution.constructors.UtModelConstructor
@@ -20,6 +21,7 @@ import java.util.*
 class ModelConstructionPhase(
     private val traceHandler: TraceHandler,
     private val utModelWithCompositeOriginConstructorFinder: (ClassId) -> UtModelWithCompositeOriginConstructor?,
+    private val idGenerator: StateBeforeAwareIdGenerator,
 ) : ExecutionPhase {
 
     override fun wrapError(e: Throwable): ExecutionPhaseException {
@@ -52,6 +54,7 @@ class ModelConstructionPhase(
                 objectToModelCache = cache,
                 utModelWithCompositeOriginConstructorFinder = utModelWithCompositeOriginConstructorFinder,
                 compositeModelStrategy = strategy,
+                idGenerator = idGenerator,
             )
         }
     }

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/phases/PhasesController.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/phases/PhasesController.kt
@@ -14,6 +14,7 @@ import org.utbot.instrumentation.instrumentation.Instrumentation
 import org.utbot.instrumentation.instrumentation.et.TraceHandler
 import org.utbot.instrumentation.instrumentation.execution.PreliminaryUtConcreteExecutionResult
 import org.utbot.instrumentation.instrumentation.execution.UtConcreteExecutionData
+import org.utbot.instrumentation.instrumentation.execution.constructors.StateBeforeAwareIdGenerator
 import org.utbot.instrumentation.instrumentation.execution.context.InstrumentationContext
 import java.security.AccessControlException
 
@@ -21,10 +22,14 @@ class PhasesController(
     private val instrumentationContext: InstrumentationContext,
     traceHandler: TraceHandler,
     delegateInstrumentation: Instrumentation<Result<*>>,
-    private val timeout: Long
+    private val timeout: Long,
+    idGenerator: StateBeforeAwareIdGenerator,
 ) {
     private var currentlyElapsed = 0L
-    val valueConstructionPhase = ValueConstructionPhase(instrumentationContext)
+    val valueConstructionPhase = ValueConstructionPhase(
+        instrumentationContext,
+        idGenerator,
+    )
 
     val preparationPhase = PreparationPhase(traceHandler)
 
@@ -34,7 +39,8 @@ class PhasesController(
 
     val modelConstructionPhase = ModelConstructionPhase(
         traceHandler = traceHandler,
-        utModelWithCompositeOriginConstructorFinder = instrumentationContext::findUtModelWithCompositeOriginConstructor
+        utModelWithCompositeOriginConstructorFinder = instrumentationContext::findUtModelWithCompositeOriginConstructor,
+        idGenerator = idGenerator,
     )
 
     val postprocessingPhase = PostprocessingPhase()

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/phases/ValueConstructionPhase.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/phases/ValueConstructionPhase.kt
@@ -6,6 +6,7 @@ import org.utbot.instrumentation.instrumentation.execution.constructors.Instrume
 import org.utbot.instrumentation.instrumentation.execution.context.InstrumentationContext
 import org.utbot.framework.plugin.api.util.isInaccessibleViaReflection
 import org.utbot.instrumentation.instrumentation.execution.PreliminaryUtConcreteExecutionResult
+import org.utbot.instrumentation.instrumentation.execution.constructors.StateBeforeAwareIdGenerator
 
 typealias ConstructedParameters = List<UtConcreteValue<*>>
 typealias ConstructedStatics = Map<FieldId, UtConcreteValue<*>>
@@ -21,7 +22,8 @@ data class ConstructedData(
  * This phase of values instantiation from given models.
  */
 class ValueConstructionPhase(
-    instrumentationContext: InstrumentationContext
+    instrumentationContext: InstrumentationContext,
+    idGenerator: StateBeforeAwareIdGenerator,
 ) : ExecutionPhase {
 
     override fun wrapError(e: Throwable): ExecutionPhaseException = ExecutionPhaseStop(
@@ -36,7 +38,11 @@ class ValueConstructionPhase(
         )
     )
 
-    private val constructor = InstrumentationContextAwareValueConstructor(instrumentationContext)
+    private val constructor = InstrumentationContextAwareValueConstructor(
+        instrumentationContext,
+        idGenerator,
+    )
+    val detectedMockingCandidates: Set<MethodId> get() = constructor.detectedMockingCandidates
 
     fun getCache(): ConstructedCache {
         return constructor.objectToModelCache

--- a/utbot-instrumentation/src/test/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/BaseConstructorTest.kt
+++ b/utbot-instrumentation/src/test/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/BaseConstructorTest.kt
@@ -27,6 +27,7 @@ abstract class BaseConstructorTest {
     protected fun <T : Any> computeReconstructed(value: T): T {
         val model = UtModelConstructor(
             objectToModelCache = IdentityHashMap(),
+            idGenerator = StateBeforeAwareIdGenerator(preExistingModels = emptySet()),
             utModelWithCompositeOriginConstructorFinder = ::findUtCustomModelConstructor
         ).construct(value, value::class.java.id)
 

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -387,7 +387,7 @@ object UtTestsDialogProcessor {
                                         }
                                         val useFuzzing = when (model.projectType) {
                                             Spring -> when (model.springTestType) {
-                                                UNIT_TEST -> false
+                                                UNIT_TEST -> UtSettings.useFuzzing
                                                 INTEGRATION_TEST -> true
                                             }
 

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -860,6 +860,18 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
 
         val settings = model.project.service<Settings>()
 
+        when (model.projectType) {
+            ProjectType.Spring -> {
+                if (!settings.isSpringHandled) {
+                    settings.isSpringHandled = true
+                    settings.fuzzingValue =
+                        if (settings.fuzzingValue == 0.0) 0.0
+                        else settings.fuzzingValue.coerceAtLeast(0.3)
+                }
+            }
+            else -> {}
+        }
+
         mockStrategies.item = when (model.projectType) {
             ProjectType.Spring -> MockStrategyApi.springDefaultItem
             else -> settings.mockStrategy

--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/JavaLanguage.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/JavaLanguage.kt
@@ -50,6 +50,7 @@ fun defaultValueProviders(idGenerator: IdentityPreservingIdGenerator<Int>) = lis
     IteratorValueProvider(idGenerator),
     EmptyCollectionValueProvider(idGenerator),
     DateValueProvider(idGenerator),
+    VoidValueProvider,
     NullValueProvider,
 )
 

--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Primitives.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Primitives.kt
@@ -2,6 +2,7 @@ package org.utbot.fuzzing.providers
 
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.UtPrimitiveModel
+import org.utbot.framework.plugin.api.UtVoidModel
 import org.utbot.framework.plugin.api.util.*
 import org.utbot.fuzzer.FuzzedContext
 import org.utbot.fuzzer.FuzzedContext.Comparison.*
@@ -236,4 +237,9 @@ object StringValueProvider : PrimitiveValueProvider(stringClassId, java.lang.Cha
             else -> false
         }
     }
+}
+
+object VoidValueProvider : PrimitiveValueProvider(voidClassId) {
+    override fun generate(description: FuzzedDescription, type: FuzzedType): Sequence<Seed<FuzzedType, FuzzedValue>> =
+        sequenceOf(Seed.Simple(UtVoidModel.fuzzed { summary = "%var% = void" }))
 }

--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/spring/unit/InjectMocks.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/spring/unit/InjectMocks.kt
@@ -1,0 +1,48 @@
+package org.utbot.fuzzing.spring.unit
+
+import org.utbot.framework.plugin.api.ClassId
+import org.utbot.framework.plugin.api.UtCompositeModel
+import org.utbot.framework.plugin.api.util.allDeclaredFieldIds
+import org.utbot.framework.plugin.api.util.isFinal
+import org.utbot.framework.plugin.api.util.isStatic
+import org.utbot.framework.plugin.api.util.jField
+import org.utbot.fuzzer.FuzzedType
+import org.utbot.fuzzer.FuzzedValue
+import org.utbot.fuzzer.IdGenerator
+import org.utbot.fuzzer.fuzzed
+import org.utbot.fuzzing.FuzzedDescription
+import org.utbot.fuzzing.JavaValueProvider
+import org.utbot.fuzzing.Routine
+import org.utbot.fuzzing.Seed
+import org.utbot.fuzzing.toFuzzerType
+
+/**
+ * Models created by this class can be used with `@InjectMock` annotation, because
+ * they are [UtCompositeModel]s similar to the ones created by the symbolic engine.
+ */
+class InjectMockValueProvider(
+    private val idGenerator: IdGenerator<Int>,
+    private val classToUseCompositeModelFor: ClassId
+) : JavaValueProvider {
+    override fun accept(type: FuzzedType): Boolean = type.classId == classToUseCompositeModelFor
+
+    override fun generate(description: FuzzedDescription, type: FuzzedType): Sequence<Seed<FuzzedType, FuzzedValue>> {
+        val fields = type.classId.allDeclaredFieldIds.filterNot { it.isStatic && it.isFinal }.toList()
+        return sequenceOf(Seed.Recursive(
+            construct = Routine.Create(types = fields.map { toFuzzerType(it.jField.genericType, description.typeCache) }) { values ->
+                emptyFuzzedValue(type.classId).also {
+                    (it.model as UtCompositeModel).fields.putAll(
+                        fields.zip(values).associate { (field, value) -> field to value.model }
+                    )
+                }
+            },
+            empty = Routine.Empty { emptyFuzzedValue(type.classId) }
+        ))
+    }
+
+    private fun emptyFuzzedValue(classId: ClassId) = UtCompositeModel(
+        id = idGenerator.createId(),
+        classId = classId,
+        isMock = false,
+    ).fuzzed { summary = "%var% = ${classId.simpleName}()" }
+}

--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/spring/unit/Mocks.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/spring/unit/Mocks.kt
@@ -1,0 +1,70 @@
+package org.utbot.fuzzing.spring.unit
+
+import mu.KotlinLogging
+import org.utbot.framework.plugin.api.ClassId
+import org.utbot.framework.plugin.api.MethodId
+import org.utbot.framework.plugin.api.UtCompositeModel
+import org.utbot.framework.plugin.api.util.executableId
+import org.utbot.framework.plugin.api.util.jClass
+import org.utbot.framework.plugin.api.util.method
+import org.utbot.fuzzer.FuzzedType
+import org.utbot.fuzzer.FuzzedValue
+import org.utbot.fuzzer.IdGenerator
+import org.utbot.fuzzer.fuzzed
+import org.utbot.fuzzing.FuzzedDescription
+import org.utbot.fuzzing.JavaValueProvider
+import org.utbot.fuzzing.Routine
+import org.utbot.fuzzing.Scope
+import org.utbot.fuzzing.ScopeProperty
+import org.utbot.fuzzing.Seed
+import org.utbot.fuzzing.toFuzzerType
+
+val methodsToMockProperty = ScopeProperty<Set<MethodId>>(
+    description = "Method ids that can be mocked by `MockValueProvider`"
+)
+
+// TODO shouldn't be used for primitives and other "easy" to create types
+class MockValueProvider(private val idGenerator: IdGenerator<Int>) : JavaValueProvider {
+    companion object {
+        private val logger = KotlinLogging.logger {}
+        private val loggedMockedMethods = mutableSetOf<MethodId>()
+    }
+
+    private val methodsToMock = mutableSetOf<MethodId>()
+
+    override fun enrich(description: FuzzedDescription, type: FuzzedType, scope: Scope) {
+        val publicMethods = type.classId.jClass.methods.map { it.executableId }
+        publicMethods.intersect(methodsToMock).takeIf { it.isNotEmpty() }?.let {
+            scope.putProperty(methodsToMockProperty, it)
+        }
+    }
+
+    override fun generate(description: FuzzedDescription, type: FuzzedType): Sequence<Seed<FuzzedType, FuzzedValue>> =
+        sequenceOf(Seed.Recursive(
+            construct = Routine.Create(types = emptyList()) { emptyMockFuzzedValue(type.classId) },
+            empty = Routine.Empty { emptyMockFuzzedValue(type.classId) },
+            modify = (description.scope?.getProperty(methodsToMockProperty)?.asSequence() ?: emptySequence()).map { methodId ->
+                if (loggedMockedMethods.add(methodId))
+                    logger.info { "Actually mocked $methodId for the first time" }
+                // TODO accept `List<returnType>` instead of singular `returnType`
+                Routine.Call(types = listOf(
+                    toFuzzerType(methodId.method.genericReturnType, description.typeCache)
+                )) { instance, (value) ->
+                    (instance.model as UtCompositeModel).mocks[methodId] = listOf(value.model)
+                }
+            }
+        ))
+
+    private fun emptyMockFuzzedValue(classId: ClassId) = UtCompositeModel(
+        id = idGenerator.createId(),
+        classId = classId,
+        isMock = true,
+        canHaveRedundantOrMissingMocks = true,
+    ).fuzzed { summary = "%var% = mock()" }
+
+    fun addMockingCandidates(detectedMockingCandidates: Set<MethodId>) =
+        detectedMockingCandidates.forEach { methodId ->
+            if (methodsToMock.add(methodId))
+                logger.info { "Detected that $methodId may need mocking" }
+        }
+}

--- a/utbot-js/src/main/kotlin/framework/codegen/model/constructor/tree/JsCgStatementConstructor.kt
+++ b/utbot-js/src/main/kotlin/framework/codegen/model/constructor/tree/JsCgStatementConstructor.kt
@@ -95,7 +95,7 @@ class JsCgStatementConstructor(context: CgContext) :
             isMutable = isMutableVar
         }
 
-        updateVariableScope(declaration.variable, model)
+        rememberVariableForModel(declaration.variable, model)
 
         return Either.left(declaration)
     }
@@ -275,7 +275,7 @@ class JsCgStatementConstructor(context: CgContext) :
 
     override fun declareVariable(type: ClassId, name: String): CgVariable =
         CgVariable(name, type).also {
-            updateVariableScope(it)
+            rememberVariableForModel(it)
         }
 
     // TODO SEVERE: think about these 2 functions

--- a/utbot-js/src/main/kotlin/framework/codegen/model/constructor/tree/JsCgVariableConstructor.kt
+++ b/utbot-js/src/main/kotlin/framework/codegen/model/constructor/tree/JsCgVariableConstructor.kt
@@ -102,7 +102,7 @@ class JsCgVariableConstructor(ctx: CgContext) : CgVariableConstructor(ctx) {
     ): Pair<CgVariable, CgDeclaration> {
         val declaration = CgDeclaration(variableType, baseVariableName.toVarName(), initializer.resolve())
         val variable = declaration.variable
-        updateVariableScope(variable)
+        rememberVariableForModel(variable)
         return variable to declaration
     }
 

--- a/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/settings/CommonSettings.kt
+++ b/utbot-ui-commons/src/main/kotlin/org/utbot/intellij/plugin/settings/CommonSettings.kt
@@ -70,6 +70,7 @@ class Settings(val project: Project) : PersistentStateComponent<Settings.State> 
         var summariesGenerationType: SummariesGenerationType = UtSettings.summaryGenerationType,
         var generationTimeoutInMillis: Long = UtSettings.utBotGenerationTimeoutInMillis,
         var enableExperimentalLanguagesSupport: Boolean = false,
+        var isSpringHandled: Boolean = false,
     ) {
 
         override fun equals(other: Any?): Boolean {
@@ -177,6 +178,16 @@ class Settings(val project: Project) : PersistentStateComponent<Settings.State> 
     var runGeneratedTestsWithCoverage = state.runGeneratedTestsWithCoverage
 
     var enableSummariesGeneration = state.summariesGenerationType
+
+    /**
+     * Defaults in Spring are slightly different, so for every Spring project we update settings, but only
+     * do it once so user is not stuck with defaults, hence this flag is needed to avoid repeated updates.
+     */
+    var isSpringHandled: Boolean
+        get() = state.isSpringHandled
+        set(value) {
+            state.isSpringHandled = value
+        }
 
     fun setClassesToMockAlways(classesToMockAlways: List<String>) {
         state.classesToMockAlways = classesToMockAlways.distinct().toTypedArray()


### PR DESCRIPTION
## Description

Fixes #2321 

To be compatible with Spring unit test paradigm fuzzer is made to mock all third party classes (other than class under test and some well know types, e.g. primitives, lists, and so on) and construct `UtCompositeModel` for class under test, so mocks can be injected into it with `@InjectMock`.

Example of fuzzer generated test (`ownerRepositoryMock` is injected into `ownerController` via `@InjectMocks`):
```java
@Test
public void testProcessFindFormByFuzzer() {
	Page pageMock1 = mock(Page.class);
	(when(pageMock1.isEmpty())).thenReturn(false);
	(when(pageMock1.getTotalElements())).thenReturn(0L, 0L);
	List listMock1 = mock(List.class);
	(when(pageMock1.getContent())).thenReturn(listMock1);
	(when(pageMock1.getTotalPages())).thenReturn(0);
	(when(ownerRepositoryMock.findByLastName(any(), any()))).thenReturn(pageMock1);
	Owner ownerMock = mock(Owner.class);
	(when(ownerMock.getLastName())).thenReturn(((String) null), ((String) null));
	((doNothing()).when(ownerMock)).setLastName(any());
	BindingResult resultMock = mock(BindingResult.class);
	Model modelMock = mock(Model.class);
	Model modelMock1 = mock(Model.class);
	(when(modelMock.addAttribute(any(), any()))).thenReturn(modelMock1, modelMock1, modelMock1, modelMock1, modelMock1);

	String actual = ownerController.processFindForm(1073741824, ownerMock, resultMock, modelMock);

	String expected = "owners/ownersList";

	assertEquals(expected, actual);
}
```

## How to test

### Manual tests

Generate unit tests with fuzzing ratio set to 100% for `OwnerController`.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.