### PR TITLE
Call `entityManager.flush()` on every `entityManager` usage and dynamically remove failing `UtStatementCallModel`s

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/mapper/UtModelDeepMapper.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/mapper/UtModelDeepMapper.kt
@@ -1,0 +1,118 @@
+package org.utbot.framework.plugin.api.mapper
+
+import org.utbot.framework.plugin.api.UtArrayModel
+import org.utbot.framework.plugin.api.UtAssembleModel
+import org.utbot.framework.plugin.api.UtClassRefModel
+import org.utbot.framework.plugin.api.UtCompositeModel
+import org.utbot.framework.plugin.api.UtCustomModel
+import org.utbot.framework.plugin.api.UtEnumConstantModel
+import org.utbot.framework.plugin.api.UtLambdaModel
+import org.utbot.framework.plugin.api.UtModel
+import org.utbot.framework.plugin.api.UtNullModel
+import org.utbot.framework.plugin.api.UtPrimitiveModel
+import org.utbot.framework.plugin.api.UtReferenceModel
+import org.utbot.framework.plugin.api.UtVoidModel
+
+/**
+ * Performs deep mapping of [UtModel]s.
+ *
+ * NOTE:
+ *  - [shallowMapper] is invoked on models **before** mapping their sub models.
+ *  - [shallowMapper] is responsible for caching own results (it may be called repeatedly on same models).
+ */
+class UtModelDeepMapper(
+    private val shallowMapper: UtModelMapper
+) : UtModelMapper {
+    /**
+     * Keys are models that have been shallowly mapped by [shallowMapper].
+     * Values are models that have been deeply mapped by this [UtModelDeepMapper].
+     * Models are only associated with models of the same type (i.e. the cache type is actually `MutableMap<T, T>`)
+     */
+    private val cache = mutableMapOf<UtModel, UtModel>()
+
+    val allInputtedModels get() = cache.keys
+    val allOutputtedModels get() = cache.values
+
+    override fun <T : UtModel> map(model: T, clazz: Class<T>): T =
+        clazz.cast(mapNestedModels(shallowMapper.map(model, clazz)))
+
+    /**
+     * Maps models contained inside [model], but not the [model] itself.
+     */
+    private fun mapNestedModels(model: UtModel): UtModel = cache.getOrPut(model) {
+        when (model) {
+            is UtNullModel,
+            is UtPrimitiveModel,
+            is UtEnumConstantModel,
+            is UtClassRefModel,
+            is UtVoidModel -> model
+            is UtArrayModel -> mapNestedModels(model)
+            is UtCompositeModel -> mapNestedModels(model)
+            is UtLambdaModel -> mapNestedModels(model)
+            is UtAssembleModel -> mapNestedModels(model)
+            is UtCustomModel -> mapNestedModels(model)
+
+            // PythonModel, JsUtModel may be here
+            else -> throw UnsupportedOperationException("UtModel $this cannot be mapped")
+        }
+    }
+
+    private fun mapNestedModels(model: UtArrayModel): UtReferenceModel {
+        val mappedModel = UtArrayModel(
+            id = model.id,
+            classId = model.classId,
+            length = model.length,
+            constModel = model.constModel,
+            stores = model.stores,
+        )
+        cache[model] = mappedModel
+
+        mappedModel.constModel = model.constModel.map(this)
+        mappedModel.stores.putAll(model.stores.mapModelValues(this))
+
+        return mappedModel
+    }
+
+    private fun mapNestedModels(model: UtCompositeModel): UtCompositeModel {
+        val mappedModel = UtCompositeModel(
+            id = model.id,
+            classId = model.classId,
+            isMock = model.isMock,
+        )
+        cache[model] = mappedModel
+
+        mappedModel.fields.putAll(model.fields.mapModelValues(this))
+        mappedModel.mocks.putAll(model.mocks.mapValuesTo(mutableMapOf()) { it.value.mapModels(this@UtModelDeepMapper) })
+
+        return mappedModel
+    }
+
+    private fun mapNestedModels(model: UtLambdaModel): UtReferenceModel = UtLambdaModel(
+        id = model.id,
+        samType = model.samType,
+        declaringClass = model.declaringClass,
+        lambdaName = model.lambdaName,
+        capturedValues = model.capturedValues.mapModels(this@UtModelDeepMapper).toMutableList()
+    )
+
+    private fun mapNestedModels(model: UtAssembleModel): UtReferenceModel = UtAssembleModel(
+        id = model.id,
+        classId = model.classId,
+        modelName = model.modelName,
+        instantiationCall = model.instantiationCall.mapModels(this),
+        modificationsChainProvider = {
+            cache[model] = this@UtAssembleModel
+            model.modificationsChain.map { it.mapModels(this@UtModelDeepMapper) }
+        },
+        origin = model.origin?.mapPreservingType<UtCompositeModel>(this)
+    )
+
+    private fun mapNestedModels(model: UtCustomModel): UtReferenceModel =
+        model.shallowMap(this)
+
+    companion object {
+        fun fromSimpleShallowMapper(shallowMapper: (UtModel) -> UtModel) = UtModelDeepMapper(
+            UtModelSafeCastingCachingShallowMapper(shallowMapper)
+        )
+    }
+}

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/mapper/UtModelMapper.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/mapper/UtModelMapper.kt
@@ -1,0 +1,18 @@
+package org.utbot.framework.plugin.api.mapper
+
+import org.utbot.framework.plugin.api.UtCompositeModel
+import org.utbot.framework.plugin.api.UtModel
+import org.utbot.framework.plugin.api.UtModelWithCompositeOrigin
+
+interface UtModelMapper {
+    /**
+     * Performs depending on the implementation deep or shallow mapping of the [model].
+     *
+     * In some cases (e.g. when mapping [UtModelWithCompositeOrigin.origin]) you may want to get result
+     * of some specific type (e.g. [UtCompositeModel]), only then you should specify specific value for [clazz].
+     *
+     * NOTE: if you are fine with result model and [model] having different types, then you should
+     * use `UtModel::class.java` as a value for [clazz] or just use [UtModel.map].
+     */
+    fun <T : UtModel> map(model: T, clazz: Class<T>): T
+}

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/mapper/UtModelNoopMapper.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/mapper/UtModelNoopMapper.kt
@@ -1,0 +1,7 @@
+package org.utbot.framework.plugin.api.mapper
+
+import org.utbot.framework.plugin.api.UtModel
+
+object UtModelNoopMapper : UtModelMapper {
+    override fun <T : UtModel> map(model: T, clazz: Class<T>): T = model
+}

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/mapper/UtModelSafeCastingCachingShallowMapper.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/mapper/UtModelSafeCastingCachingShallowMapper.kt
@@ -1,0 +1,15 @@
+package org.utbot.framework.plugin.api.mapper
+
+import org.utbot.framework.plugin.api.UtModel
+
+class UtModelSafeCastingCachingShallowMapper(
+    val mapper: (UtModel) -> UtModel
+) : UtModelMapper {
+    private val cache = mutableMapOf<UtModel, UtModel>()
+
+    override fun <T : UtModel> map(model: T, clazz: Class<T>): T {
+        val mapped = cache.getOrPut(model) { mapper(model) }
+        return if (clazz.isInstance(mapped)) clazz.cast(mapped)
+        else model
+    }
+}

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/mapper/Utils.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/mapper/Utils.kt
@@ -13,12 +13,6 @@ import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.framework.plugin.api.UtStatementModel
 import org.utbot.framework.plugin.api.UtStaticMethodInstrumentation
 
-fun collectNestedModels(topLevelModels: Iterable<UtModel>): MutableSet<UtModel> {
-    val deepMapper = UtModelDeepMapper(shallowMapper = UtModelNoopMapper)
-    topLevelModels.forEach { it.map(deepMapper) }
-    return deepMapper.allInputtedModels
-}
-
 inline fun <reified T : UtModel> T.mapPreservingType(mapper: UtModelMapper): T =
     mapper.map(this, T::class.java)
 

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/mapper/Utils.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/mapper/Utils.kt
@@ -1,0 +1,70 @@
+package org.utbot.framework.plugin.api.mapper
+
+import org.utbot.framework.plugin.api.EnvironmentModels
+import org.utbot.framework.plugin.api.UtDirectGetFieldModel
+import org.utbot.framework.plugin.api.UtDirectSetFieldModel
+import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtExecution
+import org.utbot.framework.plugin.api.UtInstrumentation
+import org.utbot.framework.plugin.api.UtModel
+import org.utbot.framework.plugin.api.UtNewInstanceInstrumentation
+import org.utbot.framework.plugin.api.UtReferenceModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
+import org.utbot.framework.plugin.api.UtStatementModel
+import org.utbot.framework.plugin.api.UtStaticMethodInstrumentation
+
+fun collectNestedModels(topLevelModels: Iterable<UtModel>): MutableSet<UtModel> {
+    val deepMapper = UtModelDeepMapper(shallowMapper = UtModelNoopMapper)
+    topLevelModels.forEach { it.map(deepMapper) }
+    return deepMapper.allInputtedModels
+}
+
+inline fun <reified T : UtModel> T.mapPreservingType(mapper: UtModelMapper): T =
+    mapper.map(this, T::class.java)
+
+fun UtModel.map(mapper: UtModelMapper) = mapPreservingType<UtModel>(mapper)
+
+fun List<UtModel>.mapModels(mapper: UtModelMapper): List<UtModel> =
+    map { model -> model.map(mapper) }
+
+fun <K> Map<K, UtModel>.mapModelValues(mapper: UtModelMapper): Map<K, UtModel> =
+    mapValues { (_, model) -> model.map(mapper) }
+
+fun UtStatementModel.mapModels(mapper: UtModelMapper): UtStatementModel =
+    when(this) {
+        is UtStatementCallModel -> mapModels(mapper)
+        is UtDirectSetFieldModel -> UtDirectSetFieldModel(
+            instance = instance.mapPreservingType<UtReferenceModel>(mapper),
+            fieldId = fieldId,
+            fieldModel = fieldModel.map(mapper)
+        )
+    }
+
+fun UtStatementCallModel.mapModels(mapper: UtModelMapper): UtStatementCallModel =
+    when(this) {
+        is UtDirectGetFieldModel -> UtDirectGetFieldModel(
+            instance = instance.mapPreservingType<UtReferenceModel>(mapper),
+            fieldAccess = fieldAccess,
+        )
+        is UtExecutableCallModel -> UtExecutableCallModel(
+            instance = instance?.mapPreservingType<UtReferenceModel>(mapper),
+            executable = executable,
+            params = params.mapModels(mapper)
+        )
+    }
+
+fun EnvironmentModels.mapModels(mapper: UtModelMapper) = EnvironmentModels(
+    thisInstance = thisInstance?.map(mapper),
+    statics = statics.mapModelValues(mapper),
+    parameters = parameters.mapModels(mapper),
+    executableToCall = executableToCall,
+)
+
+fun UtInstrumentation.mapModels(mapper: UtModelMapper) = when (this) {
+    is UtNewInstanceInstrumentation -> copy(instances = instances.mapModels(mapper))
+    is UtStaticMethodInstrumentation -> copy(values = values.mapModels(mapper))
+}
+
+fun UtExecution.mapStateBeforeModels(mapper: UtModelMapper) = copy(
+    stateBefore = stateBefore.mapModels(mapper)
+)

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SpringModelUtils.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SpringModelUtils.kt
@@ -69,6 +69,17 @@ object SpringModelUtils {
             )
         }
 
+    val flushMethodIdOrNull: MethodId?
+        get() {
+            return MethodId(
+                classId = entityManagerClassIds.firstOrNull() ?: return null,
+                name = "flush",
+                returnType = voidClassId,
+                parameters = listOf(),
+                bypassesSandbox = true // TODO may be we can use some alternative sandbox that has more permissions
+            )
+        }
+
     val detachMethodIdOrNull: MethodId?
         get() {
             return MethodId(
@@ -376,9 +387,10 @@ object SpringModelUtils {
         val headersContentModel = createHeadersContentModel(methodId, arguments, idGenerator)
         requestBuilderModel = addHeadersToRequestBuilderModel(headersContentModel, requestBuilderModel, idGenerator)
 
-        val cookieValuesModel = createCookieValuesModel(methodId, arguments, idGenerator)
-        requestBuilderModel =
-            addCookiesToRequestBuilderModel(cookieValuesModel, requestBuilderModel, idGenerator)
+//      // TODO uncomment when #2542 is fixed
+//        val cookieValuesModel = createCookieValuesModel(methodId, arguments, idGenerator)
+//        requestBuilderModel =
+//            addCookiesToRequestBuilderModel(cookieValuesModel, requestBuilderModel, idGenerator)
 
         val requestAttributes = collectArgumentsWithAnnotationModels(methodId, requestAttributesClassId, arguments)
         requestBuilderModel =

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SpringModelUtils.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SpringModelUtils.kt
@@ -193,12 +193,13 @@ object SpringModelUtils {
         parameters = listOf(httpHeaderClassId)
     )
 
-    private val mockHttpServletCookieMethodId = MethodId(
-        classId = mockHttpServletRequestBuilderClassId,
-        name = "cookie",
-        returnType = mockHttpServletRequestBuilderClassId,
-        parameters = listOf(getArrayClassIdByElementClassId(cookieClassId))
-    )
+//    // TODO uncomment when #2542 is fixed
+//    private val mockHttpServletCookieMethodId = MethodId(
+//        classId = mockHttpServletRequestBuilderClassId,
+//        name = "cookie",
+//        returnType = mockHttpServletRequestBuilderClassId,
+//        parameters = listOf(getArrayClassIdByElementClassId(cookieClassId))
+//    )
 
     private val mockHttpServletContentTypeMethodId = MethodId(
         classId = mockHttpServletRequestBuilderClassId,
@@ -467,28 +468,29 @@ object SpringModelUtils {
         return requestBuilderModel
     }
 
-    private fun addCookiesToRequestBuilderModel(
-        cookieValuesModel: UtArrayModel,
-        requestBuilderModel: UtAssembleModel,
-        idGenerator: () -> Int
-    ): UtAssembleModel {
-        @Suppress("NAME_SHADOWING")
-        var requestBuilderModel = requestBuilderModel
-
-        if(cookieValuesModel.length > 0) {
-            requestBuilderModel = UtAssembleModel(
-                id = idGenerator(),
-                classId = mockHttpServletRequestBuilderClassId,
-                modelName = "requestBuilder",
-                instantiationCall = UtExecutableCallModel(
-                    instance = requestBuilderModel,
-                    executable = mockHttpServletCookieMethodId,
-                    params = listOf(cookieValuesModel)
-                )
-            )
-        }
-        return requestBuilderModel
-    }
+//    // TODO uncomment when #2542 is fixed
+//    private fun addCookiesToRequestBuilderModel(
+//        cookieValuesModel: UtArrayModel,
+//        requestBuilderModel: UtAssembleModel,
+//        idGenerator: () -> Int
+//    ): UtAssembleModel {
+//        @Suppress("NAME_SHADOWING")
+//        var requestBuilderModel = requestBuilderModel
+//
+//        if(cookieValuesModel.length > 0) {
+//            requestBuilderModel = UtAssembleModel(
+//                id = idGenerator(),
+//                classId = mockHttpServletRequestBuilderClassId,
+//                modelName = "requestBuilder",
+//                instantiationCall = UtExecutableCallModel(
+//                    instance = requestBuilderModel,
+//                    executable = mockHttpServletCookieMethodId,
+//                    params = listOf(cookieValuesModel)
+//                )
+//            )
+//        }
+//        return requestBuilderModel
+//    }
 
     private fun addHeadersToRequestBuilderModel(
         headersContentModel: UtAssembleModel,

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/CgMethodTestSet.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/CgMethodTestSet.kt
@@ -135,6 +135,6 @@ data class CgMethodTestSet(
         return substituteExecutions(symbolicExecutionsWithoutMocking)
     }
 
-    private fun substituteExecutions(newExecutions: List<UtExecution>): CgMethodTestSet =
+    fun substituteExecutions(newExecutions: List<UtExecution>): CgMethodTestSet =
         copy().apply { executions = newExecutions }
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/TestClassModel.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/models/TestClassModel.kt
@@ -1,7 +1,8 @@
 package org.utbot.framework.codegen.domain.models
 
-import org.utbot.framework.codegen.domain.models.builders.TypedModelWrappers
 import org.utbot.framework.plugin.api.ClassId
+import org.utbot.framework.plugin.api.mapper.UtModelDeepMapper
+import org.utbot.framework.plugin.api.mapper.mapStateBeforeModels
 
 /**
  * Stores method test sets in a structure that replicates structure of their methods in [classUnderTest].
@@ -20,3 +21,13 @@ class SimpleTestClassModel(
     nestedClasses: List<SimpleTestClassModel> = listOf(),
 ): TestClassModel(classUnderTest, methodTestSets, nestedClasses)
 
+fun SimpleTestClassModel.mapStateBeforeModels(mapperProvider: () -> UtModelDeepMapper) =
+    SimpleTestClassModel(
+        classUnderTest = classUnderTest,
+        nestedClasses = nestedClasses,
+        methodTestSets = methodTestSets.map { testSet ->
+            testSet.substituteExecutions(
+                testSet.executions.map { execution -> execution.mapStateBeforeModels(mapperProvider()) }
+            )
+        }
+    )

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringIntegrationTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringIntegrationTestClassConstructor.kt
@@ -16,8 +16,14 @@ import org.utbot.framework.codegen.util.escapeControlChars
 import org.utbot.framework.codegen.util.resolve
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.ConcreteContextLoadingResult
+import org.utbot.framework.plugin.api.MethodId
 import org.utbot.framework.plugin.api.SpringSettings.*
 import org.utbot.framework.plugin.api.SpringConfiguration.*
+import org.utbot.framework.plugin.api.UtAssembleModel
+import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtModel
+import org.utbot.framework.plugin.api.UtSpringEntityManagerModel
+import org.utbot.framework.plugin.api.mapper.UtModelDeepMapper
 import org.utbot.framework.plugin.api.util.IndentUtil.TAB
 import org.utbot.framework.plugin.api.util.SpringModelUtils
 import org.utbot.framework.plugin.api.util.SpringModelUtils.activeProfilesClassId
@@ -27,7 +33,7 @@ import org.utbot.framework.plugin.api.util.SpringModelUtils.contextConfiguration
 import org.utbot.framework.plugin.api.util.SpringModelUtils.dirtiesContextClassId
 import org.utbot.framework.plugin.api.util.SpringModelUtils.dirtiesContextClassModeClassId
 import org.utbot.framework.plugin.api.util.SpringModelUtils.extendWithClassId
-import org.utbot.framework.plugin.api.util.SpringModelUtils.mockMvcClassId
+import org.utbot.framework.plugin.api.util.SpringModelUtils.flushMethodIdOrNull
 import org.utbot.framework.plugin.api.util.SpringModelUtils.repositoryClassId
 import org.utbot.framework.plugin.api.util.SpringModelUtils.runWithClassId
 import org.utbot.framework.plugin.api.util.SpringModelUtils.springBootTestClassId
@@ -52,6 +58,33 @@ class CgSpringIntegrationTestClassConstructor(
         private val logger = KotlinLogging.logger {}
     }
 
+    override fun construct(testClassModel: SimpleTestClassModel): CgClassFile = super.construct(
+        flushMethodIdOrNull?.let { flushMethodId ->
+            testClassModel.mapStateBeforeModels { UtModelDeepMapper.fromSimpleShallowMapper { model ->
+                shallowlyAddFlushes(model, flushMethodId)
+            } }
+        } ?: testClassModel
+    )
+
+    private fun shallowlyAddFlushes(model: UtModel, flushMethodId: MethodId): UtModel =
+        when (model) {
+            is UtAssembleModel -> model.copy(
+                modificationsChain = model.modificationsChain.flatMap { modification ->
+                    if (modification.instance is UtSpringEntityManagerModel)
+                        listOf(
+                            modification,
+                            UtExecutableCallModel(
+                                instance = UtSpringEntityManagerModel(),
+                                executable = flushMethodId,
+                                params = emptyList()
+                            )
+                        )
+                    else listOf(modification)
+                }
+            )
+            else -> model
+        }
+
     override fun constructTestClass(testClassModel: SimpleTestClassModel): CgClass {
         addNecessarySpringSpecificAnnotations(testClassModel)
         return super.constructTestClass(testClassModel)
@@ -59,8 +92,7 @@ class CgSpringIntegrationTestClassConstructor(
 
     override fun constructClassFields(testClassModel: SimpleTestClassModel): List<CgFieldDeclaration> {
         val autowiredFields = autowiredFieldManager.createFieldDeclarations(testClassModel)
-        val persistentContextFields = persistenceContextFieldsManager
-            ?.let { fieldsManager -> fieldsManager.createFieldDeclarations(testClassModel) }
+        val persistentContextFields = persistenceContextFieldsManager?.createFieldDeclarations(testClassModel)
             .orEmpty()
 
         return autowiredFields + persistentContextFields

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringIntegrationTestConcreteExecutionContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringIntegrationTestConcreteExecutionContext.kt
@@ -10,6 +10,7 @@ import org.utbot.framework.plugin.api.UtExecution
 import org.utbot.fuzzer.IdentityPreservingIdGenerator
 import org.utbot.instrumentation.ConcreteExecutor
 import org.utbot.instrumentation.getRelevantSpringRepositories
+import org.utbot.instrumentation.instrumentation.execution.RemovingConstructFailsUtExecutionInstrumentation
 import org.utbot.instrumentation.instrumentation.execution.UtConcreteExecutionResult
 import org.utbot.instrumentation.instrumentation.execution.UtExecutionInstrumentation
 import org.utbot.instrumentation.instrumentation.spring.SpringUtExecutionInstrumentation
@@ -29,13 +30,15 @@ class SpringIntegrationTestConcreteExecutionContext(
     }
 
     override val instrumentationFactory: UtExecutionInstrumentation.Factory<*> =
-        SpringUtExecutionInstrumentation.Factory(
-            delegateContext.instrumentationFactory,
-            springSettings,
-            springApplicationContext.beanDefinitions,
-            buildDirs = classpathWithoutDependencies.split(File.pathSeparator)
-                .map { File(it).toURI().toURL() }
-                .toTypedArray(),
+        RemovingConstructFailsUtExecutionInstrumentation.Factory(
+            SpringUtExecutionInstrumentation.Factory(
+                delegateContext.instrumentationFactory,
+                springSettings,
+                springApplicationContext.beanDefinitions,
+                buildDirs = classpathWithoutDependencies.split(File.pathSeparator)
+                    .map { File(it).toURI().toURL() }
+                    .toTypedArray(),
+            )
         )
 
     override fun loadContext(

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/Instrumentation.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/Instrumentation.kt
@@ -2,6 +2,9 @@ package org.utbot.instrumentation.instrumentation
 
 import java.lang.instrument.ClassFileTransformer
 import org.utbot.framework.plugin.api.FieldId
+import org.utbot.framework.process.kryo.KryoHelper
+import org.utbot.instrumentation.process.generated.InstrumentedProcessModel
+import org.utbot.rd.IdleWatchdog
 
 /**
  * Abstract class for the instrumentation.
@@ -26,6 +29,8 @@ interface Instrumentation<out TInvocationInstrumentation> : ClassFileTransformer
     ): TInvocationInstrumentation
 
     fun getStaticField(fieldId: FieldId): Result<*>
+
+    fun InstrumentedProcessModel.setupAdditionalRdResponses(kryoHelper: KryoHelper, watchdog: IdleWatchdog) {}
 
     interface Factory<out TIResult, out TInstrumentation : Instrumentation<TIResult>> {
         val additionalRuntimeClasspath: Set<String> get() = emptySet()

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/RemovingConstructFailsUtExecutionInstrumentation.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/RemovingConstructFailsUtExecutionInstrumentation.kt
@@ -1,0 +1,155 @@
+package org.utbot.instrumentation.instrumentation.execution
+
+import com.jetbrains.rd.util.getLogger
+import com.jetbrains.rd.util.info
+import org.utbot.framework.plugin.api.Coverage
+import org.utbot.framework.plugin.api.FieldId
+import org.utbot.framework.plugin.api.MissingState
+import org.utbot.framework.plugin.api.UtAssembleModel
+import org.utbot.framework.plugin.api.UtConcreteExecutionProcessedFailure
+import org.utbot.framework.plugin.api.UtModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
+import org.utbot.framework.plugin.api.isNull
+import org.utbot.framework.plugin.api.mapper.UtModelDeepMapper
+import org.utbot.framework.plugin.api.util.defaultValueModel
+import org.utbot.framework.process.kryo.KryoHelper
+import org.utbot.instrumentation.instrumentation.ArgumentList
+import org.utbot.instrumentation.instrumentation.execution.context.InstrumentationContext
+import org.utbot.instrumentation.instrumentation.execution.phases.ExecutionPhaseStop
+import org.utbot.instrumentation.instrumentation.execution.phases.PhasesController
+import org.utbot.instrumentation.instrumentation.execution.phases.ValueConstructionPhase
+import org.utbot.instrumentation.process.generated.InstrumentedProcessModel
+import org.utbot.rd.IdleWatchdog
+import java.security.ProtectionDomain
+
+/**
+ * [UtExecutionInstrumentation] that on [invoke] tries to run [invoke] of the [delegateInstrumentation]
+ * a few times, each time removing failing [UtStatementCallModel]s, until either max number of reruns
+ * is reached or [invoke] of the [delegateInstrumentation] no longer fails with [UtConcreteExecutionProcessedFailure].
+ *
+ * @see [UtStatementCallModel.thrownConcreteException]
+ */
+class RemovingConstructFailsUtExecutionInstrumentation(
+    instrumentationContext: InstrumentationContext,
+    delegateInstrumentationFactory: UtExecutionInstrumentation.Factory<*>
+) : UtExecutionInstrumentation {
+    companion object {
+        private const val MAX_RETRIES = 5
+        private val logger = getLogger<RemovingConstructFailsUtExecutionInstrumentation>()
+    }
+
+    private val delegateInstrumentation = delegateInstrumentationFactory.create(object : InstrumentationContext by instrumentationContext {
+        override fun handleLastCaughtConstructionException(exception: Throwable) {
+            throw ExecutionPhaseStop(
+                phase = ValueConstructionPhase::class.java.simpleName,
+                result = PreliminaryUtConcreteExecutionResult(
+                    stateAfter = MissingState,
+                    result = UtConcreteExecutionProcessedFailure(exception),
+                    coverage = Coverage()
+                )
+            )
+        }
+    })
+    private var runsCompleted = 0
+    private var nextRunIndexToLog = 1 // we log `attemptsDistribution` every run that has index that is a power of 10
+    private val attemptsDistribution = mutableMapOf<Int, Int>()
+
+    override fun invoke(
+        clazz: Class<*>,
+        methodSignature: String,
+        arguments: ArgumentList,
+        parameters: Any?,
+        phasesWrapper: PhasesController.(invokeBasePhases: () -> PreliminaryUtConcreteExecutionResult) -> PreliminaryUtConcreteExecutionResult
+    ): UtConcreteExecutionResult {
+        @Suppress("NAME_SHADOWING")
+        var parameters = parameters as UtConcreteExecutionData
+        var attempt = 0
+        var res: UtConcreteExecutionResult
+        try {
+            do {
+                res = delegateInstrumentation.invoke(clazz, methodSignature, arguments, parameters, phasesWrapper)
+
+                if (res.result !is UtConcreteExecutionProcessedFailure)
+                    return res
+
+                parameters = parameters.mapModels(UtModelDeepMapper.fromSimpleShallowMapper { model ->
+                    shallowlyRemoveFailingCalls(model)
+                })
+
+                // if `thisInstance` is present and became `isNull`, then we should stop trying to
+                // correct this execution and return `UtConcreteExecutionProcessedFailure`
+                if (parameters.stateBefore.thisInstance?.isNull() == true)
+                    return res
+
+            } while (attempt++ < MAX_RETRIES)
+
+            return res
+        } finally {
+            runsCompleted++
+            attemptsDistribution[attempt] = (attemptsDistribution[attempt] ?: 0) + 1
+            if (runsCompleted == nextRunIndexToLog) {
+                nextRunIndexToLog *= 10
+                logger.info { "Run: $runsCompleted, attemptsDistribution: $attemptsDistribution" }
+            }
+        }
+    }
+
+    private fun shallowlyRemoveFailingCalls(model: UtModel): UtModel = when {
+        model !is UtAssembleModel -> model
+        model.instantiationCall.thrownConcreteException != null -> model.classId.defaultValueModel()
+        else -> UtAssembleModel(
+            id = model.id,
+            classId = model.classId,
+            modelName = model.modelName,
+            instantiationCall = model.instantiationCall,
+            origin = model.origin,
+            modificationsChainProvider = {
+                model.modificationsChain.filter {
+                    (it as? UtStatementCallModel)?.thrownConcreteException == null &&
+                            (it.instance as? UtAssembleModel)?.instantiationCall?.thrownConcreteException == null
+                }
+            }
+        )
+    }
+
+    override fun getStaticField(fieldId: FieldId): Result<*> = delegateInstrumentation.getStaticField(fieldId)
+
+    override fun transform(
+        loader: ClassLoader?,
+        className: String,
+        classBeingRedefined: Class<*>?,
+        protectionDomain: ProtectionDomain,
+        classfileBuffer: ByteArray
+    ): ByteArray? = delegateInstrumentation.transform(
+        loader, className, classBeingRedefined, protectionDomain, classfileBuffer
+    )
+
+    override fun InstrumentedProcessModel.setupAdditionalRdResponses(kryoHelper: KryoHelper, watchdog: IdleWatchdog) =
+        delegateInstrumentation.run { setupAdditionalRdResponses(kryoHelper, watchdog) }
+
+    class Factory(
+        private val delegateInstrumentationFactory: UtExecutionInstrumentation.Factory<*>
+    ) : UtExecutionInstrumentation.Factory<UtExecutionInstrumentation> {
+        override val additionalRuntimeClasspath: Set<String>
+            get() = delegateInstrumentationFactory.additionalRuntimeClasspath
+
+        override val forceDisableSandbox: Boolean
+            get() = delegateInstrumentationFactory.forceDisableSandbox
+
+        override fun create(instrumentationContext: InstrumentationContext): UtExecutionInstrumentation =
+            RemovingConstructFailsUtExecutionInstrumentation(instrumentationContext, delegateInstrumentationFactory)
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+
+            other as Factory
+
+            return delegateInstrumentationFactory == other.delegateInstrumentationFactory
+        }
+
+        override fun hashCode(): Int {
+            return delegateInstrumentationFactory.hashCode()
+        }
+    }
+}

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/RemovingConstructFailsUtExecutionInstrumentation.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/RemovingConstructFailsUtExecutionInstrumentation.kt
@@ -72,7 +72,7 @@ class RemovingConstructFailsUtExecutionInstrumentation(
                 if (res.result !is UtConcreteExecutionProcessedFailure)
                     return res
 
-                parameters = parameters.mapModels(UtModelDeepMapper.fromSimpleShallowMapper { model ->
+                parameters = parameters.mapModels(UtModelDeepMapper { model ->
                     shallowlyRemoveFailingCalls(model)
                 })
 

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/UtExecutionInstrumentation.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/UtExecutionInstrumentation.kt
@@ -2,6 +2,8 @@ package org.utbot.instrumentation.instrumentation.execution
 
 import org.utbot.framework.UtSettings
 import org.utbot.framework.plugin.api.*
+import org.utbot.framework.plugin.api.mapper.UtModelMapper
+import org.utbot.framework.plugin.api.mapper.mapModels
 import org.utbot.instrumentation.instrumentation.ArgumentList
 import org.utbot.instrumentation.instrumentation.Instrumentation
 import org.utbot.instrumentation.instrumentation.execution.context.InstrumentationContext
@@ -20,6 +22,11 @@ data class UtConcreteExecutionData(
     val stateBefore: EnvironmentModels,
     val instrumentation: List<UtInstrumentation>,
     val timeout: Long
+)
+
+fun UtConcreteExecutionData.mapModels(mapper: UtModelMapper) = copy(
+    stateBefore = stateBefore.mapModels(mapper),
+    instrumentation = instrumentation.map { it.mapModels(mapper) }
 )
 
 /**

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/InstrumentationContextAwareValueConstructor.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/InstrumentationContextAwareValueConstructor.kt
@@ -91,6 +91,9 @@ class InstrumentationContextAwareValueConstructor(
 
     val detectedMockingCandidates: MutableSet<MethodId> = mutableSetOf()
 
+    var lastCaughtException: Throwable? = null
+        private set
+
     // TODO: JIRA:1379 -- replace UtReferenceModel with Int
     private val constructedObjects = HashMap<UtReferenceModel, Any>()
 
@@ -532,7 +535,10 @@ class InstrumentationContextAwareValueConstructor(
             .also { result ->
                 result
                     .exceptionOrNull()
-                    ?.let { callModel.thrownConcreteException = it.javaClass.id }
+                    ?.let {
+                        lastCaughtException = it
+                        callModel.thrownConcreteException = it.javaClass.id
+                    }
             }
 
 

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/StateBeforeAwareIdGenerator.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/StateBeforeAwareIdGenerator.kt
@@ -1,14 +1,13 @@
 package org.utbot.instrumentation.instrumentation.execution.constructors
 
 import org.utbot.framework.plugin.api.UtModel
-import org.utbot.framework.plugin.api.UtNewInstanceInstrumentation
 import org.utbot.framework.plugin.api.UtReferenceModel
-import org.utbot.framework.plugin.api.UtStaticMethodInstrumentation
-import org.utbot.framework.plugin.api.mapper.collectNestedModels
+import org.utbot.framework.plugin.api.mapper.UtModelDeepMapper.Companion.collectAllModels
 import org.utbot.instrumentation.instrumentation.execution.UtConcreteExecutionData
+import org.utbot.instrumentation.instrumentation.execution.mapModels
 
-class StateBeforeAwareIdGenerator(preExistingModels: Collection<UtModel>) {
-    private val seenIds = collectNestedModels(preExistingModels)
+class StateBeforeAwareIdGenerator(allPreExistingModels: Collection<UtModel>) {
+    private val seenIds = allPreExistingModels
         .filterIsInstance<UtReferenceModel>()
         .mapNotNull { it.id }
         .toMutableSet()
@@ -22,16 +21,6 @@ class StateBeforeAwareIdGenerator(preExistingModels: Collection<UtModel>) {
 
     companion object {
         fun fromUtConcreteExecutionData(data: UtConcreteExecutionData): StateBeforeAwareIdGenerator =
-            StateBeforeAwareIdGenerator(
-                listOfNotNull(data.stateBefore.thisInstance) +
-                        data.stateBefore.parameters +
-                        data.stateBefore.statics.values +
-                        data.instrumentation.flatMap {
-                            when (it) {
-                                is UtNewInstanceInstrumentation -> it.instances
-                                is UtStaticMethodInstrumentation -> it.values
-                            }
-                        }
-            )
+            StateBeforeAwareIdGenerator(collectAllModels { collector -> data.mapModels(collector) })
     }
 }

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/StateBeforeAwareIdGenerator.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/StateBeforeAwareIdGenerator.kt
@@ -1,85 +1,19 @@
 package org.utbot.instrumentation.instrumentation.execution.constructors
 
-import org.utbot.framework.plugin.api.UtArrayModel
-import org.utbot.framework.plugin.api.UtAssembleModel
-import org.utbot.framework.plugin.api.UtClassRefModel
-import org.utbot.framework.plugin.api.UtCompositeModel
-import org.utbot.framework.plugin.api.UtCustomModel
-import org.utbot.framework.plugin.api.UtDirectSetFieldModel
-import org.utbot.framework.plugin.api.UtEnumConstantModel
-import org.utbot.framework.plugin.api.UtLambdaModel
 import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.api.UtNewInstanceInstrumentation
-import org.utbot.framework.plugin.api.UtNullModel
-import org.utbot.framework.plugin.api.UtPrimitiveModel
 import org.utbot.framework.plugin.api.UtReferenceModel
-import org.utbot.framework.plugin.api.UtStatementCallModel
-import org.utbot.framework.plugin.api.UtStatementModel
 import org.utbot.framework.plugin.api.UtStaticMethodInstrumentation
-import org.utbot.framework.plugin.api.UtVoidModel
+import org.utbot.framework.plugin.api.mapper.collectNestedModels
 import org.utbot.instrumentation.instrumentation.execution.UtConcreteExecutionData
-import java.util.*
 
 class StateBeforeAwareIdGenerator(preExistingModels: Collection<UtModel>) {
-    private val seenIds = mutableSetOf<Int>()
-
-    // there's no `IdentityHashSet`, so we use `IdentityHashMap` with dummy values
-    private val seenModels = IdentityHashMap<UtModel, Unit>()
+    private val seenIds = collectNestedModels(preExistingModels)
+        .filterIsInstance<UtReferenceModel>()
+        .mapNotNull { it.id }
+        .toMutableSet()
 
     private var nextId = 0
-
-    init {
-        collectIds(preExistingModels)
-    }
-
-    private fun collectIds(models: Collection<UtModel>) =
-        models.forEach { collectIds(it) }
-
-    private fun collectIds(model: UtModel) {
-        if (model !in seenModels) {
-            seenModels[model] = Unit
-            (model as? UtReferenceModel)?.id?.let { seenIds.add(it) }
-            when (model) {
-                is UtNullModel,
-                is UtPrimitiveModel,
-                is UtEnumConstantModel,
-                is UtClassRefModel,
-                is UtVoidModel -> {}
-                is UtCompositeModel -> {
-                    collectIds(model.fields.values)
-                    model.mocks.values.forEach { collectIds(it) }
-                }
-                is UtArrayModel -> {
-                    collectIds(model.constModel)
-                    collectIds(model.stores.values)
-                }
-                is UtAssembleModel -> {
-                    model.origin?.let { collectIds(it) }
-                    collectIds(model.instantiationCall)
-                    model.modificationsChain.forEach { collectIds(it) }
-                }
-                is UtCustomModel -> {
-                    model.origin?.let { collectIds(it) }
-                    collectIds(model.dependencies)
-                }
-                is UtLambdaModel -> {
-                    collectIds(model.capturedValues)
-                }
-                else -> error("Can't collect ids from $model")
-            }
-        }
-    }
-
-    private fun collectIds(call: UtStatementModel): Unit = when (call) {
-        is UtStatementCallModel -> {
-            call.instance?.let { collectIds(it) }
-            collectIds(call.params)
-        }
-        is UtDirectSetFieldModel -> {
-            collectIds(call.instance)
-            collectIds(call.fieldModel)
-        }
-    }
 
     fun createId(): Int {
         while (nextId in seenIds) nextId++

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/UtModelConstructor.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/UtModelConstructor.kt
@@ -53,7 +53,7 @@ class UtModelConstructor(
             )
             return UtModelConstructor(
                 objectToModelCache = cache,
-                idGenerator = StateBeforeAwareIdGenerator(preExistingModels = emptySet()),
+                idGenerator = StateBeforeAwareIdGenerator(allPreExistingModels = emptySet()),
                 utModelWithCompositeOriginConstructorFinder = utModelWithCompositeOriginConstructorFinder,
                 compositeModelStrategy = strategy
             )

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/context/InstrumentationContext.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/context/InstrumentationContext.kt
@@ -1,10 +1,14 @@
 package org.utbot.instrumentation.instrumentation.execution.context
 
 import org.utbot.framework.plugin.api.ClassId
+import org.utbot.framework.plugin.api.UtAssembleModel
+import org.utbot.framework.plugin.api.UtConcreteExecutionProcessedFailure
 import org.utbot.framework.plugin.api.UtConcreteValue
 import org.utbot.framework.plugin.api.UtModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
 import org.utbot.instrumentation.instrumentation.execution.constructors.UtModelWithCompositeOriginConstructor
 import org.utbot.instrumentation.instrumentation.execution.phases.ExecutionPhase
+import org.utbot.instrumentation.instrumentation.execution.phases.ValueConstructionPhase
 import java.lang.reflect.Method
 import java.util.IdentityHashMap
 import org.utbot.instrumentation.instrumentation.mock.computeKeyForMethod
@@ -41,6 +45,17 @@ interface InstrumentationContext {
      * Implementor is expected to only perform some clean up operations (e.g. rollback transactions in Spring).
      */
     fun onPhaseTimeout(timedOutedPhase: ExecutionPhase)
+
+    /**
+     * At the very end of the [ValueConstructionPhase], instrumentation context gets to decide what to do
+     * with last caught [UtStatementCallModel.thrownConcreteException] (it can be caught if the call
+     * is non-essential for value construction, i.e. it's in [UtAssembleModel.modificationsChain]).
+     *
+     * A reasonable implementation may:
+     *   - ignore the [exception]
+     *   - cause phase to terminate with [UtConcreteExecutionProcessedFailure]
+     */
+    fun handleLastCaughtConstructionException(exception: Throwable)
 
     object MockGetter {
         data class MockContainer(private val values: List<*>) {

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/context/SimpleInstrumentationContext.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/context/SimpleInstrumentationContext.kt
@@ -24,4 +24,6 @@ class SimpleInstrumentationContext : InstrumentationContext {
         javaStdLibModelWithCompositeOriginConstructors[classId.jClass]?.invoke()
 
     override fun onPhaseTimeout(timedOutedPhase: ExecutionPhase) = Unit
+
+    override fun handleLastCaughtConstructionException(exception: Throwable) = Unit
 }

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/phases/PhasesController.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/phases/PhasesController.kt
@@ -105,6 +105,8 @@ class PhasesController(
             // here static methods and instances are mocked
             mock(parameters.instrumentation)
 
+            lastCaughtException?.let { instrumentationContext.handleLastCaughtConstructionException(it) }
+
             ConstructedData(params, statics, getCache())
         }
 

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/phases/ValueConstructionPhase.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/phases/ValueConstructionPhase.kt
@@ -43,6 +43,7 @@ class ValueConstructionPhase(
         idGenerator,
     )
     val detectedMockingCandidates: Set<MethodId> get() = constructor.detectedMockingCandidates
+    val lastCaughtException: Throwable? get() = constructor.lastCaughtException
 
     fun getCache(): ConstructedCache {
         return constructor.objectToModelCache

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/spring/SpringUtExecutionInstrumentation.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/spring/SpringUtExecutionInstrumentation.kt
@@ -87,6 +87,10 @@ class SpringUtExecutionInstrumentation(
         if (parameters !is UtConcreteExecutionData) {
             throw IllegalArgumentException("Argument parameters must be of type UtConcreteExecutionData, but was: ${parameters?.javaClass}")
         }
+
+        // `RemovingConstructFailsUtExecutionInstrumentation` may detect that we fail to
+        // construct `RequestBuilder` and use `requestBuilder = null`, leading to a nonsensical
+        // test `mockMvc.perform((RequestBuilder) null)`, which we should discard
         if (parameters.stateBefore.executableToCall == mockMvcPerformMethodId && parameters.stateBefore.parameters.single().isNull())
             return UtConcreteExecutionResult(
                 stateBefore = parameters.stateBefore,

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/rd/InstrumentedProcess.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/rd/InstrumentedProcess.kt
@@ -7,14 +7,12 @@ import org.utbot.common.debug
 import org.utbot.common.getPid
 import org.utbot.common.measureTime
 import org.utbot.framework.UtSettings
-import org.utbot.framework.plugin.api.UtModel
 import org.utbot.framework.plugin.services.WorkingDirService
 import org.utbot.framework.process.AbstractRDProcessCompanion
 import org.utbot.framework.process.kryo.KryoHelper
 import org.utbot.instrumentation.instrumentation.Instrumentation
 import org.utbot.instrumentation.process.DISABLE_SANDBOX_OPTION
 import org.utbot.instrumentation.process.generated.AddPathsParams
-import org.utbot.instrumentation.process.generated.GetSpringBeanParams
 import org.utbot.instrumentation.process.generated.InstrumentedProcessModel
 import org.utbot.instrumentation.process.generated.SetInstrumentationParams
 import org.utbot.instrumentation.process.generated.instrumentedProcessModel
@@ -24,7 +22,6 @@ import org.utbot.rd.generated.LoggerModel
 import org.utbot.rd.generated.loggerModel
 import org.utbot.rd.loggers.setup
 import org.utbot.rd.onSchedulerBlocking
-import org.utbot.rd.startBlocking
 import org.utbot.rd.startUtProcessWithRdServer
 import org.utbot.rd.terminateOnException
 import java.io.File
@@ -141,7 +138,4 @@ class InstrumentedProcess private constructor(
             return proc
         }
     }
-
-    fun getBean(beanName: String): UtModel =
-        kryoHelper.readObject(instrumentedProcessModel.getSpringBean.startBlocking(GetSpringBeanParams(beanName)).beanModel)
 }

--- a/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/rd/generated/InstrumentedProcessModel.Generated.kt
+++ b/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/rd/generated/InstrumentedProcessModel.Generated.kt
@@ -25,7 +25,6 @@ class InstrumentedProcessModel private constructor(
     private val _invokeMethodCommand: RdCall<InvokeMethodCommandParams, InvokeMethodCommandResult>,
     private val _collectCoverage: RdCall<CollectCoverageParams, CollectCoverageResult>,
     private val _computeStaticField: RdCall<ComputeStaticFieldParams, ComputeStaticFieldResult>,
-    private val _getSpringBean: RdCall<GetSpringBeanParams, GetSpringBeanResult>,
     private val _getRelevantSpringRepositories: RdCall<GetSpringRepositoriesParams, GetSpringRepositoriesResult>,
     private val _tryLoadingSpringContext: RdCall<Unit, TryLoadingSpringContextResult>
 ) : RdExtBase() {
@@ -42,8 +41,6 @@ class InstrumentedProcessModel private constructor(
             serializers.register(CollectCoverageResult)
             serializers.register(ComputeStaticFieldParams)
             serializers.register(ComputeStaticFieldResult)
-            serializers.register(GetSpringBeanParams)
-            serializers.register(GetSpringBeanResult)
             serializers.register(GetSpringRepositoriesParams)
             serializers.register(GetSpringRepositoriesResult)
             serializers.register(TryLoadingSpringContextResult)
@@ -67,7 +64,7 @@ class InstrumentedProcessModel private constructor(
         }
         
         
-        const val serializationHash = 2667021258656776274L
+        const val serializationHash = 8567129171874407469L
         
     }
     override val serializersOwner: ISerializersOwner get() = InstrumentedProcessModel
@@ -110,11 +107,6 @@ class InstrumentedProcessModel private constructor(
     val computeStaticField: RdCall<ComputeStaticFieldParams, ComputeStaticFieldResult> get() = _computeStaticField
     
     /**
-     * Gets Spring bean by name (requires Spring instrumentation)
-     */
-    val getSpringBean: RdCall<GetSpringBeanParams, GetSpringBeanResult> get() = _getSpringBean
-    
-    /**
      * Gets a list of [SpringRepositoryId]s that class specified by the [ClassId] (possibly indirectly) depends on (requires Spring instrumentation)
      */
     val getRelevantSpringRepositories: RdCall<GetSpringRepositoriesParams, GetSpringRepositoriesResult> get() = _getRelevantSpringRepositories
@@ -133,7 +125,6 @@ class InstrumentedProcessModel private constructor(
         _invokeMethodCommand.async = true
         _collectCoverage.async = true
         _computeStaticField.async = true
-        _getSpringBean.async = true
         _getRelevantSpringRepositories.async = true
         _tryLoadingSpringContext.async = true
     }
@@ -145,7 +136,6 @@ class InstrumentedProcessModel private constructor(
         bindableChildren.add("invokeMethodCommand" to _invokeMethodCommand)
         bindableChildren.add("collectCoverage" to _collectCoverage)
         bindableChildren.add("computeStaticField" to _computeStaticField)
-        bindableChildren.add("getSpringBean" to _getSpringBean)
         bindableChildren.add("getRelevantSpringRepositories" to _getRelevantSpringRepositories)
         bindableChildren.add("tryLoadingSpringContext" to _tryLoadingSpringContext)
     }
@@ -159,7 +149,6 @@ class InstrumentedProcessModel private constructor(
         RdCall<InvokeMethodCommandParams, InvokeMethodCommandResult>(InvokeMethodCommandParams, InvokeMethodCommandResult),
         RdCall<CollectCoverageParams, CollectCoverageResult>(CollectCoverageParams, CollectCoverageResult),
         RdCall<ComputeStaticFieldParams, ComputeStaticFieldResult>(ComputeStaticFieldParams, ComputeStaticFieldResult),
-        RdCall<GetSpringBeanParams, GetSpringBeanResult>(GetSpringBeanParams, GetSpringBeanResult),
         RdCall<GetSpringRepositoriesParams, GetSpringRepositoriesResult>(GetSpringRepositoriesParams, GetSpringRepositoriesResult),
         RdCall<Unit, TryLoadingSpringContextResult>(FrameworkMarshallers.Void, TryLoadingSpringContextResult)
     )
@@ -176,7 +165,6 @@ class InstrumentedProcessModel private constructor(
             print("invokeMethodCommand = "); _invokeMethodCommand.print(printer); println()
             print("collectCoverage = "); _collectCoverage.print(printer); println()
             print("computeStaticField = "); _computeStaticField.print(printer); println()
-            print("getSpringBean = "); _getSpringBean.print(printer); println()
             print("getRelevantSpringRepositories = "); _getRelevantSpringRepositories.print(printer); println()
             print("tryLoadingSpringContext = "); _tryLoadingSpringContext.print(printer); println()
         }
@@ -191,7 +179,6 @@ class InstrumentedProcessModel private constructor(
             _invokeMethodCommand.deepClonePolymorphic(),
             _collectCoverage.deepClonePolymorphic(),
             _computeStaticField.deepClonePolymorphic(),
-            _getSpringBean.deepClonePolymorphic(),
             _getRelevantSpringRepositories.deepClonePolymorphic(),
             _tryLoadingSpringContext.deepClonePolymorphic()
         )
@@ -490,120 +477,6 @@ data class ComputeStaticFieldResult (
 /**
  * #### Generated from [InstrumentedProcessModel.kt:45]
  */
-data class GetSpringBeanParams (
-    val beanName: String
-) : IPrintable {
-    //companion
-    
-    companion object : IMarshaller<GetSpringBeanParams> {
-        override val _type: KClass<GetSpringBeanParams> = GetSpringBeanParams::class
-        
-        @Suppress("UNCHECKED_CAST")
-        override fun read(ctx: SerializationCtx, buffer: AbstractBuffer): GetSpringBeanParams  {
-            val beanName = buffer.readString()
-            return GetSpringBeanParams(beanName)
-        }
-        
-        override fun write(ctx: SerializationCtx, buffer: AbstractBuffer, value: GetSpringBeanParams)  {
-            buffer.writeString(value.beanName)
-        }
-        
-        
-    }
-    //fields
-    //methods
-    //initializer
-    //secondary constructor
-    //equals trait
-    override fun equals(other: Any?): Boolean  {
-        if (this === other) return true
-        if (other == null || other::class != this::class) return false
-        
-        other as GetSpringBeanParams
-        
-        if (beanName != other.beanName) return false
-        
-        return true
-    }
-    //hash code trait
-    override fun hashCode(): Int  {
-        var __r = 0
-        __r = __r*31 + beanName.hashCode()
-        return __r
-    }
-    //pretty print
-    override fun print(printer: PrettyPrinter)  {
-        printer.println("GetSpringBeanParams (")
-        printer.indent {
-            print("beanName = "); beanName.print(printer); println()
-        }
-        printer.print(")")
-    }
-    //deepClone
-    //contexts
-}
-
-
-/**
- * #### Generated from [InstrumentedProcessModel.kt:49]
- */
-data class GetSpringBeanResult (
-    val beanModel: ByteArray
-) : IPrintable {
-    //companion
-    
-    companion object : IMarshaller<GetSpringBeanResult> {
-        override val _type: KClass<GetSpringBeanResult> = GetSpringBeanResult::class
-        
-        @Suppress("UNCHECKED_CAST")
-        override fun read(ctx: SerializationCtx, buffer: AbstractBuffer): GetSpringBeanResult  {
-            val beanModel = buffer.readByteArray()
-            return GetSpringBeanResult(beanModel)
-        }
-        
-        override fun write(ctx: SerializationCtx, buffer: AbstractBuffer, value: GetSpringBeanResult)  {
-            buffer.writeByteArray(value.beanModel)
-        }
-        
-        
-    }
-    //fields
-    //methods
-    //initializer
-    //secondary constructor
-    //equals trait
-    override fun equals(other: Any?): Boolean  {
-        if (this === other) return true
-        if (other == null || other::class != this::class) return false
-        
-        other as GetSpringBeanResult
-        
-        if (!(beanModel contentEquals other.beanModel)) return false
-        
-        return true
-    }
-    //hash code trait
-    override fun hashCode(): Int  {
-        var __r = 0
-        __r = __r*31 + beanModel.contentHashCode()
-        return __r
-    }
-    //pretty print
-    override fun print(printer: PrettyPrinter)  {
-        printer.println("GetSpringBeanResult (")
-        printer.indent {
-            print("beanModel = "); beanModel.print(printer); println()
-        }
-        printer.print(")")
-    }
-    //deepClone
-    //contexts
-}
-
-
-/**
- * #### Generated from [InstrumentedProcessModel.kt:53]
- */
 data class GetSpringRepositoriesParams (
     val classId: ByteArray
 ) : IPrintable {
@@ -659,7 +532,7 @@ data class GetSpringRepositoriesParams (
 
 
 /**
- * #### Generated from [InstrumentedProcessModel.kt:57]
+ * #### Generated from [InstrumentedProcessModel.kt:49]
  */
 data class GetSpringRepositoriesResult (
     val springRepositoryIds: ByteArray
@@ -911,7 +784,7 @@ data class SetInstrumentationParams (
 
 
 /**
- * #### Generated from [InstrumentedProcessModel.kt:61]
+ * #### Generated from [InstrumentedProcessModel.kt:53]
  */
 data class TryLoadingSpringContextResult (
     val springContextLoadingResult: ByteArray

--- a/utbot-instrumentation/src/test/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/BaseConstructorTest.kt
+++ b/utbot-instrumentation/src/test/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/BaseConstructorTest.kt
@@ -27,7 +27,7 @@ abstract class BaseConstructorTest {
     protected fun <T : Any> computeReconstructed(value: T): T {
         val model = UtModelConstructor(
             objectToModelCache = IdentityHashMap(),
-            idGenerator = StateBeforeAwareIdGenerator(preExistingModels = emptySet()),
+            idGenerator = StateBeforeAwareIdGenerator(allPreExistingModels = emptySet()),
             utModelWithCompositeOriginConstructorFinder = ::findUtCustomModelConstructor
         ).construct(value, value::class.java.id)
 

--- a/utbot-rd/src/main/rdgen/org/utbot/rd/models/InstrumentedProcessModel.kt
+++ b/utbot-rd/src/main/rdgen/org/utbot/rd/models/InstrumentedProcessModel.kt
@@ -42,14 +42,6 @@ object InstrumentedProcessModel : Ext(InstrumentedProcessRoot) {
         field("result", array(PredefinedType.byte))
     }
 
-    val GetSpringBeanParams = structdef {
-        field("beanName", PredefinedType.string)
-    }
-
-    val GetSpringBeanResult = structdef {
-        field("beanModel", array(PredefinedType.byte))
-    }
-
     val GetSpringRepositoriesParams = structdef {
         field("classId", array(PredefinedType.byte))
     }
@@ -96,10 +88,6 @@ object InstrumentedProcessModel : Ext(InstrumentedProcessRoot) {
             documentation =
                 "This command is sent to the instrumented process from the [ConcreteExecutor] if user wants to get value of static field\n" +
                         "[fieldId]"
-        }
-        call("GetSpringBean", GetSpringBeanParams, GetSpringBeanResult).apply {
-            async
-            documentation = "Gets Spring bean by name (requires Spring instrumentation)"
         }
         call("getRelevantSpringRepositories", GetSpringRepositoriesParams, GetSpringRepositoriesResult).apply {
             async


### PR DESCRIPTION
## Description

* Fixes #2533
  * When value construction phase fails, we remove `UtStatementCallModel`s that have been observed to throw an exception from `stateBefore` then try to rerun the invocation, that process is repeated until either value construction phase succeeds or limit of 5 reruns is reached.
* Adds `entityManager.flush()` on every `entityManager` usage (in codegen only).
* Fixes #2542 by reverting #2519.

## How to test

### Manual tests

Failing test from [issue](https://github.com/UnitTestBot/UTBotJava/issues/2533) should not generate (in the example from the [issue](https://github.com/UnitTestBot/UTBotJava/issues/2533), test that saves valid entity to the database is still minimized out due to it being possible to cover all branches of `OwnerController.findOwner()` without saving anything to the database, to get tests with actual saves to database, the line `if (owner == null) throw new NullPointerException("owner");` can be added to `OwnerController.findOwner()`).

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.