### PR TITLE
Make `TestCaseGenerator` use `UsvmSymbolicEngine` for entire class

### DIFF
--- a/utbot-framework/src/main/kotlin/org/utbot/engine/UsvmSymbolicEngine.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/engine/UsvmSymbolicEngine.kt
@@ -2,9 +2,15 @@ package org.utbot.engine
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
+import org.utbot.framework.plugin.api.ExecutableId
 import org.utbot.framework.plugin.api.UtResult
 
-class UsvmSymbolicEngine {
-
-    fun generateWithUsvm(): Flow<UtResult> = emptyFlow()
+object UsvmSymbolicEngine {
+    // TODO implement
+    fun runUsvmGeneration(
+        methods: List<ExecutableId>,
+        classpath: String,
+        timeoutMillis: Long
+    ): Flow<Pair<ExecutableId, UtResult>> =
+        emptyFlow()
 }


### PR DESCRIPTION
## Description

Makes it so `UsvmSymbolicEngine` is used for entire class at once, since it has its own budget management.

## How to test

Should be tested when integration with USVM is completed.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.