### PR TITLE
Add disclaimer of generating Spring integration tests

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/ui/GenerateTestsDialogWindow.kt
@@ -418,7 +418,7 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
                                 "Mocks will be used when necessary."
                     )
                 }
-                row("Tests type:") {
+                row("Test type:") {
                     cell(springTestType)
                     contextHelp(
                         "Unit tests do not initialize ApplicationContext <br>" +
@@ -667,6 +667,19 @@ class GenerateTestsDialogWindow(val model: GenerateTestsModel) : DialogWrapper(m
     }
 
     override fun doOKAction() {
+        if (isSpringConfigSelected()
+            && springTestType.selectedItem == INTEGRATION_TEST
+            && Messages.showYesNoDialog(
+                    model.project,
+                    "Generating \"Integration tests\" may lead to corrupting user data or inflicting other harm.\n" +
+                            "Please use a test configuration or profile.",
+                    "Warning",
+                    "Proceed",
+                    "Go Back",
+                    Messages.getWarningIcon()
+                ) != Messages.YES) {
+                return;
+        }
         fun now() = LocalDateTime.now().format(DateTimeFormatter.ofPattern("HH:mm:ss.SSS"))
 
         logger.info { "Tests generation instantiation phase started at ${now()}" }


### PR DESCRIPTION
## Description

These changes warn users about potentially harmful activity during generation "Integration tests"

Fixes #2609 

## How to test

### Manual tests

Choose "Integration tests" in "Generate..." dialog. For both "Generate" and "Generate and Run" there should be disclaimer dialog describing potentially dangerous operation.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.