### PR TITLE
Actualise test for using except on provider with fallback

### DIFF
--- a/utbot-fuzzing/src/test/kotlin/org/utbot/fuzzing/ProvidersTest.kt
+++ b/utbot-fuzzing/src/test/kotlin/org/utbot/fuzzing/ProvidersTest.kt
@@ -112,7 +112,7 @@ class ProvidersTest {
     }
 
     @Test
-    fun `test fallback unwrapping from providers`() {
+    fun `test using except on provider with fallback`() {
         val provider1 = p { 2 }
         val provider2 = p { 3 }
         val fallback = p { 4 }
@@ -128,8 +128,9 @@ class ProvidersTest {
         val providers2 = providers1.except(provider1)
 
         val seq2 = providers2.generate(description, Unit).toSet()
-        Assertions.assertEquals(1, seq2.count())
-        Assertions.assertEquals(3, (seq2.first() as Seed.Simple).value)
+        Assertions.assertEquals(2, seq2.count())
+        Assertions.assertEquals(4, (seq2.first() as Seed.Simple).value)
+        Assertions.assertEquals(3, (seq2.drop(1).first() as Seed.Simple).value)
     }
 
     @Test


### PR DESCRIPTION
## Description

Fixes #2659 by updating tests, that were verifying outdated semantic of `except`.

Previously `provider.except(filter)` wasn't recursive and was removing all the fallbacks. 

Semantic of `except` was updated to solve the issues with using `.except { it is ObjectValueProvider }` on the following provider causing `AbstractsObjectValueProvider` and `BuilderObjectValueProvider` to be remoed (since they are fallbacks) and `ObjectValueProvider` itself not to be removed (since it's not on the top level, i.e. it's a part of `ValueProvider.Combined` that is nested into `ValueProvider.Fallback` that is nested into another `ValueProvider.Combined`).
```kotlin
ValueProvider.of(listOf(
    BooleanValueProvider,
    IntegerValueProvider,
    FloatValueProvider,
    StringValueProvider,
    NumberValueProvider,
    anyObjectValueProvider(idGenerator),
    ArrayValueProvider(idGenerator),
    EnumValueProvider(idGenerator),
    ListSetValueProvider(idGenerator),
    MapValueProvider(idGenerator),
    IteratorValueProvider(idGenerator),
    EmptyCollectionValueProvider(idGenerator),
    DateValueProvider(idGenerator),
    (ObjectValueProvider(idGenerator)
        with ArrayValueProvider(idGenerator)
        with EnumValueProvider(idGenerator)
        with ListSetValueProvider(idGenerator)
        with MapValueProvider(idGenerator)
        with IteratorValueProvider(idGenerator)
        with EmptyCollectionValueProvider(idGenerator)
        with DateValueProvider(idGenerator))
            .withFallback(
                AbstractsObjectValueProvider(idGenerator)
                        with BuilderObjectValueProvider(idGenerator)
            ),
    VoidValueProvider,
    NullValueProvider,
))
```

## How to test

### Automated tests

> The proposed changes are verified with tests:
> `utbot-fuzzing/src/test/kotlin/org/utbot/fuzzing/ProvidersTest.kt`

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [ ] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.