### PR TITLE
Avoid spying collection-like types with @Spy if it may mislead @InjectMocks behaviour

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -404,13 +404,10 @@ fun UtModel.isMockModel() = this is UtCompositeModel && isMock
  * Checks that this [UtModel] must be constructed with @Spy annotation in generated tests.
  * Used only for construct variables with @Spy annotation.
  */
-fun UtModel.canBeSpied(): Boolean {
-    val javaClass = this.classId.jClass
+fun UtModel.canBeSpied(): Boolean =
+    this is UtAssembleModel && spiedTypes.any { type -> type.isAssignableFrom(this.classId.jClass)}
 
-    return this is UtAssembleModel &&
-            (Collection::class.java.isAssignableFrom(javaClass)
-                    || Map::class.java.isAssignableFrom(javaClass))
-}
+val spiedTypes = setOf(Collection::class.java, Map::class.java)
 
 /**
  * Get model id (symbolic null value for UtNullModel)

--- a/utbot-spring-framework/src/main/kotlin/org/utbot/framework/codegen/tree/fieldmanager/CgSpiedFieldsManager.kt
+++ b/utbot-spring-framework/src/main/kotlin/org/utbot/framework/codegen/tree/fieldmanager/CgSpiedFieldsManager.kt
@@ -67,16 +67,12 @@ class CgSpiedFieldsManager(context: CgContext) : CgAbstractClassFieldManager(con
         }
 
     /*
-     * Detects if injecting models via @Spy is possible and behavior is transparent.
+     * Filters out cases when different tests use different [clazz]
+     * implementations and hence we need to inject different types.
      *
-     * Some limitations are reasoned by @InjectMocks behaviour. It can successfully
-     * inject a @Spy if it's type is unique in this class (original variable names
-     * are hidden in test class,so we can inject by type only). It may cause problems
-     * sometimes. For example, if there is more than one collection in original class
-     * having types List<A> and List<B>, we may try to construct two listSpy objects
-     * that clash and injection will be incorrect so on.
-     *
-     * So @Spy variable may be created only if there are no clashes as described.
+     * This limitation is reasoned by @InjectMocks behaviour.
+     * Otherwise, injection may be misleading:
+     * for example, several spies may be injected into one field.
     */
     private fun getSuitableSpyModelsOfType(
         clazz: Class<*>,


### PR DESCRIPTION
## Description

If we have models of different types implementing Collection or Map, we should not construct fields of these models with `@Spy` annotation but just use `setField` for it. Otherwise it will cause problems with `@InjectMocks` in Mockito because injection by type is used and in generated tests both `List<A>` and `List<B>` are represented as `List listSpy`.

One of the possible scenarios to reproduce the bug we fix here is to generate tests for `Owner` class in `spring-petclinic` project with 100% fuzzing. Before this fix, several different spies were created but injected not as we expect after that.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.