### PR TITLE
Configure fallback from controller-specific integration tests to regular integration tests

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/context/ConcreteExecutionContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/context/ConcreteExecutionContext.kt
@@ -1,5 +1,6 @@
 package org.utbot.framework.context
 
+import org.utbot.engine.MockStrategy
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.ConcreteContextLoadingResult
 import org.utbot.framework.plugin.api.ExecutableId
@@ -27,9 +28,14 @@ interface ConcreteExecutionContext {
         rerunExecutor: ConcreteExecutor<UtConcreteExecutionResult, UtExecutionInstrumentation>,
     ): List<UtExecution>
 
-    fun tryCreateFuzzingContext(
-        concreteExecutor: ConcreteExecutor<UtConcreteExecutionResult, UtExecutionInstrumentation>,
-        classUnderTest: ClassId,
-        idGenerator: IdentityPreservingIdGenerator<Int>,
-    ): JavaFuzzingContext
+    fun tryCreateFuzzingContext(params: FuzzingContextParams): JavaFuzzingContext
+
+    data class FuzzingContextParams(
+        val concreteExecutor: ConcreteExecutor<UtConcreteExecutionResult, UtExecutionInstrumentation>,
+        val classUnderTest: ClassId,
+        val idGenerator: IdentityPreservingIdGenerator<Int>,
+        val fuzzingStartTimeMillis: Long,
+        val fuzzingEndTimeMillis: Long,
+        val mockStrategy: MockStrategy,
+    )
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/context/JavaFuzzingContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/context/JavaFuzzingContext.kt
@@ -21,5 +21,8 @@ interface JavaFuzzingContext {
         executableToCall: ExecutableId,
     ): EnvironmentModels
 
-    fun handleFuzzedConcreteExecutionResult(concreteExecutionResult: UtConcreteExecutionResult)
+    fun handleFuzzedConcreteExecutionResult(
+        methodUnderTest: ExecutableId,
+        concreteExecutionResult: UtConcreteExecutionResult,
+    )
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/context/custom/MockingJavaFuzzingContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/context/custom/MockingJavaFuzzingContext.kt
@@ -1,6 +1,7 @@
 package org.utbot.framework.context.custom
 
 import org.utbot.framework.context.JavaFuzzingContext
+import org.utbot.framework.plugin.api.ExecutableId
 import org.utbot.fuzzing.JavaValueProvider
 import org.utbot.fuzzing.providers.MapValueProvider
 import org.utbot.fuzzing.spring.unit.MockValueProvider
@@ -37,6 +38,11 @@ class MockingJavaFuzzingContext(
                     .with(NullValueProvider)
             )
 
-    override fun handleFuzzedConcreteExecutionResult(concreteExecutionResult: UtConcreteExecutionResult) =
+    override fun handleFuzzedConcreteExecutionResult(
+        methodUnderTest: ExecutableId,
+        concreteExecutionResult: UtConcreteExecutionResult
+    ) {
+        delegateContext.handleFuzzedConcreteExecutionResult(methodUnderTest, concreteExecutionResult)
         mockValueProvider.addMockingCandidates(concreteExecutionResult.detectedMockingCandidates)
+    }
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/context/simple/SimpleConcreteExecutionContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/context/simple/SimpleConcreteExecutionContext.kt
@@ -1,12 +1,11 @@
 package org.utbot.framework.context.simple
 
 import org.utbot.framework.context.ConcreteExecutionContext
+import org.utbot.framework.context.ConcreteExecutionContext.FuzzingContextParams
 import org.utbot.framework.context.JavaFuzzingContext
-import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.ConcreteContextLoadingResult
 import org.utbot.framework.plugin.api.ExecutableId
 import org.utbot.framework.plugin.api.UtExecution
-import org.utbot.fuzzer.IdentityPreservingIdGenerator
 import org.utbot.instrumentation.ConcreteExecutor
 import org.utbot.instrumentation.instrumentation.execution.SimpleUtExecutionInstrumentation
 import org.utbot.instrumentation.instrumentation.execution.UtConcreteExecutionResult
@@ -32,9 +31,6 @@ class SimpleConcreteExecutionContext(fullClassPath: String) : ConcreteExecutionC
         rerunExecutor: ConcreteExecutor<UtConcreteExecutionResult, UtExecutionInstrumentation>,
     ): List<UtExecution> = executions
 
-    override fun tryCreateFuzzingContext(
-        concreteExecutor: ConcreteExecutor<UtConcreteExecutionResult, UtExecutionInstrumentation>,
-        classUnderTest: ClassId,
-        idGenerator: IdentityPreservingIdGenerator<Int>
-    ): JavaFuzzingContext = SimpleJavaFuzzingContext(classUnderTest, idGenerator)
+    override fun tryCreateFuzzingContext(params: FuzzingContextParams): JavaFuzzingContext =
+        SimpleJavaFuzzingContext(params.classUnderTest, params.idGenerator)
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/context/simple/SimpleJavaFuzzingContext.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/context/simple/SimpleJavaFuzzingContext.kt
@@ -31,6 +31,8 @@ class SimpleJavaFuzzingContext(
         executableToCall = executableToCall
     )
 
-    override fun handleFuzzedConcreteExecutionResult(concreteExecutionResult: UtConcreteExecutionResult) =
-        Unit
+    override fun handleFuzzedConcreteExecutionResult(
+        methodUnderTest: ExecutableId,
+        concreteExecutionResult: UtConcreteExecutionResult
+    ) = Unit
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/context/utils/ConcreteExecutionContextUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/context/utils/ConcreteExecutionContextUtils.kt
@@ -1,23 +1,15 @@
 package org.utbot.framework.context.utils
 
 import org.utbot.framework.context.ConcreteExecutionContext
+import org.utbot.framework.context.ConcreteExecutionContext.FuzzingContextParams
 import org.utbot.framework.context.JavaFuzzingContext
-import org.utbot.framework.plugin.api.ClassId
-import org.utbot.fuzzer.IdentityPreservingIdGenerator
 import org.utbot.fuzzing.JavaValueProvider
-import org.utbot.instrumentation.ConcreteExecutor
-import org.utbot.instrumentation.instrumentation.execution.UtConcreteExecutionResult
-import org.utbot.instrumentation.instrumentation.execution.UtExecutionInstrumentation
 
 fun ConcreteExecutionContext.transformJavaFuzzingContext(
-    transformer: (JavaFuzzingContext) -> JavaFuzzingContext
+    transformer: FuzzingContextParams.(JavaFuzzingContext) -> JavaFuzzingContext
 ) = object : ConcreteExecutionContext by this {
-    override fun tryCreateFuzzingContext(
-        concreteExecutor: ConcreteExecutor<UtConcreteExecutionResult, UtExecutionInstrumentation>,
-        classUnderTest: ClassId,
-        idGenerator: IdentityPreservingIdGenerator<Int>
-    ): JavaFuzzingContext = transformer(
-        this@transformJavaFuzzingContext.tryCreateFuzzingContext(concreteExecutor, classUnderTest, idGenerator)
+    override fun tryCreateFuzzingContext(params: FuzzingContextParams): JavaFuzzingContext = params.transformer(
+        this@transformJavaFuzzingContext.tryCreateFuzzingContext(params)
     )
 }
 

--- a/utbot-spring-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringIntegrationTestConcreteExecutionContext.kt
+++ b/utbot-spring-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringIntegrationTestConcreteExecutionContext.kt
@@ -65,6 +65,8 @@ class SpringIntegrationTestConcreteExecutionContext(
             delegateContext = delegateContext.tryCreateFuzzingContext(params),
             relevantRepositories = relevantRepositories,
             springApplicationContext = springApplicationContext,
+            fuzzingStartTimeMillis = params.fuzzingStartTimeMillis,
+            fuzzingEndTimeMillis = params.fuzzingEndTimeMillis,
         )
     }
 }

--- a/utbot-spring-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringIntegrationTestConcreteExecutionContext.kt
+++ b/utbot-spring-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringIntegrationTestConcreteExecutionContext.kt
@@ -2,6 +2,7 @@ package org.utbot.framework.context.spring
 
 import mu.KotlinLogging
 import org.utbot.framework.context.ConcreteExecutionContext
+import org.utbot.framework.context.ConcreteExecutionContext.FuzzingContextParams
 import org.utbot.framework.context.JavaFuzzingContext
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.ConcreteContextLoadingResult
@@ -49,23 +50,19 @@ class SpringIntegrationTestConcreteExecutionContext(
             }
         }
 
-    override fun tryCreateFuzzingContext(
-        concreteExecutor: ConcreteExecutor<UtConcreteExecutionResult, UtExecutionInstrumentation>,
-        classUnderTest: ClassId,
-        idGenerator: IdentityPreservingIdGenerator<Int>
-    ): JavaFuzzingContext {
-        if (springApplicationContext.getBeansAssignableTo(classUnderTest).isEmpty())
+    override fun tryCreateFuzzingContext(params: FuzzingContextParams): JavaFuzzingContext {
+        if (springApplicationContext.getBeansAssignableTo(params.classUnderTest).isEmpty())
             error(
-                "No beans of type ${classUnderTest.name} are found. " +
+                "No beans of type ${params.classUnderTest} are found. " +
                         "Try choosing different Spring configuration or adding beans to " +
                         springSettings.configuration.fullDisplayName
             )
 
-        val relevantRepositories = concreteExecutor.getRelevantSpringRepositories(classUnderTest)
-        logger.info { "Detected relevant repositories for class $classUnderTest: $relevantRepositories" }
+        val relevantRepositories = params.concreteExecutor.getRelevantSpringRepositories(params.classUnderTest)
+        logger.info { "Detected relevant repositories for class ${params.classUnderTest}: $relevantRepositories" }
 
         return SpringIntegrationTestJavaFuzzingContext(
-            delegateContext = delegateContext.tryCreateFuzzingContext(concreteExecutor, classUnderTest, idGenerator),
+            delegateContext = delegateContext.tryCreateFuzzingContext(params),
             relevantRepositories = relevantRepositories,
             springApplicationContext = springApplicationContext,
         )

--- a/utbot-spring-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringIntegrationTestConcreteExecutionContext.kt
+++ b/utbot-spring-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringIntegrationTestConcreteExecutionContext.kt
@@ -4,10 +4,12 @@ import mu.KotlinLogging
 import org.utbot.framework.context.ConcreteExecutionContext
 import org.utbot.framework.context.ConcreteExecutionContext.FuzzingContextParams
 import org.utbot.framework.context.JavaFuzzingContext
-import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.ConcreteContextLoadingResult
+import org.utbot.framework.plugin.api.ExecutableId
 import org.utbot.framework.plugin.api.SpringSettings
-import org.utbot.fuzzer.IdentityPreservingIdGenerator
+import org.utbot.framework.plugin.api.UtExecution
+import org.utbot.framework.plugin.api.isSuccess
+import org.utbot.framework.plugin.api.util.SpringModelUtils
 import org.utbot.instrumentation.ConcreteExecutor
 import org.utbot.instrumentation.getRelevantSpringRepositories
 import org.utbot.instrumentation.instrumentation.execution.RemovingConstructFailsUtExecutionInstrumentation
@@ -68,5 +70,28 @@ class SpringIntegrationTestConcreteExecutionContext(
             fuzzingStartTimeMillis = params.fuzzingStartTimeMillis,
             fuzzingEndTimeMillis = params.fuzzingEndTimeMillis,
         )
+    }
+
+    override fun transformExecutionsBeforeMinimization(
+        executions: List<UtExecution>,
+        methodUnderTest: ExecutableId
+    ): List<UtExecution> {
+        val (mockMvcExecutions, regularExecutions) =
+            delegateContext.transformExecutionsBeforeMinimization(executions, methodUnderTest)
+                .partition { it.executableToCall == SpringModelUtils.mockMvcPerformMethodId }
+
+        val classUnderTestName = methodUnderTest.classId.name
+        val methodUnderTestSignature = methodUnderTest.signature
+
+        fun UtExecution.getMethodUnderTestCoverage(): List<Long>? =
+            coverage?.coveredInstructions?.filter {
+                it.className == classUnderTestName && it.methodSignature == methodUnderTestSignature
+            }?.map { it.id }
+
+        fun UtExecution.getKey() = getMethodUnderTestCoverage()?.let { it to result.isSuccess }
+
+        val mockMvcExecutionKeys = mockMvcExecutions.mapNotNullTo(mutableSetOf()) { it.getKey() }
+
+        return mockMvcExecutions + regularExecutions.filter { it.getKey() !in mockMvcExecutionKeys }
     }
 }

--- a/utbot-spring-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringIntegrationTestJavaFuzzingContext.kt
+++ b/utbot-spring-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringIntegrationTestJavaFuzzingContext.kt
@@ -9,8 +9,11 @@ import org.utbot.framework.plugin.api.ExecutableId
 import org.utbot.framework.plugin.api.FieldId
 import org.utbot.framework.plugin.api.MethodId
 import org.utbot.framework.plugin.api.SpringRepositoryId
+import org.utbot.framework.plugin.api.UtExecutionSuccess
 import org.utbot.framework.plugin.api.UtModel
+import org.utbot.framework.plugin.api.UtSpringMockMvcResultActionsModel
 import org.utbot.framework.plugin.api.util.SpringModelUtils
+import org.utbot.framework.plugin.api.util.SpringModelUtils.allControllerParametersAreSupported
 import org.utbot.framework.plugin.api.util.allDeclaredFieldIds
 import org.utbot.framework.plugin.api.util.jField
 import org.utbot.framework.plugin.api.util.utContext
@@ -27,11 +30,14 @@ import org.utbot.fuzzing.spring.valid.EmailValueProvider
 import org.utbot.fuzzing.spring.valid.NotBlankStringValueProvider
 import org.utbot.fuzzing.spring.valid.NotEmptyStringValueProvider
 import org.utbot.fuzzing.spring.valid.ValidEntityValueProvider
+import org.utbot.instrumentation.instrumentation.execution.UtConcreteExecutionResult
 
 class SpringIntegrationTestJavaFuzzingContext(
-    val delegateContext: JavaFuzzingContext,
+    private val delegateContext: JavaFuzzingContext,
     relevantRepositories: Set<SpringRepositoryId>,
     springApplicationContext: SpringApplicationContext,
+    private val fuzzingStartTimeMillis: Long,
+    private val fuzzingEndTimeMillis: Long,
 ) : JavaFuzzingContext by delegateContext {
     companion object {
         private val logger = KotlinLogging.logger {}
@@ -93,11 +99,13 @@ class SpringIntegrationTestJavaFuzzingContext(
         })
     }
 
+    private val methodsSuccessfullyCalledViaMockMvc = mutableSetOf<ExecutableId>()
+
     override fun createStateBefore(
         thisInstance: UtModel?,
         parameters: List<UtModel>,
         statics: Map<FieldId, UtModel>,
-        executableToCall: ExecutableId,
+        executableToCall: ExecutableId
     ): EnvironmentModels {
         val delegateStateBefore = delegateContext.createStateBefore(thisInstance, parameters, statics, executableToCall)
         return when (executableToCall) {
@@ -107,13 +115,30 @@ class SpringIntegrationTestJavaFuzzingContext(
                     methodId = executableToCall,
                     arguments = parameters,
                     idGenerator = { idGenerator.createId() }
-                ) ?: return delegateStateBefore
+                )?.takeIf {
+                    val halfOfFuzzingTimePassed = System.currentTimeMillis() > (fuzzingStartTimeMillis + fuzzingEndTimeMillis) / 2
+                    val allParamsSupported = allControllerParametersAreSupported(executableToCall)
+                    val successfullyCalledViaMockMvc = executableToCall in methodsSuccessfullyCalledViaMockMvc
+                    !halfOfFuzzingTimePassed || allParamsSupported && successfullyCalledViaMockMvc
+                } ?: return delegateStateBefore
+
                 delegateStateBefore.copy(
                     thisInstance = SpringModelUtils.createMockMvcModel(controller = thisInstance) { idGenerator.createId() },
                     parameters = listOf(requestBuilderModel),
                     executableToCall = SpringModelUtils.mockMvcPerformMethodId,
                 )
             }
+        }
+    }
+
+    override fun handleFuzzedConcreteExecutionResult(
+        methodUnderTest: ExecutableId,
+        concreteExecutionResult: UtConcreteExecutionResult
+    ) {
+        delegateContext.handleFuzzedConcreteExecutionResult(methodUnderTest, concreteExecutionResult)
+        ((concreteExecutionResult.result as? UtExecutionSuccess)?.model as? UtSpringMockMvcResultActionsModel)?.let {
+            if (it.status < 400)
+                methodsSuccessfullyCalledViaMockMvc.add(methodUnderTest)
         }
     }
 }


### PR DESCRIPTION
## Description

Fixes #2557 

When generating integration tests for Spring controllers, we don't call method directly, but rather access it via `mockMvc.perform(requestBuilder)` where via `requestBuilder` we configure request method, path and other parameters. We do that, because `mockMvc` closer resembles production environment compared to a direct controller method call, since `mockMvc` also tests controller method resolving and validates input data the same way it's done in production environment.

However, `spring-web` is an extremely large module and a huge part of it isn't yet supported in UtBot, which limits our ability to convert direct method call to indirect call via `mockMvc.perform(requestBuilder)`, so if we are unable to do that conversion it's desired to fallback to a regular flow with direct calls.

This PR implements such fallback. Now whenever we generate integration tests for controller method (i.e. when we get non-`null` result from `SpringModelUtils.createRequestBuilderModelOrNull`) we:
* spend first half of the fuzzing time trying to use `mockMvc`
* spend the second half of the fuzzing time using `mockMvc` **iff** we do support all parameters of method under test **and** during the first half of the fuzzing time we were able to get an execution that didn't throw an exception and had an HTTP status code smaller than `400`
* otherwise spend the second half of the fuzzing time using direct calls
* prior to minimization remove `UtExecution`s that use direct call and have the same coverage of method under test and same successfulness as some other `UtExecution` that uses `mockMvc` (only coverage inside method under test is considered because when `mockMvc` is used Spring may execute additional code before/after method under test which will cause coverage differ from the one obtained from direct call)

We fallback to direct calls when we only get failing executions and successful executions with HTTP status code greater or equal to `400`, because sometimes even though we technically support all the parameters, we may still be unable to trigger method under test via `mockMvc` because we are unable to pass some validation (i.e. because [user narrowed the primary mapping with not yet supported `headers = ...` in their `@RequestMapping` annotation](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/bind/annotation/RequestMapping.html#headers())), see first example in **How to test**.

We still spend half of the time **fuzzing** with `mockMvc` even when we know that we don't support some of the method under test parameters, because oftentimes Spring is able to provide reasonable defaults enabling us to still get some coverage with `mockMvc` (we prefer executions obtained from `mockMvc` because they can actually be reproduced in production), see second example in **How to test**.

## How to test

### Manual tests

1. Place the following method in the `OwnerController` class from [spring-petclinic](https://github.com/spring-projects/spring-petclinic/tree/main/src/main) project
```java
@GetMapping(path = "/owners/find", headers = "content-type=text/*")
public String initFindForm() {
	return "owners/findOwners";
}
```
Generate integration tests with `PetClinicApplication` config, there should be tests like this:
```java
@Test
@DisplayName("initFindForm: ")
public void testInitFindForm() {
	String actual = ownerController.initFindForm();

	String expected = "owners/findOwners";

	assertEquals(expected, actual);
}

@Test
@DisplayName("initFindForm: ")
public void testInitFindForm1() throws Exception {
	Object[] uriVariables = {};
	MockHttpServletRequestBuilder mockHttpServletRequestBuilder = get("/owners/find", uriVariables);

	ResultActions actual = mockMvc.perform(mockHttpServletRequestBuilder);

	actual.andDo(print());
	actual.andExpect((status()).is(400));
	actual.andExpect((content()).string(""));
}
```
2. Generate integration tests with `PetClinicApplication` config for `OwnerController.processCreationForm()` method from [spring-petclinic](https://github.com/spring-projects/spring-petclinic/tree/main/src/main) project, there should be tests like this:
```java
@Test
@DisplayName("processCreationForm: owner = Owner(), result = null")
public void testProcessCreationForm() throws Exception {
	Object[] uriVariables = {};
	MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post("/owners/new", uriVariables);

	ResultActions actual = mockMvc.perform(mockHttpServletRequestBuilder);

	actual.andDo(print());
	actual.andExpect((status()).is(200));
	actual.andExpect((view()).name("owners/createOrUpdateOwnerForm"));
	actual.andExpect((content()).string("<html>\r\n\r\n<head>\r\n\r\n  <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" />\r\n  <meta charset=\"utf-8\">\r\n  <meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\">\r\n  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\r\n\r\n  <link rel=\"shortcut icon\" type=\"image/x-icon\" href=\"/resources/images/favicon.png\">\r\n\r\n  <title>PetClinic :: a Spring Framework demonstration</title>\r\n\r\n  <!--[if lt IE 9]>\r\n    <script src=\"https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js\"></script>\r\n    <script src=\"https://oss.maxcdn.com/respond/1.4.2/respond.min.js\"></script>\r\n    <![endif]-->\r\n\r\n  <link href=\"/webjars/font-awesome/4.7.0/css/font-awesome.min.css\" rel=\"stylesheet\">\r\n  <link rel=\"stylesheet\" href=\"/resources/css/petclinic.css\" />\r\n\r\n</head>\r\n\r\n<body>\r\n\r\n  <nav class=\"navbar navbar-expand-lg navbar-dark\" role=\"navigation\">\r\n    <div class=\"container-fluid\">\r\n      <a class=\"navbar-brand\" href=\"/\"><span></span></a>\r\n      <button class=\"navbar-toggler\" type=\"button\" data-bs-toggle=\"collapse\" data-bs-target=\"#main-navbar\">\r\n        <span class=\"navbar-toggler-icon\"></span>\r\n      </button>\r\n      <div class=\"collapse navbar-collapse\" id=\"main-navbar\" style>\r\n\r\n        \r\n\r\n        <ul class=\"nav navbar-nav me-auto\">\r\n\r\n          <li class=\"nav-item\">\r\n            <a class=\"nav-link\" href=\"/\" title=\"home page\">\r\n              <span class=\"fa fa-home\"></span>\r\n              <span>Home</span>\r\n            </a>\r\n          </li>\r\n\r\n          <li class=\"nav-item\">\r\n            <a class=\"nav-link active\" href=\"/owners/find\" title=\"find owners\">\r\n              <span class=\"fa fa-search\"></span>\r\n              <span>Find owners</span>\r\n            </a>\r\n          </li>\r\n\r\n          <li class=\"nav-item\">\r\n            <a class=\"nav-link\" href=\"/vets.html\" title=\"veterinarians\">\r\n              <span class=\"fa fa-th-list\"></span>\r\n              <span>Veterinarians</span>\r\n            </a>\r\n          </li>\r\n\r\n          <li class=\"nav-item\">\r\n            <a class=\"nav-link\" href=\"/oups\" title=\"trigger a RuntimeException to see how it is handled\">\r\n              <span class=\"fa fa-exclamation-triangle\"></span>\r\n              <span>Error</span>\r\n            </a>\r\n          </li>\r\n\r\n        </ul>\r\n      </div>\r\n    </div>\r\n  </nav>\r\n  <div class=\"container-fluid\">\r\n    <div class=\"container xd-container\">\r\n\r\n      <body>\r\n\r\n  <h2>Owner</h2>\r\n  <form class=\"form-horizontal\" id=\"add-owner-form\" method=\"post\">\r\n    <div class=\"form-group has-feedback\">\r\n      \r\n      <div class=\"form-group has-error\">\r\n        <label class=\"col-sm-2 control-label\">First Name</label>\r\n        <div class=\"col-sm-10\">\r\n            <div>\r\n                <input class=\"form-control\" type=\"text\" id=\"firstName\" name=\"firstName\" value=\"\" />\r\n                \r\n            </div>\r\n          \r\n          \r\n            <span\r\n              class=\"fa fa-remove form-control-feedback\"\r\n              aria-hidden=\"true\"></span>\r\n            <span class=\"help-inline\">must not be empty</span>\r\n          \r\n        </div>\r\n      </div>\r\n    \r\n      \r\n      <div class=\"form-group has-error\">\r\n        <label class=\"col-sm-2 control-label\">Last Name</label>\r\n        <div class=\"col-sm-10\">\r\n            <div>\r\n                <input class=\"form-control\" type=\"text\" id=\"lastName\" name=\"lastName\" value=\"\" />\r\n                \r\n            </div>\r\n          \r\n          \r\n            <span\r\n              class=\"fa fa-remove form-control-feedback\"\r\n              aria-hidden=\"true\"></span>\r\n            <span class=\"help-inline\">must not be empty</span>\r\n          \r\n        </div>\r\n      </div>\r\n    \r\n      \r\n      <div class=\"form-group has-error\">\r\n        <label class=\"col-sm-2 control-label\">Address</label>\r\n        <div class=\"col-sm-10\">\r\n            <div>\r\n                <input class=\"form-control\" type=\"text\" id=\"address\" name=\"address\" value=\"\" />\r\n                \r\n            </div>\r\n          \r\n          \r\n            <span\r\n              class=\"fa fa-remove form-control-feedback\"\r\n              aria-hidden=\"true\"></span>\r\n            <span class=\"help-inline\">must not be empty</span>\r\n          \r\n        </div>\r\n      </div>\r\n    \r\n      \r\n      <div class=\"form-group has-error\">\r\n        <label class=\"col-sm-2 control-label\">City</label>\r\n        <div class=\"col-sm-10\">\r\n            <div>\r\n                <input class=\"form-control\" type=\"text\" id=\"city\" name=\"city\" value=\"\" />\r\n                \r\n            </div>\r\n          \r\n          \r\n            <span\r\n              class=\"fa fa-remove form-control-feedback\"\r\n              aria-hidden=\"true\"></span>\r\n            <span class=\"help-inline\">must not be empty</span>\r\n          \r\n        </div>\r\n      </div>\r\n    \r\n      \r\n      <div class=\"form-group has-error\">\r\n        <label class=\"col-sm-2 control-label\">Telephone</label>\r\n        <div class=\"col-sm-10\">\r\n            <div>\r\n                <input class=\"form-control\" type=\"text\" id=\"telephone\" name=\"telephone\" value=\"\" />\r\n                \r\n            </div>\r\n          \r\n          \r\n            <span\r\n              class=\"fa fa-remove form-control-feedback\"\r\n              aria-hidden=\"true\"></span>\r\n            <span class=\"help-inline\">must not be empty</span>\r\n          \r\n        </div>\r\n      </div>\r\n    \r\n    </div>\r\n    <div class=\"form-group\">\r\n      <div class=\"col-sm-offset-2 col-sm-10\">\r\n        <button\r\n          class=\"btn btn-primary\" type=\"submit\">Add Owner</button>\r\n      </div>\r\n    </div>\r\n  </form>\r\n</body>\r\n\r\n      <br />\r\n      <br />\r\n      <div class=\"container\">\r\n        <div class=\"row\">\r\n          <div class=\"col-12 text-center\">\r\n            <img src=\"/resources/images/spring-logo.svg\" alt=\"VMware Tanzu Logo\" class=\"logo\">\r\n          </div>\r\n        </div>\r\n      </div>\r\n    </div>\r\n  </div>\r\n\r\n  <script src=\"/webjars/bootstrap/5.2.3/dist/js/bootstrap.bundle.min.js\"></script>\r\n\r\n</body>\r\n\r\n</html>\r\n"));
}

@Test
@DisplayName("processCreationForm: owner = Owner(), result = BindException(Object, String)")
public void testProcessCreationForm1() {
	Owner owner = new Owner();
	owner.setTelephone("-3");
	owner.setFirstName("XZ");
	owner.setLastName("#$\\\"'");
	owner.setAddress(" ");
	owner.setCity("1@0");
	Object target = new Object();
	BindException result = new BindException(target, "\n\t\r");
	StackTraceElement[] stackTraceElementArray = new StackTraceElement[2];
	StackTraceElement stackTraceElement = new StackTraceElement("abc", "XZ", "10", Integer.MAX_VALUE);
	stackTraceElementArray[0] = stackTraceElement;
	StackTraceElement stackTraceElement1 = new StackTraceElement("\n\t\r", "\n\t\r", "#$\\\"'", "\n\t\r", "", "", 0);
	stackTraceElementArray[1] = stackTraceElement1;
	result.setStackTrace(stackTraceElementArray);

	String actual = ownerController.processCreationForm(owner, result);

	String expected = "redirect:/owners/1";

	assertEquals(expected, actual);
}
```

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.