### PR TITLE
Use assertSame instead of deepEquals if actual is a mock

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/Domain.kt
@@ -190,6 +190,8 @@ abstract class TestFramework(
 
     open val testSuperClass: ClassId? = null
 
+    open val assertSame by lazy { assertionId("assertSame", objectClassId, objectClassId) }
+
     open val assertEquals by lazy { assertionId("assertEquals", objectClassId, objectClassId) }
 
     val assertFloatEquals by lazy { assertionId("assertEquals", floatClassId, floatClassId, floatClassId) }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/TestFrameworkManager.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/services/framework/TestFrameworkManager.kt
@@ -44,6 +44,8 @@ abstract class TestFrameworkManager(val context: CgContext)
 
     val assertions = context.testFramework.assertionsClass
 
+    val assertSame = context.testFramework.assertSame
+
     val assertEquals = context.testFramework.assertEquals
     val assertFloatEquals = context.testFramework.assertFloatEquals
     val assertDoubleEquals = context.testFramework.assertDoubleEquals
@@ -84,6 +86,10 @@ abstract class TestFrameworkManager(val context: CgContext)
 
     open fun assertEquals(expected: CgValue, actual: CgValue) {
         +assertions[assertEquals](expected, actual)
+    }
+
+    open fun assertSame(expected: CgValue, actual: CgValue) {
+        +assertions[assertSame](expected, actual)
     }
 
     open fun assertFloatEquals(expected: CgExpression, actual: CgExpression, delta: Any) {

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgMethodConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgMethodConstructor.kt
@@ -1226,7 +1226,12 @@ open class CgMethodConstructor(val context: CgContext) : CgContextOwner by conte
         if (!successfullyConstructedCustomAssert) {
             val expectedVariable = variableConstructor.getOrCreateVariable(expected, expectedVariableName)
             if (emptyLineIfNeeded) emptyLineIfNeeded()
-            assertEquality(expectedVariable, actual)
+
+            if (expected.isMockModel()) {
+                testFrameworkManager.assertSame(expectedVariable, actual)
+            } else {
+                assertEquality(expectedVariable, actual)
+            }
         }
     }
 
@@ -1303,13 +1308,6 @@ open class CgMethodConstructor(val context: CgContext) : CgContextOwner by conte
                     }
                 }
                 else -> {
-                    currentExecution!!.result.onSuccess { resultModel ->
-                        if (resultModel.isMockModel()) {
-                            testFrameworkManager.assertSame(expected, actual)
-                            return
-                        }
-                    }
-
                     when (expected) {
                         is CgLiteral -> testFrameworkManager.assertEquals(expected, actual)
                         is CgNotNullAssertion -> generateForNotNullAssertion(expected, actual)

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgMethodConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgMethodConstructor.kt
@@ -115,6 +115,7 @@ import org.utbot.framework.plugin.api.UtSymbolicExecution
 import org.utbot.framework.plugin.api.UtTaintAnalysisFailure
 import org.utbot.framework.plugin.api.UtTimeoutException
 import org.utbot.framework.plugin.api.UtVoidModel
+import org.utbot.framework.plugin.api.isMockModel
 import org.utbot.framework.plugin.api.isNotNull
 import org.utbot.framework.plugin.api.isNull
 import org.utbot.framework.plugin.api.onFailure
@@ -1302,6 +1303,13 @@ open class CgMethodConstructor(val context: CgContext) : CgContextOwner by conte
                     }
                 }
                 else -> {
+                    currentExecution!!.result.onSuccess { resultModel ->
+                        if (resultModel.isMockModel()) {
+                            testFrameworkManager.assertSame(expected, actual)
+                            return
+                        }
+                    }
+
                     when (expected) {
                         is CgLiteral -> testFrameworkManager.assertEquals(expected, actual)
                         is CgNotNullAssertion -> generateForNotNullAssertion(expected, actual)

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgMethodConstructor.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/tree/CgMethodConstructor.kt
@@ -619,6 +619,11 @@ open class CgMethodConstructor(val context: CgContext) : CgContextOwner by conte
         visitedModels += modelWithField
 
         with(testFrameworkManager) {
+            if (expectedModel.isMockModel()) {
+                currentBlock += assertions[assertSame](expected, actual).toStatement()
+                return
+            }
+
             if (depth >= DEEP_EQUALS_MAX_DEPTH) {
                 currentBlock += CgSingleLineComment("Current deep equals depth exceeds max depth $DEEP_EQUALS_MAX_DEPTH")
                 currentBlock += getDeepEqualsAssertion(expected, actual).toStatement()
@@ -1226,12 +1231,7 @@ open class CgMethodConstructor(val context: CgContext) : CgContextOwner by conte
         if (!successfullyConstructedCustomAssert) {
             val expectedVariable = variableConstructor.getOrCreateVariable(expected, expectedVariableName)
             if (emptyLineIfNeeded) emptyLineIfNeeded()
-
-            if (expected.isMockModel()) {
-                testFrameworkManager.assertSame(expectedVariable, actual)
-            } else {
-                assertEquality(expectedVariable, actual)
-            }
+            assertEquality(expectedVariable, actual)
         }
     }
 

--- a/utbot-js/src/main/kotlin/framework/codegen/model/constructor/tree/JsTestFrameworkManager.kt
+++ b/utbot-js/src/main/kotlin/framework/codegen/model/constructor/tree/JsTestFrameworkManager.kt
@@ -51,6 +51,10 @@ class MochaManager(context: CgContext) : TestFrameworkManager(context) {
         +assertions[jsAssertEquals](expected, actual)
     }
 
+    override fun assertSame(expected: CgValue, actual: CgValue) {
+        error("assertSame does not exist in Mocha")
+    }
+
     override fun disableTestMethod(reason: String) {
 
     }

--- a/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/constructor/tree/PythonTestFrameworkManager.kt
+++ b/utbot-python/src/main/kotlin/org/utbot/python/framework/codegen/model/constructor/tree/PythonTestFrameworkManager.kt
@@ -81,6 +81,10 @@ internal class PytestManager(context: CgContext) : TestFrameworkManager(context)
         )
     }
 
+    override fun assertSame(expected: CgValue, actual: CgValue) {
+        error("assertSame does not exist in PyTest")
+    }
+
     fun assertIsinstance(types: List<PythonClassId>, actual: CgVariable) {
         +CgPythonAssertEquals(
             CgPythonFunctionCall(
@@ -102,10 +106,14 @@ internal class UnittestManager(context: CgContext) : TestFrameworkManager(contex
     override val isExpectedExceptionExecutionBreaking: Boolean = true
 
     override val dataProviderMethodsHolder: TestClassContext
-        get() = error("Parametrized tests are not supported for JavaScript")
+        get() = error("Parametrized tests are not supported in Unittest")
 
     override fun addAnnotationForNestedClasses() {
         error("Nested classes annotation does not exist in Unittest")
+    }
+
+    override fun assertSame(expected: CgValue, actual: CgValue) {
+        error("assertSame does not exist in Unittest")
     }
 
     override fun expectException(exception: ClassId, block: () -> Unit) {


### PR DESCRIPTION
## Description

Fixes # ([2639](https://github.com/UnitTestBot/UTBotJava/issues/2639))

## How to test

Automated tests: utbot-samples pipeline as a set of regression checks
Manual tests: scenario from issue

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.