### PR TITLE
Use `BuiltinMethodId` for `openMocksMethodId`

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/builtin/UtilMethodBuiltins.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/builtin/UtilMethodBuiltins.kt
@@ -10,6 +10,7 @@ import org.utbot.framework.codegen.tree.ututils.UtilClassKind.Companion.PACKAGE_
 import org.utbot.framework.codegen.tree.ututils.UtilClassKind.Companion.UT_UTILS_BASE_PACKAGE_NAME
 import org.utbot.framework.plugin.api.BuiltinClassId
 import org.utbot.framework.plugin.api.BuiltinConstructorId
+import org.utbot.framework.plugin.api.BuiltinMethodId
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.CodegenLanguage
 import org.utbot.framework.plugin.api.MethodId
@@ -301,16 +302,17 @@ internal val utKotlinUtilsClassId: ClassId
         isKotlinObject = true
     )
 
-/**
- * [MethodId] for [AutoCloseable.close].
- */
-val openMocksMethodId = MethodId(
+val openMocksMethodId = BuiltinMethodId(
     classId = MockitoAnnotations::class.id,
     name = "openMocks",
     returnType = AutoCloseable::class.java.id,
     parameters = listOf(objectClassId),
+    isStatic = true,
 )
 
+/**
+ * [MethodId] for [AutoCloseable.close].
+ */
 val closeMethodId = MethodId(
     classId = AutoCloseable::class.java.id,
     name = "close",


### PR DESCRIPTION
## Description

Fixes #2602 (builtins should be used for Mockito methods)

## How to test

### Manual tests

#2602 should no longer reproduce.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.