### PR TITLE
Fix bug with python interpreter detection

### DIFF
--- a/utbot-intellij-python/src/main/kotlin/org/utbot/intellij/plugin/language/python/PythonDialogProcessor.kt
+++ b/utbot-intellij-python/src/main/kotlin/org/utbot/intellij/plugin/language/python/PythonDialogProcessor.kt
@@ -24,6 +24,7 @@ import com.jetbrains.python.psi.PyElement
 import com.jetbrains.python.psi.PyFile
 import com.jetbrains.python.psi.PyFunction
 import com.jetbrains.python.psi.resolve.QualifiedNameFinder
+import com.jetbrains.python.sdk.pythonSdk
 import mu.KotlinLogging
 import org.jetbrains.kotlin.idea.base.util.module
 import org.jetbrains.kotlin.idea.base.util.sdk
@@ -119,7 +120,7 @@ object PythonDialogProcessor {
                 }
             }
         }
-        val pythonPath = getPythonPath(elementsToShow)
+        val pythonPath = getPythonPath(project)
         if (pythonPath == null) {
             showErrorDialogLater(
                 project,
@@ -334,8 +335,8 @@ object PythonDialogProcessor {
     }
 }
 
-fun getPythonPath(elementsToShow: Set<PyElement>): String? {
-    return findSrcModules(elementsToShow).first().sdk?.homePath
+fun getPythonPath(project: Project): String? {
+    return project.pythonSdk?.homePath
 }
 
 fun findSrcModules(elements: Collection<PyElement>): List<Module> {


### PR DESCRIPTION
## Description

Fixes #2612

Rewrite python interpreter detection algorithm (use special method `pythonSdk`)

## How to test

### Manual tests

1. Open python project and set non-python sdk in settings (for example `jdk`)
2. Try to generate tests for python file
3. __Expected__: error message about undetected python interpreter

## Self-check list

Check off the item if the statement is true. Hint: [x] is a marked item.

Please do not delete the list or its items.

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.