### PR TITLE
Add optional arguments to engine process

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/UtSettings.kt
@@ -309,6 +309,12 @@ object UtSettings : AbstractSettings(logger, defaultKeyForSettingsPath, defaultS
     var engineProcessLogConfigFile by getStringProperty("")
 
     /**
+     * Optional arguments to the engine java process. One may want to
+     * increase heap size in order to give Soot more room for analysis.
+     */
+    var engineProcessJavaOptionalArguments by getStringProperty("")
+
+    /**
      * The property is useful only for the IntelliJ IDEs.
      * If the property is set in true the engine process opens a debug port.
      * @see runInstrumentedProcessWithDebug

--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/process/AbstractRDProcessCompanion.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/process/AbstractRDProcessCompanion.kt
@@ -1,6 +1,7 @@
 package org.utbot.framework.process
 
 import org.utbot.common.osSpecificJavaExecutable
+import org.utbot.framework.UtSettings
 import org.utbot.framework.plugin.services.JdkInfoService
 import org.utbot.rd.rdPortArgument
 import java.io.File
@@ -26,12 +27,12 @@ abstract class AbstractRDProcessCompanion(
         val debugArgument =
             "-agentlib:jdwp=transport=dt_socket,server=n,suspend=${suspendValue},quiet=y,address=$debugPort"
                 .takeIf { runWithDebug }
-
         add(javaExecutablePathString.pathString)
         val javaVersionSpecificArgs = OpenModulesContainer.javaVersionSpecificArguments
         if (javaVersionSpecificArgs.isNotEmpty()) {
             addAll(javaVersionSpecificArgs)
         }
+        add(UtSettings.engineProcessJavaOptionalArguments)
         debugArgument?.let { add(it) }
     }
 }


### PR DESCRIPTION
## Description

Users some time like to increase heap size for the engine process.

## How to test

### Manual tests

Update ~/.utbot/settings.properties with

engineProcessJavaOptionalArguments="-Xmx3m"

the analysis should fail with OOM