### PR TITLE
Extract option values from forEach loop

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/util/SootUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/util/SootUtils.kt
@@ -96,12 +96,15 @@ private fun initSoot(buildDirs: List<Path>, classpath: String?, jdkInfo: JdkInfo
 
     Scene.v().loadNecessaryClasses()
     PackManager.v().runPacks()
+    // these options are moved out from forEach loop because they are slow due to rd communication
+    val removeUtBotClassesFromHierarchy = UtSettings.removeUtBotClassesFromHierarchy
+    val removeSootClassesFromHierarchy = UtSettings.removeSootClassesFromHierarchy
     // we need this to create hierarchy of classes
     Scene.v().classes.toList().forEach {
         val isUtBotPackage = it.packageName.startsWith(UTBOT_PACKAGE_PREFIX)
 
         // remove our own classes from the soot scene
-        if (UtSettings.removeUtBotClassesFromHierarchy && isUtBotPackage) {
+        if (removeUtBotClassesFromHierarchy && isUtBotPackage) {
             val isOverriddenPackage = it.packageName.startsWith(UTBOT_OVERRIDDEN_PACKAGE_PREFIX)
             val isExamplesPackage = it.packageName.startsWith(UTBOT_EXAMPLES_PACKAGE_PREFIX)
             val isApiPackage = it.packageName.startsWith(UTBOT_API_PACKAGE_PREFIX)
@@ -115,7 +118,7 @@ private fun initSoot(buildDirs: List<Path>, classpath: String?, jdkInfo: JdkInfo
         }
 
         // remove soot's classes from the scene, because we don't wont to analyze them
-        if (UtSettings.removeSootClassesFromHierarchy && it.packageName.startsWith(SOOT_PACKAGE_PREFIX)) {
+        if (removeSootClassesFromHierarchy && it.packageName.startsWith(SOOT_PACKAGE_PREFIX)) {
             Scene.v().removeClass(it)
             return@forEach
         }


### PR DESCRIPTION
## Description

During soot initialization an engine process uses 2 options: `UtSettings.removeUtBotClassesFromHierarchy` and `UtSettings.removeSootClassesFromHierarchy`. They both are implemented through `RdSettingsContainer#settingsFor`. To improve speed the values of these options were extracted into separate variables before the loop.

You can find more details in [this comment](https://github.com/UnitTestBot/UTBotJava/issues/2516#issuecomment-1689467618).

## How to test

No specific tests are required.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.