### PR TITLE
Fixed a bug with the loss of symbolic tests when filling summaries

### DIFF
--- a/utbot-summary/src/main/kotlin/org/utbot/summary/Summarization.kt
+++ b/utbot-summary/src/main/kotlin/org/utbot/summary/Summarization.kt
@@ -283,14 +283,26 @@ class Summarization(val sourceFile: File?, val invokeDescriptions: List<InvokeDe
                 utExecution.summary = testMethodName?.javaDoc
             }
 
-            val clusteredExecutions = groupFuzzedExecutions(methodTestSet)
-            clusteredExecutions.forEach {
-                clustersToReturn.add(
-                    UtExecutionCluster(
-                        UtClusterInfo(it.header),
-                        it.executions
+            when(descriptionSource){
+                MethodDescriptionSource.FUZZER -> {
+                    val clusteredExecutions = groupFuzzedExecutions(methodTestSet)
+                    clusteredExecutions.forEach {
+                        clustersToReturn.add(
+                            UtExecutionCluster(
+                                UtClusterInfo(it.header),
+                                it.executions
+                            )
+                        )
+                    }
+                }
+                MethodDescriptionSource.SYMBOLIC -> {
+                    clustersToReturn.add(
+                        UtExecutionCluster(
+                            UtClusterInfo(),
+                            methodTestSet.executions
+                        )
                     )
-                )
+                }
             }
         }
 


### PR DESCRIPTION
## Description

The `generateFuzzerBasedSummariesForTests` method returned an empty `clustersToReturn` when `methodDescriptionSource == SYMBOLIC`. And all symbolic tests were lost when at least one fuzzer test was generated.


## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.