### PR TITLE
Consider dynamically created mocks when pre minimizing fuzzer output and properly initialize @Mock fields 

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UtBotSymbolicEngine.kt
@@ -516,7 +516,7 @@ class UtBotSymbolicEngine(
                 trieNode = descr.tracer.add(coveredInstructions)
 
                 val earlierStateBeforeSize = coverageToMinStateBeforeSize[trieNode]
-                val curStateBeforeSize = stateBefore.calculateSize()
+                val curStateBeforeSize = concreteExecutionResult.stateBefore.calculateSize()
 
                 if (earlierStateBeforeSize == null || curStateBeforeSize < earlierStateBeforeSize)
                     coverageToMinStateBeforeSize[trieNode] = curStateBeforeSize

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgAbstractSpringTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgAbstractSpringTestClassConstructor.kt
@@ -31,6 +31,10 @@ abstract class CgAbstractSpringTestClassConstructor(context: CgContext) :
             fields += constructClassFields(testClassModel)
             clearUnwantedVariableModels()
 
+            // constructClassFields may mark fields as initialized, while they are in
+            // fact not initialized, so we clearAlreadyInitializedFieldModels()
+            variableConstructor.clearAlreadyInitializedFieldModels()
+
             constructAdditionalTestMethods()?.let { methodRegions += it }
 
             for ((testSetIndex, testSet) in testClassModel.methodTestSets.withIndex()) {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgSpringVariableConstructor.kt
@@ -14,6 +14,10 @@ class CgSpringVariableConstructor(context: CgContext) : CgVariableConstructor(co
 
     private val fieldManagerFacade = ClassFieldManagerFacade(context)
 
+    fun clearAlreadyInitializedFieldModels() {
+        fieldManagerFacade.clearAlreadyInitializedModels()
+    }
+
     override fun getOrCreateVariable(model: UtModel, name: String?): CgValue {
         val variable = fieldManagerFacade.constructVariableForField(model)
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/fieldmanager/ClassFieldManagerFacade.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/fieldmanager/ClassFieldManagerFacade.kt
@@ -11,6 +11,10 @@ class ClassFieldManagerFacade(context: CgContext) : CgContextOwner by context {
 
     private val alreadyInitializedModels = mutableSetOf<UtModelWrapper>()
 
+    fun clearAlreadyInitializedModels() {
+        alreadyInitializedModels.clear()
+    }
+
     fun constructVariableForField(model: UtModel): CgValue? {
         relevantFieldManagers.forEach { manager ->
             val alreadyCreatedVariable = manager.findCgValueByModel(model, manager.annotatedModels)


### PR DESCRIPTION
## Description

When fuzzer executions are pre minimized we should consider mocks that we were added during concrete executions for methods that were actually invoked, but whose behavior wasn't defined by the fuzzer itself.

Also, makes fixes field initialization (when creating `@InjectMock` field we should not mark `@Mock` fields as initialized).

## How to test

### Manual tests

Add the following method to `OrderService` in `spring-boot-testing` project and generate unit tests, using "Mock everything outside the class" mock strategy and `100%` fuzzing.

```java
public double getTotalPrice() {
    return orderRepository.findAll().stream().mapToDouble(Order::getPrice).sum();
}
```

There should be test with real list:
```java
public void testGetTotalPriceReturnsZero() {
    List list = emptyList();
    (when(orderRepositoryMock.findAll())).thenReturn(list);

    double actual = simpleOrderService.getTotalPrice();

    assertEquals(0.0, actual, 1.0E-6);
}
```

There should be no tests with mocked lists:
```java
public void testGetTotalPriceReturnsZero() {
    List listMock = mock(List.class);
    Stream streamMock = mock(Stream.class);
    DoubleStream doubleStreamMock = mock(DoubleStream.class);
    (when(doubleStreamMock.sum())).thenReturn(0.0);
    (when(streamMock.mapToDouble(any()))).thenReturn(doubleStreamMock);
    (when(listMock.stream())).thenReturn(streamMock);
    (when(orderRepositoryMock.findAll())).thenReturn(listMock);

    double actual = simpleOrderService.getTotalPrice();

    assertEquals(0.0, actual, 1.0E-6);
}
```

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.