### PR TITLE
Let concrete add additional mocks to `UtCompositeModel` created by the engine

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -499,7 +499,11 @@ data class UtClassRefModel(
  * - calculated field values (models)
  * - mocks for methods with return values
  * - [canHaveRedundantOrMissingMocks] flag, which is set to `true` for mocks
- *   created by fuzzer without knowing which methods will actually be called
+ *   created by:
+ *    - fuzzer which doesn't know which methods will actually be called
+ *    - engine which also doesn't know which methods will actually be
+ *      called during concrete execution that may be only **partially**
+ *      backed up by the symbolic analysis
  *
  * [fields] contains non-static fields
  */
@@ -509,7 +513,7 @@ data class UtCompositeModel(
     val isMock: Boolean,
     val fields: MutableMap<FieldId, UtModel> = mutableMapOf(),
     val mocks: MutableMap<ExecutableId, List<UtModel>> = mutableMapOf(),
-    val canHaveRedundantOrMissingMocks: Boolean = false,
+    val canHaveRedundantOrMissingMocks: Boolean = true,
 ) : UtReferenceModel(id, classId) {
     //TODO: SAT-891 - rewrite toString() method
     override fun toString() = withToStringThreadLocalReentrancyGuard {


### PR DESCRIPTION
## Description

Fixes #2549 

#2549 shows that symbolic engine may miss some mocks. I suspect that it happens when it doesn't fully execute the method symbolically and lets concrete execution to finish the execution.

Regardless of why symbolic engine misses mocks, we need to deal with missed mocks. This PR makes concrete execution to always use the mechanism for dealing with incomplete mock that was originally developed for dealing with mocks created by the fuzzer (see #2529).

**NOTE:** [generateMockitoAnswerHandlingRedundantAndMissingMocks()](https://github.com/UnitTestBot/UTBotJava/blob/4a75abc6f283c51f3f5f98c0e78362e2df217d64/utbot-instrumentation/src/main/kotlin/org/utbot/instrumentation/instrumentation/execution/constructors/InstrumentationContextAwareValueConstructor.kt#L225) should be reviewed before approving this PR.

## How to test

### Automated tests

> The proposed changes are verified with tests:
> `utbot-framework-test/src/test/kotlin/org/utbot/examples`

### Manual tests

Issue #2549 should no longer reproduce (NOTE: I wasn't able to reproduce it even before this fix).

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.