### PR TITLE
Extract tests on Exceptions into examples-part10

### DIFF
--- a/.github/workflows/framework-tests-matrix.json
+++ b/.github/workflows/framework-tests-matrix.json
@@ -26,7 +26,7 @@
     },
     {
       "PART_NAME": "examples-part2",
-      "TESTS_TO_RUN": "--tests \"org.utbot.examples.exceptions.*\" --tests \"org.utbot.examples.invokes.*\" --tests \"org.utbot.examples.lambda.*\" --tests \"org.utbot.examples.make.symbolic.*\" --tests \"org.utbot.examples.math.*\" --tests \"org.utbot.examples.mixed.*\""
+      "TESTS_TO_RUN": "--tests \"org.utbot.examples.invokes.*\" --tests \"org.utbot.examples.lambda.*\" --tests \"org.utbot.examples.make.symbolic.*\" --tests \"org.utbot.examples.math.*\" --tests \"org.utbot.examples.mixed.*\""
     },
     {
       "PART_NAME": "examples-part3",
@@ -55,6 +55,10 @@
     {
       "PART_NAME": "examples-part9",
       "TESTS_TO_RUN": "--tests \"org.utbot.examples.mock.*\" --tests \"org.utbot.examples.models.*\" --tests \"org.utbot.examples.natives.*\" --tests \"org.utbot.examples.objects.*\" --tests \"org.utbot.examples.reflection.*\" --tests \"org.utbot.examples.threads.*\""
+    },
+    {
+      "PART_NAME": "examples-part10",
+      "TESTS_TO_RUN": "--tests \"org.utbot.examples.exceptions.*\""
     },
     {
       "PART_NAME": "examples-lists",


### PR DESCRIPTION
## Description

build_and_run_tests workflow started to fail frequently with examples-part2 run.
Tests in `exceptions` package take most of the time and memory, especially `JvmCrashExamplesTest`.
So they are separated into examples-part10.

## How to test

### Manual tests

1. Open [Actions](https://github.com/UnitTestBot/UTBotJava/actions/workflows/build-and-run-tests-from-branch.yml)
2. Select this branch
3. Run workflow
4. Check [how long the run takes and whether it fails or not](https://github.com/UnitTestBot/UTBotJava/actions/runs/6169847332).

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.