### PR TITLE
Make Spring-specific no NPE speculation to only trigger for mocks

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/Traverser.kt
@@ -116,7 +116,6 @@ import org.utbot.framework.UtSettings
 import org.utbot.framework.UtSettings.preferredCexOption
 import org.utbot.framework.UtSettings.substituteStaticsWithSymbolicVariable
 import org.utbot.framework.isFromTrustedLibrary
-import org.utbot.framework.context.ApplicationContext
 import org.utbot.framework.context.NonNullSpeculator
 import org.utbot.framework.context.TypeReplacer
 import org.utbot.framework.plugin.api.ClassId
@@ -2336,10 +2335,18 @@ class Traverser(
      * Marks the [createdField] as speculatively not null if the [field] is considering
      * as not producing [NullPointerException].
      *
-     * See more detailed documentation in [ApplicationContext] mentioned methods.
+     * See more detailed documentation in [NonNullSpeculator] mentioned methods.
      */
-    private fun checkAndMarkLibraryFieldSpeculativelyNotNull(field: SootField, createdField: SymbolicValue) {
-        if (nonNullSpeculator.speculativelyCannotProduceNullPointerException(field, methodUnderTest.classId))
+    private fun checkAndMarkLibraryFieldSpeculativelyNotNull(
+        field: SootField,
+        createdField: SymbolicValue,
+    ) {
+        if (nonNullSpeculator.speculativelyCannotProduceNullPointerException(
+                field = field,
+                isMocked = (createdField as? ObjectValue)?.asWrapperOrNull is UtMockWrapper,
+                classUnderTest = methodUnderTest.classId,
+            )
+        )
             markAsSpeculativelyNotNull(createdField.addr)
     }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/context/NonNullSpeculator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/context/NonNullSpeculator.kt
@@ -8,10 +8,13 @@ interface NonNullSpeculator {
      * Checks whether accessing [field] (with a method invocation or field access) speculatively
      * cannot produce [NullPointerException] (according to its finality or accessibility).
      *
+     * @param [isMocked] true if engine decided it will use either `null` or mock for the [field] value
+     *
      * @see docs/SpeculativeFieldNonNullability.md for more information.
      */
     fun speculativelyCannotProduceNullPointerException(
         field: SootField,
+        isMocked: Boolean,
         classUnderTest: ClassId,
     ): Boolean
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/context/simple/SimpleNonNullSpeculator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/context/simple/SimpleNonNullSpeculator.kt
@@ -9,6 +9,7 @@ import soot.SootField
 class SimpleNonNullSpeculator : NonNullSpeculator {
     override fun speculativelyCannotProduceNullPointerException(
         field: SootField,
+        isMocked: Boolean,
         classUnderTest: ClassId,
     ): Boolean =
         !UtSettings.maximizeCoverageUsingReflection &&


### PR DESCRIPTION
## Description

In Spring-specific unit tests class under test field can't be mocks in one execution and null in another due to `@InjectMock` either always injecting or non injecting the mocks into class under test.

## How to test

### Manual tests

* Open `spring-boot-testing` project.
* Generate unit tests using `Mock everything outside the class` strategy for the following classes.

There should be NPE tests for `equals()` in the following class:
```java
@Getter
@Setter
@Builder
@ToString
@Jacksonized
@NoArgsConstructor
@AllArgsConstructor
@Entity
@EqualsAndHashCode
@Table(name = "orders")
public class Order {
    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    Long id;

    @Email
    @NotEmpty
    String buyer;
    Double price;
    int qty;

    @Override
    public boolean equals(Object o) {
        if (this == o) return true;
        if (o == null || !(o instanceof Order)) return false;
        Order order = (Order) o;
        return qty == order.qty && id.equals(order.id) && buyer.equals(order.buyer) && price.equals(order.price);
    }

    @Override
    public int hashCode() {
        return Objects.hash(id, buyer, price, qty);
    }
}
```

There should be no NPE tests for `createOrder()` in the following class
```java
@Service
public class OrderService {
    private final OrderRepository orderRepository;

    public Order createOrder(Order order) {
        return orderRepository.save(order);
    }
}
```

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.