### PR TITLE
Avoid stack overflow when initializing field with self mutations

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/fieldmanager/ClassFieldManagerFacade.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/fieldmanager/ClassFieldManagerFacade.kt
@@ -9,13 +9,13 @@ import org.utbot.framework.plugin.api.UtSpringContextModel
 
 class ClassFieldManagerFacade(context: CgContext) : CgContextOwner by context {
 
-    private val alreadyInitialisedModels = mutableSetOf<UtModelWrapper>()
+    private val alreadyInitializedModels = mutableSetOf<UtModelWrapper>()
 
     fun constructVariableForField(model: UtModel): CgValue? {
         relevantFieldManagers.forEach { manager ->
             val alreadyCreatedVariable = manager.findCgValueByModel(model, manager.annotatedModels)
             if (alreadyCreatedVariable != null) {
-                if (alreadyInitialisedModels.add(model.wrap()))
+                if (alreadyInitializedModels.add(model.wrap()))
                     manager.useVariableForModel(model, alreadyCreatedVariable)
                 return alreadyCreatedVariable
             }


### PR DESCRIPTION
## Description

Fixes creation of fields for cyclic models (see stack trace)

<details>
  <summary>Stack trace</summary>
  
  ```
11:56:55.786 | WARN  | CgAbstractTestClassConstructor | Code generation error
java.lang.StackOverflowError: null
	at java.util.concurrent.ConcurrentHashMap.putIfAbsent(ConcurrentHashMap.java:1541) ~[?:?]
	at java.lang.ClassLoader.getClassLoadingLock(ClassLoader.java:668) ~[?:?]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:569) ~[?:?]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:522) ~[?:?]
	at org.utbot.framework.plugin.api.util.IdUtilKt.getJClass(IdUtil.kt:105) ~[utbot-framework-api-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.plugin.api.util.IdUtilKt.getMethod(IdUtil.kt:504) ~[utbot-framework-api-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.plugin.api.MethodId.getModifiers(Api.kt:1337) ~[utbot-framework-api-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.plugin.api.util.ModifierUtilKt.isPublic(ModifierUtil.kt:64) ~[utbot-framework-api-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.util.ExecutableIdUtilKt.isAccessibleFrom(ExecutableIdUtil.kt:15) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.services.access.CgCallableAccessManagerImpl.canBeCalledWith(CgCallableAccessManager.kt:312) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.services.access.CgCallableAccessManagerImpl.invoke(CgCallableAccessManager.kt:116) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgVariableConstructor.invoke(CgVariableConstructor.kt) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgVariableConstructor.createCgExecutableCallFromUtExecutableCall(CgVariableConstructor.kt:310) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgVariableConstructor.constructAssembleForVariable(CgVariableConstructor.kt:272) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.fieldmanager.CgAutowiredFieldsManager.useVariableForModel(CgAutowiredFieldsManager.kt:32) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.fieldmanager.ClassFieldManagerFacade.constructVariableForField(ClassFieldManagerFacade.kt:16) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgSpringVariableConstructor.getOrCreateVariable(CgSpringVariableConstructor.kt:18) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgVariableConstructor.getOrCreateVariable$default(CgVariableConstructor.kt:106) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgVariableConstructor.createCgExecutableCallFromUtExecutableCall(CgVariableConstructor.kt:304) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgVariableConstructor.constructAssembleForVariable(CgVariableConstructor.kt:272) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.fieldmanager.CgAutowiredFieldsManager.useVariableForModel(CgAutowiredFieldsManager.kt:32) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.fieldmanager.ClassFieldManagerFacade.constructVariableForField(ClassFieldManagerFacade.kt:16) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgSpringVariableConstructor.getOrCreateVariable(CgSpringVariableConstructor.kt:18) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgVariableConstructor.getOrCreateVariable$default(CgVariableConstructor.kt:106) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgVariableConstructor.createCgExecutableCallFromUtExecutableCall(CgVariableConstructor.kt:304) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgVariableConstructor.constructAssembleForVariable(CgVariableConstructor.kt:272) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.fieldmanager.CgAutowiredFieldsManager.useVariableForModel(CgAutowiredFieldsManager.kt:32) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.fieldmanager.ClassFieldManagerFacade.constructVariableForField(ClassFieldManagerFacade.kt:16) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgSpringVariableConstructor.getOrCreateVariable(CgSpringVariableConstructor.kt:18) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgVariableConstructor.getOrCreateVariable$default(CgVariableConstructor.kt:106) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgVariableConstructor.createCgExecutableCallFromUtExecutableCall(CgVariableConstructor.kt:304) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgVariableConstructor.constructAssembleForVariable(CgVariableConstructor.kt:272) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.fieldmanager.CgAutowiredFieldsManager.useVariableForModel(CgAutowiredFieldsManager.kt:32) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.fieldmanager.ClassFieldManagerFacade.constructVariableForField(ClassFieldManagerFacade.kt:16) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgSpringVariableConstructor.getOrCreateVariable(CgSpringVariableConstructor.kt:18) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgVariableConstructor.getOrCreateVariable$default(CgVariableConstructor.kt:106) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgVariableConstructor.createCgExecutableCallFromUtExecutableCall(CgVariableConstructor.kt:304) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgVariableConstructor.constructAssembleForVariable(CgVariableConstructor.kt:272) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.fieldmanager.CgAutowiredFieldsManager.useVariableForModel(CgAutowiredFieldsManager.kt:32) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.fieldmanager.ClassFieldManagerFacade.constructVariableForField(ClassFieldManagerFacade.kt:16) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgSpringVariableConstructor.getOrCreateVariable(CgSpringVariableConstructor.kt:18) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgVariableConstructor.getOrCreateVariable$default(CgVariableConstructor.kt:106) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgVariableConstructor.createCgExecutableCallFromUtExecutableCall(CgVariableConstructor.kt:304) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgVariableConstructor.constructAssembleForVariable(CgVariableConstructor.kt:272) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.fieldmanager.CgAutowiredFieldsManager.useVariableForModel(CgAutowiredFieldsManager.kt:32) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.fieldmanager.ClassFieldManagerFacade.constructVariableForField(ClassFieldManagerFacade.kt:16) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgSpringVariableConstructor.getOrCreateVariable(CgSpringVariableConstructor.kt:18) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgVariableConstructor.getOrCreateVariable$default(CgVariableConstructor.kt:106) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgVariableConstructor.createCgExecutableCallFromUtExecutableCall(CgVariableConstructor.kt:304) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgVariableConstructor.constructAssembleForVariable(CgVariableConstructor.kt:272) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.fieldmanager.CgAutowiredFieldsManager.useVariableForModel(CgAutowiredFieldsManager.kt:32) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.fieldmanager.ClassFieldManagerFacade.constructVariableForField(ClassFieldManagerFacade.kt:16) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgSpringVariableConstructor.getOrCreateVariable(CgSpringVariableConstructor.kt:18) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgVariableConstructor.getOrCreateVariable$default(CgVariableConstructor.kt:106) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgVariableConstructor.createCgExecutableCallFromUtExecutableCall(CgVariableConstructor.kt:304) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgVariableConstructor.constructAssembleForVariable(CgVariableConstructor.kt:272) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.fieldmanager.CgAutowiredFieldsManager.useVariableForModel(CgAutowiredFieldsManager.kt:32) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.fieldmanager.ClassFieldManagerFacade.constructVariableForField(ClassFieldManagerFacade.kt:16) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgSpringVariableConstructor.getOrCreateVariable(CgSpringVariableConstructor.kt:18) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
	at org.utbot.framework.codegen.tree.CgVariableConstructor.getOrCreateVariable$default(CgVariableConstructor.kt:106) ~[utbot-framework-2023.08-SNAPSHOT.jar:?]
```
  
</details>


## How to test

### Manual tests

Generate integration tests for the `isMajorityExpensive` method in the following class
```java
@Service
public class SimpleOrderService {

    private final OrderRepository orderRepository;

    @Autowired
    public SimpleOrderService(OrderRepository orderRepository) {
        this.orderRepository = orderRepository;
    }

    public List<Order> getOrders() {
        return orderRepository.findAll();
    }

    public Order getOrderById(Long id) {
        return orderRepository.findById(id).orElseThrow(() -> throwException(String.valueOf(id)));
    }

    public boolean deleteOrderById(Long id) {
        Optional<Order> order = orderRepository.findById(id);
        if (order.isPresent()) {
            orderRepository.deleteById(id);
            return true;
        } else {
            throwException(String.valueOf(id));
            return false;
        }
    }

    public Order createOrder(Order order) {
        return orderRepository.save(order);
    }
    
    public boolean isMajorityExpensive(int threshold) {
        List<Order> allOrders = orderRepository.findAll();

        if (allOrders.isEmpty()) {
            return false;
        }

        List<Order> expensiveOrders = new ArrayList<>();
        for (Order order: allOrders) {
            if (order != null && order.getPrice() > threshold) {
                expensiveOrders.add(order);
            }
        }

        return expensiveOrders.size() > allOrders.size() / 2;
    }

    public OrderNotFoundException throwException(String value) {
        throw new OrderNotFoundException("Order Not Found with ID: " + value);
    }
}
```

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.