### PR TITLE
Improve detection of NPEs caused by this instance fields being null in Spring unit tests

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/TrustedPackages.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/TrustedPackages.kt
@@ -1,5 +1,6 @@
 package org.utbot.framework
 
+import org.utbot.framework.plugin.api.ClassId
 import soot.SootClass
 
 /**
@@ -10,7 +11,17 @@ private val isPackageTrusted: MutableMap<String, Boolean> = mutableMapOf()
 /**
  * Determines whether [this] class is from trusted libraries as defined in [TrustedLibraries].
  */
-fun SootClass.isFromTrustedLibrary(): Boolean {
+fun SootClass.isFromTrustedLibrary(): Boolean = isFromTrustedLibrary(packageName)
+
+/**
+ * Determines whether [this] class is from trusted libraries as defined in [TrustedLibraries].
+ */
+fun ClassId.isFromTrustedLibrary(): Boolean = isFromTrustedLibrary(packageName)
+
+/**
+ * Determines whether [packageName] is from trusted libraries as defined in [TrustedLibraries].
+ */
+fun isFromTrustedLibrary(packageName: String): Boolean {
     isPackageTrusted[packageName]?.let {
         return it
     }

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/IdUtil.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/IdUtil.kt
@@ -468,6 +468,13 @@ val ClassId.allDeclaredFieldIds: Sequence<FieldId>
 val SootField.fieldId: FieldId
     get() = FieldId(declaringClass.id, name)
 
+/**
+ * For some lambdas class names in byte code and in Soot don't match, so we may fail
+ * to convert some soot fields to Java fields, in such case `null` is returned.
+ */
+val SootField.jFieldOrNull: Field?
+    get() = runCatching { fieldId.jField }.getOrNull()
+
 // FieldId utils
 val FieldId.safeJField: Field?
     get() = declaringClass.jClass.declaredFields.firstOrNull { it.name == name }

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SpringModelUtils.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/util/SpringModelUtils.kt
@@ -22,6 +22,11 @@ private val logger = KotlinLogging.logger {}
 
 object SpringModelUtils {
     val autowiredClassId = ClassId("org.springframework.beans.factory.annotation.Autowired")
+    val injectClassIds = getClassIdFromEachAvailablePackage(
+        packages = listOf("javax", "jakarta"),
+        classNameFromPackage = "inject.Inject"
+    )
+    val componentClassId = ClassId("org.springframework.stereotype.Component")
 
     val applicationContextClassId = ClassId("org.springframework.context.ApplicationContext")
     val repositoryClassId = ClassId("org.springframework.data.repository.Repository")

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssembleModelGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/assemble/AssembleModelGenerator.kt
@@ -8,8 +8,8 @@ import org.utbot.engine.ResolvedModels
 import org.utbot.framework.UtSettings
 import org.utbot.framework.codegen.util.isAccessibleFrom
 import org.utbot.modifications.AnalysisMode.SettersAndDirectAccessors
-import org.utbot.modifications.ConstructorAnalyzer
-import org.utbot.modifications.ConstructorAssembleInfo
+import org.utbot.modifications.ExecutableAnalyzer
+import org.utbot.modifications.ExecutableAssembleInfo
 import org.utbot.modifications.UtBotFieldsModificatorsSearcher
 import org.utbot.framework.plugin.api.ClassId
 import org.utbot.framework.plugin.api.ConstructorId
@@ -77,7 +77,7 @@ class AssembleModelGenerator(private val basePackageName: String) {
         UtBotFieldsModificatorsSearcher(
             fieldInvolvementMode = FieldInvolvementMode.WriteOnly
         )
-    private val constructorAnalyzer = ConstructorAnalyzer()
+    private val executableAnalyzer = ExecutableAnalyzer()
 
     /**
      * Clears state before and after block execution.
@@ -284,8 +284,8 @@ class AssembleModelGenerator(private val basePackageName: String) {
             modelsInAnalysis.add(compositeModel)
 
             val constructorInfo =
-                if (shouldAnalyzeConstructor) constructorAnalyzer.analyze(constructorId)
-                else ConstructorAssembleInfo(constructorId)
+                if (shouldAnalyzeConstructor) executableAnalyzer.analyze(constructorId)
+                else ExecutableAssembleInfo(constructorId)
 
             val instantiationCall = constructorCall(compositeModel, constructorInfo)
             return UtAssembleModel(
@@ -406,9 +406,9 @@ class AssembleModelGenerator(private val basePackageName: String) {
      */
     private fun constructorCall(
         compositeModel: UtCompositeModel,
-        constructorInfo: ConstructorAssembleInfo,
+        constructorInfo: ExecutableAssembleInfo,
     ): UtExecutableCallModel {
-        val constructorParams = constructorInfo.constructorId.parameters.withIndex()
+        val constructorParams = constructorInfo.executableId.parameters.withIndex()
             .map { (index, param) ->
                 val modelOrNull = compositeModel.fields
                     .filter { it.key == constructorInfo.params[index] }
@@ -418,7 +418,7 @@ class AssembleModelGenerator(private val basePackageName: String) {
                 assembleModel(fieldModel)
             }
 
-        return UtExecutableCallModel(instance = null, constructorInfo.constructorId, constructorParams)
+        return UtExecutableCallModel(instance = null, constructorInfo.executableId, constructorParams)
     }
 
     /**
@@ -445,11 +445,11 @@ class AssembleModelGenerator(private val basePackageName: String) {
             val fromUtilPackage = classId.packageName.startsWith("java.util")
             constructorIds
                 .sortedBy { it.parameters.size }
-                .firstOrNull { it.parameters.isEmpty() && fromUtilPackage || constructorAnalyzer.isAppropriate(it) }
+                .firstOrNull { it.parameters.isEmpty() && fromUtilPackage || executableAnalyzer.isAppropriate(it) }
         } else {
             constructorIds
                 .sortedByDescending { it.parameters.size }
-                .firstOrNull { constructorAnalyzer.isAppropriate(it) }
+                .firstOrNull { executableAnalyzer.isAppropriate(it) }
         }
     }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/context/NonNullSpeculator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/context/NonNullSpeculator.kt
@@ -1,17 +1,28 @@
 package org.utbot.framework.context
 
 import org.utbot.framework.plugin.api.ClassId
+import org.utbot.framework.plugin.api.FieldId
 import soot.SootField
 
+/**
+ * Checks whether accessing [field] (with a method invocation or field access) speculatively
+ * cannot produce [NullPointerException] (according to its finality or accessibility).
+ *
+ * @see docs/SpeculativeFieldNonNullability.md for more information.
+ *
+ * NOTE: methods for both [FieldId] and [SootField] are provided, because for some lambdas
+ * class names in byte code and in Soot do not match, making conversion between two field
+ * representations not always possible, which in turn makes us to support both [FieldId]
+ * and [SootField] to be useful for both fuzzer and symbolic engine respectively.
+ */
 interface NonNullSpeculator {
-    /**
-     * Checks whether accessing [field] (with a method invocation or field access) speculatively
-     * cannot produce [NullPointerException] (according to its finality or accessibility).
-     *
-     * @see docs/SpeculativeFieldNonNullability.md for more information.
-     */
     fun speculativelyCannotProduceNullPointerException(
         field: SootField,
+        classUnderTest: ClassId,
+    ): Boolean
+
+    fun speculativelyCannotProduceNullPointerException(
+        field: FieldId,
         classUnderTest: ClassId,
     ): Boolean
 }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/context/simple/SimpleNonNullSpeculator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/context/simple/SimpleNonNullSpeculator.kt
@@ -4,12 +4,23 @@ import org.utbot.framework.UtSettings
 import org.utbot.framework.context.NonNullSpeculator
 import org.utbot.framework.isFromTrustedLibrary
 import org.utbot.framework.plugin.api.ClassId
+import org.utbot.framework.plugin.api.FieldId
+import org.utbot.framework.plugin.api.util.isFinal
+import org.utbot.framework.plugin.api.util.isPublic
 import soot.SootField
 
 class SimpleNonNullSpeculator : NonNullSpeculator {
     override fun speculativelyCannotProduceNullPointerException(
         field: SootField,
         classUnderTest: ClassId,
+    ): Boolean =
+        !UtSettings.maximizeCoverageUsingReflection &&
+                field.declaringClass.isFromTrustedLibrary() &&
+                (field.isFinal || !field.isPublic)
+
+    override fun speculativelyCannotProduceNullPointerException(
+        field: FieldId,
+        classUnderTest: ClassId
     ): Boolean =
         !UtSettings.maximizeCoverageUsingReflection &&
                 field.declaringClass.isFromTrustedLibrary() &&

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/context/utils/ApplicationContextUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/context/utils/ApplicationContextUtils.kt
@@ -2,6 +2,7 @@ package org.utbot.framework.context.utils
 
 import org.utbot.framework.context.ApplicationContext
 import org.utbot.framework.context.ConcreteExecutionContext
+import org.utbot.framework.context.ConcreteExecutionContext.FuzzingContextParams
 import org.utbot.fuzzing.JavaValueProvider
 
 fun ApplicationContext.transformConcreteExecutionContext(
@@ -18,5 +19,5 @@ fun ApplicationContext.transformConcreteExecutionContext(
 }
 
 fun ApplicationContext.transformValueProvider(
-    transformer: (JavaValueProvider) -> JavaValueProvider
+    transformer: FuzzingContextParams.(JavaValueProvider) -> JavaValueProvider
 ) = transformConcreteExecutionContext { it.transformValueProvider(transformer) }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/context/utils/ConcreteExecutionContextUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/context/utils/ConcreteExecutionContextUtils.kt
@@ -4,6 +4,14 @@ import org.utbot.framework.context.ConcreteExecutionContext
 import org.utbot.framework.context.ConcreteExecutionContext.FuzzingContextParams
 import org.utbot.framework.context.JavaFuzzingContext
 import org.utbot.fuzzing.JavaValueProvider
+import org.utbot.instrumentation.instrumentation.execution.UtExecutionInstrumentation
+
+fun ConcreteExecutionContext.transformInstrumentationFactory(
+    transformer: (UtExecutionInstrumentation.Factory<*>) -> UtExecutionInstrumentation.Factory<*>
+) = object : ConcreteExecutionContext by this {
+    override val instrumentationFactory: UtExecutionInstrumentation.Factory<*> =
+        transformer(this@transformInstrumentationFactory.instrumentationFactory)
+}
 
 fun ConcreteExecutionContext.transformJavaFuzzingContext(
     transformer: FuzzingContextParams.(JavaFuzzingContext) -> JavaFuzzingContext

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/context/utils/ConcreteExecutionContextUtils.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/context/utils/ConcreteExecutionContextUtils.kt
@@ -14,5 +14,7 @@ fun ConcreteExecutionContext.transformJavaFuzzingContext(
 }
 
 fun ConcreteExecutionContext.transformValueProvider(
-    transformer: (JavaValueProvider) -> JavaValueProvider
-) = transformJavaFuzzingContext { it.transformValueProvider(transformer) }
+    transformer: FuzzingContextParams.(JavaValueProvider) -> JavaValueProvider
+) = transformJavaFuzzingContext { javaFuzzingContext ->
+    javaFuzzingContext.transformValueProvider { valueProvider -> transformer(valueProvider) }
+}

--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/spring/JavaLangObject.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/spring/JavaLangObject.kt
@@ -1,0 +1,35 @@
+package org.utbot.fuzzing.spring
+
+import org.utbot.framework.plugin.api.ClassId
+import org.utbot.framework.plugin.api.util.jClass
+import org.utbot.framework.plugin.api.util.objectClassId
+import org.utbot.fuzzer.FuzzedType
+import org.utbot.fuzzer.FuzzedValue
+import org.utbot.fuzzer.toTypeParametrizedByTypeVariables
+import org.utbot.fuzzing.FuzzedDescription
+import org.utbot.fuzzing.JavaValueProvider
+import org.utbot.fuzzing.Routine
+import org.utbot.fuzzing.Seed
+import org.utbot.fuzzing.providers.nullRoutine
+import org.utbot.fuzzing.toFuzzerType
+
+class JavaLangObject(
+    private val classesToTryUsingAsJavaLangObject: List<ClassId>,
+) : JavaValueProvider {
+    override fun accept(type: FuzzedType): Boolean {
+        return type.classId == objectClassId
+    }
+
+    override fun generate(description: FuzzedDescription, type: FuzzedType): Sequence<Seed<FuzzedType, FuzzedValue>> =
+        classesToTryUsingAsJavaLangObject.map { classToUseAsObject ->
+            val fuzzedType = toFuzzerType(
+                type = classToUseAsObject.jClass.toTypeParametrizedByTypeVariables(),
+                cache = description.typeCache
+            )
+            Seed.Recursive(
+                construct = Routine.Create(listOf(fuzzedType)) { (value) -> value },
+                modify = emptySequence(),
+                empty = nullRoutine(type.classId)
+            )
+        }.asSequence()
+}

--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/spring/JavaLangObject.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzing/spring/JavaLangObject.kt
@@ -13,7 +13,7 @@ import org.utbot.fuzzing.Seed
 import org.utbot.fuzzing.providers.nullRoutine
 import org.utbot.fuzzing.toFuzzerType
 
-class JavaLangObject(
+class JavaLangObjectValueProvider(
     private val classesToTryUsingAsJavaLangObject: List<ClassId>,
 ) : JavaValueProvider {
     override fun accept(type: FuzzedType): Boolean {

--- a/utbot-modificators-analyzer/src/main/kotlin/org/utbot/modifications/ExecutableAnalyzer.kt
+++ b/utbot-modificators-analyzer/src/main/kotlin/org/utbot/modifications/ExecutableAnalyzer.kt
@@ -169,6 +169,7 @@ class ExecutableAnalyzer {
 
             val field = (assn.leftOp as? JInstanceFieldRef)?.field ?: continue
             val parameterIndex = jimpleBody.parameterLocals.indexOfFirst { it.name == jimpleLocal.name }
+            if (parameterIndex == -1) continue
             indexedFields[parameterIndex] = FieldId(field.declaringClass.id, field.name)
         }
 

--- a/utbot-spring-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringApplicationContextImpl.kt
+++ b/utbot-spring-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringApplicationContextImpl.kt
@@ -92,7 +92,10 @@ class SpringApplicationContextImpl(
                     .transformValueProvider { origValueProvider ->
                         InjectMockValueProvider(
                             idGenerator = fuzzingContext.idGenerator,
-                            classUnderTest = fuzzingContext.classUnderTest
+                            classUnderTest = fuzzingContext.classUnderTest,
+                            isFieldNonNull = { fieldId ->
+                                nonNullSpeculator.speculativelyCannotProduceNullPointerException(fieldId, classUnderTest)
+                            },
                         )
                             .withFallback(origValueProvider)
                             .replaceTypes { description, type ->

--- a/utbot-spring-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringApplicationContextImpl.kt
+++ b/utbot-spring-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringApplicationContextImpl.kt
@@ -26,7 +26,9 @@ import org.utbot.framework.plugin.api.util.SpringModelUtils.entityClassIds
 import org.utbot.framework.plugin.api.util.allSuperTypes
 import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.jClass
+import org.utbot.framework.plugin.api.util.objectClassId
 import org.utbot.framework.plugin.api.util.utContext
+import org.utbot.fuzzing.spring.JavaLangObject
 import org.utbot.fuzzing.spring.FuzzedTypeFlag
 import org.utbot.fuzzing.spring.addProperties
 import org.utbot.fuzzing.spring.decorators.replaceTypes
@@ -58,7 +60,11 @@ class SpringApplicationContextImpl(
         var delegateConcreteExecutionContext = delegateContext.createConcreteExecutionContext(
             fullClasspath,
             classpathWithoutDependencies
-        )
+        ).transformValueProvider { valueProvider ->
+            valueProvider.with(JavaLangObject(
+                classesToTryUsingAsJavaLangObject = listOf(objectClassId, classUnderTest)
+            ))
+        }
 
         // to avoid filtering out all coverage, we only filter
         // coverage when `classpathWithoutDependencies` is provided

--- a/utbot-spring-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringApplicationContextImpl.kt
+++ b/utbot-spring-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringApplicationContextImpl.kt
@@ -29,7 +29,7 @@ import org.utbot.framework.plugin.api.util.id
 import org.utbot.framework.plugin.api.util.jClass
 import org.utbot.framework.plugin.api.util.objectClassId
 import org.utbot.framework.plugin.api.util.utContext
-import org.utbot.fuzzing.spring.JavaLangObject
+import org.utbot.fuzzing.spring.JavaLangObjectValueProvider
 import org.utbot.fuzzing.spring.FuzzedTypeFlag
 import org.utbot.fuzzing.spring.addProperties
 import org.utbot.fuzzing.spring.decorators.replaceTypes
@@ -63,7 +63,7 @@ class SpringApplicationContextImpl(
             fullClasspath,
             classpathWithoutDependencies
         ).transformValueProvider { valueProvider ->
-            valueProvider.with(JavaLangObject(
+            valueProvider.with(JavaLangObjectValueProvider(
                 classesToTryUsingAsJavaLangObject = listOf(objectClassId, classUnderTest)
             ))
         }

--- a/utbot-spring-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringApplicationContextImpl.kt
+++ b/utbot-spring-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringApplicationContextImpl.kt
@@ -15,6 +15,7 @@ import org.utbot.framework.context.TypeReplacer
 import org.utbot.framework.context.custom.CoverageFilteringConcreteExecutionContext
 import org.utbot.framework.context.custom.RerunningConcreteExecutionContext
 import org.utbot.framework.context.custom.useMocks
+import org.utbot.framework.context.utils.transformInstrumentationFactory
 import org.utbot.framework.context.utils.transformJavaFuzzingContext
 import org.utbot.framework.context.utils.transformValueProvider
 import org.utbot.framework.plugin.api.BeanDefinitionData
@@ -35,6 +36,7 @@ import org.utbot.fuzzing.spring.decorators.replaceTypes
 import org.utbot.fuzzing.spring.properties
 import org.utbot.fuzzing.spring.unit.InjectMockValueProvider
 import org.utbot.fuzzing.toFuzzerType
+import org.utbot.instrumentation.instrumentation.execution.RemovingConstructFailsUtExecutionInstrumentation
 
 class SpringApplicationContextImpl(
     private val delegateContext: ApplicationContext,
@@ -115,6 +117,8 @@ class SpringApplicationContextImpl(
                         springApplicationContext = this
                     )
                 )
+        }.transformInstrumentationFactory { delegateInstrumentationFactory ->
+            RemovingConstructFailsUtExecutionInstrumentation.Factory(delegateInstrumentationFactory)
         }
     }
 

--- a/utbot-spring-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringIntegrationTestConcreteExecutionContext.kt
+++ b/utbot-spring-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringIntegrationTestConcreteExecutionContext.kt
@@ -12,7 +12,6 @@ import org.utbot.framework.plugin.api.isSuccess
 import org.utbot.framework.plugin.api.util.SpringModelUtils
 import org.utbot.instrumentation.ConcreteExecutor
 import org.utbot.instrumentation.getRelevantSpringRepositories
-import org.utbot.instrumentation.instrumentation.execution.RemovingConstructFailsUtExecutionInstrumentation
 import org.utbot.instrumentation.instrumentation.execution.UtConcreteExecutionResult
 import org.utbot.instrumentation.instrumentation.execution.UtExecutionInstrumentation
 import org.utbot.instrumentation.instrumentation.spring.SpringUtExecutionInstrumentation
@@ -32,15 +31,13 @@ class SpringIntegrationTestConcreteExecutionContext(
     }
 
     override val instrumentationFactory: UtExecutionInstrumentation.Factory<*> =
-        RemovingConstructFailsUtExecutionInstrumentation.Factory(
-            SpringUtExecutionInstrumentation.Factory(
-                delegateContext.instrumentationFactory,
-                springSettings,
-                springApplicationContext.beanDefinitions,
-                buildDirs = classpathWithoutDependencies.split(File.pathSeparator)
-                    .map { File(it).toURI().toURL() }
-                    .toTypedArray(),
-            )
+        SpringUtExecutionInstrumentation.Factory(
+            delegateContext.instrumentationFactory,
+            springSettings,
+            springApplicationContext.beanDefinitions,
+            buildDirs = classpathWithoutDependencies.split(File.pathSeparator)
+                .map { File(it).toURI().toURL() }
+                .toTypedArray(),
         )
 
     override fun loadContext(

--- a/utbot-spring-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringNonNullSpeculator.kt
+++ b/utbot-spring-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringNonNullSpeculator.kt
@@ -1,19 +1,114 @@
 package org.utbot.framework.context.spring
 
+import mu.KotlinLogging
 import org.utbot.framework.context.NonNullSpeculator
+import org.utbot.framework.context.spring.SpringNonNullSpeculator.InjectionKind.*
 import org.utbot.framework.plugin.api.ClassId
-import org.utbot.framework.plugin.api.classId
+import org.utbot.framework.plugin.api.ExecutableId
+import org.utbot.framework.plugin.api.FieldId
+import org.utbot.framework.plugin.api.util.SpringModelUtils.autowiredClassId
+import org.utbot.framework.plugin.api.util.SpringModelUtils.componentClassId
+import org.utbot.framework.plugin.api.util.SpringModelUtils.injectClassIds
 import org.utbot.framework.plugin.api.util.allDeclaredFieldIds
+import org.utbot.framework.plugin.api.util.executable
 import org.utbot.framework.plugin.api.util.fieldId
+import org.utbot.framework.plugin.api.util.id
+import org.utbot.framework.plugin.api.util.jClass
+import org.utbot.framework.plugin.api.util.jField
+import org.utbot.framework.plugin.api.util.jFieldOrNull
+import org.utbot.modifications.ExecutableAnalyzer
 import soot.SootField
+import java.lang.reflect.AnnotatedElement
 
 class SpringNonNullSpeculator(
     private val delegateNonNullSpeculator: NonNullSpeculator,
     private val springApplicationContext: SpringApplicationContext
 ) : NonNullSpeculator {
-    override fun speculativelyCannotProduceNullPointerException(field: SootField, classUnderTest: ClassId): Boolean =
-        // TODO add ` || delegateNonNullSpeculator.speculativelyCannotProduceNullPointerException(field, classUnderTest)`
-        //  (TODO is added as a part of only equivalent transformations refactoring PR and should be completed in the follow up PR)
-        field.fieldId in classUnderTest.allDeclaredFieldIds && field.type.classId !in springApplicationContext.allInjectedSuperTypes
+    private val executableAnalyzer = ExecutableAnalyzer()
 
+    companion object {
+        private val logger = KotlinLogging.logger {}
+    }
+
+    override fun speculativelyCannotProduceNullPointerException(
+        field: SootField,
+        classUnderTest: ClassId,
+    ): Boolean =
+         ((field.jFieldOrNull?.let { it.fieldId in getInjectedFields(it.declaringClass.id) } ?: false) ||
+            delegateNonNullSpeculator.speculativelyCannotProduceNullPointerException(field, classUnderTest))
+
+    override fun speculativelyCannotProduceNullPointerException(field: FieldId, classUnderTest: ClassId): Boolean =
+        (field in getInjectedFields(field.declaringClass) ||
+                delegateNonNullSpeculator.speculativelyCannotProduceNullPointerException(field, classUnderTest))
+
+    private val injectedFieldsCache = mutableMapOf<ClassId, Set<FieldId>>()
+
+    /**
+     * As described in [this issue](https://github.com/UnitTestBot/UTBotJava/issues/2589) we should consider
+     * `FieldType fieldName` to be non-`null`, iff one of the following statements holds:
+     *   - the field itself is annotated with `@Autowired(required=true)`, `@Autowired` or `@Inject`
+     *   - all the following statements hold:
+     *     - one of the following statements hold:
+     *       - there’s a constructor or a method annotated with `@Autowired(required=true)`, `@Autowired` or `@Inject`
+     *       - there’s only one constructor defined in the class, said constructor is not annotated with
+     *         `@Autowired(required=false)`, while the class itself is annotated with `@Component`-like annotation
+     *         (either `@Component` itself or other annotation that is itself annotated with `@Component`)
+     *     - said constructor/method accepts a parameter of type `FieldType` (or its subtype)
+     *     - said parameter is not annotated with `@Nullable` nor with `@Autowired(required=false)`
+     *     - said constructor/method contains an assignment of said parameter to `fieldName`
+     */
+    private fun getInjectedFields(classId: ClassId): Set<FieldId> = injectedFieldsCache.getOrPut(classId) {
+         try {
+             (classId.allDeclaredFieldIds.filter { it.jField.getInjectionAnnotationKind() == INJECTED_AND_REQUIRED } +
+                     classId.getInjectingExecutables().flatMap { injectingExecutable ->
+                         executableAnalyzer.analyze(injectingExecutable).params
+                             .map { (paramIdx, fieldId) -> injectingExecutable.executable.parameters[paramIdx] to fieldId }
+                             .filter { (param, fieldId) ->
+                                 fieldId.type.jClass.isAssignableFrom(param.type) &&
+                                         param.annotations.none {
+                                             it.annotationClass.simpleName?.endsWith("Nullable") ?: false
+                                         } &&
+                                         param.getInjectionAnnotationKind() != INJECTED_BUT_NOT_REQUIRED
+                             }
+                             .map { (_, fieldId) -> fieldId }
+                     }).toSet().also {
+                         logger.info { "Injected fields for $classId: $it" }
+                    }
+         } catch (e: Throwable) {
+            logger.warn(e) { "Failed to determine injected fields for class $classId" }
+            emptySet()
+         }
+    }
+
+    private fun ClassId.getInjectingExecutables(): Sequence<ExecutableId> {
+        return (allConstructors + allMethods).filter {
+            it.executable.getInjectionAnnotationKind() == INJECTED_AND_REQUIRED
+        } + listOfNotNull(allConstructors.singleOrNull()?.takeIf { constructor ->
+            isBeanDefiningClass() && constructor.executable.getInjectionAnnotationKind() == NOT_INJECTED
+        })
+    }
+
+    private fun ClassId.isBeanDefiningClass(): Boolean =
+        this in springApplicationContext.injectedTypes || jClass.annotations.any { it.isComponentLike() }
+
+    private fun Annotation.isComponentLike() =
+        annotationClass.id == componentClassId ||
+                annotationClass.annotations.any { it.annotationClass.id == componentClassId }
+
+    private fun AnnotatedElement.getInjectionAnnotationKind(): InjectionKind {
+        if(annotations.any { it.annotationClass.id in injectClassIds })
+            return INJECTED_AND_REQUIRED
+        val autowiredAnnotation = annotations.firstOrNull { it.annotationClass.id == autowiredClassId }
+            ?: return NOT_INJECTED
+        return if (autowiredAnnotation.annotationClass.java.getMethod("required").invoke(autowiredAnnotation) as Boolean)
+            INJECTED_AND_REQUIRED
+        else
+            INJECTED_BUT_NOT_REQUIRED
+    }
+
+    private enum class InjectionKind {
+        NOT_INJECTED,
+        INJECTED_BUT_NOT_REQUIRED,
+        INJECTED_AND_REQUIRED,
+    }
 }

--- a/utbot-spring-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringNonNullSpeculator.kt
+++ b/utbot-spring-framework/src/main/kotlin/org/utbot/framework/context/spring/SpringNonNullSpeculator.kt
@@ -72,7 +72,7 @@ class SpringNonNullSpeculator(
                              }
                              .map { (_, fieldId) -> fieldId }
                      }).toSet().also {
-                         logger.info { "Injected fields for $classId: $it" }
+                         logger.debug { "Injected fields for $classId: $it" }
                     }
          } catch (e: Throwable) {
             logger.warn(e) { "Failed to determine injected fields for class $classId" }

--- a/utbot-spring-sample/src/main/java/org/utbot/examples/spring/autowiring/twoAndMoreBeansForOneType/ServiceOfBeansWithSameType.java
+++ b/utbot-spring-sample/src/main/java/org/utbot/examples/spring/autowiring/twoAndMoreBeansForOneType/ServiceOfBeansWithSameType.java
@@ -3,9 +3,6 @@ package org.utbot.examples.spring.autowiring.twoAndMoreBeansForOneType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Service
 public class ServiceOfBeansWithSameType {
     @Autowired
@@ -14,15 +11,21 @@ public class ServiceOfBeansWithSameType {
     @Autowired
     private Person personTwo;
 
-    public final List<String> baseOrders = new ArrayList<>();
-
-    // a method for testing the case when the Engine produces one model on @Autowired variables of the same type
-    public Integer ageSum(){
-        return personOne.getAge() + personTwo.getAge();
+    // A method for testing both cases when the Engine produces
+    //  - two models for two @Autowired fields of the same type
+    //  - one model for two @Autowired fields of the same type
+    public Boolean checker() {
+        String name1 = personOne.getName();// shouldn't produce NPE because `personOne` is `@Autowired`
+        int length = name1.length(); // can produce NPE because `Person.name` isn't `@Autowired`
+        Integer age2 = personTwo.getAge(); // shouldn't produce NPE because `personTwo` is `@Autowired`
+        return personOne == personTwo;
     }
 
-    // a method for testing the case when the Engine produces two models on @Autowired variables of the same type
-    public Boolean checker() {
-        return personOne.getName().equals("k") && personTwo.getName().length() > 5 && baseOrders.isEmpty();
+    public Person getPersonOne() {
+        return personOne;
+    }
+
+    public Person getPersonTwo() {
+        return personTwo;
     }
 }

--- a/utbot-spring-test/src/test/kotlin/org/utbot/examples/spring/autowiring/twoAndMoreBeansForOneType/ServiceOfBeansWithSameTypeTest.kt
+++ b/utbot-spring-test/src/test/kotlin/org/utbot/examples/spring/autowiring/twoAndMoreBeansForOneType/ServiceOfBeansWithSameTypeTest.kt
@@ -3,7 +3,6 @@ package org.utbot.examples.spring.autowiring.twoAndMoreBeansForOneType
 import org.junit.jupiter.api.Test
 import org.utbot.examples.spring.autowiring.SpringNoConfigUtValueTestCaseChecker
 import org.utbot.examples.spring.utils.*
-import org.utbot.framework.plugin.api.UtConcreteValue
 import org.utbot.testcheckers.eq
 import org.utbot.testing.*
 
@@ -12,16 +11,15 @@ class ServiceOfBeansWithSameTypeTest : SpringNoConfigUtValueTestCaseChecker(
 ) {
 
     /**
-     *  In this test, we check the case when the Engine produces two models on two @Autowired variables of the same type.
-     *
-     *  The engine produce two models only in the tests, when `baseOrder` is a testing participant.
-     *  In these tests, we mock all the variables and get the only necessary `mock.values` in each variable.
+     *  In this test, we check  both cases when the Engine produces
+     *    - two models for two @Autowired fields of the same type
+     *    - one model for two @Autowired fields of the same type
      */
     @Test
     fun testChecker() {
         checkThisMocksAndExceptions(
             method = ServiceOfBeansWithSameType::checker,
-            branches = eq(6),
+            branches = eq(3),
             {_, mocks, r ->
                 val personOne = mocks.singleMock("personOne", namePersonCall)
 
@@ -32,109 +30,26 @@ class ServiceOfBeansWithSameTypeTest : SpringNoConfigUtValueTestCaseChecker(
                 r1 && r.isException<NullPointerException>()
             },
             {_, mocks, r ->
-                val person = mocks.singleMock("personOne", namePersonCall)
-
-                val personOneName = (person.values[0] as? UtConcreteValue<*>)?.value
-                val personTwoName = (person.values[1] as? UtConcreteValue<*>)?.value
-
-                val r1 = personOneName == "k"
-                val r2 = personTwoName == null
-
-                r1 && r2 && r.isException<NullPointerException>()
-            },
-            {_, mocks, r ->
                 val personOne = mocks.singleMock("personOne", namePersonCall)
+                val personTwo = mocks.singleMockOrNull("personTwo", namePersonCall)
 
                 val personOneName = personOne.value<String?>()
 
-                val r1 = personOneName != "k"
-
-                r1 && (r.getOrNull() == false)
-            },
-            {_, mocks, r ->
-                val person = mocks.singleMock("personOne", namePersonCall)
-
-                val personOneName = (person.values[0] as? UtConcreteValue<*>)?.value
-                val personTwoName = (person.values[1] as? UtConcreteValue<*>)?.value.toString()
-
-                val r1 = personOneName == "k"
-                val r2 = personTwoName.length <= 5
+                val r1 = personOneName != null
+                val r2 = personTwo == null // `personTwo.getName()` isn't mocked, meaning `personOne != personTwo`
 
                 r1 && r2 && (r.getOrNull() == false)
             },
-
-            //In this test Engine produces two models on two @Autowired variables of the same type
-            {thisInstance, mocks, r ->
+            {_, mocks, r ->
                 val personOne = mocks.singleMock("personOne", namePersonCall)
-                val personTwo = mocks.singleMock("personTwo", namePersonCall)
+                val personTwo = mocks.singleMockOrNull("personTwo", namePersonCall)
 
-                val personOneName = (personOne.values[0] as? UtConcreteValue<*>)?.value
-                val personTwoName = (personTwo.values[0] as? UtConcreteValue<*>)?.value.toString()
-                val baseOrders = thisInstance.baseOrders
+                val personOneName = personOne.value<String?>()
 
-                val r1 = personOneName == "k"
-                val r2 = personTwoName.length > 5
-                val r3 = baseOrders.isEmpty()
+                val r1 = personOneName != null
+                val r2 = personTwo != null // `personTwo.getName()` is mocked, meaning `personOne == personTwo`
 
-                r1 && r2 && r3 && (r.getOrNull() == true)
-            },
-
-            {thisInstance, mocks, r ->
-                val personOne = mocks.singleMock("personOne", namePersonCall)
-                val personTwo = mocks.singleMock("personTwo", namePersonCall)
-
-                val personOneName = (personOne.values[0] as? UtConcreteValue<*>)?.value
-                val personTwoName = (personTwo.values[0] as? UtConcreteValue<*>)?.value.toString()
-                val baseOrders = thisInstance.baseOrders
-
-                val r1 = personOneName == "k"
-                val r2 = personTwoName.length > 5
-                val r3 = baseOrders.isNotEmpty()
-
-                r1 && r2 && r3 && (r.getOrNull() == false)
-            },
-            coverage = DoNotCalculate,
-            mockStrategy = springMockStrategy,
-            additionalDependencies = springAdditionalDependencies,
-        )
-    }
-
-    /**
-     *  In this test, we check the case when the Engine produces one model on two @Autowired variables of the same type.
-     *
-     *  Therefore, we only mock one of the variables and get all `mock.values` in it
-     */
-    @Test
-    fun testAgeSum(){
-        checkThisMocksAndExceptions(
-            method = ServiceOfBeansWithSameType::ageSum,
-            branches = eq(3),
-            { _, mocks, r ->
-                val personOne = mocks.singleMock("personOne", agePersonCall)
-
-                val personOneAge = (personOne.values[0] as? UtConcreteValue<*>)?.value
-                val isPersonOneAgeNull = personOneAge == null
-
-                isPersonOneAgeNull && r.isException<NullPointerException>()
-            },
-            { _, mocks, r ->
-                val personOne = mocks.singleMock("personOne", agePersonCall)
-
-                val personOneAge = (personOne.values[0] as? UtConcreteValue<*>)?.value
-                val personTwoAge = (personOne.values[1] as? UtConcreteValue<*>)?.value
-
-                val isPersonOneAgeNull = personOneAge != null
-                val isPersonTwoAgeNotNull = personTwoAge == null
-
-                isPersonOneAgeNull && isPersonTwoAgeNotNull && r.isException<NullPointerException>()
-            },
-            { _, mocks, r ->
-                val personOne = mocks.singleMock("personOne", agePersonCall)
-
-                val personOneAge = (personOne.values[0] as? UtConcreteValue<*>)?.value.toString().toInt()
-                val personTwoAge = (personOne.values[1] as? UtConcreteValue<*>)?.value.toString().toInt()
-
-                personOneAge + personTwoAge == r.getOrNull()
+                r1 && r2 && (r.getOrNull() == true)
             },
             coverage = DoNotCalculate,
             mockStrategy = springMockStrategy,


### PR DESCRIPTION
## Description

Fixes #2589 (desired NPE test is generated by fuzzer, because symbolic engine has troubles dealing with `getClass() == o.getClass()` condition.

To make fuzzer able to generate `Object` of type `Order` special `JavaLangObjectValueProvider` was added that tries to use `classUnderTest` whenever `java.lang.Object` is needed (plain `new Object()` can still be used where `java.lang.Object` is needed).

In case class under test has some hard to pass validation inside of the constructor and fuzzer is asked to create multiple `java.lang.Object`s, [`RemovingConstructFailsUtExecutionInstrumentation`](https://github.com/UnitTestBot/UTBotJava/commit/c74bf37a9330b1ba0c4127724c61608705f8b114) was used in all Spring tests (in short, it detects impossible to create due to exceptions thrown by constructor models in `stateBefore` and replaces them with `UtNullModel`s, making it easier for fuzzer to find "creatable" input and actually call method under test).

Finally, `InjectMocksValueProvider` was made to respect `NonNullSpeculator` (previously fuzzer considered all fields to be non-`null`).

## How to test

### Manual tests

NPE unit be generated by fuzzer for `Order.equals()` from `spring-boot-testing` project.

Generate unit tests for the following classes individually with fuzzer only and with engine only, each of them should generate NPE tests for methods marked with "NPE expected" and no NPE tests for methods marked with "no NPE expected".

```java
package com.rest.order.services;

import com.rest.order.models.Order;
import com.rest.order.repositories.OrderRepository;
import org.springframework.beans.factory.annotation.Autowired;
import org.springframework.lang.Nullable;
import org.springframework.stereotype.Service;

import java.util.List;

@Service
public class ServiceExample {
    /// region notAutowired

    private OrderRepository notAutowired;

    public void setNotAutowired(OrderRepository notAutowired) {
        this.notAutowired = notAutowired;
    }

    @Autowired
    public void fakeSetNotAutowired(OrderRepository notAutowired) {}

    @Autowired
    public void setNonRequiredNotAutowired(@Autowired(required = false) OrderRepository notAutowired) {
        this.notAutowired = notAutowired;
    }

    @Autowired(required = false)
    public void nonRequiredSetNotAutowired(OrderRepository notAutowired) {
        this.notAutowired = notAutowired;
    }

    @Autowired
    public void setNullable(@Nullable OrderRepository notAutowired) {
        this.notAutowired = notAutowired;
    }

    public ServiceExample(OrderRepository notAutowired) {
        this.notAutowired = notAutowired;
    }

    @Autowired(required = false)
    public ServiceExample(OrderRepository notAutowired, boolean unused) {
        this.notAutowired = notAutowired;
    }

    @Autowired
    public ServiceExample(@Autowired(required = false) OrderRepository notAutowired, char unused) {
        this.notAutowired = notAutowired;
    }

    // NPE expected
    public List<Order> useNotAutowired() {
        return notAutowired.findAll();
    }

    /// endregion

    /// region autowiredViaConstructor

    private OrderRepository autowiredViaConstructor;

    @Autowired
    public ServiceExample(OrderRepository orderRepository, int unused) {
        this.autowiredViaConstructor = orderRepository;
    }

    // no NPE expected
    public List<Order> useAutowiredViaConstructor() {
        return autowiredViaConstructor.findAll();
    }

    /// endregion

    /// endregion

    /// region autowiredViaField

    @Autowired
    private OrderRepository autowiredViaField;

    // no NPE expected
    public List<Order> useAutowiredViaField() {
        return autowiredViaField.findAll();
    }

    /// endregion

    /// region autowiredViaSetter

    private OrderRepository autowiredViaSetter;

    @Autowired
    public void setAutowiredViaSetter(OrderRepository orderRepository) {
        this.autowiredViaSetter = orderRepository;
    }

    // no NPE expected
    public List<Order> useAutowiredViaSetter() {
        return autowiredViaSetter.findAll();
    }

    /// endregion

}
```

```java
package com.rest.order.services;

import com.rest.order.models.Order;
import com.rest.order.repositories.OrderRepository;
import org.springframework.stereotype.Service;

import java.util.List;

@Service
public class ServiceExample2 {
    private final OrderRepository autowiredViaOnlyConstructor;

    public ServiceExample2(OrderRepository orderRepository) {
        this.autowiredViaOnlyConstructor = orderRepository;
    }

    // no NPE expected
    public List<Order> useAutowiredViaOnlyConstructor() {
        return autowiredViaOnlyConstructor.findAll();
    }
}
```

```java
package com.rest.order.services;

import com.rest.order.models.Order;
import com.rest.order.repositories.OrderRepository;

import java.util.List;

public class ServiceExample3 {
    private final OrderRepository notAutowiredViaOnlyConstructor;

    public ServiceExample3(OrderRepository orderRepository) {
        this.notAutowiredViaOnlyConstructor = orderRepository;
    }

    // NPE expected
    public List<Order> useNotAutowiredViaOnlyConstructor() {
        return notAutowiredViaOnlyConstructor.findAll();
    }
}
```

```java
package com.rest.order.services;

import com.rest.order.models.Order;
import com.rest.order.repositories.OrderRepository;
import org.springframework.lang.Nullable;
import org.springframework.stereotype.Service;

import java.util.List;

@Service
public class ServiceExample4 {
    public OrderRepository notAutowiredViaOnlyConstructor;
    private final OrderService orderService;

    public ServiceExample4(@Nullable OrderRepository orderRepository, OrderService orderService) {
        this.notAutowiredViaOnlyConstructor = orderRepository;
        this.orderService = orderService;
    }

    // NPE expected
    public List<Order> useNotAutowiredViaOnlyConstructor() {
        return notAutowiredViaOnlyConstructor.findAll();
    }
}
```

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.