### PR TITLE
Add more correct type resolving for collections and maps

### DIFF
--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Collections.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/providers/Collections.kt
@@ -7,10 +7,9 @@ import org.utbot.fuzzer.FuzzedType
 import org.utbot.fuzzer.FuzzedValue
 import org.utbot.fuzzer.IdGenerator
 import org.utbot.fuzzer.fuzzed
+import org.utbot.fuzzer.jType
 import org.utbot.fuzzing.*
-import org.utbot.fuzzing.spring.utils.jType
 import org.utbot.fuzzing.utils.hex
-import java.lang.reflect.Method
 import kotlin.reflect.KClass
 
 class EmptyCollectionValueProvider(

--- a/utbot-java-fuzzing/src/test/java/org/utbot/fuzzing/samples/ConcreateMap.java
+++ b/utbot-java-fuzzing/src/test/java/org/utbot/fuzzing/samples/ConcreateMap.java
@@ -1,0 +1,6 @@
+package org.utbot.fuzzing.samples;
+
+import java.util.HashMap;
+
+public class ConcreateMap<V extends Number> extends HashMap<String, V> {
+}

--- a/utbot-java-fuzzing/src/test/java/org/utbot/fuzzing/samples/ConcreteList.java
+++ b/utbot-java-fuzzing/src/test/java/org/utbot/fuzzing/samples/ConcreteList.java
@@ -1,0 +1,7 @@
+package org.utbot.fuzzing.samples;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class ConcreteList extends ArrayList<Collection<String>> {
+}

--- a/utbot-java-fuzzing/src/test/kotlin/org/utbot/fuzzing/JavaValueProviderTest.kt
+++ b/utbot-java-fuzzing/src/test/kotlin/org/utbot/fuzzing/JavaValueProviderTest.kt
@@ -1,0 +1,61 @@
+package org.utbot.fuzzing
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.utbot.framework.plugin.api.Instruction
+import org.utbot.framework.plugin.api.util.collectionClassId
+import org.utbot.framework.plugin.api.util.id
+import org.utbot.framework.plugin.api.util.stringClassId
+import org.utbot.framework.plugin.api.util.voidClassId
+import org.utbot.fuzzer.FuzzedMethodDescription
+import org.utbot.fuzzer.FuzzedType
+import org.utbot.fuzzing.providers.ListSetValueProvider
+import org.utbot.fuzzing.providers.MapValueProvider
+import org.utbot.fuzzing.samples.ConcreateMap
+import org.utbot.fuzzing.samples.ConcreteList
+import org.utbot.fuzzing.utils.Trie
+import java.lang.reflect.Type
+import kotlin.random.Random
+
+fun emptyFuzzerDescription(typeCache: MutableMap<Type, FuzzedType>) = FuzzedDescription(
+    FuzzedMethodDescription("no name", voidClassId, emptyList()),
+    Trie(Instruction::id),
+    typeCache,
+    Random(42)
+)
+
+class JavaValueProviderTest {
+
+    @Test
+    fun `collection value provider correctly resolves types for concrete types of map`() {
+        val typeCache = mutableMapOf<Type, FuzzedType>()
+        runBlockingWithContext {
+            val seed = MapValueProvider(TestIdentityPreservingIdGenerator).generate(
+                emptyFuzzerDescription(typeCache),
+                toFuzzerType(ConcreateMap::class.java, typeCache)
+            ).first()
+            val collection = seed as Seed.Collection
+            val types = collection.modify.types
+            Assertions.assertEquals(2, types.size)
+            Assertions.assertEquals(types[0].classId, stringClassId)
+            Assertions.assertEquals(types[1].classId, java.lang.Number::class.java.id)
+        }
+    }
+
+    @Test
+    fun `collection value provider correctly resolves types for concrete types of list`() {
+        val typeCache = mutableMapOf<Type, FuzzedType>()
+        runBlockingWithContext {
+            val seed = ListSetValueProvider(TestIdentityPreservingIdGenerator).generate(
+                emptyFuzzerDescription(typeCache),
+                toFuzzerType(ConcreteList::class.java, typeCache)
+            ).first()
+            val collection = seed as Seed.Collection
+            val types = collection.modify.types
+            Assertions.assertEquals(1, types.size)
+            Assertions.assertEquals(types[0].classId, collectionClassId)
+            Assertions.assertEquals(1, types[0].generics.size)
+            Assertions.assertEquals(types[0].generics[0].classId, stringClassId)
+        }
+    }
+}


### PR DESCRIPTION
## Description

Fixes #2571 

The generic retrieving logic for collections and maps was naive. This PR improves that logic using guava type resolving to find out correct types. For every type it tries to resolve a type of returned values when calling such methods as `Map.keySet`, `Map.values` and `Collection.iterator`. A generic used in the returned type of those methods is a target type used for building a collection or a map.

Note, that the fix reveals another problem in the code generator. Because it uses untyped model it fails to generate a compilable test. For example, the result of fuzzing `getAnyString` method from the issue is follow:

```
    @Test
    @DisplayName("getAnyString: ")
    public void testGetAnyString() {
        Issue2571 issue2571 = new Issue2571();
        issue2571.put(((Object) "XZ"), ((Object) "abc"));

        String actual = issue2571.getAnyString();

        String expected = "XZ";

        assertEquals(expected, actual);
    }
```

This line `issue2571.put(((Object) "XZ"), ((Object) "abc"));` has syntax error because the map expects a string, not an object. @EgorkaKulikov , please, check this one.

## How to test

### Automated tests

New tests added:

> The proposed changes are verified with tests:
> utbot-java-fuzzing/src/test/kotlin/org/utbot/fuzzing/JavaValueProviderTest.kt`

### Manual tests

All manual tests from collections samples should pass.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.