### PR TITLE
Recognise `javax.validation.constraints` validation library

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SpringModelUtils.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SpringModelUtils.kt
@@ -94,7 +94,7 @@ object SpringModelUtils {
             )
         }
 
-    private val validationLibraries = listOf("jakarta.validation.constraints")
+    private val validationLibraries = listOf("javax.validation.constraints", "jakarta.validation.constraints")
     private fun validationClassIds(simpleName: String) = getClassIdFromEachAvailablePackage(validationLibraries, simpleName)
         .filter { utContext.classLoader.tryLoadClass(it.name) != null }
 


### PR DESCRIPTION
## Description

Makes `ValidEntityValueProvider` recognize annotations from `javax.validation.constraints`.

## How to test

### Manual tests

* Open `spring-boot-testing` project
* Add `spring-boot-starter-validation` dependency
* Add `@NotEmpty` and `@Email` annotations to `Order.buyer` field
* Generate integration tests for `OrderService.getOrderById()`

* There should be test that saves valid `Order` to the database

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.