### PR TITLE
Limit number of unknown coverage executions

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -394,6 +394,14 @@ object UtSettings : AbstractSettings(logger, defaultKeyForSettingsPath, defaultS
     var minimizeCrashExecutions by getBooleanProperty(true)
 
     /**
+     * Determines maximum number of executions with unknown coverage per method per result type,
+     * typically unknown coverage is caused either by JVM crash or method under test not being
+     * executed (e.g. because [ClassLoader] failed to load class containing it or some dynamic
+     * proxy intercepted invocation and never called the method under test).
+     */
+    var maxUnknownCoverageExecutionsPerMethodPerResultType by getIntProperty(2, 1, Int.MAX_VALUE)
+
+    /**
      * Enable it to calculate unsat cores for hard constraints as well.
      * It may be usefull during debug.
      *


### PR DESCRIPTION
## Description

Make it so minimizer limits number of executions with unknown coverage and identical result type, result model type, and exception type.

Previously 50 almost identical tests were generated whenever we fail to collect the coverage (see #2622 and #2625)

## How to test

### Manual tests

In scenarios described #2622 and #2625 there shouldn't be 50 identical tests with unknown coverage.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.