### PR TITLE
Keep `thisInstance` modifications in controller-specific tests

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringIntegrationTestJavaFuzzingContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringIntegrationTestJavaFuzzingContext.kt
@@ -17,7 +17,6 @@ import org.utbot.framework.plugin.api.util.utContext
 import org.utbot.fuzzer.IdentityPreservingIdGenerator
 import org.utbot.fuzzing.JavaValueProvider
 import org.utbot.fuzzing.ValueProvider
-import org.utbot.fuzzing.providers.AbstractsObjectValueProvider
 import org.utbot.fuzzing.providers.AnyDepthNullValueProvider
 import org.utbot.fuzzing.providers.ModifyingWithMethodsProviderWrapper
 import org.utbot.fuzzing.providers.ObjectValueProvider
@@ -110,7 +109,7 @@ class SpringIntegrationTestJavaFuzzingContext(
                     idGenerator = { idGenerator.createId() }
                 ) ?: return delegateStateBefore
                 delegateStateBefore.copy(
-                    thisInstance = SpringModelUtils.createMockMvcModel { idGenerator.createId() },
+                    thisInstance = SpringModelUtils.createMockMvcModel(controller = thisInstance) { idGenerator.createId() },
                     parameters = listOf(requestBuilderModel),
                     executableToCall = SpringModelUtils.mockMvcPerformMethodId,
                 )


### PR DESCRIPTION
## Description

In controller-specific integration tests `thisInstance` modifications were lost (i.e. saving data to database, invoking controller methods before method under test), this PR restores such modifications.

## How to test

### Manual tests

Generate tests on the example from #2562, there should be tests that save data to database directly or use controller methods to do that.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.