### PR TITLE
Introduce `UtilMethodProviderPlaceholder`

### DIFF
--- a/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
+++ b/utbot-framework-api/src/main/kotlin/org/utbot/framework/plugin/api/Api.kt
@@ -1427,12 +1427,12 @@ open class ConstructorId(
 
 }
 
-data class BuiltinMethodId(
-    override val classId: ClassId,
-    override val name: String,
-    override val returnType: ClassId,
-    override val parameters: List<ClassId>,
-    override val bypassesSandbox: Boolean,
+class BuiltinMethodId(
+    classId: ClassId,
+    name: String,
+    returnType: ClassId,
+    parameters: List<ClassId>,
+    bypassesSandbox: Boolean,
     override val modifiers: Int,
 ) : MethodId(classId, name, returnType, parameters, bypassesSandbox) {
     constructor(
@@ -1441,7 +1441,7 @@ data class BuiltinMethodId(
         returnType: ClassId,
         parameters: List<ClassId>,
         bypassesSandbox: Boolean = false,
-        // by default we assume that the builtin method is non-static and public
+        // by default, we assume that the builtin method is non-static and public
         isStatic: Boolean = false,
         isPublic: Boolean = true,
         isProtected: Boolean = false,
@@ -1458,6 +1458,22 @@ data class BuiltinMethodId(
             private = isPrivate
             protected = isProtected
         }
+    )
+
+    fun copy(
+        classId: ClassId = this.classId,
+        name: String = this.name,
+        returnType: ClassId = this.returnType,
+        parameters: List<ClassId> = this.parameters,
+        bypassesSandbox: Boolean = this.bypassesSandbox,
+        modifiers: Int = this.modifiers,
+    ) = BuiltinMethodId(
+        classId = classId,
+        name = name,
+        returnType = returnType,
+        parameters = parameters,
+        bypassesSandbox = bypassesSandbox,
+        modifiers = modifiers,
     )
 }
 

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/builtin/UtilMethodProviderPlaceholder.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/domain/builtin/UtilMethodProviderPlaceholder.kt
@@ -1,0 +1,50 @@
+package org.utbot.framework.codegen.domain.builtin
+
+import org.utbot.framework.plugin.api.BuiltinMethodId
+import org.utbot.framework.plugin.api.ClassId
+import org.utbot.framework.plugin.api.UtAssembleModel
+import org.utbot.framework.plugin.api.UtExecutableCallModel
+import org.utbot.framework.plugin.api.UtModel
+import org.utbot.framework.plugin.api.UtStatementCallModel
+import org.utbot.framework.plugin.api.UtStatementModel
+
+/**
+ * Can be used in `UtModel`s to denote class containing util methods,
+ * before actual [ClassId] containing these methods has been determined.
+ *
+ * At the very start of the code generation, [utilClassIdPlaceholder] is
+ * replaced with actual [ClassId] containing util methods.
+ */
+val utilClassIdPlaceholder = utJavaUtilsClassId
+object UtilMethodProviderPlaceholder : UtilMethodProvider(utilClassIdPlaceholder)
+
+fun UtModel.shallowlyFixUtilClassIds(actualUtilClassId: ClassId) = when (this) {
+    is UtAssembleModel -> UtAssembleModel(
+        id = id,
+        classId = classId,
+        modelName = modelName,
+        instantiationCall = instantiationCall.shallowlyFixUtilClassId(actualUtilClassId),
+        origin = origin,
+        modificationsChainProvider = { modificationsChain.map { it.shallowlyFixUtilClassId(actualUtilClassId) } }
+    )
+    else -> this
+}
+
+private fun UtStatementModel.shallowlyFixUtilClassId(actualUtilClassId: ClassId) =
+    when (this) {
+        is UtExecutableCallModel -> shallowlyFixUtilClassId(actualUtilClassId)
+        else -> this
+    }
+
+private fun UtStatementCallModel.shallowlyFixUtilClassId(actualUtilClassId: ClassId) =
+    when (this) {
+        is UtExecutableCallModel -> {
+            val executable = executable
+            if (executable.classId == utilClassIdPlaceholder && executable is BuiltinMethodId) {
+                copy(executable = executable.copy(classId = actualUtilClassId))
+            } else {
+                this
+            }
+        }
+        else -> this
+    }

--- a/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/generator/AbstractCodeGenerator.kt
+++ b/utbot-framework/src/main/kotlin/org/utbot/framework/codegen/generator/AbstractCodeGenerator.kt
@@ -1,11 +1,14 @@
 package org.utbot.framework.codegen.generator
 
 import mu.KotlinLogging
+import org.utbot.framework.codegen.domain.builtin.shallowlyFixUtilClassIds
 import org.utbot.framework.codegen.domain.context.CgContext
 import org.utbot.framework.codegen.domain.models.CgClassFile
 import org.utbot.framework.codegen.domain.models.CgMethodTestSet
 import org.utbot.framework.codegen.renderer.CgAbstractRenderer
 import org.utbot.framework.plugin.api.UtMethodTestSet
+import org.utbot.framework.plugin.api.mapModels
+import org.utbot.framework.plugin.api.mapper.UtModelDeepMapper
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
@@ -42,6 +45,11 @@ abstract class AbstractCodeGenerator(params: CodeGeneratorParams) {
         testSets: Collection<UtMethodTestSet>,
         testClassCustomName: String? = null,
     ): CodeGeneratorResult {
+        @Suppress("NAME_SHADOWING")
+        val testSets = testSets.mapModels(UtModelDeepMapper { model ->
+            model.shallowlyFixUtilClassIds(actualUtilClassId = context.utilsClassId)
+        })
+
         val cgTestSets = testSets.map { CgMethodTestSet(it) }.toList()
         return withCustomContext(testClassCustomName) {
             context.withTestClassFileScope {

--- a/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzer/UtFuzzedExecution.kt
+++ b/utbot-java-fuzzing/src/main/kotlin/org/utbot/fuzzer/UtFuzzedExecution.kt
@@ -22,8 +22,17 @@ class UtFuzzedExecution(
     displayName: String? = null,
     val fuzzingValues:  List<FuzzedValue>? = null,
     val fuzzedMethodDescription:  FuzzedMethodDescription? = null,
-    override val instrumentation: List<UtInstrumentation> = emptyList(),
-) : UtExecution(stateBefore, stateAfter, result, coverage, summary, testMethodName, displayName), UtExecutionWithInstrumentation {
+    instrumentation: List<UtInstrumentation> = emptyList(),
+) : UtExecutionWithInstrumentation(
+    stateBefore,
+    stateAfter,
+    result,
+    coverage,
+    summary,
+    testMethodName,
+    displayName,
+    instrumentation
+) {
     /**
      * By design the 'before' and 'after' states contain info about the same fields.
      * It means that it is not possible for a field to be present at 'before' and to be absent at 'after'.
@@ -39,7 +48,8 @@ class UtFuzzedExecution(
         coverage: Coverage?,
         summary: List<DocStatement>?,
         testMethodName: String?,
-        displayName: String?
+        displayName: String?,
+        instrumentation: List<UtInstrumentation>,
     ): UtExecution {
         return UtFuzzedExecution(
             stateBefore,

--- a/utbot-junit-contest/src/main/kotlin/org/utbot/contest/usvm/converter/UtUsvmExecution.kt
+++ b/utbot-junit-contest/src/main/kotlin/org/utbot/contest/usvm/converter/UtUsvmExecution.kt
@@ -7,9 +7,6 @@ import org.utbot.framework.plugin.api.UtExecution
 import org.utbot.framework.plugin.api.UtExecutionResult
 import org.utbot.framework.plugin.api.UtExecutionWithInstrumentation
 import org.utbot.framework.plugin.api.UtInstrumentation
-import org.utbot.framework.plugin.api.mapper.UtModelMapper
-import org.utbot.framework.plugin.api.mapper.mapModelIfExists
-import org.utbot.framework.plugin.api.mapper.mapModels
 
 class UtUsvmExecution(
     stateBefore: EnvironmentModels,
@@ -19,16 +16,17 @@ class UtUsvmExecution(
     summary: List<DocStatement>? = emptyList(),
     testMethodName: String? = null,
     displayName: String? = null,
-    override val instrumentation: List<UtInstrumentation>
-) : UtExecution(
+    instrumentation: List<UtInstrumentation>
+) : UtExecutionWithInstrumentation(
     stateBefore,
     stateAfter,
     result,
     coverage,
     summary,
     testMethodName,
-    displayName
-), UtExecutionWithInstrumentation {
+    displayName,
+    instrumentation,
+) {
     override fun copy(
         stateBefore: EnvironmentModels,
         stateAfter: EnvironmentModels,
@@ -36,7 +34,8 @@ class UtUsvmExecution(
         coverage: Coverage?,
         summary: List<DocStatement>?,
         testMethodName: String?,
-        displayName: String?
+        displayName: String?,
+        instrumentation: List<UtInstrumentation>,
     ): UtExecution = UtUsvmExecution(
         stateBefore,
         stateAfter,
@@ -47,35 +46,4 @@ class UtUsvmExecution(
         displayName,
         instrumentation,
     )
-
-    fun copy(
-        stateBefore: EnvironmentModels = this.stateBefore,
-        stateAfter: EnvironmentModels = this.stateAfter,
-        result: UtExecutionResult = this.result,
-        coverage: Coverage? = this.coverage,
-        summary: List<DocStatement>? = this.summary,
-        testMethodName: String? = this.testMethodName,
-        displayName: String? = this.displayName,
-        instrumentation: List<UtInstrumentation> = this.instrumentation,
-    ) = UtUsvmExecution(
-        stateBefore,
-        stateAfter,
-        result,
-        coverage,
-        summary,
-        testMethodName,
-        displayName,
-        instrumentation,
-    )
 }
-
-fun UtUsvmExecution.mapModels(mapper: UtModelMapper) = copy(
-    stateBefore = stateBefore.mapModels(mapper),
-    stateAfter = stateAfter.mapModels(mapper),
-    result = result.mapModelIfExists(mapper),
-    coverage = this.coverage,
-    summary = this.summary,
-    testMethodName = this.testMethodName,
-    displayName = this.displayName,
-    instrumentation = instrumentation.map { it.mapModels(mapper) },
-)


### PR DESCRIPTION
## Description

Introduces `UtilMethodProviderPlaceholder` to be latter used in `JcToUtExecutionConverter`.

## How to test

Should be tested when integration with USVM is completed.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.