### PR TITLE
Support for both Cookie libraries for different versions of Spring

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SpringModelUtils.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SpringModelUtils.kt
@@ -364,7 +364,7 @@ object SpringModelUtils {
         pathVariableClassId,
         requestParamClassId,
         requestHeaderClassId,
-//        cookieValueClassId, // TODO uncomment when #2542 is fixed
+        cookieValueClassId,
         requestAttributesClassId,
         sessionAttributesClassId,
         modelAttributesClassId,
@@ -451,15 +451,11 @@ object SpringModelUtils {
         val headersContentModel = createHeadersContentModel(methodId, arguments, idGenerator)
         requestBuilderModel = addHeadersToRequestBuilderModel(headersContentModel, requestBuilderModel, idGenerator)
 
-        val cookieClassId = cookieClassIds.singleOrNull()
-        if(cookieClassId is ClassId) {
+        cookieClassIds.singleOrNull()?.let { cookieClassId ->
             val cookieValuesModel = createCookieValuesModel(cookieClassId, methodId, arguments, idGenerator)
             requestBuilderModel =
                 addCookiesToRequestBuilderModel(cookieClassId, cookieValuesModel, requestBuilderModel, idGenerator)
-        }
-        else{
-            logger.warn { "Cookie library not found" }
-        }
+        } ?: logger.warn { "Cookie library not found" }
 
         val requestAttributes = collectArgumentsWithAnnotationModels(methodId, requestAttributesClassId, arguments)
         requestBuilderModel =


### PR DESCRIPTION
## Description

Fixes #2542

Added support for `jakarta.servlet.http.Cookie` which is used in newer versions of Spring.

## How to test

### Manual tests
Tested on the `spring-petclinic` project. (Spring Boot 3.1.3 with `jakarta.servlet.http.Cookie`)
Tested on the `spring-boot-testing` project. (Spring Boot 2.7.3 with `javax.servlet.http.Cookie`)

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.