### PR TITLE
Add USVM jars to `resources/lib`

### DIFF
--- a/utbot-usvm/build.gradle.kts
+++ b/utbot-usvm/build.gradle.kts
@@ -35,3 +35,40 @@ dependencies {
     usvmInstrumentationRunner("$usvmRepo:usvm-jvm-instrumentation:$usvmVersion")
     usvmInstrumentationRunner("$usvmRepo:usvm-jvm-instrumentation-collectors:$usvmVersion")
 }
+
+// TODO replace with runner from usvm (unavailable due to huge jar size)
+val usvmInstrumentationRunnerJarTask by tasks.register<Jar>("usvmInstrumentationRunnerJar") {
+    archiveBaseName.set("usvm-jvm-instrumentation-runner")
+    archiveVersion.set("")
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+
+    manifest {
+        attributes(
+            "Main-Class" to "org.usvm.instrumentation.rd.InstrumentedProcessKt",
+            "Premain-Class" to "org.usvm.instrumentation.agent.Agent",
+            "Can-Retransform-Classes" to "true",
+            "Can-Redefine-Classes" to "true"
+        )
+    }
+
+    from(configurations.named("usvmInstrumentationRunner").get().map {
+        if (it.isDirectory) it else zipTree(it)
+    })
+}
+
+tasks.processResources {
+    listOf(
+        approximations,
+        usvmApproximationsApi,
+        usvmInstrumentationCollector,
+        usvmInstrumentationRunnerJarTask,
+    ).forEach { source ->
+        from(source) {
+            into("lib")
+            rename {
+                it.replace("-$usvmVersion", "")
+                    .replace("-$approximationsVersion", "")
+            }
+        }
+    }
+}

--- a/utbot-usvm/src/main/kotlin/org/utbot/usvm/jc/JcJars.kt
+++ b/utbot-usvm/src/main/kotlin/org/utbot/usvm/jc/JcJars.kt
@@ -1,0 +1,17 @@
+package org.utbot.usvm.jc
+
+import org.utbot.common.JarUtils
+
+object JcJars {
+    val approximationsJar by lazy { extractUsvmJar("approximations.jar") }
+    val approximationsApiJar by lazy { extractUsvmJar("usvm-jvm-api.jar") }
+    val collectorsJar by lazy { extractUsvmJar("usvm-jvm-instrumentation-collectors.jar") }
+    val runnerJar by lazy { extractUsvmJar("usvm-jvm-instrumentation-runner.jar") }
+
+    private fun extractUsvmJar(jarFileName: String) = JarUtils.extractJarFileFromResources(
+        jarFileName = jarFileName,
+        jarResourcePath = "lib/$jarFileName",
+        targetDirectoryName = "usvm"
+    )
+}
+


### PR DESCRIPTION
## Description

USVM jars are added to `resources/lib` so they can be latter extracted when we need to use USVM from Intellij plugin or CLI.

## How to test

Should be tested when integration with USVM is completed.

## Self-check list

- [x] I've set the proper **labels** for my PR (at least, for category and component).
- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided optionally.
- [x] The **documentation** for the functionality I've been working on is up-to-date.