### PR TITLE
Add `utbot-spring-commons-shadow.jar` to engine process `utContext`

### DIFF
--- a/utbot-framework/build.gradle
+++ b/utbot-framework/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
 configurations {
     fetchSpringAnalyzerJar
+    fetchSpringCommonsJar
     fetchInstrumentationJar
 }
 
@@ -51,6 +52,7 @@ dependencies {
     implementation project(':utbot-spring-commons-api')
     implementation project(':utbot-spring-analyzer')
     fetchSpringAnalyzerJar project(path: ':utbot-spring-analyzer', configuration: 'springAnalyzerJar')
+    fetchSpringCommonsJar project(path: ':utbot-spring-commons', configuration: 'springCommonsJar')
 }
 
 processResources {
@@ -59,6 +61,10 @@ processResources {
     }
 
     from(configurations.fetchSpringAnalyzerJar) {
+        into "lib"
+    }
+
+    from(configurations.fetchSpringCommonsJar) {
         into "lib"
     }
 }

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/spring/SpringUtExecutionInstrumentation.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/spring/SpringUtExecutionInstrumentation.kt
@@ -22,6 +22,7 @@ import org.utbot.instrumentation.instrumentation.execution.context.Instrumentati
 import org.utbot.instrumentation.instrumentation.execution.phases.ExecutionPhaseFailingOnAnyException
 import org.utbot.instrumentation.instrumentation.execution.phases.PhasesController
 import org.utbot.spring.api.SpringApi
+import java.io.File
 import java.net.URL
 import java.net.URLClassLoader
 import java.security.ProtectionDomain
@@ -50,6 +51,14 @@ class SpringUtExecutionInstrumentation(
     companion object {
         private val logger = getLogger<SpringUtExecutionInstrumentation>()
         private const val SPRING_COMMONS_JAR_FILENAME = "utbot-spring-commons-shadow.jar"
+
+        val springCommonsJar: File by lazy {
+            JarUtils.extractJarFileFromResources(
+                jarFileName = SPRING_COMMONS_JAR_FILENAME,
+                jarResourcePath = "lib/$SPRING_COMMONS_JAR_FILENAME",
+                targetDirectoryName = "spring-commons"
+            )
+        }
     }
 
     fun tryLoadingSpringContext(): ConcreteContextLoadingResult {
@@ -147,11 +156,7 @@ class SpringUtExecutionInstrumentation(
         private val buildDirs: Array<URL>,
     ) : UtExecutionInstrumentation.Factory<SpringUtExecutionInstrumentation> {
         override val additionalRuntimeClasspath: Set<String>
-            get() = super.additionalRuntimeClasspath + JarUtils.extractJarFileFromResources(
-                jarFileName = SPRING_COMMONS_JAR_FILENAME,
-                jarResourcePath = "lib/$SPRING_COMMONS_JAR_FILENAME",
-                targetDirectoryName = "spring-commons"
-            ).path
+            get() = super.additionalRuntimeClasspath + springCommonsJar.path
 
         // TODO may be we can use some alternative sandbox that has more permissions
         //  (at the very least we need `ReflectPermission("suppressAccessChecks")`

--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -59,6 +59,7 @@ import org.utbot.framework.plugin.api.util.LockFile
 import org.utbot.framework.plugin.api.util.withStaticsSubstitutionRequired
 import org.utbot.framework.plugin.services.JdkInfoService
 import org.utbot.framework.plugin.services.WorkingDirService
+import org.utbot.instrumentation.instrumentation.spring.SpringUtExecutionInstrumentation
 import org.utbot.intellij.plugin.generator.CodeGenerationController.generateTests
 import org.utbot.intellij.plugin.models.GenerateTestsModel
 import org.utbot.intellij.plugin.process.EngineProcess
@@ -261,7 +262,11 @@ object UtTestsDialogProcessor {
                         val process = EngineProcess.createBlocking(project, classNameToPath)
 
                         process.terminateOnException { _ ->
-                            val classpathForClassLoader = buildDirs + classpathList
+                            val classpathForClassLoader = buildDirs + classpathList + when (model.projectType) {
+                                Spring -> listOf(SpringUtExecutionInstrumentation.springCommonsJar.path)
+                                else -> emptyList<String>()
+                            }
+
                             process.setupUtContext(classpathForClassLoader)
                             val simpleApplicationContext = SimpleApplicationContext(
                                 SimpleMockerContext(mockFrameworkInstalled, staticMockingConfigured)

--- a/utbot-spring-commons/build.gradle.kts
+++ b/utbot-spring-commons/build.gradle.kts
@@ -19,9 +19,16 @@ java {
 
 dependencies {
     implementation(project(":utbot-spring-commons-api"))
-    implementation(project(":utbot-core"))
 
-    // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot
+
+    // these dependencies are compilieOnly, because they should
+    // already be present on the classpath in all utbot processes
+    compileOnly(project(":utbot-core"))
+    compileOnly("com.jetbrains.rd:rd-core:$rdVersion") { exclude(group = "org.slf4j", module = "slf4j-api") }
+
+
+    // these dependencies are compilieOnly, because they should
+    // be picked up from user classpath if they are present there
     compileOnly("org.springframework.boot:spring-boot:$springBootVersion")
     compileOnly("org.springframework.boot:spring-boot-test-autoconfigure:$springBootVersion")
     compileOnly("org.springframework:spring-test:$springVersion")
@@ -32,8 +39,6 @@ dependencies {
 
     compileOnly("javax.persistence:javax.persistence-api:$javaxVersion")
     compileOnly("jakarta.persistence:jakarta.persistence-api:$jakartaVersion")
-
-    implementation("com.jetbrains.rd:rd-core:$rdVersion") { exclude(group = "org.slf4j", module = "slf4j-api") }
 }
 
 tasks.shadowJar {


### PR DESCRIPTION
## Description

Fixes generation of failing `contextLoads()` test after #2479 which caused it to fail with `ClassNotFoundexception: org.utbot.spring.api.UTSpringContextLoadingException`

Also, lessens the size of `utbot-spring-commons-shadow.jar` by not including common UtBot dependencies that are present in every UtBot process anyway.

## How to test

### Manual tests

Add the following class to the `spring-boot-testing-main` project and generate integration tests.
```java
@Service
public class UnrelatedService {
    public UnrelatedService() {
        throw new RuntimeException("UnrelatedService");
    }
}
```

The following tests should get generated.
```java
@ExtendWith(SpringExtension.class)
@BootstrapWith(SpringBootTestContextBootstrapper.class)
@ActiveProfiles(profiles = {"default"})
@ContextConfiguration(classes = {OrderServiceApplication.class})
@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
@Transactional
@AutoConfigureTestDatabase
public final class OrderServiceTest {


    /**
     * This sanity check test fails if the application context cannot start.
     * <p>
     * Context loading throws an exception.
     * Please try to fix your context or environment configuration.
     * Spring configuration applied: com.rest.order.OrderServiceApplication.
     */
    @Test
    public void contextLoads() {
        /* Failure caused by: java.lang.IllegalStateException: Failed to load ApplicationContext
                at org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate.loadContext(DefaultCacheAwareContextLoaderDelegate.java:132)
                at org.springframework.test.context.support.DefaultTestContext.getApplicationContext(DefaultTestContext.java:124)
                at org.utbot.spring.SpringApiImpl.getOrLoadSpringApplicationContext(SpringApiImpl.kt:49)
                ... 30 more
            Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'unrelatedService' defined in file [C:\Users\murav\IdeaProjects\spring-boot-testing-main-10\spring-boot-testing-main\target\classes\com\rest\order\services\UnrelatedService.class]: Instantiation of bean failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [com.rest.order.services.UnrelatedService]: Constructor threw exception; nested exception is java.lang.RuntimeException: UnrelatedService; nested exception is java.lang.RuntimeException: Failed to instantiate [com.rest.order.services.UnrelatedService]: Constructor threw exception; nested exception is java.lang.RuntimeException: UnrelatedService
                at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateBean(AbstractAutowireCapableBeanFactory.java:1334)
                at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1232)
                at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:582)
                at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:542)
                at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:335)
                at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234)
                at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:333)
                at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:208)
                at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:955)
                at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:918)
                at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:583)
                at org.springframework.test.context.support.AbstractGenericContextLoader.loadContext(AbstractGenericContextLoader.java:127)
                at org.springframework.test.context.support.AbstractGenericContextLoader.loadContext(AbstractGenericContextLoader.java:60)
                at org.springframework.test.context.support.AbstractDelegatingSmartContextLoader.delegateLoading(AbstractDelegatingSmartContextLoader.java:276)
                at org.springframework.test.context.support.AbstractDelegatingSmartContextLoader.loadContext(AbstractDelegatingSmartContextLoader.java:244)
                at org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate.loadContextInternal(DefaultCacheAwareContextLoaderDelegate.java:99)
                at org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate.loadContext(DefaultCacheAwareContextLoaderDelegate.java:124)
                ... 32 more
            Caused by: java.lang.RuntimeException: Failed to instantiate [com.rest.order.services.UnrelatedService]: Constructor threw exception; nested exception is java.lang.RuntimeException: UnrelatedService
                at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:224)
                at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:87)
                at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.lambda$instantiateBean$3(AbstractAutowireCapableBeanFactory.java:1322)
                at java.base/java.security.AccessController.doPrivileged(Native Method)
                at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateBean(AbstractAutowireCapableBeanFactory.java:1321)
                ... 48 more
            Caused by: java.lang.RuntimeException: UnrelatedService
                at com.rest.order.services.UnrelatedService.<init>(UnrelatedService.java:8)
                at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
                at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
                at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
                at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
                at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:211)
                ... 52 more
             */
    }


    ///region Test suites for executable com.rest.order.services.OrderService.createOrder

    ///region Errors report for createOrder

    public void testCreateOrder_errors() {
        // Couldn't generate some tests. List of errors:
        // 
        // 1 occurrences of:
        // Failed to load Spring application context

    }
    ///endregion

    ///endregion

    ///region Test suites for executable com.rest.order.services.OrderService.deleteOrderById

    ///region Errors report for deleteOrderById

    public void testDeleteOrderById_errors() {
        // Couldn't generate some tests. List of errors:
        // 
        // 1 occurrences of:
        // Failed to load Spring application context

    }
    ///endregion

    ///endregion

    ///region Test suites for executable com.rest.order.services.OrderService.getOrderById

    ///region Errors report for getOrderById

    public void testGetOrderById_errors() {
        // Couldn't generate some tests. List of errors:
        // 
        // 1 occurrences of:
        // Failed to load Spring application context

    }
    ///endregion

    ///endregion

    ///region Test suites for executable com.rest.order.services.OrderService.getOrders

    ///region Errors report for getOrders

    public void testGetOrders_errors() {
        // Couldn't generate some tests. List of errors:
        // 
        // 1 occurrences of:
        // Failed to load Spring application context

    }
    ///endregion

    ///endregion
}
```

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.