### PR TITLE
Fix gaps in settings

### DIFF
--- a/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/SettingsWindow.kt
+++ b/utbot-intellij/src/main/kotlin/org/utbot/intellij/plugin/settings/SettingsWindow.kt
@@ -64,7 +64,7 @@ class SettingsWindow(val project: Project) {
                         enableSummarizationGenerationCheckBox.isSelected = false
                     }
                 }
-            }.bottomGap(BottomGap.MEDIUM)
+            }
 
             row("Overflow detection:") {
                 createCombo(TreatOverflowAsError::class, TreatOverflowAsError.values())


### PR DESCRIPTION
## Description

Removed unnecessary space after code generation language in Java specific settings.

## How to test

### Manual tests

1. Install UnitTestBot in IntelliJ IDEA
2. Open UnitTestBot settings 
3. Open subpage with Java Specific Settings
4. Expected: 
    * Place 1: without big empty space after codegen language)
    * Place 2 and 3: these spaces are separating mocking block
![Снимок экрана (27)](https://github.com/UnitTestBot/UTBotJava/assets/23080942/323d7c19-7e15-439b-99f9-3edb5a6c2742)

## Self-check list

Check off the item if the statement is true. Hint: [x] is a marked item.

Please do not delete the list or its items.

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [ ] The **documentation** for the functionality I've been working on is up-to-date.