### PR TITLE
Fix creation of variables for class fields

### DIFF
--- a/utbot-spring-framework/src/main/kotlin/org/utbot/framework/codegen/tree/fieldmanager/CgAbstractClassFieldManager.kt
+++ b/utbot-spring-framework/src/main/kotlin/org/utbot/framework/codegen/tree/fieldmanager/CgAbstractClassFieldManager.kt
@@ -45,10 +45,21 @@ abstract class CgAbstractClassFieldManager(context: CgContext) :
 
             val baseVarName = constructBaseVarName(model)
 
-            // `withNameScope` is used to avoid saving names for sub-models of model
+            /*
+            * `withNameScope` is used to avoid saving names for sub-models of model.
+            *
+            * Different models from different executions may have the same id.
+            * Therefore, when creating a variable for a new class field and using existing `currentTestSetId` and `currentExecutionId`,
+            * field`s `model.wrap()` may match one of the values in `annotatedModels`.
+            * To avoid false matches when creating a variable for a new class field, `withTestSetIdScope(-1)` and `withExecutionIdScope(-1)` are used.
+            */
             val createdVariable = withNameScope {
-                variableConstructor.getOrCreateVariable(model, baseVarName) as? CgVariable
-                    ?: error("`CgVariable` cannot be constructed from a $model model")
+                withTestSetIdScope(-1) {
+                    withExecutionIdScope(-1) {
+                        variableConstructor.getOrCreateVariable(model, baseVarName) as? CgVariable
+                            ?: error("`CgVariable` cannot be constructed from a $model model")
+                    }
+                }
             }
             existingVariableNames.add(createdVariable.name)
 


### PR DESCRIPTION
## Description

Fixes #2638

Different models from different executions may have the same id.
Therefore, when creating a variable for a new class field and using existing `currentTestSetId` and `currentExecutionId`, field's `model.wrap()` may match one of the values in `annotatedModels`. 
To avoid false matches when creating a variable for a new class field, `withTestSetIdScope(-1)` and `withExecutionIdScope(-1)` are used.

## How to test

### Manual tests

The fix has been tested on projects:
- spring-petclinic
- spring-boot-testing

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.