### PR TITLE
Don't collect constants from every assignment statement

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/fuzzer/FuzzerFunctions.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/fuzzer/FuzzerFunctions.kt
@@ -83,6 +83,10 @@ private object ConstantsFromIfStatement: ConstantsFinder {
         // 1. compare (result = local compare constant)
         // 2. if result
         if (unit is JAssignStmt) {
+            // Accepts only those assignments statements that uses compare operation on the right
+            if (unit.rightOp !is JCmpExpr) {
+                return emptyList()
+            }
             useBoxes = unit.rightOp.useBoxes.mapNotNull { (it as? ImmediateBox)?.value }
             ifStatement = nextDirectUnit(graph, unit) as? JIfStmt
         }


### PR DESCRIPTION
## Description

Fixes #2527

The bug happens because constants are incorrectly collected on pre-process phase. An if-statement bytecode for longs and doubles has follow steps:

1. Assign a local variable the result of applying `cmp` operation
2. Compare the result corresponding to the original logic.

There's no check that an if-statement has `cmp` operation in an assignment statement, therefore it accepts any method call as well.

## How to test

### Manual tests

Example from the issue should generate 2 tests.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.