### PR TITLE
Reword message for initial stage of test generation

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/generator/UtTestsDialogProcessor.kt
@@ -82,7 +82,8 @@ object UtTestsDialogProcessor {
     private val logger = KotlinLogging.logger {}
 
     enum class ProgressRange(val from : Double, val to: Double) {
-        SOLVING(from = 0.0, to = 0.9),
+        INITIALIZATION(from = 0.01, to = 0.1),
+        SOLVING(from = 0.1, to = 0.9),
         CODEGEN(from = 0.9, to = 0.95),
         SARIF(from = 0.95, to = 1.0)
     }
@@ -218,7 +219,7 @@ object UtTestsDialogProcessor {
                         val secondsTimeout = TimeUnit.MILLISECONDS.toSeconds(model.timeout)
 
                         indicator.isIndeterminate = false
-                        updateIndicator(indicator, ProgressRange.SOLVING, "Generate tests: read classes", 0.0)
+                        updateIndicator(indicator, ProgressRange.INITIALIZATION, "Generate tests: starting engine", 0.0)
 
                         // TODO sometimes preClasspathCollectionPromises get stuck, even though all
                         //  needed dependencies get installed, we need to figure out why that happens
@@ -259,6 +260,7 @@ object UtTestsDialogProcessor {
                         val staticMockingConfigured = model.staticsMocking.isConfigured
 
                         val process = EngineProcess.createBlocking(project, classNameToPath)
+                        updateIndicator(indicator, ProgressRange.INITIALIZATION, fraction = 0.2)
 
                         process.terminateOnException { _ ->
                             val classpathForClassLoader = buildDirs + classpathList
@@ -291,6 +293,7 @@ object UtTestsDialogProcessor {
                                 }
                                 else -> simpleApplicationContext
                             }
+                            updateIndicator(indicator, ProgressRange.INITIALIZATION, fraction = 0.25)
                             process.createTestGenerator(
                                 buildDirs,
                                 classpath,
@@ -302,6 +305,7 @@ object UtTestsDialogProcessor {
                                     indicator.isCanceled
                                 })
                             }
+                            updateIndicator(indicator, ProgressRange.INITIALIZATION, fraction = 1.0)
 
                             for (srcClass in model.srcClasses) {
                                 if (indicator.isCanceled) {


### PR DESCRIPTION
## Description

Fixes #2516 

"Reading classes" message is pretty misleading because it's stage of initialization: starting engine, creating application context, creating test generator. In my environment starting engine takes ~3sec and creating test generator takes ~10sec. It requires further profiling.

### Manual tests

Start tests generation. 
For the first stage we display text "Generate tests: starting engine" then iteration through classes (with messages "Generate test cases for class XXX").

## Self-check list

Check off the item if the statement is true. Hint: [x] is a marked item.

Please do not delete the list or its items.

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.