### PR TITLE
Sort tests by estimated size and exception type

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgAbstractTestClassConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgAbstractTestClassConstructor.kt
@@ -17,7 +17,6 @@ import org.utbot.framework.codegen.domain.models.CgTestMethodCluster
 import org.utbot.framework.codegen.domain.models.CgTripleSlashMultilineComment
 import org.utbot.framework.codegen.domain.models.CgUtilEntity
 import org.utbot.framework.codegen.domain.models.CgUtilMethod
-import org.utbot.framework.codegen.domain.models.SimpleTestClassModel
 import org.utbot.framework.codegen.domain.models.TestClassModel
 import org.utbot.framework.codegen.renderer.importUtilMethodDependencies
 import org.utbot.framework.codegen.reports.TestsGenerationReport
@@ -25,8 +24,12 @@ import org.utbot.framework.codegen.services.CgNameGenerator
 import org.utbot.framework.codegen.services.framework.TestFrameworkManager
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.MethodId
+import org.utbot.framework.plugin.api.UtExecution
+import org.utbot.framework.plugin.api.UtExecutionFailure
+import org.utbot.framework.plugin.api.UtExecutionSuccess
 import org.utbot.framework.plugin.api.UtMethodTestSet
 import org.utbot.framework.plugin.api.util.description
+import org.utbot.framework.util.calculateSize
 
 abstract class CgAbstractTestClassConstructor<T : TestClassModel>(val context: CgContext):
     CgContextOwner by context,
@@ -100,11 +103,27 @@ abstract class CgAbstractTestClassConstructor<T : TestClassModel>(val context: C
                 executionIndices to false
             }
 
-            for (i in checkedRange) {
-                withExecutionIdScope(i) {
-                    currentTestCaseTestMethods += methodConstructor.createTestMethod(testSet, testSet.executions[i])
+            testSet.executions
+                .withIndex()
+                .toList()
+                .slice(checkedRange)
+                .sortedWith(
+                    // NPE tests are rendered last, because oftentimes they are meaningless in a sense
+                    // that they pass `null` somewhere where `null` is never passed in production
+                    compareBy<IndexedValue<UtExecution>> { (_, execution) ->
+                        if ((execution.result as? UtExecutionFailure)?.exception is NullPointerException) 1 else -1
+                    }
+                        // we place "smaller" tests earlier, since they are easier to read
+                        // `stateAfter` is not accounted here, because usually most of it is not rendered
+                        .thenComparingInt { (_, execution) ->
+                            execution.stateBefore.calculateSize() +
+                                    ((execution.result as? UtExecutionSuccess)?.model?.calculateSize() ?: 1)
+                        }
+                ).forEach { (i, execution) ->
+                    withExecutionIdScope(i) {
+                        currentTestCaseTestMethods += methodConstructor.createTestMethod(testSet, execution)
+                    }
                 }
-            }
 
             val comments = listOf("Actual number of generated tests (${executionIndices.last - executionIndices.first}) exceeds per-method limit (${UtSettings.maxTestsPerMethodInRegion})",
                 "The limit can be configured in '{HOME_DIR}/.utbot/settings.properties' with 'maxTestsPerMethod' property")

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/util/SizeUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/util/SizeUtils.kt
@@ -35,7 +35,7 @@ fun EnvironmentModels.calculateSize(): Int {
  * calculated the size for [this] model and [this] is [UtReferenceModel], then in codegen we would have already
  * created variable for [this] model and do not need to create it again, so size should be equal to 0.
  */
-private fun UtModel.calculateSize(used: MutableSet<UtReferenceModel> = mutableSetOf()): Int {
+fun UtModel.calculateSize(used: MutableSet<UtReferenceModel> = mutableSetOf()): Int {
     if (this in used) return 0
 
     if (this is UtReferenceModel)


### PR DESCRIPTION
## Description

Non-parametrized tests are now sorted within the cluster by their estimated size (the smaller the earlier).

Additionally, regardless of their size NPE tests are always placed after non-NPE tests.

## How to test

### Manual tests

Generate tests for the following class, tests should be properly sorted.
```java
public class Lists {
    public static int sum(List<Integer> list) {
        int sum = 0;
        for (int i: list) sum += i;
        return sum;
    }

    public static <T> T getFirst(List<T> list) {
        return list.get(0);
    }
}
```

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.