### PR TITLE
Avoid hanging instrumented processes in framework-tests

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/coverage/CoverageCalculator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/coverage/CoverageCalculator.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.runBlocking
 fun methodCoverage(executable: ExecutableId, executions: List<UtValueExecution<*>>, classpath: String): Coverage {
     val methodSignature = executable.signature
     val classId = executable.classId
-    return ConcreteExecutor(CoverageInstrumentation.Factory, classpath).let { executor ->
+    return ConcreteExecutor(CoverageInstrumentation.Factory, classpath).use { executor ->
         for (execution in executions) {
             val args = execution.stateBefore.params.map { it.value }.toMutableList()
             val caller = execution.stateBefore.caller


### PR DESCRIPTION
Fixes `InstrumentedProcessDeathException` when running framework-tests locally

## How to test

### Manual tests

Run `IntExamplesTest` locally.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.