### PR TITLE
Do necessary down casts when generating method calls

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgMethodConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgMethodConstructor.kt
@@ -1159,7 +1159,7 @@ open class CgMethodConstructor(val context: CgContext) : CgContextOwner by conte
         } else if (context.codegenLanguage == CodegenLanguage.JAVA &&
             !jField.isStatic && canBeReadViaGetterFrom(context)
         ) {
-            CgMethodCall(variable, getter, emptyList())
+            variable[getter]()
         } else {
             utilsClassId[getFieldValue](variable, this.declaringClass.name, this.name)
         }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgVariableConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgVariableConstructor.kt
@@ -215,7 +215,7 @@ open class CgVariableConstructor(val context: CgContext) :
         } else if (context.codegenLanguage == CodegenLanguage.JAVA &&
             !field.isStatic && fieldId.canBeSetViaSetterFrom(context)
         ) {
-            +CgMethodCall(obj, fieldId.setter, listOf(valueForField))
+            +obj[fieldId.setter](valueForField)
         } else {
             // composite models must not have info about static fields, hence only non-static fields are set here
             +utilsClassId[setField](obj, fieldId.declaringClass.name, fieldId.name, valueForField)

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/ConstructorUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/ConstructorUtils.kt
@@ -292,6 +292,20 @@ internal fun CgContextOwner.typeCast(
 }
 
 /**
+ * Casts [expression] to [targetType] only if downcast is needed,
+ * e.g. this method will cast `Collection` to `Set`, but not vice-versa.
+ *
+ * @see typeCast
+ */
+internal fun CgContextOwner.downcastIfNeeded(
+    targetType: ClassId,
+    expression: CgExpression,
+    isSafetyCast: Boolean = false
+): CgExpression =
+    if (expression.type isSubtypeOf targetType) expression
+    else typeCast(targetType, expression, isSafetyCast)
+
+/**
  * Sets an element of arguments array in parameterized test,
  * if test framework represents arguments as array.
  */


### PR DESCRIPTION
## Description

Fixes #2598

Since code generation uses erased types, it may need to perform downcasts when calling methods, this PR adds such down casts.

## How to test

### Manual tests

Generate tests for the following classes, all tests should compile and pass, there should be no redundant casts. 

```java
public class Box<T> {
    private final T value;

    public Box(T value) {
        this.value = value;
    }

    public T getValue() {
        return value;
    }
}
```
```java
public class StringHolder {
    private final String string;

    public StringHolder(String string) {
        this.string = string;
    }

    public String getString() {
        return string;
    }

    public static Box<StringHolder> createBoxed() {
        return new Box<>(new StringHolder("s"));
    }

    public static StringHolder create() {
        return new StringHolder("s");
    }
}
```
```java
public class StringHolderChild extends StringHolder {
    public StringHolderChild(String string) {
        super(string);
    }

    public static Box<StringHolder> createBoxed() {
        return new Box<>(new StringHolderChild("s"));
    }

    public static StringHolder create() {
        return new StringHolderChild("s");
    }
}
```

Expected tests for `SpringHolderChild` (summaries are omitted):
```java
public final class StringHolderChildTest {
    @Test
    @DisplayName("createBoxed: -> return new Box<>(new StringHolderChild(\"s\"))")
    public void testCreateBoxed_Return() {
        Box actual = StringHolderChild.createBoxed();

        String string = "s";
        StringHolderChild stringHolderChild = new StringHolderChild(string);
        Box expected = new Box(stringHolderChild);

        Object expectedValue = expected.getValue();
        Object actualValue = actual.getValue();
        String expectedValueString = (((StringHolder) expectedValue)).getString();
        String actualValueString = (((StringHolder) actualValue)).getString();
        assertEquals(expectedValueString, actualValueString);

    }
    
    @Test
    @DisplayName("create: -> return new StringHolderChild(\"s\")")
    public void testCreate_Return() {
        StringHolderChild actual = ((StringHolderChild) StringHolderChild.create());

        String string = "s";
        StringHolderChild expected = new StringHolderChild(string);

        String expectedString = expected.getString();
        String actualString = actual.getString();
        assertEquals(expectedString, actualString);

    }
}
```
</details>

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.