### PR TITLE
Make jar extraction multi-process safe

### DIFF
--- a/utbot-core/src/main/kotlin/org/utbot/common/JarUtils.kt
+++ b/utbot-core/src/main/kotlin/org/utbot/common/JarUtils.kt
@@ -4,18 +4,29 @@ import java.io.File
 import java.net.URL
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
+import java.util.*
 
 object JarUtils {
     private const val UNKNOWN_MODIFICATION_TIME = 0L
 
     fun extractJarFileFromResources(jarFileName: String, jarResourcePath: String, targetDirectoryName: String): File {
-        val targetDirectory =
-            Files.createDirectories(utBotTempDirectory.toFile().resolve(targetDirectoryName).toPath()).toFile()
-        return targetDirectory.resolve(jarFileName).also { jarFile ->
-            val resource = this::class.java.classLoader.getResource(jarResourcePath)
-                ?: error("Unable to find \"$jarResourcePath\" in resources, make sure it's on the classpath")
-            updateJarIfRequired(jarFile, resource)
+        val resource = this::class.java.classLoader.getResource(jarResourcePath)
+            ?: error("Unable to find \"$jarResourcePath\" in resources, make sure it's on the classpath")
+
+        val targetDirectory = utBotTempDirectory.toFile().resolve(targetDirectoryName).toPath()
+        fun extractToSubDir(subDir: String) =
+            Files.createDirectories(targetDirectory.resolve(subDir)).toFile().resolve(jarFileName).also { jarFile ->
+                updateJarIfRequired(jarFile, resource)
+            }
+
+        // We attempt to always extract jars to same locations, to avoid eating up drive space with
+        // every UtBot launch, but we may fail to do so if multiple processes are running in parallel.
+        repeat(10) { i ->
+            runCatching {
+                return extractToSubDir(i.toString())
+            }
         }
+        return extractToSubDir(UUID.randomUUID().toString())
     }
 
     private fun updateJarIfRequired(jarFile: File, resource: URL) {


### PR DESCRIPTION
## Description

Sometimes either under heavy loud or when running UtBot in IDE and via tests in parallel, UtBot may crush because its own jars are locked by other processes, to avoid that this PR lets UtBot dynamically change locations to which it extracts jars.

## How to test

### Manual tests

* Open `../Temp/UTBot/utbot-instrumentation/0/utbot-instrumentation-shadow.jar` with any program (e.g. run `ping google.com -t < utbot-instrumentation-shadow.jar` on Windows)
* Ensure you can't delete `utbot-instrumentation-shadow.jar` manually anymore
* Recompile utbot (make sure compilation takes place after the previous step and output isn't cached)
* Generate unit test for any method

UtBot should recognise that it can't update `../Temp/UTBot/utbot-instrumentation/0/utbot-instrumentation-shadow.jar` and extract new instrumentation jar to `../Temp/UTBot/utbot-instrumentation/1/utbot-instrumentation-shadow.jar`.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.